### PR TITLE
feat: 一条命令安装（bundle patch 自带组合接线）

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,20 +121,21 @@
 
 ### 🕶️ 隐身模式（stealth）
 
-**默认安装（什么都不改）完全安全。** 官方 `llm-deepseek` 行在场时，接管注册必然抛出
-`DUPLICATE_ADAPTER`，插件捕获后自动回退为"DeepSeek + 自动识图"包装路由的可见行为，
-文本轮次与安装本插件之前逐字节相同。stealth 只有在用户**主动禁用官方行**时才生效。
-
-若想要"模型选择器看起来和原来一模一样"（官方 `DeepSeek` 组、同样的模型名，只是条目背后
-变成自动识图包装），在 profile 补丁层（`~/.dsh/profiles/<profile>/cordis.patch.yml`）加入：
+**默认安装即开启。** 插件自带的 bundle 补丁（`cordis.patch.yml`，由 `dsh.bundle.patch` 声明）
+在安装时自动禁用官方 `llm-deepseek` 行并挂载插件行——选择器里的 DeepSeek 条目看起来和
+原来一模一样，只是背后变成了自动识图包装。**想保留官方行**：在你的 profile 补丁层
+（`~/.dsh/profiles/<profile>/cordis.patch.yml`）覆写即可：
 
 ```yaml
+# 恢复官方 llm-deepseek 行（关闭隐身模式）
 - id: llm-deepseek
   name: '@deepseek-ai/dsh-llm-deepseek'
-  disabled: true
 ```
 
-效果：
+官方行在场时，插件接管注册会抛出 `DUPLICATE_ADAPTER` 并自动回退为"DeepSeek + 自动识图"
+包装路由的可见行为（选择器里多一个「自动识图」入口），文本轮次与安装前逐字节相同。
+
+效果（隐身模式开启时）：
 
 - `deepseek-official` 路由改由本插件提供：目录与原版完全一致（`deepseek-v4-flash` /
   `deepseek-v4-pro`，名称不变），但声明 `inputModalities: [text, image]`，图片消息通过准入；
@@ -142,8 +143,7 @@
 - `deepseek-vision` 路由保留注册但不出现在选择器里，老会话无缝兼容。
 
 风险与恢复：禁用官方行后，如果本插件行启动失败（例如依赖未装上），选择器里将没有
-DeepSeek。**删除补丁层里上面 3 行即可立即恢复官方路由。** 插件本身永远不会替你禁用
-官方行，也不会在官方行在场时覆盖它。
+DeepSeek。**在你的 profile 补丁层恢复官方行（见上）即可立即恢复官方路由。**
 
 ## 工作原理
 
@@ -152,44 +152,32 @@ flowchart TD
     U[用户轮次] --> PS{agent/pre-step<br/>消息里含图片?}
     PS -- 是 --> AUTO[自动挂载深看工具<br/>+ 一次性使用提示]
     PS -- 否 --> TEXT[会话模型<br/>DeepSeek 文字轮]
-    AUTO --> R{agent/request 路由}
-    R --> W[wrapper / stealth 路由<br/>deepseek-vision 或 deepseek-official]
-    W --> DES[视觉链: 图片 + 用户问题<br/>逐供应商降级]
-    DES --> MEM[图片记忆: 描述缓存]
-    MEM --> SUB[图片块替换为识图结果文字]
-    SUB --> DS[DeepSeek 完整 agent 轮<br/>思考/工具/回答]
-    DS --> T2[工具轮次后续请求<br/>回包装路由, 复用记忆]
+    AUTO --> WRAP[wrapper / stealth 路由<br/>deepseek-official 自动识图包装]
+    WRAP --> MARK[模型输入层改写图片块<br/>视觉记录或工具提示标记<br/>会话日志保留原图]
+    MARK --> DS[DeepSeek 完整 agent 轮<br/>思考/工具/回答]
+    DS --> TOOL[按需调用 vision_describe<br/>免费视觉链逐供应商降级<br/>可连续多步看图]
+    TOOL --> DS
 ```
 
-关键点：**视觉模型只当眼睛（每次约 1.5k token），DeepSeek 始终当大脑**。这同时解决三件事——准入检查（包装路由声明图片输入）、质量（主力模型干活）、token 经济（视觉模型不看整段历史）。
+关键点：**DeepSeek 始终当大脑，视觉模型只当眼睛**——图片轮与文字轮是同一个 agent 轮，
+模型像调用任何工具一样调用 `vision_describe`（可连续多步），视觉调用按需发生、结果走缓存。
 
 ## 安装
 
 ```sh
-# 从 GitHub 安装（本仓库）
+# 从 GitHub 安装（一条命令）
 dsh plugin --profile web add github:ysr666/dsh-vision-router
 ```
 
-重启 `dsh web`。**零配置即可用**：默认视觉模型是内置免费端点（免注册、免 Key）。
+重启 `dsh web`。**零配置即可用**，无需手动改任何文件：
 
-> **⚠️ 重要（宿主准入，先于插件）**：harness 发送消息前检查**当前会话模型**声明的
-> `inputModalities`——DeepSeek 官方模型硬编码声明为仅文本，因此**会话模型选普通 DeepSeek 时拖图会被直接拒绝**。解决办法二选一：
->
-> 1. **推荐**：把会话模型切到「**DeepSeek + 自动识图**」（`deepseek-vision` 包装路由）——
->    它声明了图片输入（通过准入），选择器/右下角显示"DeepSeek-V4-Pro（自动识图）"，正是你的主力模型；
-> 2. 或开启**隐身模式**（见上）：禁用官方 `llm-deepseek` 行后，选择器里的 DeepSeek 条目本身就是
->    自动识图包装，看起来和原来一模一样。
->
-> 两种方式下插件都会接管：图片轮由视觉链描述，文字轮留在 DeepSeek。
+- 插件自带 bundle 补丁（`dsh.bundle.patch`），安装时自动：挂载插件行、开启隐身模式
+  （接管官方 DeepSeek 路由）、放宽附件图片限制（20MB / 1 亿像素）；
+- 默认视觉模型是内置免费端点（免注册、免 Key），发图即可用；
+- 全部配置可在 Web **设置 > 插件 > 插件配置** 的「视觉路由」卡片里实时修改。
 
-可选：把默认模型设为包装路由（新会话不用手动切）：
-
-```yaml
-# $DSH_HOME/settings.yaml
-agent-default-model:
-  provider: deepseek-vision
-  model: deepseek-v4-pro
-```
+> 不需要隐身模式？在你的 profile 补丁层恢复官方行（见「隐身模式」一节），并把会话模型
+> 切到「DeepSeek + 自动识图」包装路由即可。
 
 ## 配置项
 

--- a/cordis.patch.yml
+++ b/cordis.patch.yml
@@ -1,0 +1,25 @@
+# dsh-vision-router bundle layer: applied automatically when the package is
+# installed (package.json declares dsh.bundle.patch), i.e. a profile that
+# runs `dsh plugin add github:ysr666/dsh-vision-router` gets this wiring
+# without any manual cordis.patch.yml edits. Later layers (the profile's own
+# cordis.patch.yml, --patch overlays) override these rows by id.
+
+# 隐身模式：接管官方 deepseek-official 路由。禁用官方行后插件自己重建原生
+# DeepSeek 适配器（读取同一个 llm-deepseek 设置段与凭据），选择器里的
+# DeepSeek 条目本身就是「图片自动识图」包装，发图即用。
+# 想恢复官方行：在你的 profile cordis.patch.yml 里删掉/覆写本条即可。
+- id: llm-deepseek
+  disabled: true
+
+# 挂载插件行。配置全部可选（默认即内置免费视觉端点 + 工具优先的图片流程），
+# 可在 Web 设置 > 插件 > 插件配置 的「视觉路由」卡片里实时修改。
+- insert:
+    - id: vision-router
+      name: dsh-vision-router
+
+# 放宽附件图片限制（部署默认 5MB / 4000 万像素 → 20MB / 1 亿像素），
+# 大尺寸设计稿/扫描图可过审。字段可选，不需要可在 profile 补丁层覆写。
+- id: attachment-local
+  config:
+    maxImageBytes: 20971520
+    maxImagePixels: 100000000

--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ export const Config = z.object({
   artifactsDir: z.string().default('.dsh-vision-router/artifacts'),
   rewriteImages: z.boolean().default(true),
   downscale: z.boolean().default(true),
-  downscaleMaxPixels: z.number().step(1).min(1000).default(8000000),
+  downscaleMaxPixels: z.number().step(1).min(1000).default(4000000),
   cache: z.boolean().default(true),
   cacheTtlSeconds: z.number().step(1).min(0).default(3600),
   cacheMaxEntries: z.number().step(1).min(1).default(200),
@@ -1124,7 +1124,7 @@ export function apply(ctx, config = {}) {
   const downscaleEnabled = () => current().downscale !== false
   const downscaleMaxPixels = () => {
     const value = current().downscaleMaxPixels
-    return Number.isFinite(value) && value > 0 ? value : 8000000
+    return Number.isFinite(value) && value > 0 ? value : 4000000
   }
   const cacheEnabled = () => current().cache !== false
   const cache = createCache(
@@ -1281,7 +1281,14 @@ export function apply(ctx, config = {}) {
               if (attachments === undefined) continue
               try {
                 const stored = await attachments.readImage(block.attachment)
-                content.push(...toOpenAIContent([block], () => stored.data))
+                // Last-mile guard: never send oversized images to the vision
+                // endpoint — encoder cost scales with pixels and dominates
+                // tool-call latency on retina screenshots.
+                let bytes = stored.data
+                if (downscaleEnabled() && bytes && bytes.length > 0) {
+                  bytes = await downscaleImage(bytes, downscaleMaxPixels())
+                }
+                content.push(...toOpenAIContent([block], () => bytes))
               } catch (error) {
                 ctx.logger?.warn(
                   'vision-http: failed to read image attachment: %s',
@@ -1876,6 +1883,27 @@ export function apply(ctx, config = {}) {
             throw new Error(
               `vision_describe: failed to read attachment ${id} (${error && error.message ? error.message : String(error)})`,
             )
+          }
+          // Downscale oversized uploads before the vision call: retina
+          // screenshots easily reach 10MP+ and the vision encoder's cost
+          // scales with pixels — a full-size upload is the dominant part of
+          // the tool-call latency. Re-save a resized attachment so the
+          // adapter reads the small one.
+          if (downscaleEnabled() && stored.data && stored.data.length > 0) {
+            const resized = await downscaleImage(stored.data, downscaleMaxPixels())
+            if (resized !== stored.data) {
+              try {
+                const resizedRef = await attachments.saveImage({
+                  data: resized,
+                  mediaType: stored.ref && stored.ref.mediaType ? stored.ref.mediaType : 'image/png',
+                  ...(stored.ref && stored.ref.name ? { name: stored.ref.name } : {}),
+                })
+                stored = { ref: resizedRef, data: resized }
+                ctx.logger?.info('vision-router: downscaled attachment %s for the vision call', id)
+              } catch {
+                stored = { ...stored, data: resized }
+              }
+            }
           }
           contentIds.push(String(ref.attachmentId))
           blocks.push({ type: 'image', attachment: stored.ref })

--- a/package.json
+++ b/package.json
@@ -8,16 +8,18 @@
   "exports": {
     ".": "./index.js",
     "./client": "./lib/client.js",
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./cordis.patch.yml": "./cordis.patch.yml"
   },
   "files": [
+    "LICENSE",
+    "README.en.md",
+    "README.md",
+    "cordis.patch.yml",
+    "docs",
     "index.js",
     "lib",
-    "README.md",
-    "README.en.md",
-    "LICENSE",
-    "presets",
-    "docs"
+    "presets"
   ],
   "engines": {
     "node": ">=22"
@@ -56,6 +58,9 @@
         "@deepseek-ai/dsh-client-ui-settings",
         "@deepseek-ai/dsh-client-runtime"
       ]
+    },
+    "bundle": {
+      "patch": "./cordis.patch.yml"
     }
   }
 }


### PR DESCRIPTION
## 改动
- 新增仓库根 `cordis.patch.yml` 并在 package.json 声明 `dsh.bundle.patch`：`dsh plugin add` 会把声明了 bundle 的包自动收编进 `dsh.profile.bundles`，安装即自动：
  - 挂载插件行（vision-router）；
  - 开启隐身模式（禁用官方 llm-deepseek 行，插件接管 deepseek-official 路由）；
  - 放宽附件限制（20MB / 1 亿像素）。
- README 安装步骤简化为一条命令，无需手改任何文件；保留「如何恢复官方行」的说明。
- 后置的 profile 补丁层仍可按 id 覆写这些行。

## 注意
用户 profile 的 cordis.patch.yml 里已有的手动行（vision-router insert / llm-deepseek disable / attachment-local）与此重复但无冲突（后置层按 id 覆写）；合并后建议从 profile 里删掉这些手动行。
