### PR TITLE
fix: read_image attachment ids, tool-result image session locks, stale-sharp detection (#72, #74, #75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 每个版本的中英双语发布说明（GitHub Release 工作流从这里取对应版本的段落，发布前必须先写好本节）｜
 Bilingual (Chinese + English) release notes for every version — the GitHub Release workflow pulls the matching section from this file, so it must be filled in before tagging.
 
+## v1.2.2
+
+### 修复 / Fixed
+
+- **`read_image` 回挂的附件 ID 现在可被解析（#72）**：此前插件只索引 `agent/pre-step` 消息流（inbox claim，仅含用户新消息）里的图片块，宿主 `read_image` 持久化为 `tool/result` 事件的图片永远进不了索引，文本模型拿到会话中公布的 `sha256:…` ID 后调用 `vision_describe(attachmentIds=[…])` 报 `unknown attachment id`。现在索引会增量扫描会话事件日志（`user/message` / `assistant/message` / `tool/result`，含嵌套 tool-result），`lookupAttachment` 未命中时自动回退，跨回合、跨进程恢复均可用。
+- **Attachment ids produced by `read_image` now resolve (#72)**: the plugin used to index only image blocks from the `agent/pre-step` inbox-claim stream, so images the host persisted as `tool/result` events never entered the index and `vision_describe(attachmentIds=[…])` failed with `unknown attachment id`. The index now incrementally scans the session event log, and `lookupAttachment` falls back to that scan on a miss — across turns and across process resumes.
+- **工具结果里的图像块不再锁死文本模型会话（#74）**：`vision_present`（以及任何在工具结果中渲染图像的宿主工具）会把图像块持久化进会话历史，此后每一次请求都带上它，文本适配器以 `UNSUPPORTED_CONTENT` 拒绝，会话永久锁死。现在插件用宿主的表面替换机制（`surfaceOp: replace`，与压缩剪枝同一机制）把这类事件的模型视图替换为文本标记——用户界面仍显示原图（界面渲染 append-origin 事件），只有模型输入被净化；已锁死的历史会话升级后发一条消息即可自愈。净化按路由判断（与宿主 `read_image` 的门禁判定一致）：能直接看图的视觉路由仍正常内联看到 `read_image` 的结果图。同时修复了图片轮自动挂载分支提前 return 导致路由状态未登记、图片请求落到文本模型被拒的问题。
+- **Tool-result image blocks no longer lock text-model sessions (#74)**: `vision_present` (and any host tool that renders an image into its result) persisted the image block into durable history, so every later request carried it and text-only adapters rejected the session forever with `UNSUPPORTED_CONTENT`. The plugin now rewrites the model-visible surface with sanitized replacements (`surfaceOp: replace` — the same mechanism the host compaction pruner uses): the Web UI keeps showing the image (it renders append-origin events), only the model input is sanitized, and already-locked sessions heal on the next message after upgrading. Sanitization is route-aware (mirroring the host's `read_image` gate), so image-capable routes still see `read_image` results inline. Also fixed the image-turn auto-mount branch returning early before the routing state was registered, which sent image requests to the text provider.
+- **检测升级残留的旧版 sharp（#75）**：`loadSharp()` 现在对照 `package.json` 的 `peerDependencies.sharp` 范围校验实际解析到的 sharp 版本，不满足时打印明确告警（残留版本 vs 期望范围 + 清理指引），把 `colourspace: parameter space not set` 这类玄学报错变成一眼可见的修复提示。纯诊断，不改变任何行为。
+- **Stale-sharp detection on upgrade (#75)**: `loadSharp()` now validates the resolved sharp against the `peerDependencies.sharp` range in `package.json` and warns with the stale version, the expected range, and cleanup guidance — turning the cryptic `colourspace: parameter space not set` into an actionable message. Diagnostics only, no behavior change.
+
+### 升级注意 / Upgrade notes
+
+- 从 v1.1.x 升级后若像素工具报 `colourspace: parameter space not set`：删除 profile 内残留的旧 sharp（`node_modules/sharp` 与 `node_modules/@img`）后重启，或在 profile 目录执行 `pnpm install` 重装。全新安装不受影响。
+- If pixel tools report `colourspace: parameter space not set` after upgrading from v1.1.x: delete the stale sharp in the profile (`node_modules/sharp` and `node_modules/@img`) and restart, or run `pnpm install` in the profile. Fresh installs are unaffected.
+
 ## v1.2.1
 
 ### 修复 / Fixed

--- a/README.md
+++ b/README.md
@@ -28,9 +28,11 @@
 <p align="center">💬 <strong>QQ community group: 1105463028</strong></p>
 
 > [!WARNING]
-> 📌 **Announcement (v1.2.1)**
+> 📌 **Announcement (v1.2.2)**
 >
-> v1.2.1 hardens the pixel loop: all eleven pixel tools now accept uploaded-image attachment ids directly (no more `cannot read …/sha256:…` round trips), artifact filenames carry collision-free fingerprints, `vision_ground` retries degenerate boxes, the model guide replays fully from step 1 (leaving the settings first), and the settings card scrolls smoothly even with hundreds of models per provider.
+> v1.2.2 closes the last attachment-id gap — ids announced for images the host persisted itself (e.g. `read_image` re-uploads, `sha256:…`) now resolve in `vision_describe` and every pixel tool (issue #72) — stops `vision_present` and other tool-result image blocks from ever locking a text-model session with `UNSUPPORTED_CONTENT` (issue #74; already-locked sessions heal after upgrading), and warns loudly when a stale sharp left over from a pre-v1.2 upgrade would break the pixel tools with `colourspace: parameter space not set` (issue #75).
+>
+> v1.2.1 hardened the pixel loop: all eleven pixel tools now accept uploaded-image attachment ids directly (no more `cannot read …/sha256:…` round trips), artifact filenames carry collision-free fingerprints, `vision_ground` retries degenerate boxes, the model guide replays fully from step 1 (leaving the settings first), and the settings card scrolls smoothly even with hundreds of models per provider.
 
 <p align="center">
   <img src="assets/vision-demo.gif" width="640" alt="Demo: paste an image, the agent locates the send button with vision_ground / vision_crop / vision_pixel_diff and answers with coordinates" />
@@ -339,6 +341,15 @@ Settings live in the profile's settings provider and survive upgrades.
 >   config:
 >     # your overrides …
 > ```
+
+> **After upgrading from v1.1.x, pixel tools fail with
+> `colourspace: parameter space not set`:** a stale sharp 0.34.0 from the
+> v1.1.0 era still sits in the profile and its libvips DLL conflicts with the
+> host's sharp 0.35.3 in the same process (issues #42 / #75). Delete
+> `~/.dsh/profiles/<profile>/node_modules/sharp` and
+> `~/.dsh/profiles/<profile>/node_modules/@img` and restart, or run
+> `pnpm install` inside the profile. Since v1.2.2 the plugin detects the
+> stale version at runtime and prints the same guidance itself.
 
 ### Uninstall
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -28,7 +28,9 @@
 <p align="center">💬 <strong>QQ 用户交流群：1105463028</strong></p>
 
 > [!WARNING]
-> 📌 **公告（v1.2.1）**
+> 📌 **公告（v1.2.2）**
+>
+> v1.2.2 现已支持：补上最后一处附件 ID 缺口——宿主 `read_image` 回挂图片公布的 `sha256:…` ID 现在可被 `vision_describe` 与全部像素工具解析（issue #72）；`vision_present` 等工具结果里的图像块不再把文本模型会话锁死在 `UNSUPPORTED_CONTENT`（issue #74，已锁死的历史会话升级后自动修复）；检测到 v1.1.x 升级残留的旧版 sharp 时明确告警，把玄学的 `colourspace` 报错变成一眼可见的修复指引（issue #75）。
 >
 > v1.2.1 加固像素闭环：十一个像素工具可直接接受上传图片的附件 ID（告别 `cannot read …/sha256:…` 的绕路），产物文件名带指纹不再互相覆盖，`vision_ground` 对退化框自动重试，模型引导支持从第 1 步完整重放（先退出设置页），设置卡片在数百模型目录下滚动依然流畅。
 
@@ -337,6 +339,14 @@ pnpm dsh plugin --profile web update dsh-vision-router
 >   config:
 >     # 你的配置…
 > ```
+
+> **从 v1.1.x 升级后像素工具报 `colourspace: parameter space not set`：**
+> 这是 v1.1.0 时代自带的 sharp 0.34.0 残留在 profile 里、与宿主 sharp 0.35.3
+> 同进程 DLL 冲突所致（issue #42 / #75）。删除
+> `~/.dsh/profiles/<profile>/node_modules/sharp` 与
+> `~/.dsh/profiles/<profile>/node_modules/@img` 后重启，或在 profile 目录执行
+> `pnpm install` 重装依赖即可。v1.2.2 起插件会在检测到残留版本时直接告警并
+> 给出同样的指引。
 
 ### 卸载
 

--- a/index.js
+++ b/index.js
@@ -40,10 +40,136 @@ import { createHash, randomBytes } from 'node:crypto'
 // lazily and cache the resolved factory so a sharp failure degrades only the
 // pixel-level tools — the routing chain and text tools keep working.
 let sharpPromise
+// Module-level warning sink installed by apply(): the plugin routes runtime
+// diagnostics through ctx.logger instead of console.warn. Kept as a plain
+// function slot so loadSharp() stays usable outside a Cordis context (tests,
+// the doctor CLI).
+let sharpWarningHook
+export function registerSharpWarningHook(hook) {
+  sharpWarningHook = typeof hook === 'function' ? hook : undefined
+}
+
+function warnSharp(message) {
+  if (sharpWarningHook !== undefined) {
+    try {
+      sharpWarningHook(message)
+      return
+    } catch {
+      /* fall through to console */
+    }
+  }
+  if (typeof console !== 'undefined' && typeof console.warn === 'function') console.warn(message)
+}
+
+/** Split "1.2.3" / "1.2" / "1" / "1.2.3-beta.4" into comparable parts
+ * (missing minor/patch default to 0, like semver). */
+export function parseVersionParts(version) {
+  const match = String(version ?? '').trim().match(/^(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:-([0-9A-Za-z.-]+))?$/)
+  if (!match) return undefined
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2] ?? 0),
+    patch: Number(match[3] ?? 0),
+    pre: match[4],
+  }
+}
+
+function compareVersionParts(a, b) {
+  if (a.major !== b.major) return a.major < b.major ? -1 : 1
+  if (a.minor !== b.minor) return a.minor < b.minor ? -1 : 1
+  if (a.patch !== b.patch) return a.patch < b.patch ? -1 : 1
+  // A prerelease sorts below its release: 0.35.3-beta < 0.35.3.
+  if (a.pre === undefined && b.pre === undefined) return 0
+  if (a.pre === undefined) return 1
+  if (b.pre === undefined) return -1
+  return a.pre < b.pre ? -1 : a.pre > b.pre ? 1 : 0
+}
+
+/**
+ * Minimal semver range check for the comparator shapes the plugin itself
+ * declares (`>=0.35.3 <1`, space-separated clauses, `||` alternatives).
+ * @returns true when `version` satisfies `range`, false otherwise (also for
+ * malformed inputs, so an unparsable range fails safe and loud).
+ */
+export function versionSatisfies(version, range) {
+  const parts = parseVersionParts(version)
+  if (parts === undefined) return false
+  const alternatives = String(range ?? '')
+    .split('||')
+    .map((alt) => alt.trim())
+    .filter((alt) => alt !== '')
+  if (alternatives.length === 0) return false
+  return alternatives.some((alternative) => {
+    const clauses = alternative.split(/\s+/)
+    if (clauses.length === 0) return false
+    return clauses.every((clause) => {
+      const match = clause.match(/^(>=|<=|>|<|=)?\s*(.+)$/)
+      if (!match) return false
+      const op = match[1] ?? '='
+      const other = parseVersionParts(match[2])
+      if (other === undefined) return false
+      const cmp = compareVersionParts(parts, other)
+      switch (op) {
+        case '>=': return cmp >= 0
+        case '<=': return cmp <= 0
+        case '>': return cmp > 0
+        case '<': return cmp < 0
+        default: return cmp === 0
+      }
+    })
+  })
+}
+
+// Read the plugin's own peerDependencies.sharp range from the installed
+// package.json (createRequire resolves it relative to this file, so the value
+// is never hardcoded and follows package.json through releases).
+let sharpPeerRangeCache
+function sharpPeerRange() {
+  if (sharpPeerRangeCache === undefined) {
+    try {
+      const requireLocal = createRequire(import.meta.url)
+      const pkg = requireLocal('./package.json')
+      sharpPeerRangeCache =
+        pkg && pkg.peerDependencies && typeof pkg.peerDependencies.sharp === 'string'
+          ? pkg.peerDependencies.sharp
+          : undefined
+    } catch {
+      sharpPeerRangeCache = undefined
+    }
+  }
+  return sharpPeerRangeCache
+}
+
 function loadSharp() {
   if (!sharpPromise) {
     sharpPromise = import('sharp')
-      .then((mod) => mod.default ?? mod)
+      .then((mod) => {
+        const sharp = mod.default ?? mod
+        // issue #75: an upgrade from v1.1.x can leave a stale sharp 0.34.0 in
+        // the profile's node_modules; pnpm does not physically remove orphaned
+        // peer copies on upgrade. On Windows the stale copy's libvips DLL and
+        // the host's coexist in one process and every pixel tool then dies
+        // with the cryptic "colourspace: parameter space not set". Detect the
+        // violation up front and turn it into an actionable warning.
+        try {
+          const version = sharp && sharp.versions && typeof sharp.versions.sharp === 'string'
+            ? sharp.versions.sharp
+            : undefined
+          const range = sharpPeerRange()
+          if (version !== undefined && range !== undefined && !versionSatisfies(version, range)) {
+            warnSharp(
+              `dsh-vision-router: the resolved sharp ${version} does not satisfy the plugin peer range "${range}". ` +
+                'This is usually a stale sharp left in the profile from a pre-v1.2 upgrade: remove ' +
+                '`<profile>/node_modules/sharp` and `<profile>/node_modules/@img` (or run `pnpm install` in the profile) ' +
+                'and restart, so the plugin falls through to the host sharp. Until then, pixel tools may fail with ' +
+                '"colourspace: parameter space not set".',
+            )
+          }
+        } catch {
+          /* diagnostics must never break the pixel tools */
+        }
+        return sharp
+      })
       .catch((cause) => {
         sharpPromise = undefined // allow a retry after the environment is repaired
         const error = new Error(
@@ -397,27 +523,98 @@ export function renderVisionPresent(value) {
   ]
 }
 
+/** Text marker replacing a tool-produced image block (shared by the pre-step
+ * inbox sanitizer and the session-surface shadow sanitizer). */
+export function toolImageMarker(block) {
+  const attachment = block && block.attachment ? block.attachment : {}
+  const id = attachment.attachmentId || attachment.id || 'unknown'
+  const name = attachment.name || 'tool image'
+  return {
+    type: 'text',
+    text:
+      `[tool result produced image "${name}", attachment id "${id}". ` +
+      `The image was kept out of the text-model request to prevent session corruption. ` +
+      `To inspect it, call vision_describe with attachmentIds: ["${id}"] when available, ` +
+      'or use a path-based vision tool. To show a generated image to the user, use vision_present instead of read_image.]',
+  }
+}
+
 export function sanitizeToolResultImages(messages) {
   let anyChanged = false
   const rewritten = (messages ?? []).map((message) => {
     if (!message || !Array.isArray(message.content)) return message
-    const result = rewriteToolResultImages(message.content, (block) => {
-      const attachment = block.attachment || {}
-      const id = attachment.attachmentId || attachment.id || 'unknown'
-      const name = attachment.name || 'tool image'
-      return {
-        type: 'text',
-        text:
-          `[tool result produced image "${name}", attachment id "${id}". ` +
-          `The image was kept out of the text-model request to prevent session corruption. ` +
-          `To inspect it, call vision_describe with attachmentIds: ["${id}"] when available, ` +
-          'or use a path-based vision tool. To show a generated image to the user, use vision_present instead of read_image.]',
-      }
-    })
+    const result = rewriteToolResultImages(message.content, toolImageMarker)
     if (result.changed) anyChanged = true
     return result.changed ? { ...message, content: result.content } : message
   })
   return { messages: anyChanged ? rewritten : (messages ?? []), changed: anyChanged }
+}
+
+/** Recursively freeze a plain structured-clone tree (the session log keeps its
+ * messages deep-frozen; replacements must match). */
+export function deepFreezeLocal(value) {
+  if (value !== null && typeof value === 'object') {
+    for (const key of Object.keys(value)) deepFreezeLocal(value[key])
+    Object.freeze(value)
+  }
+  return value
+}
+
+/**
+ * Build the sanitized, deep-frozen copy of a tool-result message: identical
+ * to the original except that every image block (top-level or nested inside
+ * tool-result content) is replaced with a text marker. Returns the original
+ * message object unchanged when it contains no image.
+ */
+export function sanitizeToolResultMessage(message) {
+  if (!message || !Array.isArray(message.content)) return message
+  const result = rewriteImagesDeep(message.content, toolImageMarker)
+  if (!result.changed) return message
+  const clone = structuredClone(message)
+  clone.content = result.content
+  return deepFreezeLocal(clone)
+}
+
+/**
+ * Plan the shadow replacements that keep tool-produced image blocks out of
+ * the model-visible session surface.
+ *
+ * A tool result (e.g. vision_present, or the host read_image) is persisted as
+ * a durable `tool/result` event whose message nests an image block. The agent
+ * pre-step only sees the inbox claim — never the historical surface — so no
+ * pre-step rewrite can catch these blocks before `Session.deriveMessages()`
+ * feeds them to the adapter, and a text-only adapter then rejects every
+ * subsequent request (issue #74: UNSUPPORTED_CONTENT session lock).
+ *
+ * The harness supports shadowing a surface node with a replacement event that
+ * carries `surfaceOp: {op:'replace', start, end}` + `sourceEventSeqs: [seq]`:
+ * the human transcript keeps rendering the append-origin original (the user
+ * still sees the image), while every later `deriveMessages()` projection sees
+ * the sanitized replacement. This is the same mechanism the host compaction
+ * pruner uses, so it is durable, replayable, and survives session resume.
+ *
+ * This function is pure: it returns the replacement events to append. The
+ * apply() side decides which events to strip (route-aware: an image-capable
+ * route legitimately uses read_image's result image) and performs the append.
+ *
+ * @param events - the session event log array (`session.events`).
+ * @param surfaceNodes - the ordered seqs of the current surface (`session.surface.nodes`).
+ * @param shouldStrip - (seq, event) => boolean; true to plan a replacement.
+ * @returns [{ seq, event, message }] where message is the sanitized frozen
+ * replacement message for the append at `seq`.
+ */
+export function planToolResultImageShadows(events, surfaceNodes, shouldStrip) {
+  const plans = []
+  for (const seq of surfaceNodes ?? []) {
+    const event = events && events[seq]
+    if (!event || event.type !== 'tool/result') continue
+    const message = event.data && event.data.message
+    if (!message || !Array.isArray(message.content) || !blocksHaveImage(message.content)) continue
+    if (typeof shouldStrip !== 'function' || shouldStrip(seq, event) !== true) continue
+    const sanitized = sanitizeToolResultMessage(message)
+    if (sanitized !== message) plans.push({ seq, event, message: sanitized })
+  }
+  return plans
 }
 
 /** Marker text for an image the text-only model cannot see (see vision_describe). */
@@ -445,6 +642,51 @@ export function rewriteImageBlocks(messages) {
     return result.changed ? { ...message, content: result.content } : message
   })
   return { messages: anyChanged ? rewritten : (messages ?? []), attachments }
+}
+
+/**
+ * Collect distinct durable attachment refs from a session event log.
+ *
+ * The event log is the only place that sees every image that entered the
+ * conversation, including host-produced ones such as `read_image` re-uploads,
+ * which are persisted as `tool/result` events and never pass through the
+ * inbox-claim message stream a plugin sees on `agent/pre-step` (issue #72).
+ * Extracting refs here — with full metadata, so `attachments.readImage` can
+ * verify the bytes — is what lets `vision_describe` / the pixel tools resolve
+ * ids the harness announced but the plugin never indexed.
+ *
+ * Handles the same message-producing event types the host surface derives
+ * (`user/message` carries the message directly; `assistant/message` and
+ * `tool/result` nest it under `data.message`) and descends into nested
+ * `tool-result` content exactly like `rewriteImageBlocks`.
+ *
+ * @param events - the session event log (`session.events`), or any array shaped like it.
+ * @returns distinct attachment refs in first-seen order.
+ */
+export function collectEventAttachmentRefs(events) {
+  const refs = []
+  const seen = new Set()
+  for (const event of events ?? []) {
+    if (!event || !event.data) continue
+    let message
+    if (event.type === 'user/message') {
+      message = event.data
+    } else if (event.type === 'assistant/message' || event.type === 'tool/result') {
+      message = event.data.message
+    } else {
+      continue
+    }
+    if (!message || !Array.isArray(message.content)) continue
+    rewriteImagesDeep(message.content, (block) => {
+      const attachment = block && block.attachment
+      if (attachment && attachment.attachmentId && !seen.has(String(attachment.attachmentId))) {
+        seen.add(String(attachment.attachmentId))
+        refs.push(attachment)
+      }
+      return block
+    })
+  }
+  return refs
 }
 
 /** Extract a JSON object/array from model output (tolerates fences and prose). */
@@ -1755,6 +1997,11 @@ export function modelInfoAcceptsImages(info) {
 }
 
 export function apply(ctx, config = {}) {
+  // Route sharp version diagnostics (issue #75) through the harness logger
+  // instead of console.warn, so the warning lands in the server log.
+  registerSharpWarningHook((message) => {
+    ctx.logger?.warn(message)
+  })
   // Live configuration: composition entry at boot, then the resolved settings
   // section once the settings service mounts (installSettingsSection below).
   let current = () => config
@@ -2710,6 +2957,39 @@ export function apply(ctx, config = {}) {
     }
   }
 
+  // session id -> event-log length already scanned for attachment refs.
+  // Mirrors sessionAttachmentsById: sessions are long-lived objects, and only
+  // the id string survives a process resume, so the index is keyed by id.
+  const scannedSessionEventSeqs = new Map()
+
+  /**
+   * Index image attachments recorded anywhere in the session event log, not
+   * just in the inbox-claim message stream `agent/pre-step` hands us
+   * (issue #72). Host-produced images (the built-in `read_image` tool's
+   * re-uploads, persisted as `tool/result` events) never enter that stream,
+   * so the harness-announced attachment id stayed unresolvable even though
+   * the UI showed the image and the bytes are durably stored. `session.events`
+   * is the complete append-only log (seeded from storage on resume), so
+   * scanning it — incrementally, per session id — finds every ref with full
+   * metadata for a later `attachments.readImage(ref)`.
+   */
+  const scanSessionEventLog = (session) => {
+    if (!session) return
+    let events
+    try {
+      events = session.events
+    } catch {
+      return // not a host Session (or the getter is unavailable): nothing to scan
+    }
+    if (!Array.isArray(events) || events.length === 0) return
+    const key = session.id !== undefined ? String(session.id) : undefined
+    const last = key !== undefined ? (scannedSessionEventSeqs.get(key) ?? 0) : 0
+    if (last >= events.length) return
+    const refs = collectEventAttachmentRefs(events.slice(last))
+    if (key !== undefined) scannedSessionEventSeqs.set(key, events.length)
+    if (refs.length > 0) recordUploadedAttachments(session, refs)
+  }
+
   const lookupAttachment = (session, id) => {
     const byId = session && session.id !== undefined
       ? sessionAttachmentsById.get(String(session.id))
@@ -2719,7 +2999,163 @@ export function apply(ctx, config = {}) {
       if (hit !== undefined) return hit
     }
     const map = session ? sessionAttachments.get(session) : undefined
-    return map ? map.get(String(id)) : undefined
+    const hit = map ? map.get(String(id)) : undefined
+    if (hit !== undefined) return hit
+    // Miss: fall back to the session event log. Ids announced by the harness
+    // for images it persisted itself (read_image re-uploads) live there even
+    // though they never crossed the inbox-claim stream, so this resolves them
+    // exactly like user-uploaded ids (issue #72). Refs from the log carry
+    // full metadata, so a later attachments.readImage(ref) verifies and
+    // returns the bytes.
+    if (session !== undefined) {
+      scanSessionEventLog(session)
+      const afterById = session.id !== undefined
+        ? sessionAttachmentsById.get(String(session.id))
+        : undefined
+      if (afterById !== undefined) {
+        const after = afterById.get(String(id))
+        if (after !== undefined) return after
+      }
+      const afterMap = sessionAttachments.get(session)
+      const afterHit = afterMap ? afterMap.get(String(id)) : undefined
+      if (afterHit !== undefined) return afterHit
+    }
+    return undefined
+  }
+
+  // ── issue #74: shadow-sanitize tool-result image blocks on the surface ────
+  //
+  // A tool result that renders an image block (vision_present, or the host
+  // read_image on image-capable routes) is persisted as a durable
+  // `tool/result` event and then flows into EVERY later request through
+  // `Session.deriveMessages()`. A text-only adapter (DeepSeek native, pi-ai
+  // text routes) rejects nested images with UNSUPPORTED_CONTENT and the
+  // session is locked forever. The pre-step inbox sanitizer cannot see these
+  // historical events, so the surface itself is rewritten instead: each
+  // offending event is shadowed by a sanitized replacement event
+  // (`surfaceOp: {op:'replace'}`, the same mechanism the host compaction
+  // pruner uses). The Web UI transcript renders append-origin events, so the
+  // user still sees the image; only the model-visible surface is sanitized.
+  // The decision is route-aware: an image-capable route legitimately consumes
+  // read_image's result image, mirroring the host's own gate
+  // (`assertImageCapableRoute` in dsh-tool-fs).
+
+  // session -> { count: nodes examined, done: Set<seqs already decided> }
+  const sessionSurfaceScans = new WeakMap()
+
+  const sessionRouteHandlesImages = async (session) => {
+    let provider
+    let model
+    try {
+      const header = typeof session.requestHeader === 'function' ? session.requestHeader() : undefined
+      provider = header && header.config ? header.config.provider : undefined
+      model = header && header.config ? header.config.model : undefined
+    } catch {
+      return false
+    }
+    if (typeof provider !== 'string' || provider === '' || typeof model !== 'string' || model === '') {
+      return false
+    }
+    // Plugin-owned routes handle image blocks at their stream boundary: the
+    // wrapper and the provider twins rewrite them into markers/descriptions,
+    // the stealth adapter does the same, and the vision-chain route serves
+    // image-capable models.
+    if (provider === wrapperRoute() || provider === chainRoute() || provider.endsWith('-vision')) {
+      return true
+    }
+    if (stealthActive && provider === 'deepseek-official') return true
+    // Routing mode reverse-routes text-only turns back to the text provider;
+    // when neither the wrapper nor the stealth adapter is there to rewrite
+    // images, the reverse target is the bare text adapter, which rejects
+    // tool-result images. Sanitize so text turns stay usable.
+    if (routingEnabled() && reverseRoutingEnabled() && !wrapperRegistered && !stealthActive) {
+      return false
+    }
+    // Same probe the host uses to gate read_image: only routes whose models
+    // declare image input may keep tool-result images.
+    try {
+      const info = await ctx.llm.resolveModelInfo(provider, model)
+      return Array.isArray(info && info.inputModalities) && info.inputModalities.includes('image')
+    } catch {
+      return false // unknown route: fail safe and sanitize
+    }
+  }
+
+  const sanitizeSessionToolResults = async (session) => {
+    if (!session) return
+    let events
+    let nodes
+    try {
+      events = session.events
+      nodes = session.surface && session.surface.nodes
+    } catch {
+      return // not a host Session: nothing to sanitize
+    }
+    if (!Array.isArray(events) || !Array.isArray(nodes) || nodes.length === 0) return
+    let scan = sessionSurfaceScans.get(session)
+    if (!scan) {
+      scan = { count: 0, done: new Set() }
+      sessionSurfaceScans.set(session, scan)
+    }
+    // Compaction replaces the surface wholesale; a shrunk node list means the
+    // positional cursor is stale, so restart from the head. Kept decisions are
+    // memoized in `done`, so a restart is a cheap no-op for examined events.
+    if (nodes.length < scan.count) {
+      scan.count = 0
+      scan.done = new Set()
+    }
+    if (nodes.length === scan.count) return
+    let routeHandlesImages
+    const newSeqs = nodes.slice(scan.count)
+    for (const seq of newSeqs) {
+      const event = events[seq]
+      if (!event || event.type !== 'tool/result' || scan.done.has(seq)) continue
+      const message = event.data && event.data.message
+      if (!message || !Array.isArray(message.content) || !blocksHaveImage(message.content)) {
+        scan.done.add(seq)
+        continue
+      }
+      if (routeHandlesImages === undefined) {
+        routeHandlesImages = await sessionRouteHandlesImages(session)
+      }
+      if (routeHandlesImages) {
+        // Image-capable route: keep the image (read_image's result is the
+        // model's view of the file). The wrapper/twin/stealth routes rewrite
+        // it at stream time anyway.
+        scan.done.add(seq)
+        continue
+      }
+      const sanitized = sanitizeToolResultMessage(message)
+      if (sanitized === message) {
+        scan.done.add(seq)
+        continue
+      }
+      try {
+        session.append(
+          'tool/result',
+          { ...event.data, message: sanitized },
+          {
+            surfaceOp: { op: 'replace', start: seq, end: seq },
+            sourceEventSeqs: [seq],
+          },
+        )
+        scan.done.add(seq)
+        ctx.logger?.info(
+          'vision-router: sanitized a tool-result image block out of the model surface (event seq %s)',
+          seq,
+        )
+      } catch (error) {
+        // A failed shadow leaves the original event on the surface: the
+        // session stays usable (today's behavior) instead of crashing the
+        // pre-step.
+        ctx.logger?.warn(
+          'vision-router: could not sanitize tool-result image at event seq %s (%s)',
+          seq,
+          error && error.message ? error.message : String(error),
+        )
+      }
+    }
+    scan.count += newSeqs.length
   }
 
   // session -> { turn, startIndex, hasImage, routed, failures, lastError }
@@ -2735,12 +3171,37 @@ export function apply(ctx, config = {}) {
     // sanitized. This preserves attachment lookup for a later vision_describe.
     const rawImageRefs = rewriteImageBlocks(rawMessages)
     recordUploadedAttachments(session, rawImageRefs.attachments)
+    // Also index image attachments that live only in the session event log
+    // (read_image re-uploads never cross the inbox-claim message stream).
+    // Incremental: scans only new events (issue #72).
+    scanSessionEventLog(session)
     // Hard invariant: tool-produced image blocks never reach a model request.
-    // This is deliberately route-agnostic, because merely having a wrapper
-    // registered does not prove that the current request is actually using it.
+    // Two layers: (1) sanitize tool-result images in the inbox claim, and
+    // (2) shadow-sanitize historical tool/result events on the session
+    // surface (issue #74) — the only lever that can rewrite durable history.
     const sanitizedToolResults = sanitizeToolResultImages(rawMessages)
     const messages = sanitizedToolResults.messages
     const hasImage = messages.some((message) => blocksHaveImage(message && message.content))
+    try {
+      await sanitizeSessionToolResults(session)
+    } catch (error) {
+      ctx.logger?.warn(
+        'vision-router: session-surface sanitization failed (%s)',
+        error && error.message ? error.message : String(error),
+      )
+    }
+    // Register the turn state BEFORE the image-turn branches below: those
+    // branches return early (auto-mount reminder, history rewrite), and the
+    // agent/request hook must still see the state, otherwise an image turn is
+    // served by the text provider and rejected (issue #74, second root cause).
+    if (routingEnabled()) {
+      const events = session.events ?? []
+      turnState.set(session, {
+        turn: payload.turn,
+        startIndex: events.length,
+        hasImage,
+      })
+    }
     if (hasImage) {
       // Auto-mount the deep vision tools on image turns: the model can use
       // them from its very first step without the user asking for them.
@@ -2804,14 +3265,6 @@ export function apply(ctx, config = {}) {
       if (cleaned.messages !== base) {
         return { ...decision, messages: cleaned.messages }
       }
-    }
-    if (routingEnabled()) {
-      const events = session.events ?? []
-      turnState.set(session, {
-        turn: payload.turn,
-        startIndex: events.length,
-        hasImage,
-      })
     }
     return sanitizedToolResults.changed ? { ...decision, messages } : decision
   })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-vision-router",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Eyes for text-only DeepSeek Harness agents: built-in free vision chain (no key) + pixel-level vision tools (Q&A, grounding, crop, pixel diff, colors, OCR, SVG trace, cutout, screenshots). One-command install, no Python, image turns work like ordinary tool-calling turns.",
   "license": "MIT",
   "repository": {

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -22,6 +22,13 @@ import {
   rewriteImageBlocks,
   rewriteImagesDeep,
   sanitizeToolResultImages,
+  sanitizeToolResultMessage,
+  planToolResultImageShadows,
+  toolImageMarker,
+  deepFreezeLocal,
+  collectEventAttachmentRefs,
+  parseVersionParts,
+  versionSatisfies,
   renderVisionPresent,
   extractJson,
   createCache,
@@ -2072,4 +2079,174 @@ test('artifactStemOf keeps long content-addressed inputs distinct', () => {
   // Stable for the same input, different for different suffixes.
   assert.equal(artifactStemOf(upload, 'ground'), groundUpload)
   assert.notEqual(artifactStemOf(upload, 'ground'), artifactStemOf(upload, 'detect'))
+})
+
+// ── issue #72: attachment refs from the session event log ───────────────────
+
+const imageRef = (id, name) => ({
+  attachmentId: id,
+  mediaType: 'image/png',
+  bytes: 1234,
+  width: 10,
+  height: 10,
+  name,
+})
+
+test('collectEventAttachmentRefs collects refs from user/assistant/tool-result events', () => {
+  const events = [
+    { seq: 1, type: 'user/message', data: { role: 'user', content: [{ type: 'image', attachment: imageRef('sha256:aaa', 'a.png') }] } },
+    {
+      seq: 2,
+      type: 'assistant/message',
+      data: { message: { role: 'assistant', content: [{ type: 'text', text: 'no image' }] } },
+    },
+    {
+      seq: 3,
+      type: 'tool/result',
+      data: {
+        message: {
+          role: 'user',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: 'call-1',
+              content: [
+                { type: 'text', text: 'read output' },
+                { type: 'image', attachment: imageRef('sha256:bbb', 'b.png') },
+              ],
+            },
+          ],
+        },
+      },
+    },
+    { seq: 4, type: 'turn/start', data: { turn: 1 } },
+  ]
+  const refs = collectEventAttachmentRefs(events)
+  assert.deepEqual(
+    refs.map((ref) => ref.attachmentId),
+    ['sha256:aaa', 'sha256:bbb'],
+  )
+  // Full metadata survives so attachments.readImage(ref) can verify bytes.
+  assert.equal(refs[1].mediaType, 'image/png')
+  assert.equal(refs[1].bytes, 1234)
+})
+
+test('collectEventAttachmentRefs dedups by attachment id in first-seen order', () => {
+  const events = [
+    { type: 'user/message', data: { content: [{ type: 'image', attachment: imageRef('sha256:dup', 'a') }] } },
+    { type: 'tool/result', data: { message: { content: [{ type: 'tool-result', content: [{ type: 'image', attachment: imageRef('sha256:dup', 'a') }] }] } } },
+    { type: 'user/message', data: { content: [{ type: 'image', attachment: imageRef('sha256:other', 'b') }] } },
+  ]
+  const refs = collectEventAttachmentRefs(events)
+  assert.deepEqual(refs.map((ref) => ref.attachmentId), ['sha256:dup', 'sha256:other'])
+})
+
+test('collectEventAttachmentRefs tolerates missing events and data', () => {
+  assert.deepEqual(collectEventAttachmentRefs(undefined), [])
+  assert.deepEqual(collectEventAttachmentRefs([null, {}, { type: 'user/message' }, { type: 'tool/result', data: {} }]), [])
+})
+
+// ── issue #74: surface shadow sanitization of tool-result images ────────────
+
+const toolResultEvent = (seq, content, callSeq) => ({
+  seq,
+  type: 'tool/result',
+  data: {
+    turn: 1,
+    step: 1,
+    message: {
+      id: `msg-${seq}`,
+      role: 'user',
+      source: { kind: 'tool', callId: 'call-1' },
+      content: [{ type: 'tool-result', toolCallId: 'call-1', content, isError: false }],
+    },
+  },
+  sourceEventSeqs: callSeq === undefined ? undefined : [callSeq],
+})
+
+test('planToolResultImageShadows plans replacements only for image-bearing tool results', () => {
+  const events = [
+    toolResultEvent(0, [{ type: 'text', text: 'plain' }]),
+    toolResultEvent(1, [
+      { type: 'text', text: '{"safePresentation":true}' },
+      { type: 'image', attachment: imageRef('sha256:show', 'shown.png') },
+    ]),
+    { seq: 2, type: 'user/message', data: { role: 'user', content: [{ type: 'image', attachment: imageRef('sha256:user', 'u.png') }] } },
+    toolResultEvent(3, [{ type: 'text', text: 'another plain one' }]),
+  ]
+  const plans = planToolResultImageShadows(events, [0, 1, 2, 3], (seq, event) => seq === 1)
+  assert.equal(plans.length, 1)
+  assert.equal(plans[0].seq, 1)
+  const message = plans[0].message
+  // The replacement keeps the tool-result envelope and drops the image.
+  assert.equal(message.id, 'msg-1')
+  assert.equal(message.content[0].type, 'tool-result')
+  assert.equal(blocksHaveImage(message.content), false)
+  const texts = message.content[0].content.filter((block) => block.type === 'text').map((block) => block.text)
+  assert.equal(texts.some((text) => text.includes('sha256:show')), true)
+  // The original event is untouched (the caller replaces it by appending).
+  assert.equal(blocksHaveImage(events[1].data.message.content), true)
+})
+
+test('planToolResultImageShadows respects the shouldStrip decision', () => {
+  const events = [toolResultEvent(0, [{ type: 'image', attachment: imageRef('sha256:keep', 'k.png') }])]
+  assert.deepEqual(planToolResultImageShadows(events, [0], () => false), [])
+  assert.equal(planToolResultImageShadows(events, [0], () => true).length, 1)
+})
+
+test('sanitizeToolResultMessage is identity-preserving without images and frozen with them', () => {
+  const plain = toolResultEvent(0, [{ type: 'text', text: 'plain' }]).data.message
+  assert.equal(sanitizeToolResultMessage(plain), plain)
+  const withImage = toolResultEvent(1, [{ type: 'image', attachment: imageRef('sha256:x', 'x.png') }]).data.message
+  const sanitized = sanitizeToolResultMessage(withImage)
+  assert.notEqual(sanitized, withImage)
+  assert.equal(Object.isFrozen(sanitized), true)
+  assert.equal(Object.isFrozen(sanitized.content[0]), true)
+  assert.equal(blocksHaveImage(sanitized.content), false)
+})
+
+test('toolImageMarker names the attachment id and points at vision_describe', () => {
+  const marker = toolImageMarker({ attachment: imageRef('sha256:marker', 'm.png') })
+  assert.equal(marker.type, 'text')
+  assert.match(marker.text, /sha256:marker/)
+  assert.match(marker.text, /vision_describe/)
+})
+
+test('deepFreezeLocal freezes nested structures', () => {
+  const tree = { a: { b: [{ c: 1 }] } }
+  const frozen = deepFreezeLocal(tree)
+  assert.equal(frozen, tree)
+  assert.equal(Object.isFrozen(tree), true)
+  assert.equal(Object.isFrozen(tree.a), true)
+  assert.equal(Object.isFrozen(tree.a.b), true)
+})
+
+// ── issue #75: sharp peer-range diagnostics ─────────────────────────────────
+
+test('parseVersionParts handles releases, partial versions and prereleases', () => {
+  assert.deepEqual(parseVersionParts('0.35.3'), { major: 0, minor: 35, patch: 3, pre: undefined })
+  assert.deepEqual(parseVersionParts('1.2.3-beta.4'), { major: 1, minor: 2, patch: 3, pre: 'beta.4' })
+  // Partial versions pad to zero like semver ("1" means ">=1.0.0").
+  assert.deepEqual(parseVersionParts('1'), { major: 1, minor: 0, patch: 0, pre: undefined })
+  assert.deepEqual(parseVersionParts('1.2'), { major: 1, minor: 2, patch: 0, pre: undefined })
+  assert.equal(parseVersionParts('1.2.3.4'), undefined)
+  assert.equal(parseVersionParts('nonsense'), undefined)
+  assert.equal(parseVersionParts(undefined), undefined)
+})
+
+test('versionSatisfies evaluates the plugin peer range shape', () => {
+  const range = '>=0.35.3 <1'
+  assert.equal(versionSatisfies('0.34.0', range), false) // stale v1.1.x-era sharp
+  assert.equal(versionSatisfies('0.35.2', range), false)
+  assert.equal(versionSatisfies('0.35.3', range), true)
+  assert.equal(versionSatisfies('0.35.4', range), true)
+  assert.equal(versionSatisfies('1.0.0', range), false)
+  // Prereleases of the upper bound still satisfy "<1" (semver ordering).
+  assert.equal(versionSatisfies('1.0.0-beta.1', range), true)
+  // Alternatives and bare versions.
+  assert.equal(versionSatisfies('0.34.5', '>=0.35.3 <1 || 0.34.5'), true)
+  assert.equal(versionSatisfies('0.34.5', '0.34.5'), true)
+  assert.equal(versionSatisfies('0.34.5', ''), false)
+  assert.equal(versionSatisfies('0.34.5', undefined), false)
+  assert.equal(versionSatisfies(undefined, range), false)
 })


### PR DESCRIPTION
## 修复 / Fixes

Closes #72, closes #74; adds the diagnostics suggested in #75.

### #72 — `read_image` 回挂的附件 ID 无法被解析

宿主 `read_image` 把图片持久化为 `tool/result` 事件，从不经过 `agent/pre-step` 的 inbox claim 消息流，因此插件此前只索引用户新消息里的图片块，永远看不到这些 ID。现在：

- 新增 `collectEventAttachmentRefs`：从会话事件日志（`user/message` / `assistant/message` / `tool/result`，含嵌套 tool-result）增量收集附件 ref；
- `lookupAttachment` 未命中时回退扫描事件日志；`agent/pre-step` 每次也会增量扫描；
- 跨回合、跨进程恢复均可解析；ref 携带完整元数据，`attachments.readImage(ref)` 可直接验证读取。

（事件日志回退方案来自 @HualuozhE 的 PR #73，本 PR 在其思路基础上实现并补充了单元测试。）

### #74 — `vision_present` 图像块把文本模型会话锁死

工具结果里的图像块被持久化进会话历史后，会进入之后每一次请求（`Session.deriveMessages()`），文本适配器以 `UNSUPPORTED_CONTENT` 拒绝，会话永久锁死。pre-step 只能看到 inbox claim、看不到历史，原有 sanitize 覆盖不到。现在：

- 用宿主的表面替换机制（`surfaceOp: replace` + `sourceEventSeqs`，与压缩剪枝同一机制）把含图像块的 `tool/result` 事件的模型视图替换为文本标记；Web UI 渲染 append-origin 事件，用户仍然看到原图；
- 净化按路由判断（与宿主 `read_image` 的门禁一致：`resolveModelInfo(...).inputModalities`）：能直接看图的视觉路由保留 `read_image` 结果图，纯文本路由净化；反向路由缺包装/隐身适配器时同样净化；
- 已锁死的历史会话升级后发一条消息即可自愈（净化发生在下一次请求组装之前）；
- 顺带修复：图片轮 auto-mount 分支提前 return 导致 `turnState` 未登记、`agent/request` 路由失效的问题（turnState 登记移到分支之前）。

### #75 — 升级残留旧版 sharp 的 `colourspace` 报错

环境问题本身按 issue 指引清理即可。本 PR 落地其可选建议：`loadSharp()` 对照 `package.json` 的 `peerDependencies.sharp` 范围（实时读取，不写死）校验实际解析到的版本，不满足时打明确告警（残留版本 vs 期望范围 + 清理指引）。纯诊断、无行为变化；CHANGELOG 与 README 升级章节补充注意事项。

### 测试 / Tests

- 新增单元测试：`collectEventAttachmentRefs`、`planToolResultImageShadows`、`sanitizeToolResultMessage`、`toolImageMarker`、`deepFreezeLocal`、`parseVersionParts`、`versionSatisfies`；
- `pnpm test` 159 项中 157 通过（2 项失败为 macOS `/private/var` 路径的既有环境问题，与本次改动无关，Linux CI 不受影响）。