### PR TITLE
fix: persist onboarding/guide markers in settings so DSH Desktop stops re-showing the first-run dialog (#78)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 每个版本的中英双语发布说明（GitHub Release 工作流从这里取对应版本的段落，发布前必须先写好本节）｜
 Bilingual (Chinese + English) release notes for every version — the GitHub Release workflow pulls the matching section from this file, so it must be filled in before tagging.
 
+## v1.2.3
+
+### 修复 / Fixed
+
+- **DSH Desktop 每次启动都重复弹出引导弹窗（#78）**：首次使用引导（「Vision Router 已准备好」）和模型引导步骤的「已读/进度」标记原来存在 `localStorage` 里，而 DSH Desktop 每次启动都换一个随机端口（`--port 0`），`localStorage` 按 origin 隔离，等于每次启动都清零。现在这两个标记改存 `vision-router` 设置段（随 profile 设置文件持久化）：客户端通过 `ctx.settingsScope` 读写 `onboardingSeen` / `visionGuideStep` 两个字段（已加入服务端 Config schema），`localStorage` 仅保留为旧版本迁移与降级兜底；同时处理了「设置快照异步到达晚于弹窗调度」的竞态——快照到达后会自动收起已弹出的引导。只读设置提供方下行为不变（回落 localStorage）。
+- **DSH Desktop no longer re-shows the first-run dialog on every launch (#78)**: the onboarding dialog and the model-guide step markers used to live in `localStorage`, which is origin-scoped — and DSH Desktop serves the Web UI from a fresh random port on every launch (`--port 0`), wiping the markers each boot. The two flags now live in the `vision-router` settings section (persisted in the profile settings file) via `ctx.settingsScope` (`onboardingSeen` / `visionGuideStep`, both declared in the server Config schema); `localStorage` remains only as a legacy migration/downgrade fallback. A race where the async settings snapshot resolves after the dialog was scheduled is handled by auto-dismissing the already-shown overlay. Read-only settings providers keep the previous behavior (localStorage fallback).
+
 ## v1.2.2
 
 ### 修复 / Fixed

--- a/README.md
+++ b/README.md
@@ -28,9 +28,11 @@
 <p align="center">💬 <strong>QQ community group: 1105463028</strong></p>
 
 > [!WARNING]
-> 📌 **Announcement (v1.2.2)**
+> 📌 **Announcement (v1.2.3)**
 >
-> v1.2.2 closes the last attachment-id gap — ids announced for images the host persisted itself (e.g. `read_image` re-uploads, `sha256:…`) now resolve in `vision_describe` and every pixel tool (issue #72) — stops `vision_present` and other tool-result image blocks from ever locking a text-model session with `UNSUPPORTED_CONTENT` (issue #74; already-locked sessions heal after upgrading), and warns loudly when a stale sharp left over from a pre-v1.2 upgrade would break the pixel tools with `colourspace: parameter space not set` (issue #75).
+> v1.2.3 fixes DSH Desktop's re-appearing first-run dialog: the onboarding "seen" flag and the model-guide step now persist in the profile settings file instead of origin-scoped `localStorage`, which a random per-launch port (`--port 0`) wiped on every boot (issue #78).
+>
+> v1.2.2 closed the last attachment-id gap — ids announced for images the host persisted itself (e.g. `read_image` re-uploads, `sha256:…`) now resolve in `vision_describe` and every pixel tool (issue #72) — stopped `vision_present` and other tool-result image blocks from ever locking a text-model session with `UNSUPPORTED_CONTENT` (issue #74; already-locked sessions heal after upgrading), and warned loudly when a stale sharp left over from a pre-v1.2 upgrade would break the pixel tools with `colourspace: parameter space not set` (issue #75).
 >
 > v1.2.1 hardened the pixel loop: all eleven pixel tools now accept uploaded-image attachment ids directly (no more `cannot read …/sha256:…` round trips), artifact filenames carry collision-free fingerprints, `vision_ground` retries degenerate boxes, the model guide replays fully from step 1 (leaving the settings first), and the settings card scrolls smoothly even with hundreds of models per provider.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -28,7 +28,9 @@
 <p align="center">💬 <strong>QQ 用户交流群：1105463028</strong></p>
 
 > [!WARNING]
-> 📌 **公告（v1.2.2）**
+> 📌 **公告（v1.2.3）**
+>
+> v1.2.3 现已支持：修复 DSH Desktop 每次启动都重复弹出首次引导的问题——引导「已读」标记与模型引导步骤改存 profile 设置文件（不再依赖按 origin 隔离、每次随机端口重启即清零的 `localStorage`）（issue #78）。
 >
 > v1.2.2 现已支持：补上最后一处附件 ID 缺口——宿主 `read_image` 回挂图片公布的 `sha256:…` ID 现在可被 `vision_describe` 与全部像素工具解析（issue #72）；`vision_present` 等工具结果里的图像块不再把文本模型会话锁死在 `UNSUPPORTED_CONTENT`（issue #74，已锁死的历史会话升级后自动修复）；检测到 v1.1.x 升级残留的旧版 sharp 时明确告警，把玄学的 `colourspace` 报错变成一眼可见的修复指引（issue #75）。
 >

--- a/index.js
+++ b/index.js
@@ -233,6 +233,15 @@ export const Config = z.object({
   tool: z.boolean().default(true),
   progressiveTools: z.boolean().default(true),
   autoActivateOnImage: z.boolean().default(true),
+  // Client-persisted UI state (issue #78): DSH Desktop serves the Web UI from
+  // a random port on every launch, so origin-scoped localStorage forgets the
+  // first-run onboarding dialog and it re-appeared on every boot. These keys
+  // live in the settings section (the profile settings file) instead; the
+  // client still mirrors best-effort copies into localStorage for downgrades.
+  // Both are internal to the client bundle — the settings card renders them
+  // nowhere, and the server half never reads them.
+  onboardingSeen: z.boolean().default(false),
+  visionGuideStep: z.string().default(''),
   artifactsDir: z.string().default('.dsh-vision-router/artifacts'),
   rewriteImages: z.boolean().default(true),
   downscale: z.boolean().default(true),

--- a/lib/client.js
+++ b/lib/client.js
@@ -554,20 +554,116 @@ window.__ModuleLoader__.load({
     }
 
     const ONBOARDING_STORAGE_KEY = 'dsh-vision-router:onboarding:model-guide-v2'
+    // issue #78: DSH Desktop serves the Web UI from a random port on every
+    // launch (--port 0), so origin-scoped localStorage forgets everything
+    // between restarts and the first-run dialog re-appeared on every boot.
+    // The durable source of truth is now the `vision-router` settings section
+    // (the profile settings file, synced through ctx.settingsScope);
+    // localStorage survives only as a legacy/migration fallback for
+    // pre-v1.2.3 browsers and as a best-effort downgrade channel.
+    const ONBOARDING_SETTINGS_KEY = 'onboardingSeen'
     // The walkthrough has three steps: step1 (the session/text model selector
     // on the chat page), step2 (open Settings → Plugins → Vision Router), and
     // step3 (the highlighted vision chain, rendered by the settings card as a
     // callout). Only step1/step2 need persistence; step3 re-derives from the
     // card being on screen.
     const VISION_GUIDE_STORAGE_KEY = 'dsh-vision-router:guide:vision-backend-v2'
+    const VISION_GUIDE_SETTINGS_KEY = 'visionGuideStep'
     const VISION_GUIDE_EVENT = 'dsh-vision-router:vision-settings-guide'
     let visionGuidePrompt
     let visionGuideStepMemory
+    // Installed by apply(): a narrow, defensive view of the settings scope.
+    // { get, set, unset } never throw, and subscribe returns a disposer (or
+    // undefined when the scope is unavailable — the legacy paths take over).
+    let settingsPersistence
+    function installSettingsPersistence(scope) {
+      const readSection = () => {
+        try {
+          const snapshot = scope && scope.getSnapshot && scope.getSnapshot()
+          return snapshot && snapshot.value ? snapshot.value : undefined
+        } catch {
+          return undefined
+        }
+      }
+      settingsPersistence = {
+        get(field) {
+          const section = readSection()
+          return section ? section[field] : undefined
+        },
+        set(field, value) {
+          try {
+            const snapshot = scope && scope.getSnapshot && scope.getSnapshot()
+            if (!snapshot || !snapshot.writable || typeof scope.set !== 'function') return
+            void scope.set(field, value)
+          } catch {
+            // Read-only provider or unavailable scope: the localStorage
+            // fallback keeps this load functional.
+          }
+        },
+        unset(field) {
+          try {
+            const snapshot = scope && scope.getSnapshot && scope.getSnapshot()
+            if (!snapshot || !snapshot.writable || typeof scope.unset !== 'function') return
+            void scope.unset(field)
+          } catch {
+            // Same fallback reasoning as set().
+          }
+        },
+        subscribe(listener) {
+          try {
+            return scope && typeof scope.subscribe === 'function' ? scope.subscribe(listener) : undefined
+          } catch {
+            return undefined
+          }
+        },
+      }
+    }
+
+    function readOnboardingSeen() {
+      try {
+        if (settingsPersistence && settingsPersistence.get(ONBOARDING_SETTINGS_KEY) === true) return true
+      } catch {
+        // Fall through to the legacy origin-scoped marker.
+      }
+      try {
+        if (window.localStorage && window.localStorage.getItem(ONBOARDING_STORAGE_KEY) === 'seen') {
+          // Legacy value from before the settings-backed flag: migrate it so
+          // it survives desktop restarts, then honor it for this load.
+          if (settingsPersistence) settingsPersistence.set(ONBOARDING_SETTINGS_KEY, true)
+          return true
+        }
+      } catch {
+        // Best effort only.
+      }
+      return false
+    }
+    function rememberOnboardingSeen() {
+      try {
+        if (settingsPersistence) settingsPersistence.set(ONBOARDING_SETTINGS_KEY, true)
+      } catch {
+        // The dialog can still be dismissed for this page load.
+      }
+      try {
+        if (window.localStorage) window.localStorage.setItem(ONBOARDING_STORAGE_KEY, 'seen')
+      } catch {
+        // Best effort: the dialog can still be dismissed for this page load.
+      }
+    }
 
     function readVisionGuideStep() {
       try {
-        const value = window.localStorage && window.localStorage.getItem(VISION_GUIDE_STORAGE_KEY)
+        const value = settingsPersistence && settingsPersistence.get(VISION_GUIDE_SETTINGS_KEY)
         if (value === 'step1' || value === 'step2') return value
+      } catch {
+        // Fall through to the legacy origin-scoped marker.
+      }
+      try {
+        const value = window.localStorage && window.localStorage.getItem(VISION_GUIDE_STORAGE_KEY)
+        if (value === 'step1' || value === 'step2') {
+          // Legacy value: migrate into settings for desktop durability.
+          if (settingsPersistence) settingsPersistence.set(VISION_GUIDE_SETTINGS_KEY, value)
+          return value
+        }
       } catch {
         // Fall through to page-memory state when storage access is blocked.
       }
@@ -575,6 +671,14 @@ window.__ModuleLoader__.load({
     }
     function writeVisionGuideStep(step) {
       visionGuideStepMemory = step === 'step1' || step === 'step2' ? step : undefined
+      try {
+        if (settingsPersistence) {
+          if (visionGuideStepMemory) settingsPersistence.set(VISION_GUIDE_SETTINGS_KEY, visionGuideStepMemory)
+          else settingsPersistence.unset(VISION_GUIDE_SETTINGS_KEY)
+        }
+      } catch {
+        // Page-memory state still keeps the guide functional for this load.
+      }
       try {
         if (!window.localStorage) return
         if (visionGuideStepMemory) window.localStorage.setItem(VISION_GUIDE_STORAGE_KEY, visionGuideStepMemory)
@@ -677,9 +781,13 @@ window.__ModuleLoader__.load({
       syncVisionGuidePrompt(t)
       window.addEventListener(VISION_GUIDE_EVENT, sync)
       window.addEventListener('popstate', sync)
+      // The durable step now lives in the settings section; re-sync when its
+      // snapshot changes (e.g. the first read resolves after page load).
+      const unsubscribe = settingsPersistence && settingsPersistence.subscribe(sync)
       return () => {
         window.removeEventListener(VISION_GUIDE_EVENT, sync)
         window.removeEventListener('popstate', sync)
+        if (typeof unsubscribe === 'function') unsubscribe()
         removeVisionGuidePrompt()
       }
     }
@@ -687,13 +795,6 @@ window.__ModuleLoader__.load({
     let onboardingOverlay
     let onboardingKeyDown
 
-    function rememberOnboardingSeen() {
-      try {
-        if (window.localStorage) window.localStorage.setItem(ONBOARDING_STORAGE_KEY, 'seen')
-      } catch {
-        // Best effort: the dialog can still be dismissed for this page load.
-      }
-    }
     function dismissOnboarding(remember = true) {
       if (remember) rememberOnboardingSeen()
       if (typeof document !== 'undefined' && onboardingKeyDown) {
@@ -779,16 +880,33 @@ window.__ModuleLoader__.load({
     }
     function installOnboarding(t) {
       if (typeof document === 'undefined' || typeof window === 'undefined') return
-      try {
-        if (window.localStorage && window.localStorage.getItem(ONBOARDING_STORAGE_KEY) === 'seen') return
-      } catch {
-        // Privacy/storage restrictions should not prevent the guidance itself.
-      }
-
-      const timer = window.setTimeout(() => showOnboarding(t), 650)
-
-      return () => {
+      let timer
+      const clearTimer = () => {
         if (timer !== undefined) window.clearTimeout(timer)
+        timer = undefined
+      }
+      // Reactive against the settings scope: the settings snapshot arrives
+      // asynchronously on a cold page load, so a one-shot localStorage check
+      // could show the dialog before the durable "seen" flag lands. Re-sync
+      // on every snapshot change and dismiss the overlay if the flag appears.
+      const sync = () => {
+        if (readOnboardingSeen()) {
+          clearTimer()
+          if (onboardingOverlay) dismissOnboarding(false)
+          return
+        }
+        if (timer === undefined && !onboardingOverlay) {
+          timer = window.setTimeout(() => {
+            timer = undefined
+            if (!readOnboardingSeen()) showOnboarding(t)
+          }, 650)
+        }
+      }
+      sync()
+      const unsubscribe = settingsPersistence && settingsPersistence.subscribe(sync)
+      return () => {
+        clearTimer()
+        if (typeof unsubscribe === 'function') unsubscribe()
         // Unmounting is not a user choice: drop the dialog without marking
         // the guide seen, so the first-run overview can still auto-open.
         if (onboardingOverlay) dismissOnboarding(false)
@@ -1894,6 +2012,10 @@ window.__ModuleLoader__.load({
 
     function apply(ctx) {
       const scope = ctx.settingsScope.bind({ namespace: 'vision-router' })
+      // issue #78: route the onboarding/guide durability through the settings
+      // section (profile settings file) so it survives DSH Desktop's random
+      // per-launch port. Installed before the effects below run.
+      installSettingsPersistence(scope)
       const presentedImageUrls = new Map()
       const createdImageUrls = new Set()
       const loadPresentedImage = (sessionId, attachment) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-vision-router",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Eyes for text-only DeepSeek Harness agents: built-in free vision chain (no key) + pixel-level vision tools (Q&A, grounding, crop, pixel diff, colors, OCR, SVG trace, cutout, screenshots). One-command install, no Python, image turns work like ordinary tool-calling turns.",
   "license": "MIT",
   "repository": {

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -101,8 +101,41 @@ test('re-viewing the model guide replays the overview instead of skipping to ste
   // auto-show and the re-view button share it without stacking duplicates.
   assert.equal(source.includes('function showOnboarding(t)'), true)
   assert.equal(source.includes('if (onboardingOverlay) return'), true)
-  assert.equal(source.includes('setTimeout(() => showOnboarding(t), 650)'), true)
   assert.equal(source.includes('function dismissOnboarding(remember = true)'), true)
+  // The auto-show is deferred (never synchronous) and gated on the durable
+  // seen flag.
+  assert.equal(source.includes('window.setTimeout(() => {'), true)
+  assert.equal(source.includes('if (!readOnboardingSeen()) showOnboarding(t)'), true)
+})
+
+test('onboarding and guide durability live in the settings section, not origin-scoped localStorage (#78)', () => {
+  const source = readFileSync(new URL('../lib/client.js', import.meta.url), 'utf8')
+  // DSH Desktop re-randomizes the Web UI port on every launch, so
+  // origin-scoped localStorage forgets everything between restarts. The
+  // durable flags must be settings-section fields synced through
+  // ctx.settingsScope (persisted in the profile settings file).
+  assert.equal(source.includes("const ONBOARDING_SETTINGS_KEY = 'onboardingSeen'"), true)
+  assert.equal(source.includes("const VISION_GUIDE_SETTINGS_KEY = 'visionGuideStep'"), true)
+  assert.equal(source.includes('function installSettingsPersistence(scope)'), true)
+  assert.equal(source.includes('installSettingsPersistence(scope)'), true)
+  assert.equal(source.includes('function readOnboardingSeen()'), true)
+  assert.equal(source.includes('settingsPersistence.get(ONBOARDING_SETTINGS_KEY) === true'), true)
+  assert.equal(source.includes('settingsPersistence.set(ONBOARDING_SETTINGS_KEY, true)'), true)
+  // The legacy localStorage marker still exists as a migration/downgrade
+  // fallback, not as the source of truth.
+  assert.equal(source.includes("ONBOARDING_STORAGE_KEY = 'dsh-vision-router:onboarding:model-guide-v2'"), true)
+  assert.equal(source.includes("window.localStorage.getItem(ONBOARDING_STORAGE_KEY) === 'seen'"), true)
+  // The guide step mirrors the same dual-channel strategy.
+  assert.equal(source.includes('settingsPersistence.get(VISION_GUIDE_SETTINGS_KEY)'), true)
+  assert.equal(source.includes('settingsPersistence.set(VISION_GUIDE_SETTINGS_KEY, visionGuideStepMemory)'), true)
+  // Both installers re-sync when the settings snapshot changes (the first
+  // snapshot resolves asynchronously after page load).
+  assert.equal(source.includes('settingsPersistence.subscribe(sync)'), true)
+  // Server half declares the two keys in the Config schema so the settings
+  // provider accepts and persists them.
+  const serverSource = readFileSync(new URL('../index.js', import.meta.url), 'utf8')
+  assert.equal(serverSource.includes('onboardingSeen: z.boolean().default(false)'), true)
+  assert.equal(serverSource.includes("visionGuideStep: z.string().default('')"), true)
 })
 
 test('the walkthrough walks step 1 (session model), step 2 (open settings), step 3 (chain callout)', () => {


### PR DESCRIPTION
## 修复 / Fixes

Closes #78.

### 根因 / Root cause

DSH Desktop 用随机端口启动 Web 服务（`--port 0`），而首次引导弹窗（「Vision Router 已准备好」）与模型引导步骤的「已读/进度」标记此前存在 `localStorage` 里；`localStorage` 按 origin（协议+域名+端口）隔离，于是每次启动端口变化都等于清零，弹窗每次启动都会再弹。

### 改动 / Changes

- **服务端（index.js）**：Config schema 新增两个内部字段 `onboardingSeen`（boolean）与 `visionGuideStep`（string），设置提供方会随 profile 设置文件持久化；卡片不渲染它们，服务端也不读取。
- **客户端（lib/client.js）**：通过 `ctx.settingsScope` 读写这两个字段：
  - `readOnboardingSeen` / `rememberOnboardingSeen`：设置段优先；旧版 `localStorage` 标记作为迁移来源（读到就回写进设置）与降级兜底通道，写操作双写两处（尽力而为）；
  - 模型引导步骤 `visionGuideStep` 同样双通道；
  - `installOnboarding` / `installVisionSettingsGuide` 订阅设置快照：快照在页面加载后异步到达、晚于弹窗调度的竞态会被处理——快照到达发现「已读」会自动收起已弹出的引导，且不会重复写标记；
  - 只读设置提供方下行为与之前一致（回落 localStorage）。
- **测试**：client.test.js 新增源码断言 + 覆盖五个场景的行为断言（设置已读不弹、全新安装弹一次且「稍后」双写、旧 localStorage 迁移、快照竞态自动收起、只读提供方回落）。

### 发布 / Release

版本升到 v1.2.3，CHANGELOG 双语条目与 README.md / README.zh.md 顶部公告条同步更新。