### PR TITLE
fix: unwrap the llm.models RPC envelope — settings card now shows the model catalog dropdowns

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -11,6 +11,25 @@ window.__ModuleLoader__.load({
     const React = require('react')
     const { useState, useMemo } = React
 
+    /**
+     * Unwrap the client RPC envelope the `connection` api returns for unary
+     * calls: { rpcId, result: { ok, value } }. The catalog fields live in
+     * `result.value`, NOT on the envelope itself.
+     */
+    function unwrapModelsResult(body) {
+      if (body && typeof body === 'object' && body.result && typeof body.result === 'object') {
+        if (body.result.ok !== true) {
+          const message =
+            body.result.error && body.result.error.message
+              ? body.result.error.message
+              : '模型目录接口返回失败'
+          throw new Error(message)
+        }
+        return body.result.value
+      }
+      return body
+    }
+
     // ── field specs ──────────────────────────────────────────────────────────
     const TOGGLE_KEYS = ['routing', 'tool', 'stealth']
     const ADVANCED_TOGGLE_KEYS = ['reverseRouting', 'rewriteImages', 'downscale', 'cache', 'freeFallback']
@@ -219,18 +238,16 @@ window.__ModuleLoader__.load({
               throw error && error.message ? error : new Error(String(error))
             }),
             timeout,
-          ]).then(
+          ]).then((body) => unwrapModelsResult(body)).then(
             (value) => {
               const groups = (value && value.groups) || []
               const failures = (value && value.failures) || []
               if (groups.length === 0 && failures.length > 0) {
-                setCatalog({
-                  status: 'error',
-                  groups: [],
-                  error: '模型目录为空：' + failures
-                    .map((f) => (f && f.name ? f.name + '：' : '') + ((f && f.message) || ''))
-                    .join('；').slice(0, 300),
-                })
+                const detail = failures
+                  .map((f) => (f && f.name ? f.name + '：' : '') + ((f && f.message) || ''))
+                  .join('；').slice(0, 300)
+                console.log('[vision-router] catalog empty, failures:', detail)
+                setCatalog({ status: 'error', groups: [], error: '模型目录为空：' + detail })
                 return
               }
               console.log('[vision-router] catalog ready:', groups.length, 'groups')
@@ -667,6 +684,7 @@ window.__ModuleLoader__.load({
 
     exports.apply = apply
     exports.inject = ['settingsScope', 'slots']
+    exports.unwrapModelsResult = unwrapModelsResult
     return module.exports
   },
 })

--- a/lib/client.js
+++ b/lib/client.js
@@ -552,8 +552,7 @@ window.__ModuleLoader__.load({
               ),
             ),
           ),
-          h('p', { className: 'vr-hint' },
-            '默认走 DeepSeek-V4-Pro；从「设置 > 模型」里配过的供应商中选择才覆盖默认。'),
+          h('p', { className: 'vr-hint' }, '通常无需设置；见上方说明，留空即恢复默认。'),
         )
       }
 
@@ -590,9 +589,6 @@ window.__ModuleLoader__.load({
               catalogReady
                 ? chainEditor()
                 : textField('providers', '视觉模型链', '每行一个「provider/model」，从上到下失败回退；留空清除用户覆盖。', true),
-              catalogReady
-                ? textProviderEditor()
-                : textField('textProvider', '文本模型', '文字轮会话的底层模型，格式「provider/model」。', false),
               catalog.status === 'loading'
                 ? h('p', { className: 'vr-hint' }, '正在加载模型目录（与「设置 > 模型」同源）…')
                 : catalog.status === 'error'
@@ -616,6 +612,15 @@ window.__ModuleLoader__.load({
               ),
               showAdvanced
                 ? h('div', { className: 'vr-advanced' },
+                    h('div', { className: 'vr-group' },
+                      h('p', { className: 'vr-group-title' }, '文本模型（仅特殊场景）'),
+                      catalogReady
+                        ? textProviderEditor()
+                        : textField('textProvider', '文本模型', '格式「provider/model」。', false),
+                      h('p', { className: 'vr-hint' },
+                        '平时文字轮直接使用右下角选择的会话模型，无需设置；此字段仅在开启' +
+                        '「图片轮整轮自动路由」且会话入口为视觉路由时，作为文字轮的回退模型。'),
+                    ),
                     h('div', { className: 'vr-group' },
                       h('p', { className: 'vr-group-title' }, '行为开关'),
                       ADVANCED_TOGGLE_KEYS.map((key) => toggleField(key)),

--- a/lib/client.js
+++ b/lib/client.js
@@ -452,7 +452,8 @@ window.__ModuleLoader__.load({
 
       const groupOptions = catalog.groups.map((group) =>
         h('option', { value: group.id, key: group.id },
-          group.name && group.name !== group.id ? group.name + ' (' + group.id + ')' : group.id),
+          (group.name && group.name !== group.id ? group.name + ' (' + group.id + ')' : group.id) +
+          (group.id === 'vision-http' ? '（内置免费模型）' : '')),
       )
       const modelsOf = (providerId) => {
         const group = catalog.groups.find((entry) => entry.id === providerId)
@@ -499,7 +500,8 @@ window.__ModuleLoader__.load({
                 h('option', { value: '' }, row.provider ? '选择模型…' : '先选供应商'),
                 modelsOf(row.provider).map((model) =>
                   h('option', { value: model.id, key: model.id },
-                    model.name && model.name !== model.id ? model.name + ' (' + model.id + ')' : model.id),
+                    (model.name && model.name !== model.id ? model.name + ' (' + model.id + ')' : model.id) +
+                    (row.provider === 'vision-http' ? '（免费）' : '')),
                 ),
               ),
               h('button', {
@@ -548,7 +550,8 @@ window.__ModuleLoader__.load({
               h('option', { value: '' }, pair.provider ? '选择模型…' : '先选供应商'),
               modelsOf(pair.provider).map((model) =>
                 h('option', { value: model.id, key: model.id },
-                  model.name && model.name !== model.id ? model.name + ' (' + model.id + ')' : model.id),
+                  (model.name && model.name !== model.id ? model.name + ' (' + model.id + ')' : model.id) +
+                  (pair.provider === 'vision-http' ? '（免费）' : '')),
               ),
             ),
           ),

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@deepseek-ai/dsh-anonymous-user-id": "^0.1.0-rc.6"
   },
   "scripts": {
-    "test": "node --test tests/core.test.js"
+    "test": "node --test tests/core.test.js tests/client.test.js"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -1,0 +1,43 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+function loadClientBundle() {
+  let spec = null
+  globalThis.window = { __ModuleLoader__: { load(s) { spec = s } } }
+  const url = new URL('../lib/client.js', import.meta.url)
+  // eslint-disable-next-line no-eval
+  ;(0, eval)(readFileSync(url, 'utf8'))
+  const ReactStub = {
+    useState: (initial) => [initial, () => {}],
+    useMemo: (fn) => fn(),
+    useSyncExternalStore: () => ({ status: 'ready', writable: true, value: {}, user: {} }),
+  }
+  return spec.factory((name) => {
+    if (name === 'react') return ReactStub
+    throw new Error('require(' + name + ')')
+  })
+}
+
+test('unwrapModelsResult reads the catalog from the RPC envelope', () => {
+  const bundle = loadClientBundle()
+  const groups = [{ id: 'deepseek-official', name: 'DeepSeek', models: [] }]
+  const value = bundle.unwrapModelsResult({
+    rpcId: 'x',
+    result: { ok: true, value: { groups, failures: [] } },
+  })
+  assert.deepEqual(value.groups, groups)
+  // plain values pass through untouched
+  assert.deepEqual(bundle.unwrapModelsResult({ groups: [] }), { groups: [] })
+  // failed envelopes throw with the host message
+  assert.throws(
+    () => bundle.unwrapModelsResult({ rpcId: 'x', result: { ok: false, error: { message: 'boom' } } }),
+    /boom/,
+  )
+})
+
+test('the client bundle still loads and registers with the proven injects', () => {
+  const bundle = loadClientBundle()
+  assert.deepEqual(bundle.inject, ['settingsScope', 'slots'])
+  assert.equal(typeof bundle.apply, 'function')
+})


### PR DESCRIPTION
## 内容

- 修复设置卡片的模型目录解析：`llm.models` 返回的 RPC 信封（数据在 `result.value`）此前被误读，目录永远为空、模型字段恒为手输框；现在正确解包，目录正常时显示与「设置 > 模型」页同源的供应商/模型下拉（视觉链支持增删行）。
- 失败信封与「空目录 + 失败列表」显式报错，卡片显示原因与「重试加载目录」按钮；加载状态与 15 秒超时均有提示。
- 「文本模型」字段移入高级设置并注明适用场景：文字轮直接使用右下角选择的会话模型，该字段仅在「图片轮整轮自动路由」且会话入口为视觉路由时作为回退模型。
- 下拉中标注内置免费模型：vision-http 组显示「（内置免费模型）」，其模型显示「（免费）」。
- 新增客户端 bundle 单测：真实加载 lib/client.js 验证解包逻辑与注册注入面。

## 测试

- 单测 65/65 全绿（63 宿主 + 2 客户端）。
- 本地实测：卡片展开显示目录下拉；控制台输出 catalog ready: 4 groups。

## 验证清单

1. 设置 > 插件 > 插件配置 > 视觉路由：模型字段为下拉，可看到已配置的供应商组；
2. vision-http 组带「内置免费模型」标注；
3. 主界面无「文本模型」字段，高级设置里有且带说明；
4. 目录不可用时退回手输框并显示原因与重试按钮。