### PR TITLE
fix: locale 方法绑定——英文切换后卡片消失

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -384,9 +384,19 @@ window.__ModuleLoader__.load({
       const t = props.t
       const locale = props.locale
       // Re-render on language switches: t() re-reads the active dictionary.
-      if (locale && typeof locale.subscribe === 'function' && typeof locale.getSnapshot === 'function') {
-        React.useSyncExternalStore(locale.subscribe, locale.getSnapshot)
-      }
+      // The locale face's subscribe/getSnapshot are prototype methods using
+      // `this` exactly like the settings binder — bind them before handing
+      // them to useSyncExternalStore, or the card crashes with "Cannot read
+      // properties of undefined" and gets abdicated.
+      const localeSubscribe = useMemo(
+        () => (locale && typeof locale.subscribe === 'function' ? locale.subscribe.bind(locale) : () => () => {}),
+        [locale],
+      )
+      const localeGetSnapshot = useMemo(
+        () => (locale && typeof locale.getSnapshot === 'function' ? locale.getSnapshot.bind(locale) : () => undefined),
+        [locale],
+      )
+      React.useSyncExternalStore(localeSubscribe, localeGetSnapshot)
       // The binder's getSnapshot/subscribe are prototype methods using `this`:
       // passing them bare to useSyncExternalStore detaches the receiver and
       // crashes with "Cannot read properties of undefined (reading 'store')".


### PR DESCRIPTION
locale 服务的 subscribe/getSnapshot 是使用 this 的原型方法，裸传给 useSyncExternalStore 在渲染时抛错并被错误边界退役，导致切换到英文后卡片消失。与之前 settingsScope 同类问题，改为先 bind 再传入；83/83 测试通过。