### PR TITLE
ci: publish to npm automatically when a release is published

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,53 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  # id-token is required for npm provenance
+  id-token: write
+
+concurrency:
+  group: npm-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org/'
+
+      - name: Verify the release tag matches package.json
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: bash
+        run: |
+          PKG_VERSION="$(node -p "require('./package.json').version")"
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::package.json version ($PKG_VERSION) does not match the release tag ($TAG_VERSION)"
+            exit 1
+          fi
+
+      - name: Skip if this version is already on npm
+        shell: bash
+        run: |
+          PKG_VERSION="$(node -p "require('./package.json').version")"
+          if npm view "dsh-vision-router@${PKG_VERSION}" version >/dev/null 2>&1; then
+            echo "dsh-vision-router@${PKG_VERSION} is already published — nothing to do."
+            exit 0
+          fi
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Adds `.github/workflows/npm-publish.yml`:

- Triggers: GitHub Release published, `v*` tag push, or manual dispatch
- Verifies the release tag matches `package.json` version before publishing
- Skips versions that already exist on npm (idempotent re-runs)
- Publishes with npm provenance (`--provenance`)

Requires the repo secret `NPM_TOKEN` (a granular npm access token with publish rights for `dsh-vision-router`).