### PR TITLE
fix: 用户报告整改——魔数识别格式、报错提示、去重、v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ dsh plugin --profile web add github:ysr666/dsh-vision-router
 | `model` | `ovh/Qwen2.5-VL-72B-Instruct` | 主视觉模型（简写形式；**默认即内置免费端点**）。 |
 | `fallbacks` | `[]` | 同一供应商的备用模型（简写形式）。 |
 | `providers` | `[]` | **多供应商形式**：`{ provider, model, fallbacks[] }` 列表，逐条尝试；优先于简写形式。 |
-| `routing` | `false` | 图片轮整轮自动路由到视觉链（一次性整轮回答）。**默认关闭**：图片轮像普通文本轮一样由会话模型调用视觉工具看图，可连续多步操作；`true` = 恢复旧行为。 |
+| `routing` | `false` | 图片轮整轮自动路由到视觉链（一次性整轮回答）。**默认关闭**：图片轮像普通文本轮一样由会话模型调用视觉工具看图，可连续多步操作；`true` = 恢复旧行为。⚠️ `routing: true` 时降级链只含 `provider + fallbacks`，`httpProviders`（含免费兜底端点）不参与；工具模式下两者都会尝试。 |
 | `reverseRouting` | `true` | 开启 `routing` 时，文字轮反向路由回 `textProvider`。 |
 | `wrapperRoute` | `deepseek-vision` | 包装路由名（选择器显示"DeepSeek + 自动识图"）；置空关闭。 |
 | `chainRoute` | `vision-chain` | 视觉降级链路由名（仅 `routing: true` 时挂载；识图工具直接走真实 provider）。 |

--- a/index.js
+++ b/index.js
@@ -98,6 +98,27 @@ export function mediaTypeOf(path) {
   return match ? IMAGE_EXTENSIONS[match[1]] : undefined
 }
 
+/**
+ * Detect the image format from magic bytes instead of the file extension.
+ * Attachments are stored as content-addressed files WITHOUT an extension,
+ * so extension-based detection rejects them; the pixel tools must sniff.
+ */
+export function sniffMediaType(bytes) {
+  if (!bytes || bytes.length < 12) return undefined
+  const head = (offset, count) => {
+    const parts = []
+    for (let i = offset; i < offset + count; i++) parts.push(bytes[i].toString(16).padStart(2, '0'))
+    return parts.join('')
+  }
+  if (head(0, 8) === '89504e470d0a1a0a') return 'image/png'
+  if (head(0, 3) === 'ffd8ff') return 'image/jpeg'
+  const riff = head(0, 4)
+  const webp = head(8, 4)
+  if (riff === '52494646' && webp === '57454250') return 'image/webp'
+  if (riff === '47494638') return 'image/gif' // GIF87a / GIF89a
+  return undefined
+}
+
 export function basenameOf(path) {
   const parts = String(path).split('/')
   return parts[parts.length - 1] || undefined
@@ -761,7 +782,14 @@ export function dedupeHttpProviders(pairs, httpProviders) {
       .filter((pair) => pair && pair.provider === 'vision-http')
       .map((pair) => pair.model),
   )
-  return (httpProviders ?? []).filter((p) => p && !covered.has(`${p.name}/${p.model}`))
+  // Also drop http entries whose `name` duplicates a chain pair's provider:
+  // a config like provider: zhipu + an httpProviders entry named zhipu would
+  // otherwise call the same model twice (once through the adapter, once
+  // through the direct HTTP path).
+  const providers = new Set((pairs ?? []).map((pair) => pair && pair.provider))
+  return (httpProviders ?? []).filter(
+    (p) => p && !covered.has(`${p.name}/${p.model}`) && !providers.has(p.name),
+  )
 }
 
 /** Convert harness image/text blocks plus resolved image bytes into OpenAI wire content. */
@@ -1548,7 +1576,11 @@ export function apply(ctx, config = {}) {
           reason: {
             kind: 'error',
             failure: {
-              message: `all vision models failed: ${failures.join(' | ')}`,
+              message:
+                `all vision models failed: ${failures.join(' | ')}` +
+                (httpProviders().length > 0
+                  ? ' note: httpProviders (including the free fallback) are skipped while routing=true — set routing=false for the tools-first flow that uses them'
+                  : ''),
               code: 'VISION_CHAIN_EXHAUSTED',
             },
           },
@@ -1830,12 +1862,6 @@ export function apply(ctx, config = {}) {
           if (fs === undefined) {
             throw new Error('vision_describe: the fs service is not available in this deployment')
           }
-          const mediaType = mediaTypeOf(path)
-          if (mediaType === undefined) {
-            throw new Error(
-              `vision_describe: unsupported image format ${path} (png/jpeg/webp/gif only)`,
-            )
-          }
           let bytes
           try {
             const target = await fs.resolve(path)
@@ -1843,6 +1869,15 @@ export function apply(ctx, config = {}) {
           } catch (error) {
             throw new Error(
               `vision_describe: failed to read ${path} (${error && error.message ? error.message : String(error)})`,
+            )
+          }
+          // Sniff the format from the bytes (attachments are stored as
+          // extensionless content-addressed files); fall back to the file
+          // extension only when sniffing cannot decide.
+          const mediaType = sniffMediaType(bytes) ?? mediaTypeOf(path)
+          if (mediaType === undefined) {
+            throw new Error(
+              `vision_describe: unsupported image format ${path} (png/jpeg/webp/gif only)`,
             )
           }
           if (downscaleEnabled()) {
@@ -2073,12 +2108,16 @@ export function apply(ctx, config = {}) {
     const readImageBytes = async (imagePath) => {
       const fs = ctx.get('fs')
       if (fs === undefined) throw new Error('vision-router: the fs service is not available')
-      const mediaType = mediaTypeOf(imagePath)
+      const target = await fs.resolve(imagePath)
+      const bytes = await fs.readBytes(target, undefined, 20 * 1024 * 1024)
+      // Attachments are stored as content-addressed files without an
+      // extension: sniff the format from the bytes, and fall back to the
+      // extension only when sniffing cannot decide.
+      const mediaType = sniffMediaType(bytes) ?? mediaTypeOf(imagePath)
       if (mediaType === undefined) {
         throw new Error(`unsupported image format ${imagePath} (png/jpeg/webp/gif only)`)
       }
-      const target = await fs.resolve(imagePath)
-      return fs.readBytes(target, undefined, 20 * 1024 * 1024)
+      return { bytes, mediaType }
     }
 
     const imageDims = async (bytes) => {
@@ -2180,10 +2219,9 @@ export function apply(ctx, config = {}) {
       },
       output: stringOutput,
       async execute(args, exec) {
-        const bytes = await readImageBytes(args.image)
+        const { bytes, mediaType } = await readImageBytes(args.image)
         const { width, height } = await imageDims(bytes)
         if (width <= 0 || height <= 0) throw new Error('vision_ground: could not read image dimensions')
-        const mediaType = mediaTypeOf(args.image)
         const instruction =
           `Target to locate: "${String(args.target).slice(0, 500)}". ` +
           `The image is ${width}x${height} pixels. Return ONE JSON object with integer fields ` +
@@ -2234,7 +2272,7 @@ export function apply(ctx, config = {}) {
       },
       output: stringOutput,
       async execute(args, exec) {
-        const bytes = await readImageBytes(args.image)
+        const { bytes, mediaType: sniffedType } = await readImageBytes(args.image)
         const { width, height } = await imageDims(bytes)
         const box = parseBox(args.region)
         if (box === undefined) {
@@ -2280,8 +2318,8 @@ export function apply(ctx, config = {}) {
       },
       output: stringOutput,
       async execute(args, exec) {
-        const originalBytes = await readImageBytes(args.original)
-        const rebuiltBytes = await readImageBytes(args.rebuilt)
+        const { bytes: originalBytes } = await readImageBytes(args.original)
+        const { bytes: rebuiltBytes } = await readImageBytes(args.rebuilt)
         const meta = await sharp(originalBytes, { failOn: 'none' }).metadata()
         const width = meta.width ?? 0
         const height = meta.height ?? 0
@@ -2344,7 +2382,7 @@ export function apply(ctx, config = {}) {
       },
       output: stringOutput,
       async execute(args) {
-        const bytes = await readImageBytes(args.image)
+        const { bytes, mediaType: sniffedType } = await readImageBytes(args.image)
         const top = Number.isInteger(args.top) && args.top > 0 ? args.top : 8
         const raw = await sharp(bytes, { failOn: 'none' })
           .resize(64, 64, { fit: 'inside' })
@@ -2376,7 +2414,7 @@ export function apply(ctx, config = {}) {
       },
       output: stringOutput,
       async execute(args) {
-        const bytes = await readImageBytes(args.image)
+        const { bytes, mediaType: sniffedType } = await readImageBytes(args.image)
         const engine = args.engine === 'tesseract' || args.engine === 'vision' ? args.engine : 'auto'
         if (engine !== 'vision') {
           try {
@@ -2394,7 +2432,7 @@ export function apply(ctx, config = {}) {
         }
         const { text } = await answerVision(
           bytes,
-          mediaTypeOf(args.image),
+          sniffedType,
           '请原样转述图中的所有文字，保持阅读顺序（从上到下、从左到右）与段落结构，不要添加解释。只输出文字本身。',
         )
         return JSON.stringify({ engine: 'vision', text })
@@ -2417,7 +2455,7 @@ export function apply(ctx, config = {}) {
       },
       output: stringOutput,
       async execute(args, exec) {
-        const bytes = await readImageBytes(args.image)
+        const { bytes, mediaType: sniffedType } = await readImageBytes(args.image)
         const steps = Number.isInteger(args.steps) && args.steps > 0 ? Math.min(args.steps, 16) : 4
         let svg
         try {
@@ -2452,7 +2490,7 @@ export function apply(ctx, config = {}) {
       },
       output: stringOutput,
       async execute(args, exec) {
-        const bytes = await readImageBytes(args.image)
+        const { bytes, mediaType: sniffedType } = await readImageBytes(args.image)
         const tolerance = Number.isFinite(args.tolerance) && args.tolerance >= 0 ? Math.round(args.tolerance) : 40
         const { data, info } = await sharp(bytes, { failOn: 'none' })
           .ensureAlpha()

--- a/lib/client.js
+++ b/lib/client.js
@@ -23,7 +23,8 @@ window.__ModuleLoader__.load({
       routing:
         '默认关闭：图片轮不整轮切到视觉模型，而是像普通文本轮一样由会话模型调用 ' +
         'vision_describe 等工具看图，可连续多步操作（定位→裁剪→对比…）。' +
-        '开启后恢复旧的整轮一次性自动识图行为。',
+        '开启后恢复旧的整轮一次性自动识图行为；注意：开启时降级链只包含 ' +
+        '「视觉模型链」里的 provider+fallbacks，httpProviders（含免费兜底端点）不参与。',
       tool: 'vision_describe / vision_ground 等像素级视觉工具；关闭后这些工具不可用。',
       rewriteImages:
         '把消息里的图片块替换为文字：已有视觉记录就给出记录，否则给出附件标记，' +

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-vision-router",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "DeepSeek Harness plugin: turn-level vision routing with provider fallback chains, a cached vision_describe tool with JSON output and image downscaling, and optional per-host proxy support.",
   "license": "LGPL-3.0",
   "type": "module",

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 import sharp from 'sharp'
 import {
   mediaTypeOf,
+  sniffMediaType,
   basenameOf,
   blocksHaveImage,
   eventHasImage,
@@ -44,6 +45,19 @@ import {
   apply,
   Config,
 } from '../index.js'
+
+test('sniffMediaType detects formats from magic bytes', () => {
+  const png = Buffer.from('89504e470d0a1a0a0000000000000000', 'hex')
+  assert.equal(sniffMediaType(png), 'image/png')
+  const jpeg = Buffer.from('ffd8ffe000104a464946000101000001', 'hex')
+  assert.equal(sniffMediaType(jpeg), 'image/jpeg')
+  const webp = Buffer.from('524946461200000057454250565038', 'hex')
+  assert.equal(sniffMediaType(webp), 'image/webp')
+  const gif = Buffer.from('474946383961000000000000000000', 'hex')
+  assert.equal(sniffMediaType(gif), 'image/gif')
+  assert.equal(sniffMediaType(Buffer.from('000102030405060708090a0b', 'hex')), undefined)
+  assert.equal(sniffMediaType(Buffer.alloc(4)), undefined)
+})
 
 test('mediaTypeOf maps extensions', () => {
   assert.equal(mediaTypeOf('/a/b.PNG'), 'image/png')
@@ -365,6 +379,20 @@ test('httpProvidersOf falls back to the built-in default unless disabled', () =>
   const custom = [{ name: 'x', baseURL: 'https://x/v1', model: 'm' }]
   assert.deepEqual(httpProvidersOf({ httpProviders: custom }), custom)
   assert.deepEqual(httpProvidersOf({ httpProviders: custom }, false), custom)
+})
+
+test('dedupeHttpProviders also drops entries duplicating a chain provider name', () => {
+  const http = [{ name: 'zhipu', baseURL: 'https://x/v1', model: 'glm-4v-flash' }]
+  // a pair already covers provider zhipu through the adapter
+  assert.deepEqual(
+    dedupeHttpProviders([{ provider: 'zhipu', model: 'glm-4.6v-flash' }], http),
+    [],
+  )
+  // an unrelated provider name keeps the http entry
+  assert.equal(
+    dedupeHttpProviders([{ provider: 'openrouter', model: 'qwen' }], http).length,
+    1,
+  )
 })
 
 test('dedupeHttpProviders drops only entries the vision-http chain covers', () => {


### PR DESCRIPTION
处理用户反馈的全部建议：

1. **附件无扩展名问题（重点）**：附件按内容寻址存储、没有扩展名，vision_ocr / vision_ground 等按路径调用的工具全部报 `unsupported image format`。现在所有读取路径改为**按魔数识别格式**（png/jpeg/webp/gif），扩展名仅作兜底。
2. **误导性报错**：routing: true 的链耗尽消息现在追加说明——httpProviders（含免费兜底）在该模式下不参与，提示切回 routing: false 工具流。
3. **配置冗余**：dedupeHttpProviders 现在也会去掉与链 provider 同名的 http 条目（如同时写 provider: zhipu 和 httpProviders 里的 zhipu，不再重复调用同一模型）。
4. **配置语义文档**：设置卡片的 routing 开关提示 + README 都标注了 routing: true 只走 provider+fallbacks 的语义。
5. **版本号**：0.1.0 → **0.2.0**（版本此前从未更新）。

测试 60/60 通过（新增魔数识别与同名去重用例）。
