### PR TITLE
ci: guard the npm publish step with the already-published check

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -38,16 +38,20 @@ jobs:
             exit 1
           fi
 
-      - name: Skip if this version is already on npm
+      - name: Check whether this version is already on npm
+        id: already-published
         shell: bash
         run: |
           PKG_VERSION="$(node -p "require('./package.json').version")"
           if npm view "dsh-vision-router@${PKG_VERSION}" version >/dev/null 2>&1; then
             echo "dsh-vision-router@${PKG_VERSION} is already published — nothing to do."
-            exit 0
+            echo "published=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "published=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Publish to npm
+        if: steps.already-published.outputs.published == 'false'
         run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
The first dispatch exposed a logic bug: `exit 0` ends only the current step, so the publish step still ran (and npm correctly rejected the duplicate version — which also proved the NPM_TOKEN secret works in CI).\n\nThis change routes the check through `GITHUB_OUTPUT` and guards the publish step with `if:`, so already-published versions skip cleanly and the run stays green.