### PR TITLE
docs: 升级指引 — 旧版手动 insert 与 bundle 补丁重复挂载（duplicate loader entry id: vision-router）

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,22 @@ Both are MIT-licensed and one command away. Pick this plugin when you want image
 
 ## Quick start
 
+Recommended for normal npm/npx installs (the same launch style used by the DSH README):
+
 ```sh
-dsh plugin --profile web add dsh-vision-router
+npx @deepseek-ai/dsh plugin --profile web add dsh-vision-router
+npx @deepseek-ai/dsh web
 ```
 
-Restart `dsh web` — done. Zero configuration:
+If you run DeepSeek Harness from a source checkout with pnpm, use the workspace script instead — `dsh` is not necessarily on your shell `PATH`:
+
+```sh
+cd deepseek-harness
+pnpm dsh plugin --profile web add dsh-vision-router
+pnpm dsh web
+```
+
+If you already installed the DSH CLI globally and `dsh` is on `PATH`, the shorter `dsh ...` form works too. Restart a long-lived Web profile after installation — done. Zero configuration:
 
 - the plugin's bundle patch mounts the row, adds the admission wrapper and relaxes attachment limits to 20 MB / 100 MP — pure-additive, it never touches the core rows; whether the official DeepSeek route is taken over is decided by the optional stealth setting (off by default);
 - the default vision chain is the built-in free endpoint;
@@ -222,7 +233,7 @@ Everything is optional; defaults work out of the box. Edit via the Web card or a
 
 ## Requirements
 
-- DeepSeek Harness with a Web profile and `pnpm` available to `dsh plugin`.
+- DeepSeek Harness Web profile. Normal installs can use `npx @deepseek-ai/dsh ...`; source checkouts use `pnpm dsh ...`. A bare `dsh ...` command only works when the CLI is already on your shell `PATH`.
 - Node ≥ 22 (host side).
 - No API key for the default free chain; a credential reference (`apiKeyEnv`) only for paid `httpProviders`.
 - Chrome / Chromium / Edge only for `vision_html_screenshot`; every other tool works without a browser.
@@ -232,9 +243,18 @@ Everything is optional; defaults work out of the box. Edit via the Web card or a
 
 ### Install
 
+Normal npm/npx install:
+
 ```sh
-dsh plugin --profile web add dsh-vision-router
-dsh --profile web --dump-config | grep vision-router   # one row, mounted by the bundle patch
+npx @deepseek-ai/dsh plugin --profile web add dsh-vision-router
+npx @deepseek-ai/dsh --profile web --dump-config | grep vision-router
+```
+
+From a DeepSeek Harness source checkout:
+
+```sh
+pnpm dsh plugin --profile web add dsh-vision-router
+pnpm dsh --profile web --dump-config | grep vision-router
 ```
 
 Restart a long-lived Web profile. The host discovers the browser bundle through `dsh.client` at startup.
@@ -251,7 +271,11 @@ Set it back to `false` to re-enable. Unloading removes the wrapper routes, tools
 ### Upgrade
 
 ```sh
-dsh plugin --profile web update dsh-vision-router
+# normal npm/npx install
+npx @deepseek-ai/dsh plugin --profile web update dsh-vision-router
+
+# DeepSeek Harness source checkout
+pnpm dsh plugin --profile web update dsh-vision-router
 ```
 
 Settings live in the profile's settings provider and survive upgrades.
@@ -280,7 +304,11 @@ Settings live in the profile's settings provider and survive upgrades.
 ### Uninstall
 
 ```sh
-dsh plugin --profile web remove dsh-vision-router
+# normal npm/npx install
+npx @deepseek-ai/dsh plugin --profile web remove dsh-vision-router
+
+# DeepSeek Harness source checkout
+pnpm dsh plugin --profile web remove dsh-vision-router
 ```
 
 This removes the dependency and the bundle layer. If you disabled the stock DeepSeek row manually, re-enable it in your profile patch.

--- a/README.md
+++ b/README.md
@@ -256,6 +256,27 @@ dsh plugin --profile web update dsh-vision-router
 
 Settings live in the profile's settings provider and survive upgrades.
 
+> **Upgrading from a pre-bundle-patch install (v0.x):** the package now mounts
+> itself through its own bundle patch, so a leftover manual row in
+> `~/.dsh/profiles/<profile>/cordis.patch.yml` duplicates it and `dsh web`
+> fails at startup with `duplicate loader entry id: vision-router`. Delete the
+> old block:
+>
+> ```yaml
+> - insert:            # remove this whole block
+>     - id: vision-router
+>       name: dsh-vision-router
+> ```
+>
+> To keep custom settings, replace it with a plain by-id override (no
+> `insert`):
+>
+> ```yaml
+> - id: vision-router
+>   config:
+>     # your overrides …
+> ```
+
 ### Uninstall
 
 ```sh

--- a/README.zh.md
+++ b/README.zh.md
@@ -59,11 +59,22 @@
 
 ## 快速开始
 
+普通 npm / npx 安装方式推荐这样用（与 DSH 官方 README 的启动方式一致）：
+
 ```sh
-dsh plugin --profile web add dsh-vision-router
+npx @deepseek-ai/dsh plugin --profile web add dsh-vision-router
+npx @deepseek-ai/dsh web
 ```
 
-重启 `dsh web`——完成，零配置：
+如果你是从 DeepSeek Harness 源码仓库通过 pnpm 运行，`dsh` 不一定在系统 `PATH` 里，请改用工作区脚本：
+
+```sh
+cd deepseek-harness
+pnpm dsh plugin --profile web add dsh-vision-router
+pnpm dsh web
+```
+
+如果你已经全局安装 DSH CLI，并且终端里能直接执行 `dsh`，也可以继续使用较短的 `dsh ...` 写法。长期运行的 Web profile 安装后重启——完成，零配置：
 
 - 插件的 bundle 补丁自动挂载插件行、挂上准入包装并放宽附件限制到 20MB / 1 亿像素——纯增量、不碰核心行；是否接管官方 DeepSeek 路由由「隐身模式」开关决定（默认关）；
 - 默认视觉链就是内置免费端点；
@@ -222,7 +233,7 @@ Web 配置页在 **设置 → 插件 → 插件配置** 下注册「视觉路由
 
 ## 环境要求
 
-- DeepSeek Harness 的 Web profile，且 `dsh plugin` 可用 `pnpm`。
+- DeepSeek Harness 的 Web profile。普通安装可用 `npx @deepseek-ai/dsh ...`；从源码仓库运行时用 `pnpm dsh ...`。只有 CLI 已经进入系统 `PATH` 时才能直接写 `dsh ...`。
 - Node ≥ 22（宿主侧）。
 - 默认免费链路无需 API Key；付费 `httpProviders` 只需一个凭据引用（`apiKeyEnv`）。
 - `vision_html_screenshot` 才需要 Chrome / Chromium / Edge；其余工具无浏览器也能用。
@@ -232,9 +243,18 @@ Web 配置页在 **设置 → 插件 → 插件配置** 下注册「视觉路由
 
 ### 安装
 
+普通 npm / npx 安装：
+
 ```sh
-dsh plugin --profile web add dsh-vision-router
-dsh --profile web --dump-config | grep vision-router   # 一行，由 bundle 补丁挂载
+npx @deepseek-ai/dsh plugin --profile web add dsh-vision-router
+npx @deepseek-ai/dsh --profile web --dump-config | grep vision-router
+```
+
+从 DeepSeek Harness 源码仓库运行：
+
+```sh
+pnpm dsh plugin --profile web add dsh-vision-router
+pnpm dsh --profile web --dump-config | grep vision-router
 ```
 
 长期运行的 Web profile 需重启。宿主在启动时通过 `dsh.client` 声明发现浏览器端包。
@@ -251,7 +271,11 @@ dsh --profile web --dump-config | grep vision-router   # 一行，由 bundle 补
 ### 升级
 
 ```sh
-dsh plugin --profile web update dsh-vision-router
+# 普通 npm / npx 安装
+npx @deepseek-ai/dsh plugin --profile web update dsh-vision-router
+
+# DeepSeek Harness 源码仓库
+pnpm dsh plugin --profile web update dsh-vision-router
 ```
 
 设置存放在 profile 的设置提供方里，升级不丢失。
@@ -278,7 +302,11 @@ dsh plugin --profile web update dsh-vision-router
 ### 卸载
 
 ```sh
-dsh plugin --profile web remove dsh-vision-router
+# 普通 npm / npx 安装
+npx @deepseek-ai/dsh plugin --profile web remove dsh-vision-router
+
+# DeepSeek Harness 源码仓库
+pnpm dsh plugin --profile web remove dsh-vision-router
 ```
 
 同时移除依赖与 bundle 层。若你曾手动禁用官方 DeepSeek 行，记得在 profile 补丁里恢复。

--- a/README.zh.md
+++ b/README.zh.md
@@ -256,6 +256,25 @@ dsh plugin --profile web update dsh-vision-router
 
 设置存放在 profile 的设置提供方里，升级不丢失。
 
+> **从 bundle 补丁之前（v0.x）升级：** 现在插件由自带的 bundle 补丁自动挂载，
+> 若 `~/.dsh/profiles/<profile>/cordis.patch.yml` 里还残留旧版手动行，会与之
+> 重复，`dsh web` 启动即报 `duplicate loader entry id: vision-router`。删除
+> 旧块：
+>
+> ```yaml
+> - insert:            # 删除整块
+>     - id: vision-router
+>       name: dsh-vision-router
+> ```
+>
+> 若要保留自定义配置，改为不带 insert 的按 id 覆盖行：
+>
+> ```yaml
+> - id: vision-router
+>   config:
+>     # 你的配置…
+> ```
+
 ### 卸载
 
 ```sh


### PR DESCRIPTION
## What

Upgrading from a pre-bundle-patch install (v0.x) currently crashes `dsh web` at startup:

```
dsh: plugin tree failed to load: failed to apply loader entry include (cordis:include): duplicate loader entry id: vision-router
```

Since v1.0.0 the package mounts itself via `dsh.bundle.patch`; a leftover manual `insert` from the v0.x install duplicates the row and the loader rejects duplicate ids. This PR documents the migration in both READMEs: delete the old block, or convert it to a plain by-id override.

## 变更内容

- `README.md` / `README.zh.md` 的「Upgrade / 升级」小节新增迁移说明：
  - 删除旧版手动 `insert` 块；
  - 或改为不带 `insert` 的按 id 覆盖行，以保留自定义配置。

## Verification

Reproduced and verified end-to-end in an isolated `DSH_HOME` profile against harness `0.1.0-rc.6`:

| Scenario | Result |
| --- | --- |
| Stale manual insert kept | Crash: `duplicate loader entry id: vision-router` (same stack as the reported screenshot) |
| Manual insert removed | Boots cleanly |
| By-id override with custom config | Boots cleanly; composed config has exactly one `vision-router` row with the override applied |

Docs-only change; no code touched.