### PR TITLE
fix: resolve read_image re-upload attachment ids via the session event log (#72)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 每个版本的中英双语发布说明（GitHub Release 工作流从这里取对应版本的段落，发布前必须先写好本节）｜
 Bilingual (Chinese + English) release notes for every version — the GitHub Release workflow pulls the matching section from this file, so it must be filled in before tagging.
 
+## v1.2.2
+
+### 修复 / Fixed
+
+- **`read_image` 回挂的附件 id 现在可被 `vision_describe` / 像素工具解析**：此前插件只索引 `agent/pre-step` 消息流（inbox claim，仅含用户新消息）里的图片块，`read_image` 持久化为 `tool/result` 事件的图片永远进不了索引，文本模型拿到宿主公布的 `sha256:…` id 后调用 `vision_describe(attachmentIds=[…])` 报 `unknown attachment id`。现在索引改从会话事件日志（`session.events`）增量收集所有消息类事件（`user/message` / `assistant/message` / `tool/result`，含嵌套 tool-result）里的附件 ref，`lookupAttachment` 未命中时自动回退扫描，跨回合、跨进程恢复均可用。
+- **Attachment ids produced by `read_image` are now resolvable by `vision_describe` and the pixel tools**: the plugin used to index only image blocks from the `agent/pre-step` message stream (inbox claim — new user messages only), so images that `read_image` persists as `tool/result` events never entered the index, and a text-only model calling `vision_describe(attachmentIds=[…])` with the harness-announced `sha256:…` id failed with `unknown attachment id`. The index now collects attachment refs incrementally from the full session event log (`session.events` — `user/message` / `assistant/message` / `tool/result`, including nested tool-results), and `lookupAttachment` falls back to that scan on a miss, so ids resolve across turns and across process resumes.
+
 ## v1.2.1
 
 ### 修复 / Fixed

--- a/README.md
+++ b/README.md
@@ -28,9 +28,11 @@
 <p align="center">💬 <strong>QQ community group: 1105463028</strong></p>
 
 > [!WARNING]
-> 📌 **Announcement (v1.2.1)**
+> 📌 **Announcement (v1.2.2)**
 >
-> v1.2.1 hardens the pixel loop: all ten pixel tools now accept uploaded-image attachment ids directly (no more `cannot read …/sha256:…` round trips), artifact filenames carry collision-free fingerprints, `vision_ground` retries degenerate boxes, the model guide replays fully from step 1 (leaving the settings first), and the settings card scrolls smoothly even with hundreds of models per provider.
+> v1.2.2 fixes the last attachment-id gap: ids announced for images the host persisted itself — e.g. `read_image` re-uploads (`sha256:…`) — are now indexed from the session event log, so `vision_describe(attachmentIds=[…])` and every pixel tool resolve them exactly like user-uploaded ids (issue #72).
+>
+> v1.2.1 hardened the pixel loop: all ten pixel tools now accept uploaded-image attachment ids directly (no more `cannot read …/sha256:…` round trips), artifact filenames carry collision-free fingerprints, `vision_ground` retries degenerate boxes, the model guide replays fully from step 1 (leaving the settings first), and the settings card scrolls smoothly even with hundreds of models per provider.
 
 <p align="center">
   <img src="assets/vision-demo.gif" width="640" alt="Demo: paste an image, the agent locates the send button with vision_ground / vision_crop / vision_pixel_diff and answers with coordinates" />

--- a/index.js
+++ b/index.js
@@ -546,6 +546,52 @@ export function collectImageBlocks(messages) {
   return out
 }
 
+/**
+ * Collect distinct durable attachment refs from a session event log.
+ *
+ * The session event log is the only place that sees every image that entered
+ * the conversation, including host-produced ones such as `read_image`
+ * re-uploads, which are persisted as `tool/result` (or nested-dispatch
+ * `user/message`) events and never pass through the inbox-claim message stream
+ * a plugin sees on `agent/pre-step`. Extracting refs here — with full
+ * metadata, so `attachments.readImage` can verify the bytes — is what lets
+ * `vision_describe` / the pixel tools resolve ids the harness announced but
+ * the plugin never indexed.
+ *
+ * Handles the same message-producing event types the host surface derives
+ * (`user/message` carries the message directly; `assistant/message` and
+ * `tool/result` nest it under `data.message`) and descends into nested
+ * `tool-result` content exactly like `rewriteImageBlocks`.
+ *
+ * @param events - the session event log (`session.events`), or any array shaped like it.
+ * @returns distinct attachment refs in first-seen order.
+ */
+export function collectEventAttachmentRefs(events) {
+  const refs = []
+  const seen = new Set()
+  for (const event of events ?? []) {
+    if (!event || !event.data) continue
+    let message
+    if (event.type === 'user/message') {
+      message = event.data
+    } else if (event.type === 'assistant/message' || event.type === 'tool/result') {
+      message = event.data.message
+    } else {
+      continue
+    }
+    if (!message || !Array.isArray(message.content)) continue
+    rewriteImagesDeep(message.content, (block) => {
+      const attachment = block && block.attachment
+      if (attachment && attachment.attachmentId && !seen.has(String(attachment.attachmentId))) {
+        seen.add(String(attachment.attachmentId))
+        refs.push(attachment)
+      }
+      return block
+    })
+  }
+  return refs
+}
+
 /** Text blocks of the last user message, joined. */
 export function lastUserText(messages) {
   for (let i = (messages ?? []).length - 1; i >= 0; i--) {
@@ -2710,6 +2756,40 @@ export function apply(ctx, config = {}) {
     }
   }
 
+  // session id -> seq already scanned in that session's event log. Mirror of
+  // sessionAttachmentsById: the web host disables module-level HMR, so a
+  // session object is long-lived and only its id string survives a resume.
+  const scannedSessionSeqs = new Map()
+
+  /**
+   * Index image attachments recorded anywhere in the session event log, not
+   * just in the inbox-claim message stream `agent/pre-step` hands us.
+   *
+   * Host-produced images (e.g. the built-in `read_image` tool's re-uploads,
+   * persisted as `tool/result` events, or a nested dispatch's deferred
+   * `user/message`) never enter that stream, so the announced attachment id
+   * stayed unresolvable even though the harness UI showed the image and the
+   * bytes are durably stored. `session.events` is the complete append-only
+   * log (seeded from storage on resume), so scanning it — incrementally, per
+   * session id — finds every ref with full metadata.
+   */
+  const scanSessionEventLog = (session) => {
+    if (!session) return
+    let events
+    try {
+      events = session.events
+    } catch {
+      return // not a host Session (or the getter is unavailable): nothing to scan
+    }
+    if (!Array.isArray(events) || events.length === 0) return
+    const key = session.id !== undefined ? String(session.id) : undefined
+    const last = key !== undefined ? (scannedSessionSeqs.get(key) ?? 0) : 0
+    if (last >= events.length) return
+    const refs = collectEventAttachmentRefs(events.slice(last))
+    if (key !== undefined) scannedSessionSeqs.set(key, events.length)
+    if (refs.length > 0) recordUploadedAttachments(session, refs)
+  }
+
   const lookupAttachment = (session, id) => {
     const byId = session && session.id !== undefined
       ? sessionAttachmentsById.get(String(session.id))
@@ -2719,7 +2799,28 @@ export function apply(ctx, config = {}) {
       if (hit !== undefined) return hit
     }
     const map = session ? sessionAttachments.get(session) : undefined
-    return map ? map.get(String(id)) : undefined
+    const hit = map ? map.get(String(id)) : undefined
+    if (hit !== undefined) return hit
+    // Miss: fall back to the session event log. Ids announced by the harness
+    // for images it persisted itself (read_image re-uploads) live there even
+    // though they never crossed the inbox-claim stream, so this resolves them
+    // exactly like user-uploaded ids. Ref data from the log carries full
+    // metadata, so a later attachments.readImage(ref) verifies and returns
+    // the bytes.
+    if (session !== undefined) {
+      scanSessionEventLog(session)
+      const afterById = session.id !== undefined
+        ? sessionAttachmentsById.get(String(session.id))
+        : undefined
+      if (afterById !== undefined) {
+        const after = afterById.get(String(id))
+        if (after !== undefined) return after
+      }
+      const afterMap = sessionAttachments.get(session)
+      const afterHit = afterMap ? afterMap.get(String(id)) : undefined
+      if (afterHit !== undefined) return afterHit
+    }
+    return undefined
   }
 
   // session -> { turn, startIndex, hasImage, routed, failures, lastError }
@@ -2735,6 +2836,10 @@ export function apply(ctx, config = {}) {
     // sanitized. This preserves attachment lookup for a later vision_describe.
     const rawImageRefs = rewriteImageBlocks(rawMessages)
     recordUploadedAttachments(session, rawImageRefs.attachments)
+    // Also index image attachments that live only in the session event log
+    // (read_image re-uploads and other host-produced images never cross the
+    // inbox-claim message stream). Incremental: scans only new events.
+    scanSessionEventLog(session)
     // Hard invariant: tool-produced image blocks never reach a model request.
     // This is deliberately route-agnostic, because merely having a wrapper
     // registered does not prove that the current request is actually using it.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-vision-router",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Eyes for text-only DeepSeek Harness agents: built-in free vision chain (no key) + pixel-level vision tools (Q&A, grounding, crop, pixel diff, colors, OCR, SVG trace, cutout, screenshots). One-command install, no Python, image turns work like ordinary tool-calling turns.",
   "license": "MIT",
   "repository": {

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -21,6 +21,7 @@ import {
   providersOf,
   rewriteImageBlocks,
   rewriteImagesDeep,
+  collectEventAttachmentRefs,
   sanitizeToolResultImages,
   renderVisionPresent,
   extractJson,
@@ -2072,4 +2073,105 @@ test('artifactStemOf keeps long content-addressed inputs distinct', () => {
   // Stable for the same input, different for different suffixes.
   assert.equal(artifactStemOf(upload, 'ground'), groundUpload)
   assert.notEqual(artifactStemOf(upload, 'ground'), artifactStemOf(upload, 'detect'))
+})
+
+test('collectEventAttachmentRefs gathers refs from every message-producing event', () => {
+  const uploadRef = {
+    attachmentId: 'sha256:295be0356ade856a977e7afea9bae37cf91e405e2f01dad6f09fefcc2f2ab7ab',
+    mediaType: 'image/png',
+    bytes: 123,
+    width: 10,
+    height: 20,
+    name: 'sample.png',
+  }
+  const toolRef = {
+    attachmentId: 'sha256:af672871af2edbed961b8280e0b527efff2501afce39d96391be60cefdf4cfa2',
+    mediaType: 'image/jpeg',
+    bytes: 456,
+    width: 30,
+    height: 40,
+    name: 'photo.jpg',
+  }
+  const nestedRef = {
+    attachmentId: 'sha256:92ecfeb1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    mediaType: 'image/webp',
+    bytes: 789,
+    width: 50,
+    height: 60,
+  }
+  const events = [
+    // user upload: message is the event data itself
+    { type: 'user/message', data: { role: 'user', content: [{ type: 'image', attachment: uploadRef }] } },
+    // assistant message nests under data.message
+    {
+      type: 'assistant/message',
+      data: { message: { role: 'assistant', content: [{ type: 'text', text: 'ok' }] } },
+    },
+    // tool/result from read_image: the image block may be nested in tool-result
+    {
+      type: 'tool/result',
+      data: {
+        message: {
+          role: 'tool',
+          content: [
+            { type: 'text', text: '<path>sample.png</path>' },
+            { type: 'tool-result', content: [{ type: 'image', attachment: toolRef }] },
+          ],
+        },
+      },
+    },
+    // plain text user message: no refs
+    { type: 'user/message', data: { role: 'user', content: [{ type: 'text', text: 'hi' }] } },
+    // duplicate id in a later event: only the first occurrence is kept
+    {
+      type: 'tool/result',
+      data: { message: { role: 'tool', content: [{ type: 'image', attachment: { ...toolRef, name: 'again.jpg' } }] } },
+    },
+    // nested tool-result image
+    {
+      type: 'tool/result',
+      data: {
+        message: {
+          role: 'tool',
+          content: [{ type: 'tool-result', content: [{ type: 'image', attachment: nestedRef }] }],
+        },
+      },
+    },
+    // non-message events are ignored
+    { type: 'turn/start', data: { turn: 1 } },
+    { type: 'agent/inbox/spliced', data: { inserted: [{ role: 'user', content: [{ type: 'image', attachment: uploadRef }] }] } },
+  ]
+  const refs = collectEventAttachmentRefs(events)
+  assert.equal(refs.length, 3)
+  assert.equal(refs[0].attachmentId, uploadRef.attachmentId)
+  assert.equal(refs[0].name, 'sample.png')
+  assert.equal(refs[1].attachmentId, toolRef.attachmentId)
+  // the first-seen ref wins over the later duplicate
+  assert.equal(refs[1].name, 'photo.jpg')
+  assert.equal(refs[2].attachmentId, nestedRef.attachmentId)
+  // full metadata survives, so attachments.readImage can verify the bytes
+  assert.deepEqual(
+    { mediaType: refs[1].mediaType, bytes: refs[1].bytes, width: refs[1].width, height: refs[1].height },
+    { mediaType: toolRef.mediaType, bytes: toolRef.bytes, width: toolRef.width, height: toolRef.height },
+  )
+})
+
+test('collectEventAttachmentRefs tolerates malformed and empty inputs', () => {
+  assert.deepEqual(collectEventAttachmentRefs(undefined), [])
+  assert.deepEqual(collectEventAttachmentRefs(null), [])
+  assert.deepEqual(collectEventAttachmentRefs([]), [])
+  assert.deepEqual(collectEventAttachmentRefs([null, {}, { data: null }, { type: 'turn/start', data: {} }]), [])
+  // a message whose content is missing or not an array is skipped
+  assert.deepEqual(
+    collectEventAttachmentRefs([
+      { type: 'tool/result', data: { message: { role: 'tool' } } },
+      { type: 'user/message', data: { role: 'user', content: 'not-an-array' } },
+    ]),
+    [],
+  )
+  // an image block without a usable attachment id is skipped
+  const noId = collectEventAttachmentRefs([
+    { type: 'user/message', data: { role: 'user', content: [{ type: 'image', attachment: { name: 'x.png' } }] } },
+  ])
+  assert.deepEqual(noId, [])
 })


### PR DESCRIPTION
## 修复 / Fixes

修复 #72：`read_image` 回挂的附件 id 无法被 `vision_describe` / 像素工具解析（`unknown attachment id`）。

Fixes #72: attachment ids produced by `read_image` re-uploads could not be resolved by `vision_describe` / the pixel tools (`unknown attachment id`).

## 根因 / Root cause

插件只在 `agent/pre-step` 通过 `rewriteImageBlocks(rawMessages)` 收集 inbox-claim 消息流（仅含用户新消息）里的图片块并写入 `recordUploadedAttachments`；`read_image` 的图片块作为 `tool/result` 会话事件持久化，从不经过该消息流，因此其附件 id 永远进不了索引——即使宿主已在会话中公布该 id、字节也已通过 `attachments.saveImage` 内容寻址落库。

The plugin only indexed image blocks from the inbox-claim message stream seen on `agent/pre-step` (new user messages only). `read_image` persists its image block as a `tool/result` session event, which never crosses that stream, so its attachment id never entered the index — even though the harness announced the id in the conversation and the bytes were durably committed via `attachments.saveImage` (content-addressed).

## 修复方案 / Fix

- 新增导出的纯函数 `collectEventAttachmentRefs(events)`：从会话事件日志提取所有消息类事件（`user/message` / `assistant/message` / `tool/result`，含嵌套 tool-result）里的图片附件 ref（带完整元数据，供 `attachments.readImage` 校验字节）。
- 新增 `scanSessionEventLog(session)`：按会话 id 增量扫描 `session.events`（宿主完整追加式事件日志，跨进程恢复时从存储 seed 完整还原），扫描过的 seq 会缓存避免重复扫描。
- `lookupAttachment` 未命中时自动回退到事件日志扫描——`vision_describe(attachmentIds)`、`vision_describe(paths=[id])` 及所有像素工具共享此路径，一处修复全覆盖。
- `agent/pre-step` 也预扫描事件日志，保持索引就绪。

- New exported pure helper `collectEventAttachmentRefs(events)`: extracts distinct image attachment refs (with full metadata, so `attachments.readImage` can verify the bytes) from every message-producing event (`user/message` / `assistant/message` / `tool/result`, including nested tool-result content).
- New `scanSessionEventLog(session)`: incrementally scans `session.events` (the host's complete append-only event log, fully restored from storage on resume) with a per-session scanned-seq cache.
- `lookupAttachment` now falls back to the event-log scan on a miss — `vision_describe(attachmentIds)`, `vision_describe(paths=[id])` and every pixel tool share this path, so one fix covers all of them.
- `agent/pre-step` also pre-scans the event log to keep the index warm.

## 测试 / Tests

- 新增 2 个回归测试（`tests/core.test.js`）：`collectEventAttachmentRefs` 从各类事件（含嵌套 tool-result、去重、畸形输入容错）正确提取 ref。
- 全套 151 个测试通过。
- 已在运行中的 DSH web（文本模型会话）实测复现 #72 场景：`read_image` 本地图片 → 用回挂的 `sha256:…` id 调 `vision_describe(attachmentIds=[…])` → ✅ 成功识别；用户上传 id 路径无回归。

- 2 new regression tests in `tests/core.test.js` covering event extraction (nested tool-results, dedup, malformed inputs).
- Full suite: 151 tests pass.
- Verified live against a running DSH web (text-only session): `read_image` a local image → `vision_describe(attachmentIds=[…])` with the re-uploaded `sha256:…` id → ✅ resolves; user-uploaded ids show no regression.

## 版本 / Version

bump to 1.2.2，CHANGELOG 与 README 公告已更新。