### PR TITLE
docs: add self-updating Star History chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,3 +225,13 @@ This removes the dependency and the bundle layer. If you disabled the stock Deep
 ## License
 
 [LGPL-3.0](LICENSE)
+
+<!-- star-history-chart -->
+## Star History
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ysr666/dsh-vision-router/star-history/assets/star-history/star-history-dark.svg">
+    <img alt="Star history chart" src="https://raw.githubusercontent.com/ysr666/dsh-vision-router/star-history/assets/star-history/star-history-light.svg" width="100%">
+  </picture>
+</p>

--- a/README.zh.md
+++ b/README.zh.md
@@ -225,3 +225,13 @@ dsh plugin --profile web remove dsh-vision-router
 ## License
 
 [LGPL-3.0](LICENSE)
+
+<!-- star-history-chart -->
+## Star 趋势
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ysr666/dsh-vision-router/star-history/assets/star-history/star-history-dark.svg">
+    <img alt="Star 历史趋势图" src="https://raw.githubusercontent.com/ysr666/dsh-vision-router/star-history/assets/star-history/star-history-light.svg" width="100%">
+  </picture>
+</p>


### PR DESCRIPTION
Adds a Star History chart to the bottom of both README files. The chart assets live on the dedicated `star-history` branch so they can refresh automatically without bypassing `main` branch protection.

- English + Chinese README sections only
- light/dark theme-aware SVGs
- chart refreshes on new stars and every 6 hours
- no personal access token required