### PR TITLE
feat: add standalone doctor and BOM repair CLI

### DIFF
--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -1,0 +1,52 @@
+# Vision Router doctor / repair
+
+Vision Router ships a small standalone diagnostic CLI. It does not need DSH to boot first, so it can still run when DSH exits while parsing a broken profile manifest.
+
+## Normal installation stays unchanged
+
+Use DSH's own plugin command:
+
+```sh
+npx @deepseek-ai/dsh plugin --profile web add dsh-vision-router
+npx @deepseek-ai/dsh web
+```
+
+For a DeepSeek Harness source checkout:
+
+```sh
+pnpm dsh plugin --profile web add dsh-vision-router
+pnpm dsh web
+```
+
+The doctor is a recovery/diagnostic tool, not a replacement installer.
+
+## Diagnose profiles
+
+```sh
+npx dsh-vision-router doctor
+```
+
+To inspect only the Web profile:
+
+```sh
+npx dsh-vision-router doctor --profile web
+```
+
+The command locates the DSH home (`$DSH_HOME` when set, otherwise `~/.dsh`), scans profile `package.json` files, reports UTF-8 BOM bytes, validates the JSON after ignoring a leading BOM for diagnosis, and reports whether `dsh-vision-router` is present as a profile dependency and bundle layer.
+
+## Repair the UTF-8 BOM startup failure
+
+If DSH fails before plugins can load with an error such as:
+
+```text
+SyntaxError: Unexpected token ... is not valid JSON
+at readProfileManifest (.../profile.ts:...)
+```
+
+run:
+
+```sh
+npx dsh-vision-router repair --profile web
+```
+
+`repair` removes only the three-byte UTF-8 BOM prefix (`EF BB BF`) when it is present, then validates the remaining JSON. It does not reformat, regenerate, or otherwise rewrite the profile contents. If JSON is still invalid for another reason, the command reports that and stops rather than guessing a repair.

--- a/lib/doctor-cli.js
+++ b/lib/doctor-cli.js
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+
+import { pathToFileURL } from 'node:url'
+import { doctorProfiles, resolveDshHome } from './doctor.js'
+
+function usage() {
+  return `dsh-vision-router doctor [--profile <name>] [--fix]\ndsh-vision-router repair [--profile <name>]\n\nChecks DSH profile manifests even when DSH itself cannot boot.\n\nCommands:\n  doctor   Diagnose profile package.json files.\n  repair   Diagnose and safely remove a leading UTF-8 BOM.\n\nOptions:\n  --profile <name>  Check only one profile (for example: web).\n  --fix             With doctor, remove a leading UTF-8 BOM when found.\n  --help            Show this help.\n`
+}
+
+function parseArgs(argv) {
+  const args = [...argv]
+  let command = 'doctor'
+  if (args[0] && !args[0].startsWith('-')) command = args.shift()
+  let profile
+  let fix = command === 'repair'
+
+  for (let index = 0; index < args.length; index += 1) {
+    const value = args[index]
+    if (value === '--help' || value === '-h') return { help: true }
+    if (value === '--fix') {
+      fix = true
+      continue
+    }
+    if (value === '--profile') {
+      profile = args[index + 1]
+      index += 1
+      if (!profile) throw new Error('--profile requires a name')
+      continue
+    }
+    if (value.startsWith('--profile=')) {
+      profile = value.slice('--profile='.length)
+      if (!profile) throw new Error('--profile requires a name')
+      continue
+    }
+    throw new Error(`unknown argument: ${value}`)
+  }
+
+  if (command !== 'doctor' && command !== 'repair') {
+    throw new Error(`unknown command: ${command}`)
+  }
+  if (profile && (!/^[A-Za-z0-9._-]+$/.test(profile) || profile === '.' || profile === '..')) {
+    throw new Error(`invalid profile name: ${profile}`)
+  }
+  return { command, profile, fix }
+}
+
+function statusLine(profile) {
+  const prefix = profile.validJson ? '✓' : '✗'
+  const parts = [`${prefix} ${profile.name}`]
+  if (!profile.exists) {
+    parts.push('package.json not found')
+    return parts.join(' — ')
+  }
+  if (profile.hasBom) {
+    parts.push(profile.repaired ? 'UTF-8 BOM removed' : 'UTF-8 BOM detected')
+  } else {
+    parts.push('no BOM')
+  }
+  parts.push(profile.validJson ? 'JSON valid' : `JSON invalid: ${profile.jsonError}`)
+  if (profile.validJson) {
+    parts.push(profile.pluginDependency ? `dependency ${profile.pluginDependency}` : 'Vision Router dependency not present')
+    parts.push(profile.pluginBundle ? 'bundle registered' : 'bundle not registered')
+  }
+  return parts.join(' — ')
+}
+
+export function run(argv = process.argv.slice(2), io = console, env = process.env) {
+  let options
+  try {
+    options = parseArgs(argv)
+  } catch (error) {
+    io.error(`dsh-vision-router: ${error instanceof Error ? error.message : String(error)}`)
+    io.error(usage().trimEnd())
+    return 2
+  }
+
+  if (options.help) {
+    io.log(usage().trimEnd())
+    return 0
+  }
+
+  const dshHome = resolveDshHome(env)
+  let report
+  try {
+    report = doctorProfiles({ dshHome, profile: options.profile, fix: options.fix })
+  } catch (error) {
+    io.error(`dsh-vision-router: doctor failed: ${error instanceof Error ? error.message : String(error)}`)
+    return 1
+  }
+
+  io.log(`DSH home: ${report.dshHome}`)
+  if (report.profiles.length === 0) {
+    io.error('✗ No DSH profiles found.')
+    io.error('  Expected profiles under <DSH_HOME>/profiles. If you use a custom home, set DSH_HOME first.')
+    return 1
+  }
+
+  for (const profile of report.profiles) io.log(statusLine(profile))
+
+  const pendingBom = report.profiles.some((profile) => profile.hasBom && !profile.repaired)
+  if (pendingBom) {
+    io.log('Run `npx dsh-vision-router repair` to remove detected UTF-8 BOM bytes safely.')
+  }
+  if (report.profiles.some((profile) => !profile.validJson)) {
+    io.error('At least one profile is still invalid JSON. The repair command only removes a leading UTF-8 BOM; it does not rewrite other JSON content.')
+  }
+  return report.ok ? 0 : 1
+}
+
+const entry = process.argv[1]
+if (entry && import.meta.url === pathToFileURL(entry).href) {
+  process.exitCode = run()
+}

--- a/lib/doctor.js
+++ b/lib/doctor.js
@@ -1,0 +1,112 @@
+import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import path from 'node:path'
+
+const UTF8_BOM = Buffer.from([0xef, 0xbb, 0xbf])
+
+function expandHome(value, home = homedir()) {
+  if (value === '~') return home
+  if (value.startsWith('~/') || value.startsWith('~\\')) return path.join(home, value.slice(2))
+  return value
+}
+
+export function resolveDshHome(env = process.env, home = homedir()) {
+  const configured = typeof env?.DSH_HOME === 'string' ? env.DSH_HOME.trim() : ''
+  return path.resolve(expandHome(configured || path.join(home, '.dsh'), home))
+}
+
+export function hasUtf8Bom(buffer) {
+  return Buffer.isBuffer(buffer)
+    && buffer.length >= UTF8_BOM.length
+    && buffer[0] === UTF8_BOM[0]
+    && buffer[1] === UTF8_BOM[1]
+    && buffer[2] === UTF8_BOM[2]
+}
+
+export function inspectProfileManifest(manifestPath, { fix = false } = {}) {
+  const original = readFileSync(manifestPath)
+  const bom = hasUtf8Bom(original)
+  const bytes = bom ? original.subarray(UTF8_BOM.length) : original
+  let repaired = false
+
+  if (bom && fix) {
+    writeFileSync(manifestPath, bytes)
+    repaired = true
+  }
+
+  let manifest
+  let jsonError
+  try {
+    manifest = JSON.parse(bytes.toString('utf8'))
+  } catch (error) {
+    jsonError = error instanceof Error ? error.message : String(error)
+  }
+
+  const dependencies = manifest && typeof manifest === 'object' && !Array.isArray(manifest)
+    ? manifest.dependencies ?? {}
+    : {}
+  const bundles = manifest && typeof manifest === 'object' && !Array.isArray(manifest)
+    ? manifest.dsh?.profile?.bundles ?? []
+    : []
+
+  return {
+    path: manifestPath,
+    hasBom: bom,
+    repaired,
+    validJson: jsonError === undefined,
+    jsonError,
+    manifest,
+    pluginDependency: typeof dependencies?.['dsh-vision-router'] === 'string'
+      ? dependencies['dsh-vision-router']
+      : undefined,
+    pluginBundle: Array.isArray(bundles) && bundles.includes('dsh-vision-router'),
+  }
+}
+
+export function listProfileNames(dshHome, requestedProfile) {
+  if (requestedProfile) return [requestedProfile]
+  const profilesDir = path.join(dshHome, 'profiles')
+  if (!existsSync(profilesDir)) return []
+  return readdirSync(profilesDir)
+    .filter((name) => {
+      const full = path.join(profilesDir, name)
+      try {
+        return statSync(full).isDirectory()
+      } catch {
+        return false
+      }
+    })
+    .sort()
+}
+
+export function doctorProfiles({
+  dshHome = resolveDshHome(),
+  profile,
+  fix = false,
+} = {}) {
+  const names = listProfileNames(dshHome, profile)
+  const profiles = []
+
+  for (const name of names) {
+    const manifestPath = path.join(dshHome, 'profiles', name, 'package.json')
+    if (!existsSync(manifestPath)) {
+      profiles.push({
+        name,
+        path: manifestPath,
+        exists: false,
+        validJson: false,
+        jsonError: 'profile package.json does not exist',
+      })
+      continue
+    }
+    profiles.push({ name, exists: true, ...inspectProfileManifest(manifestPath, { fix }) })
+  }
+
+  return {
+    dshHome,
+    requestedProfile: profile,
+    fix,
+    profiles,
+    ok: profiles.length > 0 && profiles.every((item) => item.exists && item.validJson),
+  }
+}

--- a/lib/doctor.js
+++ b/lib/doctor.js
@@ -107,6 +107,7 @@ export function doctorProfiles({
     requestedProfile: profile,
     fix,
     profiles,
-    ok: profiles.length > 0 && profiles.every((item) => item.exists && item.validJson),
+    ok: profiles.length > 0 && profiles.every((item) =>
+      item.exists && item.validJson && (!item.hasBom || item.repaired)),
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
   "homepage": "https://github.com/ysr666/dsh-vision-router",
   "type": "module",
   "main": "index.js",
+  "bin": {
+    "dsh-vision-router": "./lib/doctor-cli.js"
+  },
   "exports": {
     ".": "./index.js",
     "./client": "./lib/client.js",
@@ -58,7 +61,7 @@
     "sharp": "^0.35.3"
   },
   "scripts": {
-    "test": "node --test tests/core.test.js tests/client.test.js tests/http-compat.test.js tests/update-check.test.js tests/self-update.test.js"
+    "test": "node --test tests/core.test.js tests/client.test.js tests/http-compat.test.js tests/update-check.test.js tests/self-update.test.js tests/doctor.test.js"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/tests/doctor.test.js
+++ b/tests/doctor.test.js
@@ -1,0 +1,83 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { doctorProfiles, hasUtf8Bom, inspectProfileManifest, resolveDshHome } from '../lib/doctor.js'
+
+function fixture(manifestText, { profile = 'web' } = {}) {
+  const home = mkdtempSync(path.join(tmpdir(), 'dsh-doctor-'))
+  const dir = path.join(home, 'profiles', profile)
+  mkdirSync(dir, { recursive: true })
+  const manifestPath = path.join(dir, 'package.json')
+  writeFileSync(manifestPath, manifestText)
+  return { home, dir, manifestPath }
+}
+
+const validManifest = JSON.stringify({
+  name: 'dsh-profile-web',
+  dependencies: { 'dsh-vision-router': 'github:ysr666/dsh-vision-router' },
+  dsh: { profile: { bundles: ['@deepseek-ai/dsh-base', 'dsh-vision-router'] } },
+}, null, 2) + '\n'
+
+test('hasUtf8Bom recognizes only the UTF-8 BOM prefix', () => {
+  assert.equal(hasUtf8Bom(Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), Buffer.from('{}')])), true)
+  assert.equal(hasUtf8Bom(Buffer.from('{}')), false)
+  assert.equal(hasUtf8Bom(Buffer.from([0xef, 0xbb])), false)
+})
+
+test('inspectProfileManifest diagnoses BOM without mutating by default', () => {
+  const original = Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), Buffer.from(validManifest)])
+  const { manifestPath } = fixture(original)
+  const result = inspectProfileManifest(manifestPath)
+  assert.equal(result.hasBom, true)
+  assert.equal(result.repaired, false)
+  assert.equal(result.validJson, true)
+  assert.equal(result.pluginDependency, 'github:ysr666/dsh-vision-router')
+  assert.equal(result.pluginBundle, true)
+  assert.deepEqual(readFileSync(manifestPath), original)
+})
+
+test('inspectProfileManifest repair removes only the leading BOM', () => {
+  const { manifestPath } = fixture(Buffer.concat([
+    Buffer.from([0xef, 0xbb, 0xbf]),
+    Buffer.from(validManifest),
+  ]))
+  const result = inspectProfileManifest(manifestPath, { fix: true })
+  assert.equal(result.hasBom, true)
+  assert.equal(result.repaired, true)
+  assert.equal(result.validJson, true)
+  assert.equal(readFileSync(manifestPath, 'utf8'), validManifest)
+})
+
+test('repair does not paper over non-BOM JSON errors', () => {
+  const broken = '{"name":"web", trailing}\n'
+  const { manifestPath } = fixture(Buffer.concat([
+    Buffer.from([0xef, 0xbb, 0xbf]),
+    Buffer.from(broken),
+  ]))
+  const result = inspectProfileManifest(manifestPath, { fix: true })
+  assert.equal(result.repaired, true)
+  assert.equal(result.validJson, false)
+  assert.equal(readFileSync(manifestPath, 'utf8'), broken)
+})
+
+test('doctorProfiles can scan all profiles or a requested profile', () => {
+  const first = fixture(validManifest)
+  const secondDir = path.join(first.home, 'profiles', 'headless')
+  mkdirSync(secondDir, { recursive: true })
+  writeFileSync(path.join(secondDir, 'package.json'), '{}\n')
+
+  const all = doctorProfiles({ dshHome: first.home })
+  assert.deepEqual(all.profiles.map((item) => item.name), ['headless', 'web'])
+  assert.equal(all.ok, true)
+
+  const one = doctorProfiles({ dshHome: first.home, profile: 'web' })
+  assert.deepEqual(one.profiles.map((item) => item.name), ['web'])
+})
+
+test('resolveDshHome respects DSH_HOME and expands tilde', () => {
+  const fakeHome = path.join(tmpdir(), 'doctor-home')
+  assert.equal(resolveDshHome({}, fakeHome), path.resolve(fakeHome, '.dsh'))
+  assert.equal(resolveDshHome({ DSH_HOME: '~/custom-dsh' }, fakeHome), path.resolve(fakeHome, 'custom-dsh'))
+})

--- a/tests/doctor.test.js
+++ b/tests/doctor.test.js
@@ -38,6 +38,21 @@ test('inspectProfileManifest diagnoses BOM without mutating by default', () => {
   assert.deepEqual(readFileSync(manifestPath), original)
 })
 
+test('doctor reports an unresolved BOM as unhealthy and repair clears it', () => {
+  const { home } = fixture(Buffer.concat([
+    Buffer.from([0xef, 0xbb, 0xbf]),
+    Buffer.from(validManifest),
+  ]))
+  const before = doctorProfiles({ dshHome: home, profile: 'web' })
+  assert.equal(before.profiles[0].validJson, true)
+  assert.equal(before.profiles[0].hasBom, true)
+  assert.equal(before.ok, false)
+
+  const after = doctorProfiles({ dshHome: home, profile: 'web', fix: true })
+  assert.equal(after.profiles[0].repaired, true)
+  assert.equal(after.ok, true)
+})
+
 test('inspectProfileManifest repair removes only the leading BOM', () => {
   const { manifestPath } = fixture(Buffer.concat([
     Buffer.from([0xef, 0xbb, 0xbf]),


### PR DESCRIPTION
## What changed

- Adds a standalone `dsh-vision-router` CLI that can run even when DSH itself cannot boot.
- `npx dsh-vision-router doctor` scans DSH profile manifests, detects UTF-8 BOM bytes, validates JSON, and reports whether Vision Router is present as a dependency/bundle.
- `npx dsh-vision-router repair --profile web` safely removes only a leading UTF-8 BOM (`EF BB BF`) and then re-validates the JSON.
- Honors `DSH_HOME`; otherwise uses `~/.dsh`.
- Keeps the normal installation path unchanged: `npx @deepseek-ai/dsh plugin --profile web add dsh-vision-router`.
- Preserves the update-check / one-click-update tests already on main and adds doctor regression coverage.

## Safety

`repair` only removes the three-byte UTF-8 BOM prefix. It does not reformat, regenerate, or guess repairs for other invalid JSON. If the remaining profile is still invalid, it reports the error and exits non-zero.

## Context

Rebased on current main after the update-check/self-update feature merged. Supersedes #57.