### PR TITLE
docs: use the npm short name for install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Both are MIT-licensed and one command away. Pick this plugin when you want image
 ## Quick start
 
 ```sh
-dsh plugin --profile web add github:ysr666/dsh-vision-router
+dsh plugin --profile web add dsh-vision-router
 ```
 
 Restart `dsh web` — done. Zero configuration:
@@ -214,7 +214,7 @@ Everything is optional; defaults work out of the box. Edit via the Web card or a
 ### Install
 
 ```sh
-dsh plugin --profile web add github:ysr666/dsh-vision-router
+dsh plugin --profile web add dsh-vision-router
 dsh --profile web --dump-config | grep vision-router   # one row, mounted by the bundle patch
 ```
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -55,7 +55,7 @@
 ## 快速开始
 
 ```sh
-dsh plugin --profile web add github:ysr666/dsh-vision-router
+dsh plugin --profile web add dsh-vision-router
 ```
 
 重启 `dsh web`——完成，零配置：
@@ -214,7 +214,7 @@ Web 配置页在 **设置 → 插件 → 插件配置** 下注册「视觉路由
 ### 安装
 
 ```sh
-dsh plugin --profile web add github:ysr666/dsh-vision-router
+dsh plugin --profile web add dsh-vision-router
 dsh --profile web --dump-config | grep vision-router   # 一行，由 bundle 补丁挂载
 ```
 


### PR DESCRIPTION
dsh-vision-router is published on npm (v1.0.0), so the bare package name is now the canonical install spec:

```sh
dsh plugin --profile web add dsh-vision-router
```

Updates the install commands in both READMEs.