### PR TITLE
feat: add auto-vision onboarding and clearer model guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 > [!WARNING]
 > 📌 **Announcement (v1.1.1)**
 >
-> Existing DSH providers are now **auto-wrapped on install**: text-only routes gain paste-and-go vision automatically, while native multimodal models keep their original image input and use Vision Router tools only when useful. Windows sharp/libvips startup conflicts are fixed by sharing the host sharp; install/update docs now distinguish npm/npx from source-checkout pnpm usage.
+> Existing DSH providers are now **auto-wrapped on install**: text-only routes gain a same-name **“+ Auto Vision”** model group, while native multimodal models keep their original image input and use Vision Router tools only when useful. **Before sending an image, choose the “+ Auto Vision” group from the lower-right model selector; the original group is intentionally left untouched.** Model and wrapper changes hot-update without a restart. Windows sharp/libvips startup conflicts are fixed by sharing the host sharp; install/update docs distinguish npm/npx from source-checkout pnpm usage.
 
 <p align="center">
   <img src="assets/vision-demo.gif" width="640" alt="Demo: paste an image, the agent locates the send button with vision_ground / vision_crop / vision_pixel_diff and answers with coordinates" />
@@ -48,7 +48,7 @@ The closest alternative is [@anionex/dsh-vision-toolkit](https://github.com/Anio
 |---|---|---|
 | Image Q&A out of the box | ✅ Built-in free chain (anonymous OVHcloud endpoint) — no account, no key | Requires your own vision API key (local pixel tools work without one) |
 | Runtime | ✅ Node only — no Python | Python 3.11+ managed runtime |
-| Getting an image in | ✅ Paste it — the turn auto-routes to the vision chain and auto-mounts the tools | Workspace path + `/vision-tools` command, then explicit tool calls |
+| Getting an image in | ✅ Pick a “+ Auto Vision” group once, then paste directly | Workspace path + `/vision-tools` command, then explicit tool calls |
 | Turn routing | ✅ Image turns switch to vision, text turns switch back to DeepSeek — optional stealth takeover keeps the model picker looking stock | Tool-driven; no whole-turn auto-routing |
 | Profiles | Web | Web + Headless |
 | Playbooks | The pixel loop: ground → crop → diff → fix → screenshot again | Richer case library (long-screenshot OCR, UI restoration, GUI automation) |
@@ -58,6 +58,8 @@ The closest alternative is [@anionex/dsh-vision-toolkit](https://github.com/Anio
 Both are MIT-licensed and one command away. Pick this plugin when you want images to *just work* with zero setup; pick theirs when you need headless profiles or the extended playbook library. (Feature comparison reflects their README as of 2026-08.)
 
 ## Quick start
+
+### 1. Install and load the plugin
 
 Recommended for normal npm/npx installs (the same launch style used by the DSH README):
 
@@ -74,14 +76,32 @@ pnpm dsh plugin --profile web add dsh-vision-router
 pnpm dsh web
 ```
 
-If you already installed the DSH CLI globally and `dsh` is on `PATH`, the shorter `dsh ...` form works too. Restart a long-lived Web profile after installation — done. Zero configuration:
+If you already installed the DSH CLI globally and `dsh` is on `PATH`, the shorter `dsh ...` form works too.
 
-- the plugin's bundle patch mounts the row, adds the admission wrapper and relaxes attachment limits to 20 MB / 100 MP — pure-additive, it never touches the core rows; whether the official DeepSeek route is taken over is decided by the optional stealth setting (off by default);
-- the default vision chain is the built-in free endpoint;
-- custom/third-party routes (e.g. opencode) gain image input through **Extra vision wrappers**;
-- every setting is editable live in **Settings → Plugins → Plugin config → 视觉路由（自动识图）**.
+> [!NOTE]
+> If you install the plugin **into a Web process that was already running long-term**, let that DSH Web process reload once so the plugin bundle itself is discovered. After the plugin is loaded, adding/removing models or changing wrapper scope **hot-updates without further DSH restarts**.
 
-Then just paste an image into a conversation. The agent mounts the vision tools automatically and looks at it through `vision_describe` (and friends) — multi-step if needed.
+### 2. Switch to a “+ Auto Vision” model group in chat
+
+Once loaded, the plugin discovers the model groups enabled under **Settings → Models** and creates same-name auto-vision entries. For example:
+
+```text
+opencode-go                 ← original model group, unchanged
+opencode-go + Auto Vision   ← choose this when sending images
+```
+
+> [!IMPORTANT]
+> **Before sending an image, open the model selector in the lower-right corner of the chat composer and choose a group marked “+ Auto Vision”.**
+>
+> Vision Router deliberately **does not modify the original model group**. If the conversation still uses the original text-only opencode / DeepSeek route, DSH can reject the image with “the current model does not support images” *before Vision Router gets a chance to handle it*. That is a model-entry selection issue, not a broken vision backend.
+
+The auto-vision group follows the live DSH model catalog. Adding models or changing wrapper scope does not require a restart.
+
+### 3. Paste or upload the image
+
+After choosing the “+ Auto Vision” group, paste or upload an image normally. The agent auto-mounts the vision tools and can use `vision_describe`, `vision_ground`, `vision_crop`, and the rest across multiple steps when needed.
+
+The built-in free vision backend is already configured, so normal image use needs no API key or extra setup. Advanced options live under **Settings → Plugins → Plugin config → 视觉路由（自动识图）**.
 
 ### See it in action
 
@@ -165,6 +185,9 @@ The vision chain walks providers in order and only surfaces an error after every
 2. configured `httpProviders` (direct OpenAI-compatible endpoints with optional `apiKeyEnv`);
 3. configured `providers` / `provider` + `fallbacks` (any adapter-backed provider, e.g. a Pi-AI profile like OpenRouter or Zhipu).
 
+> [!IMPORTANT]
+> This “vision chain” is the **vision backend** called by Vision Router. Its models must genuinely accept image input. It is separate from the “+ Auto Vision” conversation model group in the lower-right selector; do not put a text-only DeepSeek/opencode model here as a vision fallback.
+
 > In the legacy `routing: true` mode, the whole-turn chain walks only `provider + fallbacks` — `httpProviders` (including the free fallback) do not participate there. The default `routing: false` (tools-first) tries everything.
 
 Failures are classified (region / tos / quota / rate-limit / context / network) and the final error carries advice; `429` responses honor `Retry-After` once with a capped backoff. Oversized uploads are downscaled before the call (default budget 4 MP) to keep tool calls fast.
@@ -183,21 +206,29 @@ With stealth on, the plugin takes over the official `deepseek-official` route: t
 
 With the stock row present, the plugin falls back to the visible wrapper entry. Conversely, with stealth off but the stock row still disabled, the plugin performs a keep-alive takeover so the DeepSeek models don't vanish (the settings card explains this); to restore the fully official route, flip the `disabled` above back to `false` and restart.
 
-> Stealth mode **only affects the official DeepSeek route**. Custom/third-party routes like opencode are unrelated — use **Extra vision wrappers** below to give them image input.
+> Stealth mode **only affects the official DeepSeek route**. Custom/third-party routes such as opencode are auto-wrapped into “+ Auto Vision” groups by default.
 
-## Extra vision wrappers
+## Auto-vision model groups and manual wrappers
 
-`wrappedProviders` registers an auto-vision twin for any third-party/custom text route: pick the twin in the model selector and send images; text turns delegate to the original route unchanged. The typical use case is a custom interface such as opencode — it only declares text input, and one wrapper row makes it image-ready. In the settings card, configure it with two dropdowns (provider + model); leaving the model empty wraps every model of that route.
+`autoWrapProviders` is on by default. The plugin discovers the provider/model entries currently enabled under **Settings → Models** and registers a same-name “+ Auto Vision” model group for them. **The original group is never changed**: choose the auto-vision group for images, or keep using the original group for plain text. DSH `llm/adapters-updated` events are synced live, so adding/removing models does not require a restart.
+
+`wrappedProviders` is an **optional manual scope control**, not a required setup step. Use it only when:
+
+1. automatic wrapping is off and you want to pick which provider/models receive an auto-vision entry; or
+2. automatic wrapping remains on but one provider should expose only selected models in its “+ Auto Vision” group.
+
+The settings card uses provider + model dropdowns; an empty model means every model on that route. Add multiple rows to select multiple models. Changes apply immediately with no restart.
 
 ## Web settings
 
-The Web profile registers a **视觉路由（自动识图）** card under **Settings → Plugins → Plugin config**, styled like the built-in cards. It live-edits:
+The Web profile registers a **视觉路由（自动识图）** card under **Settings → Plugins → Plugin config**. Its top callout spells out the only step most users need: **return to chat → lower-right model selector → choose a “+ Auto Vision” model group → send the image**. The remaining controls are advanced customization:
 
-- switches: whole-turn legacy routing, vision tools, image-block rewriting, stealth (official DeepSeek route only);
-- **extra vision wrappers**: provider + model dropdowns that register image-capable twin entries for custom routes such as opencode;
-- vision request timeout, wrapper/chain route names;
-- the **vision chain** (one `provider/model` per line, top-down fallback) and the text model;
-- every field shows an "overridden" badge with a one-click reset to the composition default, plus discard/save;
+- **Auto-create “+ Auto Vision” model groups**: enabled by default; follows the live model catalog with no restart;
+- **Manual auto-vision scope (optional)**: only for disabling auto-wrap or limiting selected models;
+- **Vision backend chain**: the real image-capable models used by `vision_describe` and friends; the built-in free Qwen is normally enough, and text-only models should not be placed here;
+- switches for legacy whole-turn routing, vision tools, image-block rewriting and stealth mode (official DeepSeek route only);
+- timeout, wrapper/chain route names, proxy and other advanced parameters;
+- every field shows an overridden badge with one-click reset plus discard/save;
 - a **Test connection** button probes the first vision provider and reports latency inline;
 - artifact-producing tools render dedicated call cards with result facts and open-file buttons.
 
@@ -213,15 +244,16 @@ Everything is optional; defaults work out of the box. Edit via the Web card or a
 
 | Field | Default | Meaning |
 |---|---|---|
-| `provider` / `model` | `vision-http` / `ovh/Qwen2.5-VL-72B-Instruct` | shorthand chain (adapter-backed provider + model) |
-| `fallbacks` | `[]` | backup models for the shorthand provider |
-| `providers` | built-in free `vision-http` pair | multi-provider chain `{ provider, model, fallbacks[] }`, tried in order; wins over the shorthand. The first row ships as the built-in free model |
+| `provider` / `model` | `vision-http` / `ovh/Qwen2.5-VL-72B-Instruct` | shorthand **vision backend** route (adapter-backed provider + model that genuinely accepts images) |
+| `fallbacks` | `[]` | backup image models for the shorthand vision provider |
+| `providers` | built-in free `vision-http` pair | multi-provider **vision backend** chain `{ provider, model, fallbacks[] }`, tried in order; do not put text-only models here |
 | `httpProviders` | built-in OVH entry | direct OpenAI-compatible endpoints `{ name, baseURL, model, apiKeyEnv, maxTokens }` |
-| `wrappedProviders` | `[{ provider: 'deepseek-official', models: [] }]` | extra text routes to wrap as image-capable twins: `{ provider, models[] }` — registers an auto-vision twin for any custom/third-party route (e.g. opencode); in the card, provider + model dropdowns, empty model = wrap all. The pre-filled deepseek-official row marks the built-in wrapper and is a no-op; changes apply live |
+| `autoWrapProviders` | `true` | discover enabled provider/models and live-sync same-name “+ Auto Vision” groups; original groups stay unchanged |
+| `wrappedProviders` | `[{ provider: 'deepseek-official', models: [] }]` | optional manual wrapper scope `{ provider, models[] }`, used after disabling auto-wrap or to restrict one provider to selected models; changes apply live, no restart |
 | `routing` | `false` | legacy whole-turn chain routing (one-shot answer). `false` = tools-first flow (recommended) |
 | `reverseRouting` | `true` | with `routing: true`, route text turns back to `textProvider` |
 | `wrapperRoute` / `chainRoute` | `deepseek-vision` / `vision-chain` | admission wrapper route name / fallback chain route name (empty disables) |
-| `stealth` | `false` | take over the official `deepseek-official` route (official row only; custom routes use `wrappedProviders`) |
+| `stealth` | `false` | take over the official `deepseek-official` route (official row only; custom routes are auto-wrapped by default) |
 | `textProvider` | `deepseek-official` / `deepseek-v4-pro` | the model that reasons (your daily model) |
 | `tool` / `progressiveTools` / `autoActivateOnImage` | `true` ×3 | vision tools on / progressive mounting / auto-mount on image turns |
 | `rewriteImages` | `true` | rewrite image blocks in the model input (cached description or tool-hint marker); the UI log keeps images |
@@ -257,7 +289,7 @@ pnpm dsh plugin --profile web add dsh-vision-router
 pnpm dsh --profile web --dump-config | grep vision-router
 ```
 
-Restart a long-lived Web profile. The host discovers the browser bundle through `dsh.client` at startup.
+When first adding the plugin to an already long-lived Web profile, let that Web process reload the plugin bundle; the host discovers the browser bundle through `dsh.client` at startup. **After the plugin is loaded, model-catalog and wrapper-scope changes hot-update and do not require a restart.**
 
 ### Disable / re-enable
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -23,7 +23,7 @@
 > [!WARNING]
 > 📌 **公告（v1.1.1）**
 >
-> 现在安装后会**自动包装 DSH 已有模型**：纯文本路由自动获得粘贴即用的识图入口，原生多模态模型保留原图直传，仅在需要精确定位 / OCR / 像素验证时按需使用 Vision Router 工具。另修复 Windows sharp/libvips 启动冲突，并补齐 npm/npx 与源码 pnpm 两套安装/升级指引。
+> 现在安装后会**自动包装 DSH 已有模型**：纯文本路由自动获得同名的「+ 自动识图」模型组，原生多模态模型保留原图直传，仅在需要精确定位 / OCR / 像素验证时按需使用 Vision Router 工具。**发图时请在聊天页右下角切换到带「+ 自动识图」的模型组；原模型组不会被修改。** 模型与包装范围后续会热更新，无需重启。另修复 Windows sharp/libvips 启动冲突，并补齐 npm/npx 与源码 pnpm 两套安装/升级指引。
 
 <p align="center">
   <img src="assets/vision-demo.gif" width="640" alt="演示：粘贴图片，Agent 用 vision_ground / vision_crop / vision_pixel_diff 定位发送按钮并给出坐标" />
@@ -48,7 +48,7 @@
 |---|---|---|
 | 开箱图片问答 | ✅ 内置免费视觉链（OVHcloud 匿名端点），免注册免 Key | 远程工具需自备视觉 API Key（本地像素工具免 Key） |
 | 运行时 | ✅ 纯 Node，无需 Python | 需要 Python 3.11+ 受管运行时 |
-| 图片怎么进来 | ✅ 直接粘贴——轮次自动切视觉链并自动挂载工具 | 工作区路径 + `/vision-tools` 命令，再显式调用工具 |
+| 图片怎么进来 | ✅ 选一次「+ 自动识图」模型组后直接粘贴 | 工作区路径 + `/vision-tools` 命令，再显式调用工具 |
 | 轮次路由 | ✅ 图片轮切视觉、文本轮切回 DeepSeek——可选隐身接管，模型选择器与官方一致 | 工具驱动，无整轮自动路由 |
 | 支持 profile | Web | Web + Headless |
 | 玩法库 | 像素循环：定位 → 裁剪 → 对比 → 修复 → 再截图 | 更丰富的案例库（长截图 OCR、UI 还原、GUI 自动化） |
@@ -58,6 +58,8 @@
 两者都是 MIT 许可、一条命令安装。想要图片**粘贴即用**、零配置就选本插件；需要 Headless 部署或更丰富的案例库，可以看 @anionex/dsh-vision-toolkit。（功能对比以其 README 2026-08 状态为准。）
 
 ## 快速开始
+
+### 1. 安装并让插件加载
 
 普通 npm / npx 安装方式推荐这样用（与 DSH 官方 README 的启动方式一致）：
 
@@ -74,14 +76,32 @@ pnpm dsh plugin --profile web add dsh-vision-router
 pnpm dsh web
 ```
 
-如果你已经全局安装 DSH CLI，并且终端里能直接执行 `dsh`，也可以继续使用较短的 `dsh ...` 写法。长期运行的 Web profile 安装后重启——完成，零配置：
+如果你已经全局安装 DSH CLI，并且终端里能直接执行 `dsh`，也可以继续使用较短的 `dsh ...` 写法。
 
-- 插件的 bundle 补丁自动挂载插件行、挂上准入包装并放宽附件限制到 20MB / 1 亿像素——纯增量、不碰核心行；是否接管官方 DeepSeek 路由由「隐身模式」开关决定（默认关）；
-- 默认视觉链就是内置免费端点；
-- opencode 等自定义/第三方路由用「额外识图包装」获得发图能力；
-- 全部配置可在 **设置 → 插件 → 插件配置 → 视觉路由（自动识图）** 实时修改。
+> [!NOTE]
+> 如果你是把插件**首次安装进一个已经长期运行的 Web 进程**，需要让 DSH Web 进程重新加载一次插件本体。插件加载完成后，新增/删除模型、修改自动识图包装范围都会**热更新，无需再重启 DSH**。
 
-然后直接往对话里贴一张图。Agent 自动挂载视觉工具，通过 `vision_describe`（以及其余 8 个工具）看图，需要时连续多步。
+### 2. 在聊天页切换到「+ 自动识图」模型组
+
+插件加载后会自动发现 **设置 → 模型** 里已启用的模型组，并为它们额外创建同名的自动识图入口。例如：
+
+```text
+opencode-go                 ← 原模型组，保持不变
+opencode-go + 自动识图       ← 发图片时选这个
+```
+
+> [!IMPORTANT]
+> **发图前，请点击聊天页输入区右下角的模型选择器，选择带「+ 自动识图」的模型组。**
+>
+> Vision Router 故意**不修改原模型组**。因此如果当前仍选着原来的纯文本 `opencode-go` / DeepSeek 路由，DSH 会在插件处理图片之前先提示“当前模型不支持图片”。这不是视觉后端配置失败，只是还没有切到自动识图入口。
+
+这个模型组的模型列表会跟随 DSH 的模型目录实时同步；新增模型或修改包装范围后无需重启。
+
+### 3. 直接粘贴或上传图片
+
+选好「+ 自动识图」模型组后，直接往对话里贴图即可。Agent 会自动挂载视觉工具，通过 `vision_describe`、`vision_ground`、`vision_crop` 等工具看图，需要时连续多步操作。
+
+默认已经有内置免费视觉后端，无需额外配置 Key。高级配置在 **设置 → 插件 → 插件配置 → 视觉路由（自动识图）**；如果只是普通看图，通常不需要改设置。
 
 ### 实际效果
 
@@ -165,6 +185,9 @@ vision_long_screenshot_ocr image="chat-log.png" chunkHeight=1200 overlap=120
 2. 配置的 `httpProviders`（OpenAI 兼容直连端点，可选 `apiKeyEnv`）；
 3. 配置的 `providers` / `provider` + `fallbacks`（任何有适配器的供应商，例如 Pi-AI 配置的 OpenRouter 或智谱）。
 
+> [!IMPORTANT]
+> 这里的“视觉链”是 Vision Router 调用的**视觉后端**，必须填写真正支持图片输入的模型；它和聊天页右下角的「+ 自动识图」会话模型组不是一回事。不要把纯文本 DeepSeek / opencode 模型当成视觉后端备用模型。
+
 > 在旧版 `routing: true` 模式下，整轮链只走 `provider + fallbacks`——`httpProviders`（含免费兜底）不参与。默认的 `routing: false`（工具优先）会尝试全部。
 
 失败会分类（地区 / 风控 / 额度 / 限流 / 上下文 / 网络），最终报错附带建议；`429` 会尊重 `Retry-After` 做一次有上限的退避重试。超大上传图在调用前自动压缩（默认预算 400 万像素），保证工具调用不卡。
@@ -183,20 +206,28 @@ vision_long_screenshot_ocr image="chat-log.png" chunkHeight=1200 overlap=120
 
 官方行在场时，插件自动回退为可见包装入口。反过来，隐身模式关闭但官方行仍被禁用时，插件会做 keep-alive 兜底接管，保住 DeepSeek 模型（设置卡片会给出提示）；想完全恢复官方原生行，把上面的 `disabled` 改回 `false` 再重启即可。
 
-> 隐身模式**只作用于官方 DeepSeek 路由**。opencode 等自定义/第三方文本路由与隐身模式无关——用「额外识图包装」让它们支持发图。
+> 隐身模式**只作用于官方 DeepSeek 路由**。opencode 等自定义/第三方文本路由与隐身模式无关——默认会被自动包装成「+ 自动识图」模型组。
 
-## 额外识图包装
+## 自动识图模型组与手动包装
 
-`wrappedProviders` 给任意第三方/自定义文本路由注册「自动识图」孪生条目：模型选择器里选中它就能发图，文字轮原样交给原路由处理。典型用法是 opencode 等接入的自定义接口——它们默认只声明文本输入，加一行包装即可直接发图。设置卡片里用两个下拉（provider + 模型）配置；模型留空 = 包装该路由的全部模型，同一 provider 要包装多个模型就添加多行。
+默认开启 `autoWrapProviders`：插件会自动发现 **设置 → 模型** 中当前已启用的 provider / model，并额外注册同名的「+ 自动识图」模型组。**原模型组完全不变**；发图片时选自动识图组，纯文字仍可继续用原组。DSH 的 `llm/adapters-updated` 变化会触发同步，所以新增/删除模型后无需重启。
+
+`wrappedProviders` 是**可选的手动范围控制**，不是普通用户必须配置的步骤。只有两种情况需要它：
+
+1. 关闭了自动包装，想手动指定哪些 provider / model 获得自动识图入口；
+2. 自动包装保持开启，但只想让某个 provider 的部分模型出现在「+ 自动识图」组。
+
+设置卡片里用两个下拉（provider + 模型）配置；模型留空 = 包装该路由的全部模型，同一 provider 要限定多个模型就添加多行。修改即时生效，无需重启。
 
 ## Web 设置
 
-Web 配置页在 **设置 → 插件 → 插件配置** 下注册「视觉路由（自动识图）」卡片，样式与内置卡片一致，可实时修改：
+Web 配置页在 **设置 → 插件 → 插件配置** 下注册「视觉路由（自动识图）」卡片，顶部会直接提示最重要的使用步骤：**回到聊天页 → 右下角模型选择器 → 选择「+ 自动识图」模型组 → 发图**。其余设置主要用于高级定制：
 
+- **自动创建「+ 自动识图」模型组**：默认开启，自动发现已有模型；模型目录变化热更新，无需重启；
+- **手动限定自动识图范围（可选）**：仅在需要关闭自动包装或限制部分模型时使用；
+- **视觉后端链**：给 `vision_describe` 等视觉工具调用的真正图片模型，默认内置免费 Qwen 即可；不要填纯文本模型；
 - 开关：整轮自动路由（旧模式）、识图工具、图片块改写、隐身模式（仅官方 DeepSeek 路由）；
-- **额外识图包装**：provider + 模型双下拉，给 opencode 等自定义路由注册可发图的孪生条目；
-- 视觉请求超时、包装/链路由名；
-- **视觉模型链**（每行一个 `provider/model`，自上而下降级）与文本模型；
+- 视觉请求超时、包装/链路由名、代理等高级参数；
 - 每个字段都有「已覆盖」徽标与一键恢复组合默认，以及放弃/保存；
 - 「测试连接」按钮探测第一个视觉提供方并内联显示延迟/失败原因；
 - 产出制品的工具在对话里渲染专用调用卡（关键字段 + 打开文件按钮）。
@@ -213,15 +244,16 @@ Web 配置页在 **设置 → 插件 → 插件配置** 下注册「视觉路由
 
 | 字段 | 默认值 | 含义 |
 |---|---|---|
-| `provider` / `model` | `vision-http` / `ovh/Qwen2.5-VL-72B-Instruct` | 简写链路（有适配器的供应商 + 模型） |
-| `fallbacks` | `[]` | 简写供应商的备用模型 |
-| `providers` | 内置免费 `vision-http` 条目 | 多供应商链路 `{ provider, model, fallbacks[] }`，按序尝试；优先于简写形式。第一行开箱预置内置免费模型 |
+| `provider` / `model` | `vision-http` / `ovh/Qwen2.5-VL-72B-Instruct` | 简写视觉后端链路（有适配器且真正支持图片输入的供应商 + 模型） |
+| `fallbacks` | `[]` | 简写视觉供应商的备用图片模型 |
+| `providers` | 内置免费 `vision-http` 条目 | 多供应商视觉后端链 `{ provider, model, fallbacks[] }`，按序尝试；优先于简写形式。不要填写纯文本模型 |
 | `httpProviders` | 内置 OVH 条目 | OpenAI 兼容直连端点 `{ name, baseURL, model, apiKeyEnv, maxTokens }` |
-| `wrappedProviders` | `[{ provider: 'deepseek-official', models: [] }]` | 额外识图包装：`{ provider, models[] }`，给 opencode 等任意第三方/自定义文本路由注册可发图的孪生条目（卡片里 provider + 模型双下拉；模型留空 = 包装全部）。预置的 deepseek-official 条目标记内置包装、无副作用；改动即时生效 |
+| `autoWrapProviders` | `true` | 自动发现当前已启用 provider / model，并热更新同名「+ 自动识图」模型组；原模型组不变 |
+| `wrappedProviders` | `[{ provider: 'deepseek-official', models: [] }]` | 可选的手动包装范围 `{ provider, models[] }`；用于关闭自动包装后手动指定，或限制某个 provider 只包装部分模型。改动即时生效，无需重启 |
 | `routing` | `false` | 旧版整轮链路由（一次性整轮回答）。`false` = 工具优先流程（推荐） |
 | `reverseRouting` | `true` | 开启 `routing` 时，文字轮路由回 `textProvider` |
 | `wrapperRoute` / `chainRoute` | `deepseek-vision` / `vision-chain` | 准入包装路由名 / 降级链路由名（置空关闭） |
-| `stealth` | `false` | 接管官方 `deepseek-official` 路由（仅官方行；自定义路由用 `wrappedProviders`） |
+| `stealth` | `false` | 接管官方 `deepseek-official` 路由（仅官方行；自定义路由默认由自动包装处理） |
 | `textProvider` | `deepseek-official` / `deepseek-v4-pro` | 负责思考的模型（你的日常模型） |
 | `tool` / `progressiveTools` / `autoActivateOnImage` | `true` ×3 | 视觉工具开关 / 渐进式挂载 / 图片轮自动挂载 |
 | `rewriteImages` | `true` | 模型输入层改写图片块（缓存描述或工具提示标记）；界面日志保留图片 |
@@ -257,7 +289,7 @@ pnpm dsh plugin --profile web add dsh-vision-router
 pnpm dsh --profile web --dump-config | grep vision-router
 ```
 
-长期运行的 Web profile 需重启。宿主在启动时通过 `dsh.client` 声明发现浏览器端包。
+首次把插件装进已经长期运行的 Web profile 时，需要让 Web 进程重新加载插件本体；宿主在启动时通过 `dsh.client` 声明发现浏览器端包。**插件加载完成后，模型目录与包装范围的变化会热更新，不需要为这些变化重启。**
 
 ### 禁用 / 恢复
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -15,7 +15,17 @@ window.__ModuleLoader__.load({
     const NS = 'vision-router'
     const zh = {
       nav: '视觉路由（自动识图）',
-      desc: '内置免费视觉模型开箱即用；已配置的文本模型默认自动获得「自动识图」入口，也可手动限定包装范围 · 面板 v5',
+      desc: '安装后会自动创建「原模型组 + 自动识图」；发图时在聊天页右下角选它 · 面板 v6',
+      quickStartTitle: '发图前只做这一步',
+      quickStartBody: '回到聊天页，点击右下角模型选择器，选择带「+ 自动识图」的模型组（如 opencode-go + 自动识图），然后直接粘贴或上传图片。原模型组保持不变，仍用于纯文字对话。',
+      quickStartLive: '模型和包装范围会热更新：新增或修改后无需重启 DSH。',
+      onboardingTitle: 'Vision Router 已准备好 👁️',
+      onboardingBody: '你已有的模型已经自动获得识图入口。要发送图片，请点击聊天页右下角的模型选择器，选择带「+ 自动识图」的模型组。',
+      onboardingExampleLabel: '例如',
+      onboardingExample: 'opencode-go + 自动识图',
+      onboardingFoot: '原来的模型组不会被修改；它仍可照常用于纯文字对话。模型增删与包装范围会热更新，无需重启。',
+      onboardingGotIt: '知道了',
+      onboardingClose: '关闭',
       pending: '未保存',
       readOnly: '当前设置提供方只读。',
       overridden: '已覆盖',
@@ -29,16 +39,15 @@ window.__ModuleLoader__.load({
       pickProviderFirst: '先选供应商',
       freeTag: '（免费）',
       builtinFreeTag: '（内置免费模型）',
-      chainLabel: '视觉模型链（按顺序失败回退）',
-      chainHint: '第一行是主视觉模型，后面的行在其失败时依次回退；清空 = 仅用内置免费模型兜底。',
-      addFallback: '+ 添加备用模型',
+      chainLabel: '视觉后端链（给识图工具用）',
+      chainHint: '这里必须选择真正支持图片输入的视觉模型；不要把纯文本 DeepSeek / opencode 模型当作备用视觉模型。第一行是主视觉模型，后面的行在失败时依次回退。',
+      addFallback: '+ 添加备用视觉模型',
       remove: '移除',
       removeTitle: '移除这一行',
       textModelLabel: '文本模型（文字轮走它）',
       textModelHint: '通常无需设置；见上方说明，留空即恢复默认。',
       defaultChainNote:
-        '第一行默认是内置免费视觉模型（免注册、免 Key，每 IP 2 次/分钟）；「设置 > 模型」里配过的供应商会出现在下面的下拉里，' +
-        '往下加行即按顺序降级。',
+        '下面是识图工具真正调用的“眼睛”后端，不是聊天页右下角要选择的会话模型组。第一行默认是内置免费视觉模型（免注册、免 Key，每 IP 2 次/分钟）；通常保留默认即可。',
       catalogLoading: '正在加载模型目录（与「设置 > 模型」同源）…',
       catalogUnavailable: '连接服务不可用（拿不到模型目录），退回手动输入。',
       catalogTimeout: '目录请求超时（15 秒）',
@@ -72,7 +81,7 @@ window.__ModuleLoader__.load({
       toggleRouting: '图片轮整轮自动路由',
       toggleReverseRouting: '文字轮反向路由',
       toggleTool: '识图工具',
-      toggleAutoWrapProviders: '自动包装已有模型',
+      toggleAutoWrapProviders: '自动创建「+ 自动识图」模型组',
       toggleRewriteImages: '图片块改写',
       toggleDownscale: '图片自动压缩',
       toggleCache: '识图答案缓存',
@@ -82,10 +91,10 @@ window.__ModuleLoader__.load({
         '默认关闭：图片轮不整轮切到视觉模型，而是像普通文本轮一样由会话模型调用 ' +
         'vision_describe 等工具看图，可连续多步操作（定位→裁剪→对比…）。' +
         '开启后恢复旧的整轮一次性自动识图行为；注意：开启时降级链只包含 ' +
-        '「视觉模型链」里的 provider+fallbacks，httpProviders（含免费兜底端点）不参与。',
+        '「视觉后端链」里的 provider+fallbacks，httpProviders（含免费兜底端点）不参与。',
       hintReverseRouting: '开启图片轮整轮路由时，把纯文字轮反向路由回文本模型；默认开启。',
       hintTool: 'vision_describe / vision_ground 等像素级视觉工具；关闭后这些工具不可用。',
-      hintAutoWrapProviders: '默认开启：自动发现「设置 → 模型」里当前已启用的路由，为其中模型生成额外的「+ 自动识图」入口；原模型完全不变。原生多模态模型在自动识图入口里仍直接接收原图，vision-router 工具只作为按需增强。关闭后仅使用下方手动「额外识图包装」。改动即时生效。',
+      hintAutoWrapProviders: '推荐保持开启。插件会自动发现「设置 → 模型」里已启用的路由，并额外创建同名的「+ 自动识图」模型组；发图时请在聊天页右下角选择这个新组。原模型组完全不变。模型增删与包装范围会热更新，无需重启。',
       hintRewriteImages:
         '把消息里的图片块替换为文字：已有视觉记录就给出记录，否则给出附件标记，' +
         '文本模型始终不会收到它看不懂的图片内容。',
@@ -96,7 +105,7 @@ window.__ModuleLoader__.load({
         '只作用于官方 DeepSeek 路由：接管后模型选择器保持原样。需在 profile 补丁层 ' +
         '（cordis.patch.yml）禁用官方 llm-deepseek 行后才真正接管；官方行还在时 ' +
         '插件自动回退为选择器里的「自动识图」包装路由。opencode 等自定义路由与隐身模式无关，' +
-        '用下方「额外识图包装」让它们支持发图。改动后需重启 dsh 生效。',
+        '它们默认由「自动创建 + 自动识图模型组」处理；只有要限制范围时才用下方手动包装。改动后需重启 dsh 生效。',
       stealthOfficialDeadHint:
         '提示：检测到官方 DeepSeek 行当前被禁用（profile 补丁层），所以即使关闭隐身模式，' +
         '本插件仍会接管 deepseek-official 路由，否则 DeepSeek 模型会从选择器消失。' +
@@ -113,20 +122,30 @@ window.__ModuleLoader__.load({
       textChainRoute: '视觉链路由名',
       textHintWrapperRoute: '模型选择器里显示的「自动识图」入口路由名。',
       textHintChainRoute: '视觉链的挂载路由名（识图工具经由真实 provider 直接调用，不经过它）。',
-      textWrappedProviders: '额外识图包装',
-      groupWrappers: '额外识图包装',
-      textHintWrappedProviders: '给 opencode 等任意第三方/自定义文本路由注册「自动识图」孪生条目，选择器里就能选中它来发图。每行 `provider` 包装全部模型，或 `provider/model1,model2` 只包装指定模型；改动即时生效。',
-      wrapHint: '默认会自动发现并包装「设置 → 模型」里已启用的模型；这里用于手动限定某个 provider 的模型范围，或在关闭「自动包装已有模型」后手动指定。每行选一个 provider + 一个模型；模型留空 = 该路由全部模型。原模型始终保留不变；原生多模态模型仍可直接看原图，视觉工具按需使用。改动即时生效，无需重启。',
+      textWrappedProviders: '手动包装模型（可选）',
+      groupWrappers: '手动限定自动识图范围（可选）',
+      textHintWrappedProviders: '通常不用配置。只有关闭自动创建，或只想让某些模型出现在「+ 自动识图」组时才使用：每行 `provider` 包装全部模型，或 `provider/model1,model2` 只包装指定模型。改动即时生效，无需重启。',
+      wrapHint: '通常无需配置：默认会自动发现并包装「设置 → 模型」里已启用的模型。只有想限制某个 provider 的自动识图范围，或关闭上方自动创建后手动指定时才在这里添加；模型留空 = 该路由全部模型。原模型组始终保留不变。改动即时生效，无需重启。',
       wrapAllModels: '全部模型（不选 = 包装全部）',
-      addWrapper: '+ 添加包装',
-      textProviders: '视觉模型链',
-      textProvidersHint: '每行一个「provider/model」，从上到下失败回退；留空清除用户覆盖。',
+      addWrapper: '+ 添加手动包装',
+      textProviders: '视觉后端链',
+      textProvidersHint: '每行一个真正支持图片输入的「provider/model」，从上到下失败回退；不要填写纯文本模型。留空清除用户覆盖。',
       textTextProvider: '文本模型',
       textTextProviderHint: '格式「provider/model」。',
     }
     const en = {
       nav: 'Vision Router (auto image understanding)',
-      desc: 'Built-in free vision out of the box; configured text models automatically gain an auto-vision entry, with optional manual scoping · panel v5',
+      desc: 'Automatically creates “original model group + auto vision”; pick it from the lower-right model selector before sending images · panel v6',
+      quickStartTitle: 'One step before sending an image',
+      quickStartBody: 'Return to chat, open the model selector in the lower-right corner, choose a group marked “+ Auto Vision” (for example, opencode-go + Auto Vision), then paste or upload the image. Your original model group stays unchanged for normal text chat.',
+      quickStartLive: 'Models and wrapper scope hot-update: adding or changing them does not require a DSH restart.',
+      onboardingTitle: 'Vision Router is ready 👁️',
+      onboardingBody: 'Your existing models now have image-ready entries. To send an image, open the model selector in the lower-right corner of chat and choose a model group marked “+ Auto Vision”.',
+      onboardingExampleLabel: 'For example',
+      onboardingExample: 'opencode-go + Auto Vision',
+      onboardingFoot: 'The original model group is never modified and remains available for normal text chat. Model and wrapper changes hot-update without a restart.',
+      onboardingGotIt: 'Got it',
+      onboardingClose: 'Close',
       pending: 'Unsaved',
       readOnly: 'The active settings provider is read-only.',
       overridden: 'Overridden',
@@ -140,16 +159,15 @@ window.__ModuleLoader__.load({
       pickProviderFirst: 'Pick a provider first',
       freeTag: ' (free)',
       builtinFreeTag: ' (built-in free model)',
-      chainLabel: 'Vision chain (top-down failover)',
-      chainHint: 'The first row is the primary vision model; later rows are tried in order on failure. Empty = the built-in free fallback only.',
-      addFallback: '+ Add fallback model',
+      chainLabel: 'Vision backend chain (used by the vision tools)',
+      chainHint: 'Only put models here that genuinely accept image input. Do not use a text-only DeepSeek/opencode model as a vision fallback. The first row is primary; later rows are tried in order on failure.',
+      addFallback: '+ Add vision fallback',
       remove: 'Remove',
       removeTitle: 'Remove this row',
       textModelLabel: 'Text model (text turns use it)',
       textModelHint: 'Usually unneeded; leave empty to restore the default.',
       defaultChainNote:
-        'The first row is the built-in free vision model (no signup, no key, 2 req/min per IP); providers configured in ' +
-        'Settings → Models appear in the dropdowns below. Add rows beneath it for top-down failover.',
+        'The section below configures the actual “eyes” backend called by the vision tools; it is not the conversation model group you pick in the lower-right selector. The first row is the built-in free vision model (no signup, no key, 2 req/min per IP); the default is usually enough.',
       catalogLoading: 'Loading the model catalog (same source as Settings → Models)…',
       catalogUnavailable: 'Connection service unavailable (no model catalog); falling back to free-text input.',
       catalogTimeout: 'Catalog request timed out (15s)',
@@ -183,7 +201,7 @@ window.__ModuleLoader__.load({
       toggleRouting: 'Whole-turn vision routing',
       toggleReverseRouting: 'Reverse routing for text turns',
       toggleTool: 'Vision tools',
-      toggleAutoWrapProviders: 'Auto-wrap configured models',
+      toggleAutoWrapProviders: 'Auto-create “+ Auto Vision” model groups',
       toggleRewriteImages: 'Image-block rewriting',
       toggleDownscale: 'Auto downscale',
       toggleCache: 'Vision answer cache',
@@ -194,10 +212,10 @@ window.__ModuleLoader__.load({
         'session model looks at images through vision_describe and friends like any tool call, enabling ' +
         'continuous multi-step work (ground → crop → diff → …). Turning it on restores the legacy one-shot ' +
         'whole-turn behavior. Note: with routing on, the fallback chain only contains provider+fallbacks ' +
-        'from the vision chain; httpProviders (including the free fallback) do not participate.',
+        'from the vision backend chain; httpProviders (including the free fallback) do not participate.',
       hintReverseRouting: 'With whole-turn routing on, route plain text turns back to the text model; on by default.',
       hintTool: 'Pixel-level vision tools such as vision_describe / vision_ground; turning this off disables them.',
-      hintAutoWrapProviders: 'On by default: discovers routes currently enabled in Settings → Models and creates an additional + auto-vision entry for their models. The original route is never changed. Native multimodal models still receive the original image directly in the auto-vision entry; vision-router tools are optional precision helpers. Turn this off to use only the manual Extra vision wrappers below. Applies immediately.',
+      hintAutoWrapProviders: 'Recommended on. The plugin discovers routes enabled in Settings → Models and creates an additional same-name “+ Auto Vision” model group. Choose that new group from the lower-right chat model selector when sending images; the original group is never changed. Model and wrapper changes hot-update without a restart.',
       hintRewriteImages:
         'Replaces image blocks in the model input with text: a recorded vision description when one exists, ' +
         'otherwise an attachment marker — a text-only model never receives image content it cannot handle.',
@@ -207,9 +225,9 @@ window.__ModuleLoader__.load({
       hintStealth:
         'Only affects the official DeepSeek route: takes it over while the model picker looks exactly like stock. Requires the ' +
         'official llm-deepseek row to be disabled in your profile patch layer (cordis.patch.yml); while the ' +
-        'stock row is present the plugin falls back to the visible "auto image understanding" wrapper entry. ' +
-        'Custom routes like opencode are unrelated to stealth — use "Extra vision wrappers" below to give them image input. ' +
-        'Restart dsh after changing this.',
+        'stock row is present the plugin falls back to the visible auto-vision wrapper entry. Custom routes like opencode ' +
+        'are auto-wrapped by default; use the manual wrapper section below only when you want to restrict their scope. ' +
+        'Restart dsh after changing stealth/profile takeover.',
       stealthOfficialDeadHint:
         'Notice: the official DeepSeek row is currently disabled (profile patch layer), so this plugin keeps ' +
         'serving the deepseek-official route even with stealth mode off — otherwise the DeepSeek models would ' +
@@ -225,16 +243,16 @@ window.__ModuleLoader__.load({
       numHintCacheMaxEntries: 'Cache LRU capacity; default 200.',
       textWrapperRoute: 'Wrapper route name',
       textChainRoute: 'Chain route name',
-      textHintWrapperRoute: 'The "auto image understanding" entry route shown in the model picker.',
+      textHintWrapperRoute: 'The auto-vision entry route shown in the model picker.',
       textHintChainRoute: 'The fallback chain mount route (vision tools call real providers directly, not through it).',
-      textWrappedProviders: 'Extra vision wrappers',
-      groupWrappers: 'Extra vision wrappers',
-      textHintWrappedProviders: 'Registers an auto-vision twin for any third-party/custom text route (e.g. opencode) so you can pick it in the model selector and send images. One `provider` per line wraps all of its models; `provider/model1,model2` wraps specific models. Applies immediately.',
-      wrapHint: 'Configured models are discovered and wrapped automatically by default; use this section to narrow one provider to selected models, or to specify wrappers manually after disabling "Auto-wrap configured models". Each row = one provider + one model; leave the model empty to wrap every model on that route. The original route always remains available; native multimodal models keep direct image input and use vision tools only when useful. Applies immediately, no restart.',
+      textWrappedProviders: 'Manual model wrappers (optional)',
+      groupWrappers: 'Limit auto-vision scope manually (optional)',
+      textHintWrappedProviders: 'Usually leave this alone. Use it only after disabling automatic creation, or when only selected models should appear in a “+ Auto Vision” group: one `provider` wraps all models, while `provider/model1,model2` limits the set. Applies immediately; no restart.',
+      wrapHint: 'Usually no configuration is needed: enabled models from Settings → Models are discovered and wrapped automatically. Add rows here only to restrict one provider’s auto-vision scope, or after turning off automatic creation above. Empty model = every model on that route. The original model group always remains untouched. Applies immediately; no restart.',
       wrapAllModels: 'All models (empty = wrap all)',
-      addWrapper: '+ Add wrapper',
-      textProviders: 'Vision chain',
-      textProvidersHint: 'One "provider/model" per line, top-down failover; empty clears the override.',
+      addWrapper: '+ Add manual wrapper',
+      textProviders: 'Vision backend chain',
+      textProvidersHint: 'One genuinely image-capable "provider/model" per line, top-down failover. Do not put text-only models here. Empty clears the override.',
       textTextProvider: 'Text model',
       textTextProviderHint: 'Format "provider/model".',
     }
@@ -334,6 +352,11 @@ window.__ModuleLoader__.load({
       '.vr-chevron-open{transform:rotate(180deg)}' +
       '.vr-body{border-top:1px solid var(--dsw-alias-border-l2);margin:0 16px;padding-bottom:8px}' +
       '.vr-readOnly{color:var(--dsw-alias-label-tertiary);margin:12px 0 0;font-size:12px;line-height:1.5}' +
+      '.vr-quickstart{margin:12px 0 2px;padding:12px 14px;border:1px solid var(--dsw-alias-brand-primary);border-radius:10px;background:var(--dsw-alias-bg-module-platform);display:flex;flex-direction:column;gap:5px}' +
+      '.vr-quickstart-title{color:var(--dsw-alias-label-primary);font-size:13px;font-weight:650;line-height:1.5}' +
+      '.vr-quickstart-body,.vr-quickstart-live{margin:0;font-size:12px;line-height:1.6}' +
+      '.vr-quickstart-body{color:var(--dsw-alias-label-secondary)}' +
+      '.vr-quickstart-live{color:var(--dsw-alias-brand-primary)}' +
       '.vr-field{flex-direction:column;gap:6px;padding:12px 0;display:flex}' +
       '.vr-field + .vr-field{border-top:1px solid var(--dsw-alias-border-l2)}' +
       '.vr-field-head{align-items:center;gap:8px;display:flex}' +
@@ -365,7 +388,20 @@ window.__ModuleLoader__.load({
       '.vr-btn:hover:not(:disabled){color:var(--dsw-alias-label-primary);border-color:var(--dsw-alias-label-dimmed)}' +
       '.vr-btn-save{background:var(--dsw-alias-label-primary);color:var(--dsw-alias-bg-layer-3);border-color:#0000}' +
       '.vr-btn:disabled{opacity:.4;cursor:default}' +
-      '.vr-btn:focus-visible{outline:2px solid var(--dsw-alias-brand-primary);outline-offset:1px}'
+      '.vr-btn:focus-visible{outline:2px solid var(--dsw-alias-brand-primary);outline-offset:1px}' +
+      '.vr-onboarding-backdrop{position:fixed;inset:0;z-index:10000;background:#0006;display:flex;align-items:center;justify-content:center;padding:24px;box-sizing:border-box}' +
+      '.vr-onboarding-dialog{position:relative;width:min(480px,100%);box-sizing:border-box;border:1px solid var(--dsw-alias-border-l2);border-radius:16px;background:var(--dsw-alias-bg-layer-2);box-shadow:0 18px 60px #0005;padding:22px;display:flex;flex-direction:column;gap:12px;color:var(--dsw-alias-label-primary)}' +
+      '.vr-onboarding-title{margin:0;padding-right:32px;font-size:18px;font-weight:700;line-height:1.4}' +
+      '.vr-onboarding-text{margin:0;color:var(--dsw-alias-label-secondary);font-size:14px;line-height:1.65}' +
+      '.vr-onboarding-example{display:flex;align-items:center;gap:9px;flex-wrap:wrap;border:1px solid var(--dsw-alias-border-l2);border-radius:10px;background:var(--dsw-alias-bg-layer-3);padding:10px 12px;font-size:13px}' +
+      '.vr-onboarding-example-label{color:var(--dsw-alias-label-tertiary)}' +
+      '.vr-onboarding-example-value{font-weight:650;color:var(--dsw-alias-brand-primary)}' +
+      '.vr-onboarding-close{position:absolute;top:12px;right:12px;appearance:none;border:0;background:none;color:var(--dsw-alias-label-tertiary);font:inherit;font-size:22px;line-height:1;cursor:pointer;padding:5px 8px;border-radius:8px}' +
+      '.vr-onboarding-close:hover{background:var(--dsw-alias-bg-module-platform);color:var(--dsw-alias-label-primary)}' +
+      '.vr-onboarding-actions{display:flex;justify-content:flex-end;padding-top:2px}' +
+      '.vr-onboarding-primary{appearance:none;border:0;border-radius:9px;background:var(--dsw-alias-label-primary);color:var(--dsw-alias-bg-layer-3);font:inherit;font-size:14px;font-weight:600;cursor:pointer;padding:8px 18px}' +
+      '.vr-onboarding-primary:focus-visible,.vr-onboarding-close:focus-visible{outline:2px solid var(--dsw-alias-brand-primary);outline-offset:2px}' +
+      '@media(max-width:640px){.vr-onboarding-backdrop{align-items:flex-end;padding:0}.vr-onboarding-dialog{width:100%;border-radius:16px 16px 0 0;padding:20px 18px max(20px,env(safe-area-inset-bottom))}}'
 
     let stylesInstalled = false
     function installStyles() {
@@ -379,6 +415,101 @@ window.__ModuleLoader__.load({
       return () => {
         tag.remove()
         stylesInstalled = false
+      }
+    }
+
+    const ONBOARDING_STORAGE_KEY = 'dsh-vision-router:onboarding:auto-vision-v1'
+    function installOnboarding(t) {
+      if (typeof document === 'undefined' || typeof window === 'undefined') return
+      try {
+        if (window.localStorage && window.localStorage.getItem(ONBOARDING_STORAGE_KEY) === 'seen') return
+      } catch {
+        // Privacy/storage restrictions should not prevent the guidance itself.
+      }
+
+      let overlay
+      let timer
+      const remember = () => {
+        try {
+          if (window.localStorage) window.localStorage.setItem(ONBOARDING_STORAGE_KEY, 'seen')
+        } catch {
+          // Best effort: the dialog can still be dismissed for this page load.
+        }
+      }
+      const onKeyDown = (event) => {
+        if (event && event.key === 'Escape') dismiss()
+      }
+      const dismiss = () => {
+        remember()
+        document.removeEventListener('keydown', onKeyDown)
+        if (overlay) overlay.remove()
+        overlay = undefined
+      }
+
+      timer = window.setTimeout(() => {
+        timer = undefined
+        if (!document.body) return
+
+        overlay = document.createElement('div')
+        overlay.className = 'vr-onboarding-backdrop'
+        overlay.setAttribute('role', 'presentation')
+
+        const dialog = document.createElement('div')
+        dialog.className = 'vr-onboarding-dialog'
+        dialog.setAttribute('role', 'dialog')
+        dialog.setAttribute('aria-modal', 'true')
+        dialog.setAttribute('aria-labelledby', 'vr-onboarding-title')
+
+        const title = document.createElement('h2')
+        title.id = 'vr-onboarding-title'
+        title.className = 'vr-onboarding-title'
+        title.textContent = t('onboardingTitle')
+
+        const body = document.createElement('p')
+        body.className = 'vr-onboarding-text'
+        body.textContent = t('onboardingBody')
+
+        const example = document.createElement('div')
+        example.className = 'vr-onboarding-example'
+        const exampleLabel = document.createElement('span')
+        exampleLabel.className = 'vr-onboarding-example-label'
+        exampleLabel.textContent = t('onboardingExampleLabel')
+        const exampleValue = document.createElement('span')
+        exampleValue.className = 'vr-onboarding-example-value'
+        exampleValue.textContent = t('onboardingExample')
+        example.append(exampleLabel, exampleValue)
+
+        const foot = document.createElement('p')
+        foot.className = 'vr-onboarding-text'
+        foot.textContent = t('onboardingFoot')
+
+        const close = document.createElement('button')
+        close.type = 'button'
+        close.className = 'vr-onboarding-close'
+        close.setAttribute('aria-label', t('onboardingClose'))
+        close.textContent = '×'
+        close.addEventListener('click', dismiss)
+
+        const actions = document.createElement('div')
+        actions.className = 'vr-onboarding-actions'
+        const primary = document.createElement('button')
+        primary.type = 'button'
+        primary.className = 'vr-onboarding-primary'
+        primary.textContent = t('onboardingGotIt')
+        primary.addEventListener('click', dismiss)
+        actions.appendChild(primary)
+
+        dialog.append(title, body, example, foot, close, actions)
+        overlay.appendChild(dialog)
+        document.body.appendChild(overlay)
+        document.addEventListener('keydown', onKeyDown)
+        primary.focus()
+      }, 650)
+
+      return () => {
+        if (timer !== undefined) window.clearTimeout(timer)
+        document.removeEventListener('keydown', onKeyDown)
+        if (overlay) overlay.remove()
       }
     }
 
@@ -964,6 +1095,11 @@ window.__ModuleLoader__.load({
         open
           ? h('div', { className: 'vr-body' },
               !writable ? h('p', { className: 'vr-readOnly' }, t('readOnly')) : null,
+              h('div', { className: 'vr-quickstart' },
+                h('div', { className: 'vr-quickstart-title' }, t('quickStartTitle')),
+                h('p', { className: 'vr-quickstart-body' }, t('quickStartBody')),
+                h('p', { className: 'vr-quickstart-live' }, t('quickStartLive')),
+              ),
               TOGGLE_KEYS.map((key) => toggleField(key)),
               stealthNotice(),
               h('div', { className: 'vr-group' },
@@ -1158,6 +1294,7 @@ window.__ModuleLoader__.load({
         }
       }
       ctx.effect(installStyles, 'vision-router: card styles')
+      ctx.effect(() => installOnboarding(t), 'vision-router: first-run onboarding')
       ctx.effect(
         () =>
           ctx.slots.inject('settings.plugin.item', function* () {


### PR DESCRIPTION
## Summary
- show a one-time onboarding dialog explaining that image turns require selecting the lower-right `+ 自动识图 / + Auto Vision` model group
- add a persistent quick-start callout and rewrite settings copy so auto-wrap vs manual scope is obvious
- clarify the vision chain as the actual image-capable backend chain and warn against text-only fallbacks
- rewrite the Chinese and English quick-start docs around the real model-picker flow and hot-update behavior

## Behavior
- no routing/runtime semantics changed
- original model groups remain untouched
- model/wrapper catalog changes still hot-update without restart
- only initial plugin loading into an already-running long-lived Web process may require reloading that process

## Validation
- CI