### PR TITLE
chore: ignore debug directories and logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@ node_modules/
 .claude-flow/
 .deepflow/
 .DS_Store
+
+# 调试产物与日志
+.debug/
+debug/
+*.log


### PR DESCRIPTION
Keeps debug artifacts and log files out of version control.