### PR TITLE
fix: bundle 补丁纯增量 + 隐身模式显式 opt-in + v1.0.1（issue #34）

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 Most DSH vision plugins bridge images to DeepSeek as *text descriptions* — lossy, one-shot, and blind to pixels. This plugin keeps the **original pixels on the vision model's side** and DeepSeek on the reasoning side, and makes looking at an image an **ordinary tool call**:
 
-- **One command install.** The package ships its own composition patch (`dsh.bundle.patch`): `dsh plugin add` wires the row, the admission wrapper, the stealth takeover and the attachment limits automatically — zero manual file edits.
+- **One command install, purely additive.** The package ships its own composition patch (`dsh.bundle.patch`): `dsh plugin add` mounts the plugin row and nothing else — no core row is disabled or overridden (issue #34).
 - **Free by default.** The vision chain starts with a built-in OVHcloud anonymous endpoint (`Qwen2.5-VL-72B-Instruct`, no account, no key, 2 req/min per IP). Paid chains (OpenRouter, Pi-AI providers, direct OpenAI-compatible endpoints) are optional upgrades.
 - **No Python.** The whole pipeline — downscale, grounding, crop, pixel diff, palette, OCR, SVG trace, cutout, HTML screenshot — runs on sharp / potrace / tesseract / system Chrome.
 - **Continuous multi-step image work.** An image turn is a text turn that calls tools: `vision_ground` → `vision_crop` → `vision_describe` → `vision_pixel_diff` → fix → screenshot again. The agent keeps iterating until the work is done.
@@ -59,7 +59,7 @@ dsh plugin --profile web add dsh-vision-router
 
 Restart `dsh web` — done. Zero configuration:
 
-- the plugin's bundle patch mounts the row, takes over the official DeepSeek route (stealth mode — the model picker looks exactly like stock), and relaxes attachment limits to 20 MB / 100 MP;
+- the plugin's bundle patch mounts the row only: the official DeepSeek route stays untouched, and image turns use the "自动识图" wrapper entry in the picker (or the extra wrappers you configure);
 - the default vision chain is the built-in free endpoint;
 - every setting is editable live in **Settings → Plugins → Plugin config → 视觉路由（自动识图）**.
 
@@ -151,16 +151,15 @@ Failures are classified (region / tos / quota / rate-limit / context / network) 
 
 ## Stealth mode
 
-A default install takes over the official `deepseek-official` route: the model picker looks exactly like stock (same DeepSeek group, same model names), but each entry is the auto-vision wrapper that declares image input and delegates text turns to a rebuilt native DeepSeek adapter (same `llm-deepseek` settings section and credentials). Old sessions keep working through the hidden `deepseek-vision` alias.
-
-To keep the stock row instead, override it in your profile patch layer (`~/.dsh/profiles/<profile>/cordis.patch.yml`):
+**Stealth mode is opt-in.** The plugin never disables the official `llm-deepseek` row by itself (issue #34). To take over the official `deepseek-official` route — the model picker looks exactly like stock, but each entry is the auto-vision wrapper that declares image input and delegates text turns to a rebuilt native DeepSeek adapter — add the disable to YOUR profile patch layer:
 
 ```yaml
 - id: llm-deepseek
   name: '@deepseek-ai/dsh-llm-deepseek'
+  disabled: true
 ```
 
-With the stock row present, the plugin falls back to the visible "DeepSeek + 自动识图" wrapper entry — pick it in the model picker for image turns. Recovery from a broken install is the same one-line override.
+Without the takeover, the plugin registers the visible "DeepSeek + 自动识图" (`deepseek-vision`) wrapper entry — pick it in the model picker for image turns; for third-party text routes, add them to the settings card's **extra vision wrappers**. Recovery from a broken install is the same one-line override (delete the `disabled` line).
 
 ## Web settings
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -28,7 +28,7 @@
 
 大多数 DSH 视觉插件把图片“翻译”成一段文字描述再喂给 DeepSeek——有损、一次性、看不见像素。本插件把**原图像素留在视觉模型侧**、把推理留在 DeepSeek 侧，并把“看图”变成一次**普通的工具调用**：
 
-- **一条命令安装。** 包自带组合补丁（`dsh.bundle.patch`）：`dsh plugin add` 自动完成插件行挂载、准入包装、隐身接管与附件限制放宽——不用手改任何文件。
+- **一条命令安装，纯增量。** 包自带组合补丁（`dsh.bundle.patch`）：`dsh plugin add` 只挂载插件行，不禁用、不覆写任何核心行（issue #34）。
 - **默认免费。** 视觉链内置 OVHcloud 匿名端点（`Qwen2.5-VL-72B-Instruct`，免注册、免 Key，每 IP 2 次/分钟）。付费链路（OpenRouter、Pi-AI 供应商、任意 OpenAI 兼容直连端点）是可选升级。
 - **无 Python。** 整条管线——缩放、定位、裁剪、像素对比、取色、OCR、SVG 矢量化、抠图、HTML 截图——全部基于 sharp / potrace / tesseract / 系统 Chrome。
 - **可连续多步看图。** 图片轮 = 调用工具的文本轮：`vision_ground` → `vision_crop` → `vision_describe` → `vision_pixel_diff` → 修复 → 再截图，Agent 可以一直迭代到任务完成。
@@ -59,7 +59,7 @@ dsh plugin --profile web add dsh-vision-router
 
 重启 `dsh web`——完成，零配置：
 
-- 插件的 bundle 补丁自动挂载插件行、接管官方 DeepSeek 路由（隐身模式——模型选择器看起来和原版一模一样）、放宽附件限制到 20MB / 1 亿像素；
+- 插件的 bundle 补丁只挂载插件行：官方 DeepSeek 路由保持原样，图片入口使用选择器里的「自动识图」包装条目（或你在设置里配置的额外包装）；
 - 默认视觉链就是内置免费端点；
 - 全部配置可在 **设置 → 插件 → 插件配置 → 视觉路由（自动识图）** 实时修改。
 
@@ -151,16 +151,15 @@ vision_html_screenshot source="page.html" width=1200 height=720
 
 ## 隐身模式
 
-默认安装即接管官方 `deepseek-official` 路由：模型选择器看起来和原版完全一样（同一个 DeepSeek 组、同样的模型名），但每个条目背后都是声明了图片输入的自动识图包装；文字轮交给插件重建的原生 DeepSeek 适配器（读取同一个 `llm-deepseek` 设置段与凭据）。老会话通过隐藏的 `deepseek-vision` 别名继续工作。
-
-想保留官方行，在你的 profile 补丁层（`~/.dsh/profiles/<profile>/cordis.patch.yml`）覆写即可：
+**隐身模式改为显式可选。** 插件永远不会自己禁用官方 `llm-deepseek` 行（issue #34）。想接管官方 `deepseek-official` 路由——模型选择器看起来和原版完全一样，但每个条目背后都是声明了图片输入的自动识图包装，文字轮交给插件重建的原生 DeepSeek 适配器——在你自己的 profile 补丁层加上：
 
 ```yaml
 - id: llm-deepseek
   name: '@deepseek-ai/dsh-llm-deepseek'
+  disabled: true
 ```
 
-官方行在场时，插件回退为选择器里可见的「DeepSeek + 自动识图」包装入口——发图前选它即可。安装出问题时同样用这一行恢复。
+不接管时，插件注册选择器里可见的「DeepSeek + 自动识图」（`deepseek-vision`）包装入口——发图前选它即可；第三方文本路由则在设置卡片的「额外识图包装」里添加。安装出问题时删掉 `disabled` 行即可恢复。
 
 ## Web 设置
 

--- a/cordis.patch.yml
+++ b/cordis.patch.yml
@@ -4,22 +4,13 @@
 # without any manual cordis.patch.yml edits. Later layers (the profile's own
 # cordis.patch.yml, --patch overlays) override these rows by id.
 
-# 隐身模式：接管官方 deepseek-official 路由。禁用官方行后插件自己重建原生
-# DeepSeek 适配器（读取同一个 llm-deepseek 设置段与凭据），选择器里的
-# DeepSeek 条目本身就是「图片自动识图」包装，发图即用。
-# 想恢复官方行：在你的 profile cordis.patch.yml 里删掉/覆写本条即可。
-- id: llm-deepseek
-  disabled: true
-
-# 挂载插件行。配置全部可选（默认即内置免费视觉端点 + 工具优先的图片流程），
-# 可在 Web 设置 > 插件 > 插件配置 的「视觉路由」卡片里实时修改。
+# 纯增量安装：只挂载插件行，不改动任何核心行。
+# 官方 llm-deepseek 行保持原样（安装即安全，无隐式接管）；
+# 图片入口使用选择器里插件注册的「自动识图」包装条目（deepseek-vision），
+# 或把第三方文本路由写入设置卡片的「额外识图包装」。
+# 想要隐身模式（接管 deepseek-official、选择器看起来和原来一模一样）时，
+# 由用户在自己的 profile cordis.patch.yml 里显式禁用官方行——插件永不
+# 自动替用户禁用核心行（issue #34）。
 - insert:
     - id: vision-router
       name: dsh-vision-router
-
-# 放宽附件图片限制（部署默认 5MB / 4000 万像素 → 20MB / 1 亿像素），
-# 大尺寸设计稿/扫描图可过审。字段可选，不需要可在 profile 补丁层覆写。
-- id: attachment-local
-  config:
-    maxImageBytes: 20971520
-    maxImagePixels: 100000000

--- a/index.js
+++ b/index.js
@@ -65,7 +65,9 @@ export const Config = z.object({
   reverseRouting: z.boolean().default(true),
   wrapperRoute: z.string().default('deepseek-vision'),
   chainRoute: z.string().default('vision-chain'),
-  stealth: z.boolean().default(true),
+  // 显式 opt-in（issue #34）：默认不尝试接管官方路由；开启后还需在
+  // profile 补丁层禁用官方 llm-deepseek 行才真正生效。
+  stealth: z.boolean().default(false),
   textProvider: z
     .object({
       provider: z.string().default('deepseek-official'),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-vision-router",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Eyes for text-only DeepSeek Harness agents: built-in free vision chain (no key) + pixel-level vision tools (Q&A, grounding, crop, pixel diff, colors, OCR, SVG trace, cutout, screenshots). One-command install, no Python, image turns work like ordinary tool-calling turns.",
   "license": "MIT",
   "repository": {

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -1114,6 +1114,7 @@ test('apply registers the stealth deepseek-official route with the stock catalog
     provider: 'openrouter',
     providers: [{ provider: 'openrouter', model: 'qwen/qwen3-vl-235b-a22b-instruct' }],
     routing: true,
+    stealth: true,
   }))
 
   // all four routes came up: hidden native, public deepseek-official, the
@@ -1142,7 +1143,10 @@ test('apply skips the chain route by default: image turns go through the vision 
   // vision-http backend for vision_describe stays mounted
   assert.equal(adapters.has('vision-chain'), false)
   assert.ok(adapters.has('vision-http'))
-  assert.ok(adapters.has('deepseek-official-native'))
+  // stealth is opt-in now: no hidden native route by default, but the
+  // visible deepseek-vision wrapper is always registered for admission
+  assert.equal(adapters.has('deepseek-official-native'), false)
+  assert.ok(adapters.has('deepseek-vision'))
 })
 
 // ── legacy routing fallback (routing: true, chainRoute: '') ────────────────


### PR DESCRIPTION
修复 issue #34（安装插件时隐式禁用核心 llm-deepseek 行）：

1. bundle 补丁改为**纯增量**：只挂载 vision-router 行，不再 disable 官方行、不再覆写 attachment-local；
2. 配置默认 `stealth: false`（显式 opt-in）：设置面板的隐身模式开关默认关闭；开启后还需用户在自己的 profile 补丁层禁用官方行才真正接管（双重确认）；
3. README（EN+ZH）同步：安装零副作用、隐身模式 opt-in 步骤与恢复方法、第三方文本路由用「额外识图包装」；
4. 版本 1.0.0 → 1.0.1，npm 用户随 release 自动拉取。
