### PR TITLE
fix: 客户端测试恢复（unwrapModelsResult 导出 + locale 注入断言）

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -850,6 +850,7 @@ window.__ModuleLoader__.load({
 
     exports.apply = apply
     exports.inject = ['settingsScope', 'slots', 'locale']
+    exports.unwrapModelsResult = unwrapModelsResult
     return module.exports
   },
 })

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -38,6 +38,6 @@ test('unwrapModelsResult reads the catalog from the RPC envelope', () => {
 
 test('the client bundle still loads and registers with the proven injects', () => {
   const bundle = loadClientBundle()
-  assert.deepEqual(bundle.inject, ['settingsScope', 'slots'])
+  assert.deepEqual(bundle.inject, ['settingsScope', 'slots', 'locale'])
   assert.equal(typeof bundle.apply, 'function')
 })


### PR DESCRIPTION
修复 #18 合并后 main 上 tests/client.test.js 红的问题：恢复 unwrapModelsResult 模块导出、更新注入断言加入 locale。core+client 全量 81/81。