### PR TITLE
fix: vision_html_screenshot resolves fs targets to real paths before existsSync

### DIFF
--- a/index.js
+++ b/index.js
@@ -1088,6 +1088,21 @@ export function hostMatchesAny(hostname, hosts) {
   return (hosts ?? []).some((host) => hostname === host || hostname.endsWith(`.${host}`))
 }
 
+/**
+ * Turn the fs service's resolve() result into a real filesystem path.
+ * resolve() may return a plain string or a target object ({ targetKey, ... });
+ * existsSync / pathToFileURL need an actual path string.
+ */
+export function toRealPath(fsService, resolved) {
+  if (typeof resolved === 'string') return resolved
+  if (typeof fsService?.processPath === 'function') {
+    const p = fsService.processPath(resolved)
+    if (typeof p === 'string' && p !== '') return p
+  }
+  const key = resolved?.targetKey
+  return typeof key === 'string' && key !== '' ? key : String(resolved ?? '')
+}
+
 /** Downscale bytes whose intrinsic pixel count exceeds maxPixels; returns original bytes on failure. */
 export async function downscaleImage(bytes, maxPixels) {
   try {
@@ -3020,7 +3035,11 @@ export function apply(ctx, config = {}) {
         if (fsService === undefined) {
           throw new Error('vision_html_screenshot: the fs service is not available')
         }
-        const targetPath = await fsService.resolve(source)
+        const resolved = await fsService.resolve(source)
+        // The fs service may return a target object ({ targetKey, displayPath })
+        // instead of a plain path string; convert it before touching the real
+        // filesystem (existsSync / pathToFileURL need an actual path).
+        const targetPath = toRealPath(fsService, resolved)
         if (!existsSync(targetPath)) {
           throw new Error(`vision_html_screenshot: file not found: ${source}`)
         }

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -23,6 +23,7 @@ import {
   createCache,
   downscaleImage,
   toOpenAIContent,
+  toRealPath,
   callOpenAICompatible,
   cacheKeyFor,
   adapterAvailable,
@@ -1438,4 +1439,16 @@ test('posterizeSvgColor rejects on timeout', async () => {
     () => posterizeSvgColor(raw, { width: 64, height: 64 }, [{ hex: '#ffffff', count: 1, share: 1 }], 0),
     /timed out/,
   )
+})
+
+test('toRealPath converts fs resolve results to real paths', () => {
+  assert.equal(toRealPath(null, '/abs/page.html'), '/abs/page.html')
+  assert.equal(toRealPath(null, 'rel/page.html'), 'rel/page.html')
+  assert.equal(
+    toRealPath({ processPath: (t) => String(t.targetKey) }, { targetKey: '/abs/page.html', displayPath: '/abs/page.html' }),
+    '/abs/page.html',
+  )
+  assert.equal(toRealPath({}, { targetKey: '/abs/page.html' }), '/abs/page.html')
+  assert.equal(toRealPath(null, { targetKey: '/abs/page.html' }), '/abs/page.html')
+  assert.equal(toRealPath({}, { targetKey: '' }), '[object Object]')
 })


### PR DESCRIPTION
The fs service's `resolve()` may return a target object (`{ targetKey, displayPath }`) instead of a plain path string. `vision_html_screenshot` passed the result straight to `existsSync()`, so every existing file was reported as "file not found" and the tool was unusable. Convert the resolved value through a small `toRealPath()` helper (string passthrough, `fsService.processPath()`, `targetKey` fallback) and add a unit test.