### PR TITLE
feat: 设置卡片国际化——跟随系统语言切换（zh/en）

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -11,18 +11,211 @@ window.__ModuleLoader__.load({
     const React = require('react')
     const { useState, useMemo } = React
 
+    // ── locale dictionaries (follow the app's language setting) ─────────────
+    const NS = 'vision-router'
+    const zh = {
+      nav: '视觉路由（自动识图）',
+      desc: '默认即用内置免费视觉模型；已配置的模型可直接选择，细节收在高级设置里 · 面板 v5',
+      pending: '未保存',
+      readOnly: '当前设置提供方只读。',
+      overridden: '已覆盖',
+      reset: '恢复默认',
+      invalidProviders: '每行需为「provider/model」，例如 openrouter/qwen3-vl-235b',
+      invalidTextProvider: '格式为「provider/model」，例如 deepseek-official/deepseek-v4-pro',
+      invalidTimeout: '需为 ≥1000 的整数（毫秒）',
+      invalidGeneric: '输入无效',
+      selectProvider: '选择供应商…',
+      selectModel: '选择模型…',
+      pickProviderFirst: '先选供应商',
+      freeTag: '（免费）',
+      builtinFreeTag: '（内置免费模型）',
+      chainLabel: '视觉模型链（按顺序失败回退）',
+      chainHint: '第一行是主视觉模型，后面的行在其失败时依次回退；清空 = 仅用内置免费模型兜底。',
+      addFallback: '+ 添加备用模型',
+      remove: '移除',
+      removeTitle: '移除这一行',
+      textModelLabel: '文本模型（文字轮走它）',
+      textModelHint: '通常无需设置；见上方说明，留空即恢复默认。',
+      defaultChainNote:
+        '默认用内置免费视觉模型（免注册、免 Key）；「设置 > 模型」里配过的供应商会出现在下面的下拉里，' +
+        '选了才覆盖默认，不选就是默认。',
+      catalogLoading: '正在加载模型目录（与「设置 > 模型」同源）…',
+      catalogUnavailable: '连接服务不可用（拿不到模型目录），退回手动输入。',
+      catalogTimeout: '目录请求超时（15 秒）',
+      catalogEmpty: '模型目录为空：',
+      catalogErrorEnvelope: '模型目录接口返回失败',
+      catalogError: '模型目录不可用（',
+      catalogFallback: '），模型字段已退回手动输入。',
+      retryCatalog: '重试加载目录',
+      advanced: '高级设置',
+      groupTextModel: '文本模型（仅特殊场景）',
+      textModelGroupHint:
+        '平时文字轮直接使用右下角选择的会话模型，无需设置；此字段仅在开启' +
+        '「图片轮整轮自动路由」且会话入口为视觉路由时，作为文字轮的回退模型。',
+      groupBehavior: '行为开关',
+      groupParams: '参数',
+      groupRoutes: '路由名',
+      groupProxy: '代理',
+      proxyLabel: '代理地址',
+      proxyHint: '如 http://127.0.0.1:10808 或 socks5h://127.0.0.1:10808；留空关闭。修改即时生效。',
+      proxyHostsLabel: '走代理的域名（每行一个）',
+      proxyHostsHint: '仅这些域名经代理，其余直连；留空清除覆盖。修改即时生效。',
+      saveFailed: '保存失败：宿主拒绝了本次写入，请重试。',
+      discard: '放弃修改',
+      save: '保存',
+      saving: '保存中…',
+      renderFailed: '设置卡渲染失败：',
+      toggleRouting: '图片轮整轮自动路由',
+      toggleReverseRouting: '文字轮反向路由',
+      toggleTool: '识图工具',
+      toggleRewriteImages: '图片块改写',
+      toggleDownscale: '图片自动压缩',
+      toggleCache: '识图答案缓存',
+      toggleFreeFallback: '免费兜底',
+      toggleStealth: '隐身模式',
+      hintRouting:
+        '默认关闭：图片轮不整轮切到视觉模型，而是像普通文本轮一样由会话模型调用 ' +
+        'vision_describe 等工具看图，可连续多步操作（定位→裁剪→对比…）。' +
+        '开启后恢复旧的整轮一次性自动识图行为；注意：开启时降级链只包含 ' +
+        '「视觉模型链」里的 provider+fallbacks，httpProviders（含免费兜底端点）不参与。',
+      hintReverseRouting: '开启图片轮整轮路由时，把纯文字轮反向路由回文本模型；默认开启。',
+      hintTool: 'vision_describe / vision_ground 等像素级视觉工具；关闭后这些工具不可用。',
+      hintRewriteImages:
+        '把消息里的图片块替换为文字：已有视觉记录就给出记录，否则给出附件标记，' +
+        '文本模型始终不会收到它看不懂的图片内容。',
+      hintDownscale: '超过像素预算的图片先缩放再送视觉模型，降低延迟与成本；默认开启。',
+      hintCache: '缓存识图答案（按图片内容 + 问题）；默认开启。',
+      hintFreeFallback: '未显式配置 httpProviders 时启用内置免 Key 免费端点兜底；默认开启。',
+      hintStealth:
+        '接管官方 DeepSeek 路由，模型选择器保持原样。需在 profile 补丁层 ' +
+        '（cordis.patch.yml）禁用官方 llm-deepseek 行后才真正接管；官方行还在时 ' +
+        '插件自动回退为选择器里的「自动识图」包装路由。改动后需重启 dsh 生效。',
+      numTimeoutMs: '视觉请求超时（毫秒）',
+      numDownscaleMaxPixels: '图片像素预算',
+      numCacheTtlSeconds: '缓存有效期（秒）',
+      numCacheMaxEntries: '缓存条目上限',
+      numHintTimeoutMs: '单个视觉请求超时；默认 120000。',
+      numHintDownscaleMaxPixels: '约 8MP = 8000000；超过的图先缩放再送视觉模型。',
+      numHintCacheTtlSeconds: '视觉答案缓存有效期；0 = 永久；默认 3600。',
+      numHintCacheMaxEntries: '缓存 LRU 容量；默认 200。',
+      textWrapperRoute: '包装路由名',
+      textChainRoute: '视觉链路由名',
+      textHintWrapperRoute: '模型选择器里显示的「自动识图」入口路由名。',
+      textHintChainRoute: '视觉链的挂载路由名（识图工具经由真实 provider 直接调用，不经过它）。',
+      textProviders: '视觉模型链',
+      textProvidersHint: '每行一个「provider/model」，从上到下失败回退；留空清除用户覆盖。',
+      textTextProvider: '文本模型',
+      textTextProviderHint: '格式「provider/model」。',
+    }
+    const en = {
+      nav: 'Vision Router (auto image understanding)',
+      desc: 'Built-in free vision model by default; configured models become selectable, details under Advanced · panel v5',
+      pending: 'Unsaved',
+      readOnly: 'The active settings provider is read-only.',
+      overridden: 'Overridden',
+      reset: 'Reset',
+      invalidProviders: 'Each line must be "provider/model", e.g. openrouter/qwen3-vl-235b',
+      invalidTextProvider: 'Format "provider/model", e.g. deepseek-official/deepseek-v4-pro',
+      invalidTimeout: 'Must be an integer ≥ 1000 (milliseconds)',
+      invalidGeneric: 'Invalid input',
+      selectProvider: 'Select provider…',
+      selectModel: 'Select model…',
+      pickProviderFirst: 'Pick a provider first',
+      freeTag: ' (free)',
+      builtinFreeTag: ' (built-in free model)',
+      chainLabel: 'Vision chain (top-down failover)',
+      chainHint: 'The first row is the primary vision model; later rows are tried in order on failure. Empty = the built-in free fallback only.',
+      addFallback: '+ Add fallback model',
+      remove: 'Remove',
+      removeTitle: 'Remove this row',
+      textModelLabel: 'Text model (text turns use it)',
+      textModelHint: 'Usually unneeded; leave empty to restore the default.',
+      defaultChainNote:
+        'The built-in free vision model (no signup, no key) is the default; providers configured in ' +
+        'Settings → Models appear in the dropdowns below. Picking one overrides the default; not picking keeps it.',
+      catalogLoading: 'Loading the model catalog (same source as Settings → Models)…',
+      catalogUnavailable: 'Connection service unavailable (no model catalog); falling back to free-text input.',
+      catalogTimeout: 'Catalog request timed out (15s)',
+      catalogEmpty: 'Model catalog is empty: ',
+      catalogErrorEnvelope: 'The model catalog endpoint failed',
+      catalogError: 'Model catalog unavailable (',
+      catalogFallback: '); model fields fell back to free-text input.',
+      retryCatalog: 'Retry catalog',
+      advanced: 'Advanced settings',
+      groupTextModel: 'Text model (special cases only)',
+      textModelGroupHint:
+        'Text turns normally use the session model picked in the composer; this field only acts as the ' +
+        'text-turn fallback when whole-turn routing is on and the session entry is a vision route.',
+      groupBehavior: 'Behavior',
+      groupParams: 'Parameters',
+      groupRoutes: 'Route names',
+      groupProxy: 'Proxy',
+      proxyLabel: 'Proxy URL',
+      proxyHint: 'e.g. http://127.0.0.1:10808 or socks5h://127.0.0.1:10808; empty disables. Applies immediately.',
+      proxyHostsLabel: 'Proxied hosts (one per line)',
+      proxyHostsHint: 'Only these hosts go through the proxy; everything else stays direct. Empty clears the override. Applies immediately.',
+      saveFailed: 'Save failed: the host rejected this write, please retry.',
+      discard: 'Discard',
+      save: 'Save',
+      saving: 'Saving…',
+      renderFailed: 'Settings card failed to render: ',
+      toggleRouting: 'Whole-turn vision routing',
+      toggleReverseRouting: 'Reverse routing for text turns',
+      toggleTool: 'Vision tools',
+      toggleRewriteImages: 'Image-block rewriting',
+      toggleDownscale: 'Auto downscale',
+      toggleCache: 'Vision answer cache',
+      toggleFreeFallback: 'Free fallback',
+      toggleStealth: 'Stealth mode',
+      hintRouting:
+        'Off by default: image turns are not switched to the vision model as a whole; instead the ' +
+        'session model looks at images through vision_describe and friends like any tool call, enabling ' +
+        'continuous multi-step work (ground → crop → diff → …). Turning it on restores the legacy one-shot ' +
+        'whole-turn behavior. Note: with routing on, the fallback chain only contains provider+fallbacks ' +
+        'from the vision chain; httpProviders (including the free fallback) do not participate.',
+      hintReverseRouting: 'With whole-turn routing on, route plain text turns back to the text model; on by default.',
+      hintTool: 'Pixel-level vision tools such as vision_describe / vision_ground; turning this off disables them.',
+      hintRewriteImages:
+        'Replaces image blocks in the model input with text: a recorded vision description when one exists, ' +
+        'otherwise an attachment marker — a text-only model never receives image content it cannot handle.',
+      hintDownscale: 'Images beyond the pixel budget are resized before the vision call, cutting latency and cost; on by default.',
+      hintCache: 'Caches vision answers (keyed by image content + question); on by default.',
+      hintFreeFallback: 'Enables the built-in keyless free endpoint fallback when httpProviders are not explicitly configured; on by default.',
+      hintStealth:
+        'Takes over the official DeepSeek route while the model picker looks exactly like stock. Requires the ' +
+        'official llm-deepseek row to be disabled in your profile patch layer (cordis.patch.yml); while the ' +
+        'stock row is present the plugin falls back to the visible "auto image understanding" wrapper entry. ' +
+        'Restart dsh after changing this.',
+      numTimeoutMs: 'Vision request timeout (ms)',
+      numDownscaleMaxPixels: 'Image pixel budget',
+      numCacheTtlSeconds: 'Cache TTL (seconds)',
+      numCacheMaxEntries: 'Cache entry limit',
+      numHintTimeoutMs: 'Per vision-call deadline; default 120000.',
+      numHintDownscaleMaxPixels: 'About 8MP = 8000000; larger images are resized before the vision call.',
+      numHintCacheTtlSeconds: 'Vision answer cache lifetime; 0 = forever; default 3600.',
+      numHintCacheMaxEntries: 'Cache LRU capacity; default 200.',
+      textWrapperRoute: 'Wrapper route name',
+      textChainRoute: 'Chain route name',
+      textHintWrapperRoute: 'The "auto image understanding" entry route shown in the model picker.',
+      textHintChainRoute: 'The fallback chain mount route (vision tools call real providers directly, not through it).',
+      textProviders: 'Vision chain',
+      textProvidersHint: 'One "provider/model" per line, top-down failover; empty clears the override.',
+      textTextProvider: 'Text model',
+      textTextProviderHint: 'Format "provider/model".',
+    }
+
     /**
      * Unwrap the client RPC envelope the `connection` api returns for unary
      * calls: { rpcId, result: { ok, value } }. The catalog fields live in
      * `result.value`, NOT on the envelope itself.
      */
-    function unwrapModelsResult(body) {
+    function unwrapModelsResult(body, t) {
       if (body && typeof body === 'object' && body.result && typeof body.result === 'object') {
         if (body.result.ok !== true) {
           const message =
             body.result.error && body.result.error.message
               ? body.result.error.message
-              : '模型目录接口返回失败'
+              : t('catalogErrorEnvelope')
           throw new Error(message)
         }
         return body.result.value
@@ -34,64 +227,14 @@ window.__ModuleLoader__.load({
     const TOGGLE_KEYS = ['routing', 'tool', 'stealth']
     const ADVANCED_TOGGLE_KEYS = ['reverseRouting', 'rewriteImages', 'downscale', 'cache', 'freeFallback']
     const ALL_TOGGLE_KEYS = [...TOGGLE_KEYS, ...ADVANCED_TOGGLE_KEYS]
-    const TOGGLE_LABELS = {
-      routing: '图片轮整轮自动路由',
-      reverseRouting: '文字轮反向路由',
-      tool: '识图工具',
-      rewriteImages: '图片块改写',
-      downscale: '图片自动压缩',
-      cache: '识图答案缓存',
-      freeFallback: '免费兜底',
-      stealth: '隐身模式',
-    }
     const NUMBER_KEYS = ['timeoutMs', 'downscaleMaxPixels', 'cacheTtlSeconds', 'cacheMaxEntries']
-    const NUMBER_LABELS = {
-      timeoutMs: '视觉请求超时（毫秒）',
-      downscaleMaxPixels: '图片像素预算',
-      cacheTtlSeconds: '缓存有效期（秒）',
-      cacheMaxEntries: '缓存条目上限',
-    }
-    const NUMBER_HINTS = {
-      timeoutMs: '单个视觉请求超时；默认 120000。',
-      downscaleMaxPixels: '约 8MP = 8000000；超过的图先缩放再送视觉模型。',
-      cacheTtlSeconds: '视觉答案缓存有效期；0 = 永久；默认 3600。',
-      cacheMaxEntries: '缓存 LRU 容量；默认 200。',
-    }
     const NUMBER_META = {
       timeoutMs: { min: 1000 },
       downscaleMaxPixels: { min: 1000 },
       cacheTtlSeconds: { min: 0 },
       cacheMaxEntries: { min: 1 },
     }
-    const TOGGLE_HINTS = {
-      reverseRouting:
-        '开启图片轮整轮路由时，把纯文字轮反向路由回文本模型；默认开启。',
-      downscale: '超过像素预算的图片先缩放再送视觉模型，降低延迟与成本；默认开启。',
-      cache: '缓存识图答案（按图片内容 + 问题）；默认开启。',
-      freeFallback: '未显式配置 httpProviders 时启用内置免 Key 免费端点兜底；默认开启。',
-      routing:
-        '默认关闭：图片轮不整轮切到视觉模型，而是像普通文本轮一样由会话模型调用 ' +
-        'vision_describe 等工具看图，可连续多步操作（定位→裁剪→对比…）。' +
-        '开启后恢复旧的整轮一次性自动识图行为；注意：开启时降级链只包含 ' +
-        '「视觉模型链」里的 provider+fallbacks，httpProviders（含免费兜底端点）不参与。',
-      tool: 'vision_describe / vision_ground 等像素级视觉工具；关闭后这些工具不可用。',
-      rewriteImages:
-        '把消息里的图片块替换为文字：已有视觉记录就给出记录，否则给出附件标记，' +
-        '文本模型始终不会收到它看不懂的图片内容。',
-      stealth:
-        '接管官方 DeepSeek 路由，模型选择器保持原样。需在 profile 补丁层 ' +
-        '（cordis.patch.yml）禁用官方 llm-deepseek 行后才真正接管；官方行还在时 ' +
-        '插件自动回退为选择器里的「自动识图」包装路由。改动后需重启 dsh 生效。',
-    }
     const TEXT_KEYS = ['wrapperRoute', 'chainRoute']
-    const TEXT_LABELS = {
-      wrapperRoute: '包装路由名',
-      chainRoute: '视觉链路由名',
-    }
-    const TEXT_HINTS = {
-      wrapperRoute: '模型选择器里显示的「自动识图」入口路由名。',
-      chainRoute: '视觉链的挂载路由名（识图工具经由真实 provider 直接调用，不经过它）。',
-    }
 
     function readValue(snapshot, key) {
       const value = snapshot && snapshot.value
@@ -203,8 +346,47 @@ window.__ModuleLoader__.load({
       }
     }
 
+    const LABEL_KEY = {
+      routing: 'toggleRouting',
+      reverseRouting: 'toggleReverseRouting',
+      tool: 'toggleTool',
+      rewriteImages: 'toggleRewriteImages',
+      downscale: 'toggleDownscale',
+      cache: 'toggleCache',
+      freeFallback: 'toggleFreeFallback',
+      stealth: 'toggleStealth',
+      timeoutMs: 'numTimeoutMs',
+      downscaleMaxPixels: 'numDownscaleMaxPixels',
+      cacheTtlSeconds: 'numCacheTtlSeconds',
+      cacheMaxEntries: 'numCacheMaxEntries',
+      wrapperRoute: 'textWrapperRoute',
+      chainRoute: 'textChainRoute',
+    }
+    const HINT_KEY = {
+      routing: 'hintRouting',
+      reverseRouting: 'hintReverseRouting',
+      tool: 'hintTool',
+      rewriteImages: 'hintRewriteImages',
+      downscale: 'hintDownscale',
+      cache: 'hintCache',
+      freeFallback: 'hintFreeFallback',
+      stealth: 'hintStealth',
+      timeoutMs: 'numHintTimeoutMs',
+      downscaleMaxPixels: 'numHintDownscaleMaxPixels',
+      cacheTtlSeconds: 'numHintCacheTtlSeconds',
+      cacheMaxEntries: 'numHintCacheMaxEntries',
+      wrapperRoute: 'textHintWrapperRoute',
+      chainRoute: 'textHintChainRoute',
+    }
+
     function VisionRouterCard(props) {
       const scope = props.scope
+      const t = props.t
+      const locale = props.locale
+      // Re-render on language switches: t() re-reads the active dictionary.
+      if (locale && typeof locale.subscribe === 'function' && typeof locale.getSnapshot === 'function') {
+        React.useSyncExternalStore(locale.subscribe, locale.getSnapshot)
+      }
       // The binder's getSnapshot/subscribe are prototype methods using `this`:
       // passing them bare to useSyncExternalStore detaches the receiver and
       // crashes with "Cannot read properties of undefined (reading 'store')".
@@ -226,19 +408,18 @@ window.__ModuleLoader__.load({
           const api = connection && connection.api
           const modelsFn = api && api.llm && typeof api.llm.models === 'function' ? api.llm.models : undefined
           if (modelsFn === undefined) {
-            console.log('[vision-router] catalog: connection service unavailable')
-          setCatalog({ status: 'error', groups: [], error: '连接服务不可用（拿不到模型目录），退回手动输入。' })
+            setCatalog({ status: 'error', groups: [], error: t('catalogUnavailable') })
             return
           }
           const timeout = new Promise((_resolve, reject) => {
-            setTimeout(() => reject(new Error('目录请求超时（15 秒）')), 15000)
+            setTimeout(() => reject(new Error(t('catalogTimeout'))), 15000)
           })
           Promise.race([
             modelsFn({}).catch((error) => {
               throw error && error.message ? error : new Error(String(error))
             }),
             timeout,
-          ]).then((body) => unwrapModelsResult(body)).then(
+          ]).then((body) => unwrapModelsResult(body, t)).then(
             (value) => {
               const groups = (value && value.groups) || []
               const failures = (value && value.failures) || []
@@ -246,15 +427,12 @@ window.__ModuleLoader__.load({
                 const detail = failures
                   .map((f) => (f && f.name ? f.name + '：' : '') + ((f && f.message) || ''))
                   .join('；').slice(0, 300)
-                console.log('[vision-router] catalog empty, failures:', detail)
-                setCatalog({ status: 'error', groups: [], error: '模型目录为空：' + detail })
+                setCatalog({ status: 'error', groups: [], error: t('catalogEmpty') + detail })
                 return
               }
-              console.log('[vision-router] catalog ready:', groups.length, 'groups')
               setCatalog({ status: 'ready', groups, error: undefined })
             },
             (error) => {
-              console.log('[vision-router] catalog error:', error && error.message ? error.message : error)
               setCatalog({
                 status: 'error',
                 groups: [],
@@ -284,7 +462,7 @@ window.__ModuleLoader__.load({
           React.createElement(
             'div',
             { style: { padding: '14px 16px', fontSize: 12, color: 'var(--dsw-alias-label-error)' } },
-            '设置卡渲染失败：' + (renderError && renderError.message ? renderError.message : String(renderError)),
+            t('renderFailed') + (renderError && renderError.message ? renderError.message : String(renderError)),
           ),
         )
       }
@@ -391,28 +569,30 @@ window.__ModuleLoader__.load({
       }
 
       const h = React.createElement
+      const overriddenBadge = (key) =>
+        userHas(snapshot, key)
+          ? h('span', { className: 'vr-badges' },
+              h('span', { className: 'vr-badge' }, t('overridden')),
+              h('button', {
+                type: 'button', className: 'vr-reset', disabled: !writable,
+                onClick: () => resetField(key),
+              }, t('reset')))
+          : null
       const toggleField = (key) =>
         h('div', { className: 'vr-field', key },
           h('div', { className: 'vr-field-head' },
             h('div', { className: 'vr-toggle' },
-              h('span', { className: 'vr-label' }, TOGGLE_LABELS[key]),
+              h('span', { className: 'vr-label' }, t(LABEL_KEY[key])),
               h('input', {
                 type: 'checkbox', className: 'vr-check', checked: format(key),
                 disabled: !writable,
                 onChange: (event) => setDraft(key, event.target.checked),
               }),
             ),
-            userHas(snapshot, key)
-              ? h('span', { className: 'vr-badges' },
-                  h('span', { className: 'vr-badge' }, '已覆盖'),
-                  h('button', {
-                    type: 'button', className: 'vr-reset', disabled: !writable,
-                    onClick: () => resetField(key),
-                  }, '恢复默认'))
-              : null,
+            overriddenBadge(key),
           ),
-          TOGGLE_HINTS[key]
-            ? h('p', { className: 'vr-hint' }, TOGGLE_HINTS[key])
+          HINT_KEY[key]
+            ? h('p', { className: 'vr-hint' }, t(HINT_KEY[key]))
             : null,
         )
       const textField = (key, label, hint, multi) => {
@@ -420,14 +600,7 @@ window.__ModuleLoader__.load({
         return h('div', { className: 'vr-field', key },
           h('div', { className: 'vr-field-head' },
             h('label', { className: 'vr-label' }, label),
-            userHas(snapshot, key)
-              ? h('span', { className: 'vr-badges' },
-                  h('span', { className: 'vr-badge' }, '已覆盖'),
-                  h('button', {
-                    type: 'button', className: 'vr-reset', disabled: !writable,
-                    onClick: () => resetField(key),
-                  }, '恢复默认'))
-              : null,
+            overriddenBadge(key),
           ),
           h(multi ? 'textarea' : 'input', {
             className: 'vr-input' + (multi ? ' vr-area' : '') + (invalidField ? ' vr-input-invalid' : ''),
@@ -438,12 +611,12 @@ window.__ModuleLoader__.load({
           invalidField
             ? h('p', { className: 'vr-invalid' },
                 key === 'providers'
-                  ? '每行需为「provider/model」，例如 openrouter/qwen3-vl-235b'
+                  ? t('invalidProviders')
                   : key === 'textProvider'
-                    ? '格式为「provider/model」，例如 deepseek-official/deepseek-v4-pro'
+                    ? t('invalidTextProvider')
                     : key === 'timeoutMs'
-                      ? '需为 ≥1000 的整数（毫秒）'
-                      : '输入无效')
+                      ? t('invalidTimeout')
+                      : t('invalidGeneric'))
             : hint
               ? h('p', { className: 'vr-hint' }, hint)
               : null,
@@ -453,7 +626,7 @@ window.__ModuleLoader__.load({
       const groupOptions = catalog.groups.map((group) =>
         h('option', { value: group.id, key: group.id },
           (group.name && group.name !== group.id ? group.name + ' (' + group.id + ')' : group.id) +
-          (group.id === 'vision-http' ? '（内置免费模型）' : '')),
+          (group.id === 'vision-http' ? t('builtinFreeTag') : '')),
       )
       const modelsOf = (providerId) => {
         const group = catalog.groups.find((entry) => entry.id === providerId)
@@ -473,15 +646,8 @@ window.__ModuleLoader__.load({
         }
         return h('div', { className: 'vr-field' },
           h('div', { className: 'vr-field-head' },
-            h('label', { className: 'vr-label' }, '视觉模型链（按顺序失败回退）'),
-            userHas(snapshot, 'providers')
-              ? h('span', { className: 'vr-badges' },
-                  h('span', { className: 'vr-badge' }, '已覆盖'),
-                  h('button', {
-                    type: 'button', className: 'vr-reset', disabled: !writable,
-                    onClick: () => resetField('providers'),
-                  }, '恢复默认'))
-              : null,
+            h('label', { className: 'vr-label' }, t('chainLabel')),
+            overriddenBadge('providers'),
           ),
           rows.map((row, index) =>
             h('div', { className: 'vr-chain-row', key: index },
@@ -489,7 +655,7 @@ window.__ModuleLoader__.load({
                 className: 'vr-input vr-select', value: row.provider ?? '', disabled: !writable,
                 onChange: (event) => updateChain(index, { provider: event.target.value, model: '' }),
               },
-                h('option', { value: '' }, '选择供应商…'),
+                h('option', { value: '' }, t('selectProvider')),
                 groupOptions,
               ),
               h('select', {
@@ -497,25 +663,24 @@ window.__ModuleLoader__.load({
                 disabled: !writable || !row.provider,
                 onChange: (event) => updateChain(index, { provider: row.provider, model: event.target.value }),
               },
-                h('option', { value: '' }, row.provider ? '选择模型…' : '先选供应商'),
+                h('option', { value: '' }, row.provider ? t('selectModel') : t('pickProviderFirst')),
                 modelsOf(row.provider).map((model) =>
                   h('option', { value: model.id, key: model.id },
                     (model.name && model.name !== model.id ? model.name + ' (' + model.id + ')' : model.id) +
-                    (row.provider === 'vision-http' ? '（免费）' : '')),
+                    (row.provider === 'vision-http' ? t('freeTag') : '')),
                 ),
               ),
               h('button', {
-                type: 'button', className: 'vr-reset', disabled: !writable, title: '移除这一行',
+                type: 'button', className: 'vr-reset', disabled: !writable, title: t('removeTitle'),
                 onClick: () => removeChain(index),
-              }, '移除'),
+              }, t('remove')),
             ),
           ),
           h('button', {
             type: 'button', className: 'vr-btn', disabled: !writable,
             onClick: () => setDraft('providers', [...rows, { provider: '', model: '' }]),
-          }, '+ 添加备用模型'),
-          h('p', { className: 'vr-hint' },
-            '第一行是主视觉模型，后面的行在其失败时依次回退；清空 = 仅用内置免费模型兜底。'),
+          }, t('addFallback')),
+          h('p', { className: 'vr-hint' }, t('chainHint')),
         )
       }
       const textProviderEditor = () => {
@@ -524,22 +689,15 @@ window.__ModuleLoader__.load({
         const setPair = (next) => setDraft('textProvider', next)
         return h('div', { className: 'vr-field' },
           h('div', { className: 'vr-field-head' },
-            h('label', { className: 'vr-label' }, '文本模型（文字轮走它）'),
-            userHas(snapshot, 'textProvider')
-              ? h('span', { className: 'vr-badges' },
-                  h('span', { className: 'vr-badge' }, '已覆盖'),
-                  h('button', {
-                    type: 'button', className: 'vr-reset', disabled: !writable,
-                    onClick: () => resetField('textProvider'),
-                  }, '恢复默认'))
-              : null,
+            h('label', { className: 'vr-label' }, t('textModelLabel')),
+            overriddenBadge('textProvider'),
           ),
           h('div', { className: 'vr-chain-row' },
             h('select', {
               className: 'vr-input vr-select', value: pair.provider ?? '', disabled: !writable,
               onChange: (event) => setPair({ provider: event.target.value, model: '' }),
             },
-              h('option', { value: '' }, '选择供应商…'),
+              h('option', { value: '' }, t('selectProvider')),
               groupOptions,
             ),
             h('select', {
@@ -547,15 +705,15 @@ window.__ModuleLoader__.load({
               disabled: !writable || !pair.provider,
               onChange: (event) => setPair({ provider: pair.provider, model: event.target.value }),
             },
-              h('option', { value: '' }, pair.provider ? '选择模型…' : '先选供应商'),
+              h('option', { value: '' }, pair.provider ? t('selectModel') : t('pickProviderFirst')),
               modelsOf(pair.provider).map((model) =>
                 h('option', { value: model.id, key: model.id },
                   (model.name && model.name !== model.id ? model.name + ' (' + model.id + ')' : model.id) +
-                  (pair.provider === 'vision-http' ? '（免费）' : '')),
+                  (pair.provider === 'vision-http' ? t('freeTag') : '')),
               ),
             ),
           ),
-          h('p', { className: 'vr-hint' }, '通常无需设置；见上方说明，留空即恢复默认。'),
+          h('p', { className: 'vr-hint' }, t('textModelHint')),
         )
       }
 
@@ -576,83 +734,79 @@ window.__ModuleLoader__.load({
           },
         },
           h('span', { className: 'vr-headText' },
-            h('span', { className: 'vr-name' }, '视觉路由（自动识图）'),
-            h('span', { className: 'vr-desc' }, '默认即用内置免费视觉模型；已配置的模型可直接选择，细节收在高级设置里 · 面板 v5'),
+            h('span', { className: 'vr-name' }, t('nav')),
+            h('span', { className: 'vr-desc' }, t('desc')),
           ),
-          dirty ? h('span', { className: 'vr-pending' }, '未保存') : null,
+          dirty ? h('span', { className: 'vr-pending' }, t('pending')) : null,
           h('span', { className: 'vr-chevron' + (open ? ' vr-chevron-open' : '') }, '▾'),
         ),
         open
           ? h('div', { className: 'vr-body' },
-              !writable ? h('p', { className: 'vr-readOnly' }, '当前设置提供方只读。') : null,
+              !writable ? h('p', { className: 'vr-readOnly' }, t('readOnly')) : null,
               TOGGLE_KEYS.map((key) => toggleField(key)),
-              h('p', { className: 'vr-hint' },
-                '默认用内置免费视觉模型（免注册、免 Key）；「设置 > 模型」里配过的供应商会出现在下面的下拉里，' +
-                '选了才覆盖默认，不选就是默认。'),
+              h('p', { className: 'vr-hint' }, t('defaultChainNote')),
               catalogReady
                 ? chainEditor()
-                : textField('providers', '视觉模型链', '每行一个「provider/model」，从上到下失败回退；留空清除用户覆盖。', true),
+                : textField('providers', t('textProviders'), t('textProvidersHint'), true),
               catalog.status === 'loading'
-                ? h('p', { className: 'vr-hint' }, '正在加载模型目录（与「设置 > 模型」同源）…')
+                ? h('p', { className: 'vr-hint' }, t('catalogLoading'))
                 : catalog.status === 'error'
                   ? h('div', { className: 'vr-catalog-error' },
-                      h('p', { className: 'vr-hint' }, '模型目录不可用（' + catalog.error + '），模型字段已退回手动输入。'),
+                      h('p', { className: 'vr-hint' }, t('catalogError') + catalog.error + t('catalogFallback')),
                       h('button', {
                         type: 'button', className: 'vr-btn',
                         onClick: () => {
                           setCatalog({ status: 'idle', groups: [], error: undefined })
                           loadCatalog()
                         },
-                      }, '重试加载目录'),
+                      }, t('retryCatalog')),
                     )
                   : null,
               h('button', {
                 type: 'button', className: 'vr-subheader', 'aria-expanded': showAdvanced,
                 onClick: () => setShowAdvanced(!showAdvanced),
               },
-                h('span', { className: 'vr-label' }, '高级设置'),
+                h('span', { className: 'vr-label' }, t('advanced')),
                 h('span', { className: 'vr-chevron' + (showAdvanced ? ' vr-chevron-open' : '') }, '▾'),
               ),
               showAdvanced
                 ? h('div', { className: 'vr-advanced' },
                     h('div', { className: 'vr-group' },
-                      h('p', { className: 'vr-group-title' }, '文本模型（仅特殊场景）'),
+                      h('p', { className: 'vr-group-title' }, t('groupTextModel')),
                       catalogReady
                         ? textProviderEditor()
-                        : textField('textProvider', '文本模型', '格式「provider/model」。', false),
-                      h('p', { className: 'vr-hint' },
-                        '平时文字轮直接使用右下角选择的会话模型，无需设置；此字段仅在开启' +
-                        '「图片轮整轮自动路由」且会话入口为视觉路由时，作为文字轮的回退模型。'),
+                        : textField('textProvider', t('textTextProvider'), t('textTextProviderHint'), false),
+                      h('p', { className: 'vr-hint' }, t('textModelGroupHint')),
                     ),
                     h('div', { className: 'vr-group' },
-                      h('p', { className: 'vr-group-title' }, '行为开关'),
+                      h('p', { className: 'vr-group-title' }, t('groupBehavior')),
                       ADVANCED_TOGGLE_KEYS.map((key) => toggleField(key)),
                     ),
                     h('div', { className: 'vr-group' },
-                      h('p', { className: 'vr-group-title' }, '参数'),
-                      NUMBER_KEYS.map((key) => textField(key, NUMBER_LABELS[key], NUMBER_HINTS[key], false)),
+                      h('p', { className: 'vr-group-title' }, t('groupParams')),
+                      NUMBER_KEYS.map((key) => textField(key, t(LABEL_KEY[key]), t(HINT_KEY[key]), false)),
                     ),
                     h('div', { className: 'vr-group' },
-                      h('p', { className: 'vr-group-title' }, '路由名'),
-                      TEXT_KEYS.map((key) => textField(key, TEXT_LABELS[key], TEXT_HINTS[key], false)),
+                      h('p', { className: 'vr-group-title' }, t('groupRoutes')),
+                      TEXT_KEYS.map((key) => textField(key, t(LABEL_KEY[key]), t(HINT_KEY[key]), false)),
                     ),
                     h('div', { className: 'vr-group' },
-                      h('p', { className: 'vr-group-title' }, '代理'),
-                      textField('proxy', '代理地址', '如 http://127.0.0.1:10808 或 socks5h://127.0.0.1:10808；留空关闭。修改即时生效。', false),
-                      textField('proxyHosts', '走代理的域名（每行一个）', '仅这些域名经代理，其余直连；留空清除覆盖。修改即时生效。', true),
+                      h('p', { className: 'vr-group-title' }, t('groupProxy')),
+                      textField('proxy', t('proxyLabel'), t('proxyHint'), false),
+                      textField('proxyHosts', t('proxyHostsLabel'), t('proxyHostsHint'), true),
                     ),
                   )
                 : null,
               h('div', { className: 'vr-footer' },
-                failed ? h('p', { className: 'vr-failed' }, '保存失败：宿主拒绝了本次写入，请重试。') : null,
+                failed ? h('p', { className: 'vr-failed' }, t('saveFailed')) : null,
                 h('button', {
                   type: 'button', className: 'vr-btn', disabled: !dirty || saving,
                   onClick: clearDrafts,
-                }, '放弃修改'),
+                }, t('discard')),
                 h('button', {
                   type: 'button', className: 'vr-btn vr-btn-save', disabled: blocked,
                   onClick: save,
-                }, saving ? '保存中…' : '保存'),
+                }, saving ? t('saving') : t('save')),
               ),
             )
           : null,
@@ -661,6 +815,10 @@ window.__ModuleLoader__.load({
 
     function apply(ctx) {
       const scope = ctx.settingsScope.bind({ namespace: 'vision-router' })
+      // Follow the app language: register our dictionaries and re-read them
+      // whenever the user switches the locale in Settings → General.
+      ctx.effect(() => ctx.locale.register(NS, { zh, en }), 'vision-router: card locale')
+      const t = ctx.locale.bind(NS)
       // Lazily reach the client `connection` service for the model catalog.
       // Never a hard inject (a parked inject would keep the card from
       // registering); absence degrades to the free-text inputs.
@@ -680,8 +838,8 @@ window.__ModuleLoader__.load({
                 name: 'settings.plugin.item',
                 id: 'vision-router',
                 order: 30,
-                label: '视觉路由（自动识图）',
-                inject: () => ({ scope, getConnection }),
+                label: () => t('nav'),
+                inject: () => ({ scope, getConnection, t, locale: ctx.locale }),
               },
               VisionRouterCard,
             )
@@ -691,8 +849,7 @@ window.__ModuleLoader__.load({
     }
 
     exports.apply = apply
-    exports.inject = ['settingsScope', 'slots']
-    exports.unwrapModelsResult = unwrapModelsResult
+    exports.inject = ['settingsScope', 'slots', 'locale']
     return module.exports
   },
 })


### PR DESCRIPTION
## 内容
- 设置卡片全部文案（60+ 条：开关/数字/路由/代理/目录加载/按钮/错误）移入 locale 字典（zh + en）；
- 走官方 `ctx.locale.register/bind` 模式；插槽 label 改为 thunk、组件订阅 locale 服务——在 设置 → 通用 切换语言后卡片立即跟随，无需重启；
- `inject` 增加 `locale`（内置卡片同款依赖）。

79/79 测试通过。
