### PR TITLE
fix: vision_trace 卡死——potrace 移入 worker 线程 + 硬超时 + 1MP 预算

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,8 @@ import { DeepSeekAdapter, resolveAdapterOptions } from '@deepseek-ai/dsh-llm-dee
 import { getOrCreateAnonymousUserId } from '@deepseek-ai/dsh-anonymous-user-id'
 import { existsSync } from 'node:fs'
 import { execFile } from 'node:child_process'
+import { Worker } from 'node:worker_threads'
+import { createRequire } from 'node:module'
 import { pathToFileURL } from 'node:url'
 import { promisify } from 'node:util'
 import potrace from 'potrace'
@@ -666,14 +668,66 @@ export function bitmapOfGray(raw, width, height, threshold = 128) {
 }
 
 /** Vectorize an image buffer into an SVG string via potrace posterization. */
-export function posterizeSvg(bytes, steps = 4, fillStrategy = 'dominant') {
+export function posterizeSvg(bytes, steps = 4, fillStrategy = 'dominant', timeoutMs = 60000) {
+  // potrace is CPU-bound and runs its computation in long synchronous
+  // chunks: on the main thread it blocks the whole dsh process (other
+  // sessions time out) and a setTimeout-based timeout can NEVER fire while
+  // the loop is blocked. Run it in a worker thread instead — the main loop
+  // stays responsive, and a timeout hard-terminates the worker.
   return new Promise((resolve, reject) => {
-    try {
-      potrace.posterize(bytes, { steps, fillStrategy }, (error, svg) =>
-        error ? reject(error) : resolve(svg),
+    let settled = false
+    let worker
+    const finish = (error, svg) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      void worker?.terminate()
+      if (error) reject(error)
+      else resolve(svg)
+    }
+    const timer = setTimeout(() => {
+      if (settled) return
+      settled = true
+      void worker?.terminate()
+      reject(
+        new Error(
+          'potrace timed out — the image is too large or too complex; crop it to the target region first',
+        ),
       )
+    }, timeoutMs)
+    try {
+      // Resolve potrace's entry to an absolute file URL the worker can import
+      // regardless of the dsh process cwd or the worker's module mode.
+      const potraceUrl = pathToFileURL(createRequire(import.meta.url).resolve('potrace')).href
+      const source = `
+        import('node:worker_threads').then(({ parentPort, workerData }) => {
+          import(workerData.potraceUrl).then((mod) => {
+            const potrace = mod.default ?? mod
+            potrace.posterize(Buffer.from(workerData.bytes), {
+              steps: workerData.steps,
+              fillStrategy: workerData.fillStrategy,
+            }, (error, svg) => {
+              parentPort.postMessage(error ? { error: String((error && error.message) || error) } : { svg })
+            })
+          }).catch((error) => {
+            parentPort.postMessage({ error: String((error && error.message) || error) })
+          })
+        })
+      `
+      worker = new Worker(source, {
+        eval: true,
+        workerData: { potraceUrl, bytes, steps, fillStrategy },
+      })
+      worker.once('message', (message) => {
+        if (message && message.error) finish(new Error(message.error))
+        else finish(undefined, message && message.svg)
+      })
+      worker.once('error', (error) => finish(error))
+      worker.once('exit', (code) => {
+        if (code !== 0 && !settled) finish(new Error(`potrace worker exited with code ${code}`))
+      })
     } catch (error) {
-      reject(error)
+      finish(error)
     }
   })
 }
@@ -2542,9 +2596,17 @@ export function apply(ctx, config = {}) {
       async execute(args, exec) {
         const { bytes, mediaType: sniffedType } = await readImageBytes(args.image)
         const steps = Number.isInteger(args.steps) && args.steps > 0 ? Math.min(args.steps, 16) : 4
+        // Trace-specific pixel budget: vectorization gains nothing beyond
+        // ~1MP (a 1MP bitmap already yields smooth paths), and potrace's cost
+        // grows steeply with pixels — 4MP at 16 levels exceeds 60s on a busy
+        // machine, so cap the trace input harder than the general budget.
+        let traceBytes = bytes
+        if (downscaleEnabled() && bytes && bytes.length > 0) {
+          traceBytes = await downscaleImage(bytes, Math.min(downscaleMaxPixels(), 1000000))
+        }
         let svg
         try {
-          svg = await posterizeSvg(bytes, steps)
+          svg = await posterizeSvg(traceBytes, steps)
         } catch (error) {
           throw new Error(
             `vision_trace: potrace failed (${error && error.message ? error.message : String(error)})`,
@@ -2576,8 +2638,14 @@ export function apply(ctx, config = {}) {
       output: stringOutput,
       async execute(args, exec) {
         const { bytes, mediaType: sniffedType } = await readImageBytes(args.image)
+        // Same CPU guard as vision_trace: the flood fill is a synchronous
+        // pixel walk — cap oversized inputs before it runs.
+        let fgBytes = bytes
+        if (downscaleEnabled() && bytes && bytes.length > 0) {
+          fgBytes = await downscaleImage(bytes, downscaleMaxPixels())
+        }
         const tolerance = Number.isFinite(args.tolerance) && args.tolerance >= 0 ? Math.round(args.tolerance) : 40
-        const { data, info } = await sharp(bytes, { failOn: 'none' })
+        const { data, info } = await sharp(fgBytes, { failOn: 'none' })
           .ensureAlpha()
           .raw()
           .toBuffer({ resolveWithObject: true })

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -1287,3 +1287,36 @@ test('DEFAULT_PROXY_HOSTS covers the common foreign AI API domains', () => {
   }
   assert.ok(!DEFAULT_PROXY_HOSTS.includes('api.deepseek.com'), 'DeepSeek stays direct')
 })
+
+test('posterizeSvg rejects on timeout instead of hanging forever', async () => {
+  const png = await sharp({
+    create: { width: 64, height: 64, channels: 3, background: { r: 255, g: 255, b: 255 } },
+  }).png().toBuffer()
+  await assert.rejects(() => posterizeSvg(png, 4, 'dominant', 0), /timed out/)
+})
+
+test('posterizeSvg resolves normally when potrace finishes in time', async () => {
+  const png = await sharp({
+    create: { width: 8, height: 8, channels: 4, background: { r: 255, g: 255, b: 255, alpha: 1 } },
+  })
+    .composite([{ input: Buffer.from('<svg width="8" height="8"><rect x="2" y="2" width="4" height="4" fill="black"/></svg>') }])
+    .png()
+    .toBuffer()
+  const svg = await posterizeSvg(png, 2, 'dominant', 30000)
+  assert.ok(svg.includes('<svg'))
+})
+
+test('posterizeSvg keeps the main thread responsive while potrace computes', async () => {
+  const noise = Buffer.alloc(1024 * 1024 * 3)
+  for (let i = 0; i < noise.length; i++) noise[i] = (i * 31 + 17) % 256
+  const png = await sharp(noise, { raw: { width: 1024, height: 1024, channels: 3 } }).png().toBuffer()
+  let ticks = 0
+  const timer = setInterval(() => { ticks += 1 }, 50)
+  await assert.rejects(
+    () => posterizeSvg(png, 16, 'dominant', 1000),
+    /timed out/,
+  )
+  clearInterval(timer)
+  // the main loop must keep ticking while the worker computes
+  assert.ok(ticks > 5, `expected main-thread ticks during the compute, got ${ticks}`)
+})


### PR DESCRIPTION
## 问题
调用 `vision_trace` 会让整个 dsh 卡死：potrace 在主线程上做长段同步计算，事件循环被占死——其他会话发消息全部 signal timeout，任何 setTimeout 超时都无法触发，进程永久卡住。

## 修复
- potrace 移入 **worker 线程**：主循环全程空闲（实测 3 秒等待内主线程定时器照常跳动），超时时间到由主线程调 `worker.terminate()` 硬打断正在计算的 worker（V8 循环回边终止检查），60 秒准时退出并报清晰错误；
- worker 源码纯 `import()` 写法（ESM/CJS 两种模块模式通吃），potrace 入口以绝对 file URL 解析，不依赖 dsh 进程 cwd；
- `vision_trace` 输入压到 1MP 像素预算（矢量化 1MP 已足够平滑，potrace 耗时随像素暴涨，4MP/16 级实测超过 60 秒）；
- `vision_extract_foreground` 同步洪泛遍历同样加压缩护栏；
- 其余 CPU 工具实测无风险：pixel_diff 0.05s / colors 0.02s / floodFill 0.13s（4MP 输入）。

## 测试
73/73 通过，含「主线程在 potrace 计算期间保持响应」回归测试。
