### PR TITLE
fix: keep vision tool schema stable by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ The auto-vision group follows the live DSH model catalog. Adding models or chang
 
 ### 3. Paste or upload the image
 
-After choosing the “+ Auto Vision” group, paste or upload an image normally. The agent auto-mounts the vision tools and can use `vision_describe`, `vision_ground`, `vision_crop`, and the rest across multiple steps when needed.
+After choosing the “+ Auto Vision” group, paste or upload an image normally. By default the complete vision tool schema is stable from session start, so the agent can immediately use `vision_describe`, `vision_ground`, `vision_crop`, and the rest across multiple steps when needed.
 
 The built-in anonymous OVH vision fallback is already configured, so normal image use needs no signup or API key. **The lower-right chat picker selects only the brain/conversation model**; vision backends do not belong there. Advanced options live under **Settings → Plugins → Plugin config → 视觉路由（自动识图）**: each vision-backend row selects one image-capable user model already configured under **Settings → Models**. Leaving every user row empty is valid; the OVH chain remains the final fallback. `Vision HTTP` is an internal transport route, not a model group users should select.
 
@@ -129,7 +129,7 @@ The built-in anonymous OVH vision fallback is already configured, so normal imag
 - **Automatic failover with classified errors.** Region blocks, ToS filtering, 402 quota, 429 rate limits (with Retry-After backoff), context overflow, network failures — the chain walks providers one by one and only reports after all of them failed, with actionable advice.
 - **Image memory.** Vision answers are cached by attachment content hash; later text turns substitute the recorded description (marked as untrusted evidence), so DeepSeek genuinely remembers earlier images without re-spending vision calls.
 - **A verifiable pixel loop.** Reference → `vision_html_screenshot` → `vision_pixel_diff` (ratio + red heatmap + worst-region ranking) → fix → repeat until the mismatch converges. UI restoration becomes measurable instead of eyeballed.
-- **Progressive schema exposure.** Only a zero-arg `vision_activate` bootstrap is always visible; image turns auto-mount all eleven deep tools with a one-time usage note, and a `vision-tools` skill is registered for text-only turns.
+- **Stable tool schema.** All eleven deep tools are registered from session start by default, avoiding a mid-conversation tool-list expansion that can invalidate long-context KV/prefix caches. `progressiveTools: true` remains an advanced boot-time opt-in; only then does `vision_activate` mount the tools on demand. See [`docs/progressive-tools-cache.md`](docs/progressive-tools-cache.md).
 - **Selective proxy.** Only the configured vision provider hosts go through your local proxy; DeepSeek stays direct.
 
 ### Pixel loop in practice
@@ -150,7 +150,7 @@ The vision model is **only the eyes**; DeepSeek is **always the brain**. An imag
 
 ## Tools
 
-All eleven deep tools mount automatically on image turns (`autoActivateOnImage`); text turns can mount them via `vision_activate` or the `/vision-tools` skill. Built on sharp / potrace / tesseract / system Chrome — no Python:
+Default `progressiveTools: false`: all eleven deep tools stay registered from plugin startup, so text and image turns can call them immediately. If you explicitly set `progressiveTools: true` in the profile/composition `cordis.patch.yml`, progressive mode is restored: only `vision_activate` is exposed initially, the full tool set mounts on first use, and the `vision-tools` skill is registered. This is a boot-time switch; restart DSH after changing it. Built on sharp / potrace / tesseract / system Chrome — no Python:
 
 <p align="center">
   <img src="assets/vision-tools.svg" width="100%" alt="Eleven vision tools available in DSH Vision Router." />
@@ -266,7 +266,7 @@ Everything is optional; defaults work out of the box. Edit via the Web card or a
 | `wrapperRoute` / `chainRoute` | `deepseek-vision` / `vision-chain` | admission wrapper route name / fallback chain route name (empty disables) |
 | `stealth` | `false` | take over the official `deepseek-official` route (official row only; custom routes are auto-wrapped by default) |
 | `textProvider` | `deepseek-official` / `deepseek-v4-pro` | the model that reasons (your daily model) |
-| `tool` / `progressiveTools` / `autoActivateOnImage` | `true` ×3 | vision tools on / progressive mounting / auto-mount on image turns |
+| `tool` / `progressiveTools` / `autoActivateOnImage` | `true` / `false` / `true` | vision tools on / progressive mounting (off by default for a stable tool schema) / image-turn auto-mount when progressive mode is enabled; `progressiveTools` is boot-time config |
 | `rewriteImages` | `true` | rewrite image blocks in the model input (cached description or tool-hint marker); the UI log keeps images |
 | `downscale` / `downscaleMaxPixels` | `true` / `4000000` | pre-call downscale and its pixel budget (latency guard) |
 | `cache` / `cacheTtlSeconds` / `cacheMaxEntries` | `true` / `3600` / `200` | vision answer cache |

--- a/README.zh.md
+++ b/README.zh.md
@@ -110,7 +110,7 @@ opencode-go + 自动识图       ← 发图片时选这个
 
 ### 3. 直接粘贴或上传图片
 
-选好「+ 自动识图」模型组后，直接往对话里贴图即可。Agent 会自动挂载视觉工具，通过 `vision_describe`、`vision_ground`、`vision_crop` 等工具看图，需要时连续多步操作。
+选好「+ 自动识图」模型组后，直接往对话里贴图即可。默认情况下完整视觉工具表从会话开始就保持稳定，Agent 可直接调用 `vision_describe`、`vision_ground`、`vision_crop` 等工具看图，需要时连续多步操作。
 
 默认已经有内置 OVH 匿名视觉兜底，无需注册、无需 Key。**聊天页右下角只选择“脑子/会话模型”**；视觉模型不要在那里选。高级配置在 **设置 → 插件 → 插件配置 → 视觉路由（自动识图）**：视觉后端链每一行只选择一个你在 **设置 → 模型** 中已经配置且支持图片输入的用户模型；一行都不填也可以，OVH 免费链会固定在最后兜底。插件内部的 `Vision HTTP` 只是传输实现，不是用户需要选择的模型组。
 
@@ -129,7 +129,7 @@ opencode-go + 自动识图       ← 发图片时选这个
 - **自动降级 + 分类报错。** 地区限制、ToS 风控、402 额度、429 限流（尊重 Retry-After 退避重试）、上下文超长、网络故障——链路逐供应商尝试，全部失败才报错并给出可操作的建议。
 - **图片记忆。** 视觉答案按附件内容哈希缓存；后续文字轮用记录的描述替换历史图片（标注为不可信证据），DeepSeek 真正“记得”之前发过的图，且不重复消耗视觉调用。
 - **可验证的像素闭环。** 参照图 → `vision_html_screenshot` → `vision_pixel_diff`（差异率 + 红色热力图 + 最差区域排行）→ 修复 → 再对比，直到差异收敛。UI 还原从“目测”变成“实测”。
-- **渐进式 schema 暴露。** 平时只有一个零参引导工具 `vision_activate`；图片轮自动挂载全部 11 个深看工具（附一次性使用提示），并为纯文字轮注册 `vision-tools` 技能。
+- **稳定工具 schema。** 默认从会话开始就注册完整 11 个深看工具，避免图片轮中途扩展工具列表导致长上下文的 KV / prefix cache 失效。仍保留 `progressiveTools: true` 作为高级启动期 opt-in；开启后才使用 `vision_activate` 按需挂载。详见 [`docs/progressive-tools-cache.md`](docs/progressive-tools-cache.md)。
 - **选择性代理。** 只有配置的视觉供应商域名走本地代理；DeepSeek 保持直连。
 
 ### 像素闭环实测
@@ -150,7 +150,7 @@ Agent 仅根据参考图复刻 UI，再用 `vision_pixel_diff` 验证最终结�
 
 ## 工具
 
-11 个深看工具在图片轮自动挂载（`autoActivateOnImage`）；文字轮可通过 `vision_activate` 或 `/vision-tools` 技能挂载。全部基于 sharp / potrace / tesseract / 系统 Chrome——无 Python：
+默认 `progressiveTools: false`：11 个深看工具从插件启动时就保持常驻，文本轮和图片轮都可直接调用。若你在 profile / composition 的 `cordis.patch.yml` 中显式开启 `progressiveTools: true`，才会恢复渐进模式：初始只暴露 `vision_activate`，首次需要时再挂载完整工具，并注册 `vision-tools` 技能。该开关是启动期配置，修改后需重启 DSH。全部工具基于 sharp / potrace / tesseract / 系统 Chrome——无 Python：
 
 <p align="center">
   <img src="assets/vision-tools-zh.svg" width="100%" alt="DSH Vision Router 的 11 个视觉工具。" />
@@ -266,7 +266,7 @@ Web 配置页在 **设置 → 插件 → 插件配置** 下注册「视觉路由
 | `wrapperRoute` / `chainRoute` | `deepseek-vision` / `vision-chain` | 准入包装路由名 / 降级链路由名（置空关闭） |
 | `stealth` | `false` | 接管官方 `deepseek-official` 路由（仅官方行；自定义路由默认由自动包装处理） |
 | `textProvider` | `deepseek-official` / `deepseek-v4-pro` | 负责思考的模型（你的日常模型） |
-| `tool` / `progressiveTools` / `autoActivateOnImage` | `true` ×3 | 视觉工具开关 / 渐进式挂载 / 图片轮自动挂载 |
+| `tool` / `progressiveTools` / `autoActivateOnImage` | `true` / `false` / `true` | 视觉工具总开关 / 渐进式挂载（默认关闭以稳定工具 schema）/ 渐进模式下图片轮自动挂载；`progressiveTools` 为启动期配置 |
 | `rewriteImages` | `true` | 模型输入层改写图片块（缓存描述或工具提示标记）；界面日志保留图片 |
 | `downscale` / `downscaleMaxPixels` | `true` / `4000000` | 调用前压缩及其像素预算（延迟保护） |
 | `cache` / `cacheTtlSeconds` / `cacheMaxEntries` | `true` / `3600` / `200` | 视觉答案缓存 |

--- a/cordis.patch.yml
+++ b/cordis.patch.yml
@@ -10,8 +10,8 @@
 
 # 挂载插件行。默认保持完整视觉工具表常驻（issue #81）：虽然渐进挂载可以
 # 少发一小段工具 schema，但图片轮首次扩展工具列表会改变请求前缀，可能让
-# 长会话的 provider KV/prefix cache 整体失效。高级用户仍可在设置层显式把
-# progressiveTools 改回 true；profile/user patch 仍可覆盖这里的默认值。
+# 长会话的 provider KV/prefix cache 整体失效。高级用户仍可在 profile /
+# composition 补丁中显式把 progressiveTools 改回 true（启动期配置）。
 - insert:
     - id: vision-router
       name: dsh-vision-router

--- a/cordis.patch.yml
+++ b/cordis.patch.yml
@@ -8,11 +8,15 @@
 # 挂载后是否接管官方 deepseek-official 路由由设置里的「隐身模式」开关决定
 # （默认关；开启后需自行在 profile 补丁层禁用 llm-deepseek 行）。
 
-# 挂载插件行。配置全部可选（默认即内置免费视觉端点 + 工具优先的图片流程），
-# 可在 Web 设置 > 插件 > 插件配置 的「视觉路由」卡片里实时修改。
+# 挂载插件行。默认保持完整视觉工具表常驻（issue #81）：虽然渐进挂载可以
+# 少发一小段工具 schema，但图片轮首次扩展工具列表会改变请求前缀，可能让
+# 长会话的 provider KV/prefix cache 整体失效。高级用户仍可在设置层显式把
+# progressiveTools 改回 true；profile/user patch 仍可覆盖这里的默认值。
 - insert:
     - id: vision-router
       name: dsh-vision-router
+      config:
+        progressiveTools: false
 
 # 放宽附件图片限制（部署默认 5MB / 4000 万像素 → 20MB / 1 亿像素），
 # 大尺寸设计稿/扫描图可过审。字段可选，不需要可在 profile 补丁层覆写。

--- a/docs/progressive-tools-cache.md
+++ b/docs/progressive-tools-cache.md
@@ -11,16 +11,21 @@ vision-router:
   progressiveTools: false
 ```
 
+插件入口本身也把 `progressiveTools` 的 schema 默认值设为 `false`，因此即使后续 profile patch 整块覆盖了 bundle 的 `config`、但没有重述这个字段，也不会意外回到渐进模式。
+
 原因是很多模型服务的 KV / prefix cache 会把工具 schema 视为请求前缀的一部分。若长会话一开始只暴露 `vision_activate`，第一次图片轮再挂载完整视觉工具，工具列表发生变化后可能导致此前的大段会话前缀无法命中缓存。
 
-渐进式暴露仍然保留为高级 opt-in。如果你更在意平时请求中少携带工具 schema，而不依赖长会话前缀缓存，可以在 `settings.yaml` 或 profile patch 中显式设置：
+渐进式暴露仍然保留为高级 opt-in。如果你更在意平时请求中少携带工具 schema，而不依赖长会话前缀缓存，请在 **profile / composition 的 `cordis.patch.yml`** 中显式给 `vision-router` 设置：
 
 ```yaml
-vision-router:
-  progressiveTools: true
+- id: vision-router
+  config:
+    progressiveTools: true
 ```
 
-这不会改变视觉工具本身，只改变它们是从会话开始常驻，还是第一次需要时再挂载。
+`progressiveTools` 决定插件启动时注册哪组工具，因此它是**启动期配置**；不要依赖运行中的 Web 设置热切换这个字段。修改 profile patch 后重启 DSH。
+
+开启后，平时只暴露 `vision_activate`，首次需要时再挂载完整视觉工具；默认关闭时，完整视觉工具从一开始就常驻。视觉工具本身的能力不变。
 
 ## English
 
@@ -31,13 +36,18 @@ vision-router:
   progressiveTools: false
 ```
 
+The public plugin entrypoint also makes `false` the schema default. Therefore a later profile patch that replaces the bundle `config` without restating this field cannot accidentally fall back to progressive mode.
+
 Many model providers include tool schemas in the KV/prefix-cacheable request prefix. If a long conversation starts with only `vision_activate` and the first image turn later mounts the complete vision tool set, that prefix change can invalidate a large cached history.
 
-Progressive exposure remains available as an advanced opt-in. If minimizing the always-present tool schema matters more than long-context prefix-cache stability, explicitly set the following in `settings.yaml` or a profile patch:
+Progressive exposure remains available as an advanced opt-in. If minimizing the always-present tool schema matters more than long-context prefix-cache stability, explicitly set it in the **profile/composition `cordis.patch.yml`**:
 
 ```yaml
-vision-router:
-  progressiveTools: true
+- id: vision-router
+  config:
+    progressiveTools: true
 ```
 
-This changes only when the tools are mounted; it does not change the vision tools themselves.
+`progressiveTools` determines which tools are registered at plugin startup, so it is a **boot-time setting**; do not rely on changing this field through live Web settings. Restart DSH after changing the profile patch.
+
+When enabled, only `vision_activate` is exposed initially and the complete vision tool set mounts on first use. With the default disabled mode, the complete vision tool set is present from the start. The vision capabilities themselves are unchanged.

--- a/docs/progressive-tools-cache.md
+++ b/docs/progressive-tools-cache.md
@@ -4,11 +4,13 @@
 
 ## 中文
 
-Vision Router 默认让完整视觉工具表从会话开始就保持稳定。正常通过 DSH bundle 安装时，`cordis.patch.yml` 会提供：
+Vision Router 默认让完整视觉工具表从会话开始就保持稳定。正常通过 DSH bundle 安装时，组合层会提供：
 
 ```yaml
-vision-router:
-  progressiveTools: false
+- id: vision-router
+  name: dsh-vision-router
+  config:
+    progressiveTools: false
 ```
 
 插件入口本身也把 `progressiveTools` 的 schema 默认值设为 `false`，因此即使后续 profile patch 整块覆盖了 bundle 的 `config`、但没有重述这个字段，也不会意外回到渐进模式。
@@ -29,11 +31,13 @@ vision-router:
 
 ## English
 
-Vision Router keeps the complete vision tool schema stable from the beginning of a session by default. Normal DSH bundle installs provide:
+Vision Router keeps the complete vision tool schema stable from the beginning of a session by default. Normal DSH bundle installs provide this composition layer:
 
 ```yaml
-vision-router:
-  progressiveTools: false
+- id: vision-router
+  name: dsh-vision-router
+  config:
+    progressiveTools: false
 ```
 
 The public plugin entrypoint also makes `false` the schema default. Therefore a later profile patch that replaces the bundle `config` without restating this field cannot accidentally fall back to progressive mode.

--- a/docs/progressive-tools-cache.md
+++ b/docs/progressive-tools-cache.md
@@ -1,0 +1,43 @@
+# Progressive tools and prefix cache
+
+中文 | English
+
+## 中文
+
+Vision Router 默认让完整视觉工具表从会话开始就保持稳定。正常通过 DSH bundle 安装时，`cordis.patch.yml` 会提供：
+
+```yaml
+vision-router:
+  progressiveTools: false
+```
+
+原因是很多模型服务的 KV / prefix cache 会把工具 schema 视为请求前缀的一部分。若长会话一开始只暴露 `vision_activate`，第一次图片轮再挂载完整视觉工具，工具列表发生变化后可能导致此前的大段会话前缀无法命中缓存。
+
+渐进式暴露仍然保留为高级 opt-in。如果你更在意平时请求中少携带工具 schema，而不依赖长会话前缀缓存，可以在 `settings.yaml` 或 profile patch 中显式设置：
+
+```yaml
+vision-router:
+  progressiveTools: true
+```
+
+这不会改变视觉工具本身，只改变它们是从会话开始常驻，还是第一次需要时再挂载。
+
+## English
+
+Vision Router keeps the complete vision tool schema stable from the beginning of a session by default. Normal DSH bundle installs provide:
+
+```yaml
+vision-router:
+  progressiveTools: false
+```
+
+Many model providers include tool schemas in the KV/prefix-cacheable request prefix. If a long conversation starts with only `vision_activate` and the first image turn later mounts the complete vision tool set, that prefix change can invalidate a large cached history.
+
+Progressive exposure remains available as an advanced opt-in. If minimizing the always-present tool schema matters more than long-context prefix-cache stability, explicitly set the following in `settings.yaml` or a profile patch:
+
+```yaml
+vision-router:
+  progressiveTools: true
+```
+
+This changes only when the tools are mounted; it does not change the vision tools themselves.

--- a/entry.js
+++ b/entry.js
@@ -1,0 +1,29 @@
+// Public plugin entrypoint.
+//
+// Keep the large implementation in index.js, but normalize the progressive
+// tools switch here before Cordis reads the exported Config. Issue #81 showed
+// that changing the tool schema mid-session can invalidate provider prefix/KV
+// caches for very long conversations, so progressive exposure is now an
+// explicit opt-in rather than the implicit fallback.
+
+import z from '@deepseek-ai/schemastery'
+import * as core from './index.js'
+
+// Schemastery object schemas expose set() as the supported way to replace a
+// field schema. This mutates the Config object that index.js itself later uses
+// for the settings namespace, so composition config and settings validation
+// agree on the same default.
+core.Config.set('progressiveTools', z.boolean().default(false))
+
+export * from './index.js'
+export const Config = core.Config
+
+// Defense in depth for direct/programmatic callers that invoke apply() without
+// first running the Cordis Config resolver: only an explicit true enables the
+// schema-changing progressive mode.
+export function apply(ctx, config = {}) {
+  return core.apply(ctx, {
+    ...config,
+    progressiveTools: config.progressiveTools === true,
+  })
+}

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "sharp": "^0.35.3"
   },
   "scripts": {
-    "test": "node --test tests/core.test.js tests/client.test.js tests/http-compat.test.js tests/update-check.test.js tests/self-update.test.js tests/doctor.test.js"
+    "test": "node --test tests/core.test.js tests/client.test.js tests/http-compat.test.js tests/update-check.test.js tests/self-update.test.js tests/doctor.test.js tests/bundle-defaults.test.js"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/package.json
+++ b/package.json
@@ -9,12 +9,12 @@
   },
   "homepage": "https://github.com/ysr666/dsh-vision-router",
   "type": "module",
-  "main": "index.js",
+  "main": "entry.js",
   "bin": {
     "dsh-vision-router": "./lib/doctor-cli.js"
   },
   "exports": {
-    ".": "./index.js",
+    ".": "./entry.js",
     "./client": "./lib/client.js",
     "./package.json": "./package.json",
     "./cordis.patch.yml": "./cordis.patch.yml"
@@ -26,6 +26,7 @@
     "assets",
     "cordis.patch.yml",
     "docs",
+    "entry.js",
     "index.js",
     "lib",
     "presets"

--- a/tests/bundle-defaults.test.js
+++ b/tests/bundle-defaults.test.js
@@ -1,6 +1,7 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import { readFile } from 'node:fs/promises'
+import { Config } from '../entry.js'
 
 const bundlePatch = new URL('../cordis.patch.yml', import.meta.url)
 
@@ -10,4 +11,12 @@ test('installed bundle keeps the full vision tool schema stable by default', asy
     text,
     /- id: vision-router[\s\S]*?name: dsh-vision-router[\s\S]*?config:\s*\n\s+progressiveTools: false/,
   )
+})
+
+test('public plugin config defaults progressive tools off', () => {
+  assert.equal(Config({}).progressiveTools, false)
+})
+
+test('progressive tools remain an explicit opt-in', () => {
+  assert.equal(Config({ progressiveTools: true }).progressiveTools, true)
 })

--- a/tests/bundle-defaults.test.js
+++ b/tests/bundle-defaults.test.js
@@ -1,0 +1,13 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+
+const bundlePatch = new URL('../cordis.patch.yml', import.meta.url)
+
+test('installed bundle keeps the full vision tool schema stable by default', async () => {
+  const text = await readFile(bundlePatch, 'utf8')
+  assert.match(
+    text,
+    /- id: vision-router[\s\S]*?name: dsh-vision-router[\s\S]*?config:\s*\n\s+progressiveTools: false/,
+  )
+})


### PR DESCRIPTION
## What changed

- keep the complete vision tool schema stable by default (`progressiveTools: false`) to protect long-context prefix/KV cache reuse
- set the same default in both the installed bundle layer and the public plugin entrypoint, so later profile config replacement or direct/programmatic loading cannot silently fall back to progressive mode
- preserve progressive mounting as an explicit boot-time opt-in (`progressiveTools: true` in the profile/composition patch)
- add regression coverage for the bundle default, public Config default, and explicit opt-in
- update Chinese/English README guidance and add a bilingual cache/opt-in note

## Why

Issue #81 demonstrates that expanding the tool list on the first image turn changes the request prefix. On providers that cache the prefix/KV state, that schema change can invalidate a very large cached conversation history and make an image turn unexpectedly expensive.

Stable mode already existed in the runtime; this PR changes which mode is the default. Progressive mode remains available for users who prefer a smaller always-present tool schema over long-context cache stability.

## Compatibility details

- normal bundle installs: stable mode from `cordis.patch.yml`
- profile patches that replace the bundle `config` but omit `progressiveTools`: still stable because the package entrypoint Config defaults it to false
- explicit `progressiveTools: true`: preserves the previous progressive behavior (`vision_activate`, on-demand full tool mounting, `vision-tools` skill)
- this switch is boot-time because tool registration is decided when the plugin starts; it is documented as a profile/composition setting rather than a live Web toggle

## Validation

- previous code/test revision passed GitHub CI on Node 22 and 24 plus macOS, Windows, and Ubuntu host-sharp jobs
- the final entrypoint/default changes add dedicated regression tests; this PR should only be merged after CI succeeds on the latest code head

Closes #81