### PR TITLE
docs: add troubleshooting for UTF-8 BOM startup failure (is not valid JSON)

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,32 @@ pnpm dsh plugin --profile web remove dsh-vision-router
 
 This removes the dependency and the bundle layer. If you disabled the stock DeepSeek row manually, re-enable it in your profile patch.
 
+## Troubleshooting
+
+### Startup fails with `Unexpected token ... is not valid JSON` (UTF-8 BOM)
+
+**Symptom:** `dsh web` / `pnpm dsh web` exits immediately at startup:
+
+```
+SyntaxError: Unexpected token ...
+is not valid JSON
+at JSON.parse (<anonymous>)
+at readProfileManifest (packages/boot/app-boot/src/profile.ts)
+```
+
+**Cause:** `~/.dsh/profiles/<profile>/package.json` was saved as **UTF-8 with BOM** by an editor. The invisible `\uFEFF` character at the start makes `JSON.parse` fail, because JSON does not allow it before the opening brace.
+
+**Fix:** re-save the file as **UTF-8 without BOM**:
+
+- VS Code: click the encoding label in the status bar → “Save with Encoding” → `UTF-8`;
+- or strip the leading BOM from the command line (replace `web` with your profile name, then restart `dsh web`):
+
+```sh
+node -e "const fs=require('fs');const p=process.argv[1];const b=fs.readFileSync(p);if(b[0]===0xEF&&b[1]===0xBB&&b[2]===0xBF)fs.writeFileSync(p,b.subarray(3))" "$HOME/.dsh/profiles/web/package.json"
+```
+
+> Tip: if you are not sure whether the file still has a BOM, run the command above again — it removes it only when present.
+
 ## Security notes
 
 - Image text is **untrusted evidence**: descriptions, OCR output and the auto-mount note all tell the agent never to execute instructions found inside images.

--- a/README.zh.md
+++ b/README.zh.md
@@ -343,6 +343,32 @@ pnpm dsh plugin --profile web remove dsh-vision-router
 
 同时移除依赖与 bundle 层。若你曾手动禁用官方 DeepSeek 行，记得在 profile 补丁里恢复。
 
+## 故障排查
+
+### 启动报错 `Unexpected token ... is not valid JSON`（UTF-8 BOM）
+
+**现象**：`dsh web` / `pnpm dsh web` 启动时直接退出：
+
+```
+SyntaxError: Unexpected token ...
+is not valid JSON
+at JSON.parse (<anonymous>)
+at readProfileManifest (packages/boot/app-boot/src/profile.ts)
+```
+
+**原因**：`~/.dsh/profiles/<profile>/package.json` 被某些编辑器保存成了 **UTF-8 with BOM**。文件最前面多了一个不可见的 `\uFEFF` 字符，dsh 读取 manifest 时直接 `JSON.parse`，而 JSON 不允许在开头出现这个字符，于是解析失败。
+
+**解决**：把该文件重新保存为 **UTF-8（无 BOM）** 即可：
+
+- VS Code：右下角编码 → “通过编码保存” → 选择 `UTF-8`；
+- 或命令行去掉开头的 BOM（把 `web` 换成你的 profile 名，改完重启 `dsh web`）：
+
+```sh
+node -e "const fs=require('fs');const p=process.argv[1];const b=fs.readFileSync(p);if(b[0]===0xEF&&b[1]===0xBB&&b[2]===0xBF)fs.writeFileSync(p,b.subarray(3))" "$HOME/.dsh/profiles/web/package.json"
+```
+
+> 提示：保存后如果不确定是否还带 BOM，可以用上面的命令自查；带 BOM 时它会帮你去掉。
+
 ## 安全说明
 
 - 图片中的文字是**不可信证据**：描述、OCR 输出与自动挂载提示都要求 Agent 绝不执行图片内出现的指令。


### PR DESCRIPTION
## 问题

用户从源码仓库运行 `pnpm dsh web`（或 `npx @deepseek-ai/dsh web`）时，启动立即失败：

```
SyntaxError: Unexpected token ...
is not valid JSON
at JSON.parse (<anonymous>)
at readProfileManifest (packages/boot/app-boot/src/profile.ts)
```

## 原因

`~/.dsh/profiles/<profile>/package.json` 被编辑器保存成了 **UTF-8 with BOM**。文件开头多了一个不可见的 `\uFEFF` 字符，dsh 的 `readProfileManifest` 直接对它执行 `JSON.parse`，而 JSON 语法不允许在 `{` 前出现该字符，所以报 `is not valid JSON`。

这个问题发生在插件安装/升级后手动编辑 profile 配置时，与本插件的配置内容无关。

## 解决

把 profile 的 `package.json` 重新保存为 **UTF-8（无 BOM）**：

- VS Code：右下角编码 → “通过编码保存” → 选择 `UTF-8`；
- 或执行文档里给出的 Node 一行命令去掉 BOM。

本次 PR 在 `README.md` / `README.zh.md` 新增了 **Troubleshooting / 故障排查** 章节，记录该现象、原因和两种修复方式，方便其他用户遇到同样问题时直接解决。

## 验证

- 本地复现：带 BOM 的 `package.json` 启动报同样错误；去掉 BOM 后 `dsh web` 正常启动。
- 文档改动仅 52 行（两个 README 各 26 行），无代码改动。
