### PR TITLE
feat: recognize undeclared vision models (Zhipu official channel) with a dropdown override and a direct channel bridge

### DIFF
--- a/index.js
+++ b/index.js
@@ -233,6 +233,12 @@ export const Config = z.object({
   tool: z.boolean().default(true),
   progressiveTools: z.boolean().default(true),
   autoActivateOnImage: z.boolean().default(true),
+  // User feedback (Zhipu official channel): some channels expose vision
+  // models whose catalog metadata does not declare image input. Models the
+  // built-in name inference does not recognize can be forced here — one model
+  // id (or "provider/model") per entry. Only consulted for vision BACKEND
+  // capability (the session-side admission stays host-owned).
+  extraVisionModels: z.array(z.string()).default([]),
   // Client-persisted UI state (issue #78): DSH Desktop serves the Web UI from
   // a random port on every launch, so origin-scoped localStorage forgets the
   // first-run onboarding dialog and it re-appeared on every boot. These keys
@@ -2005,6 +2011,96 @@ export function modelInfoAcceptsImages(info) {
   return Array.isArray(info && info.inputModalities) && info.inputModalities.includes('image')
 }
 
+// User feedback: channels like the Zhipu official one (open.bigmodel.cn,
+// configured with a custom model list) expose vision models whose catalog
+// metadata does NOT declare image input, even though the models accept images
+// (e.g. glm-4.6v). DSH's Web settings do not write the `input: [text, image]`
+// declaration for custom channels either, so a strict metadata check hides
+// perfectly usable vision backends. The conservative, curated name patterns
+// below recognize well-known multimodal model families as a fallback; models
+// that still do not match can be forced via the `extraVisionModels` setting.
+const VISION_MODEL_NAME_HINTS = [
+  // Zhipu VLM family: glm-4.6v, glm-4.6v-flash, glm-4v-plus, glm-4.5v(-plus)…
+  /(^|\/)glm-4[\w.-]*v(?=$|[-/])/i,
+  /(^|\/)glm-4v(?=$|[-/])/i,
+  // Qwen VL / QVQ vision-reasoning family (excludes plain qwen3-14b etc.).
+  /(^|\/)qwen[\w.-]*(vl|vision)/i,
+  /(^|\/)qvq(?=$|[-.])/i,
+  // OpenAI multimodal line (gpt-4o*, gpt-4.1*, gpt-5*, gpt-oss*).
+  /(^|\/)gpt-(4o|4\.1|5|oss)(?=$|[-.])/i,
+  /(^|\/)gemini/i,
+  // Claude 3+ / Sonnet/Opus/Haiku are multimodal (claude-2 is not).
+  /(^|\/)(claude-(3|4)(?=$|[-.])|claude[\w.-]*(sonnet|opus|haiku))/i,
+  /(^|\/)(internvl|cogvlm|llava|pixtral)/i,
+  /(^|\/)(doubao|hunyuan|minimax|ernie)[\w.-]*(vl|vision)/i,
+  /(^|\/)ernie-4\.5/i,
+  /(^|\/)(yi-vision|kimi[\w.-]*vision|moonshot[\w.-]*vision)/i,
+  /(^|\/)step[\w.-]*(v|vision)(?=$|[-/])/i,
+  /(^|\/)grok[\w.-]*vision/i,
+  /(^|\/)grok-4(?=$|[-.])/i,
+  /(^|\/)llama[\w.-]*vision/i,
+  /(^|\/)mistral[\w.-]*pixtral/i,
+  /(^|\/)(phi[\w.-]*vision|florence[\w.-]*)/i,
+]
+
+/**
+ * Conservative name-based inference for vision capability: true only when the
+ * model id matches a well-known multimodal naming pattern. Used as a fallback
+ * when catalog metadata does not declare image input; never overrides an
+ * explicit text-only declaration on the session/twin paths.
+ */
+export function looksLikeVisionModel(modelId) {
+  const id = String(modelId ?? '').trim()
+  if (id === '') return false
+  return VISION_MODEL_NAME_HINTS.some((pattern) => pattern.test(id))
+}
+
+/**
+ * Pure capability decision for a vision backend: explicit metadata first,
+ * then the user's `extraVisionModels` override list, then the name-based
+ * inference, and finally a text-only verdict.
+ *
+ * @param info - resolved model metadata (may be undefined when the lookup failed).
+ * @param provider - provider id, used to match "provider/model" override entries.
+ * @param model - model id.
+ * @param extraVisionModels - user-configured model ids (or "provider/model") forced vision-capable.
+ * @returns { image, inputModalities, inferred, reason } where `inferred` is
+ * false for declared image input, 'override' for the user list, 'name' for the
+ * naming heuristic, and `reason` explains a text-only verdict.
+ */
+export function decideVisionBackendCapability(info, provider, model, extraVisionModels) {
+  const inputModalities = Array.isArray(info && info.inputModalities)
+    ? info.inputModalities.filter((item) => typeof item === 'string')
+    : []
+  const modelId = String(model ?? '').trim()
+  if (inputModalities.includes('image')) {
+    return { image: true, inputModalities, inferred: false, reason: undefined }
+  }
+  const extras = Array.isArray(extraVisionModels)
+    ? extraVisionModels.map((entry) => String(entry ?? '').trim()).filter((entry) => entry !== '')
+    : []
+  if (modelId !== '' && extras.some((entry) => entry === modelId)) {
+    return { image: true, inputModalities: [...inputModalities, 'image'], inferred: 'override', reason: undefined }
+  }
+  const providerId = String(provider ?? '').trim()
+  if (
+    modelId !== '' &&
+    providerId !== '' &&
+    extras.some((entry) => entry === `${providerId}/${modelId}`)
+  ) {
+    return { image: true, inputModalities: [...inputModalities, 'image'], inferred: 'override', reason: undefined }
+  }
+  if (modelId !== '' && looksLikeVisionModel(modelId)) {
+    return { image: true, inputModalities: [...inputModalities, 'image'], inferred: 'name', reason: undefined }
+  }
+  return {
+    image: false,
+    inputModalities,
+    inferred: false,
+    reason: 'model metadata does not declare image input',
+  }
+}
+
 export function apply(ctx, config = {}) {
   // Route sharp version diagnostics (issue #75) through the harness logger
   // instead of console.warn, so the warning lands in the server log.
@@ -2640,21 +2736,83 @@ export function apply(ctx, config = {}) {
     }
     try {
       const info = await ctx.llm.resolveModelInfo(provider, model)
-      const inputModalities = Array.isArray(info && info.inputModalities)
-        ? info.inputModalities.filter((item) => typeof item === 'string')
-        : []
-      return {
-        image: modelInfoAcceptsImages(info),
-        inputModalities,
-        reason: modelInfoAcceptsImages(info) ? undefined : 'model metadata does not declare image input',
-      }
+      return decideVisionBackendCapability(info, provider, model, current().extraVisionModels)
     } catch (error) {
+      // Metadata lookup failed (custom model lists often do): fall back to
+      // the user override list and the name heuristic before declaring the
+      // model text-only.
+      const fallback = decideVisionBackendCapability(undefined, provider, model, current().extraVisionModels)
+      if (fallback.image) return fallback
       return {
         image: false,
         inputModalities: [],
         reason: error && error.message ? error.message : String(error),
       }
     }
+  }
+
+  // ── direct OpenAI-compatible bridge for undeclared vision channels ─────────
+  //
+  // User feedback (Zhipu official channel, open.bigmodel.cn): some channels
+  // expose vision models whose catalog metadata does NOT declare image input,
+  // so the channel adapter refuses image requests at the wire
+  // (UNSUPPORTED_CONTENT: model "x" does not support image input) even though
+  // the models accept images. For backends recognized only through the name
+  // inference or the extraVisionModels override, fall back to calling the
+  // channel's OpenAI-compatible endpoint directly with the channel's own
+  // baseURL and credential — no hand-edited settings.yaml needed. Defensive
+  // reads only: if the channel settings section, the baseURL, or the
+  // credential cannot be resolved, the bridge is simply unavailable and the
+  // adapter's own error is reported.
+  const channelProfileOf = (provider) => {
+    try {
+      const settings = ctx.get('settings')
+      const section =
+        settings && typeof settings.get === 'function' ? settings.get('llm-pi-ai') : undefined
+      const profile = section && section.providers ? section.providers[provider] : undefined
+      if (!profile || typeof profile.baseURL !== 'string' || profile.baseURL === '') return undefined
+      return profile
+    } catch {
+      return undefined
+    }
+  }
+  const resolveChannelApiKey = async (provider, profile) => {
+    const ref =
+      profile && typeof profile.apiKeyEnv === 'string' && profile.apiKeyEnv !== ''
+        ? profile.apiKeyEnv
+        : undefined
+    if (ref === undefined) return undefined
+    try {
+      const credentials = ctx.get('credentials')
+      if (credentials !== undefined) {
+        const hit = await credentials.resolve(ref)
+        if (hit && typeof hit.value === 'string' && hit.value.length > 0) return hit.value
+      }
+    } catch {
+      /* fall through to the ambient environment */
+    }
+    if (typeof process !== 'undefined' && process.env && typeof process.env[ref] === 'string') {
+      return process.env[ref]
+    }
+    return undefined
+  }
+  const directChannelVisionAnswer = async (provider, model, blocks, instruction, signal) => {
+    const profile = channelProfileOf(provider)
+    if (profile === undefined) return undefined
+    const apiKey = await resolveChannelApiKey(provider, profile)
+    if (apiKey === undefined || apiKey === '') return undefined
+    const attachments = ctx.get('attachments')
+    if (attachments === undefined) return undefined
+    const content = []
+    for (const block of blocks) {
+      const stored = await attachments.readImage(block.attachment)
+      content.push(...toOpenAIContent([block], () => stored.data))
+    }
+    return callOpenAICompatible(
+      { name: provider, baseURL: profile.baseURL, model, apiKeyEnv: '__vision-router-channel__' },
+      [{ role: 'user', content: [...content, { type: 'text', text: instruction }] }],
+      { maxTokens: 4096, signal, resolveCredential: () => apiKey },
+    )
   }
 
   const collectVisionBackendCapabilities = async () => {
@@ -3768,6 +3926,7 @@ export function apply(ctx, config = {}) {
       const block = await visionBlocksFromBytes(imageBytes, mediaType)
       const signal = AbortSignal.timeout(timeoutMs())
       const usablePairs = await resolveToolVisionPairs()
+      const pairCapabilities = new Map()
       for (const pair of pairs()) {
         if (!pair || pair.provider === HTTP_ROUTE) continue
         if (!adapterAvailable(ctx.llm, pair.provider)) {
@@ -3775,6 +3934,7 @@ export function apply(ctx, config = {}) {
           continue
         }
         const capability = await resolveVisionBackendCapability(pair.provider, pair.model)
+        pairCapabilities.set(`${pair.provider}/${pair.model}`, capability)
         if (!capability.image) {
           errors.push(
             `${pair.provider}/${pair.model}: not an image-capable backend (${capability.reason ?? 'unknown capability'})`,
@@ -3794,6 +3954,30 @@ export function apply(ctx, config = {}) {
           })
           if (text && text.trim() !== '') return { text: text.trim() }
         } catch (error) {
+          // Channels whose catalog does not declare image input reject images
+          // at the adapter wire. When the backend was recognized by the name
+          // inference or the extraVisionModels override, call the channel's
+          // OpenAI-compatible endpoint directly with its own baseURL and
+          // credential before giving up on this pair.
+          const capability = pairCapabilities.get(`${pair.provider}/${pair.model}`)
+          if (capability && capability.inferred) {
+            try {
+              const direct = await directChannelVisionAnswer(
+                pair.provider,
+                pair.model,
+                [block],
+                instruction,
+                signal,
+              )
+              if (direct && direct.trim() !== '') return { text: direct.trim() }
+            } catch (bridgeError) {
+              errors.push(
+                `${pair.provider}/${pair.model}: direct channel fallback failed (${
+                  bridgeError && bridgeError.message ? bridgeError.message : String(bridgeError)
+                })`,
+              )
+            }
+          }
           errors.push(`${pair.provider}/${pair.model}: ${error && error.message ? error.message : String(error)}`)
         }
       }

--- a/lib/client.js
+++ b/lib/client.js
@@ -59,7 +59,7 @@ window.__ModuleLoader__.load({
       builtinFallbackDisabled: '已关闭',
       builtinFallbackBody: 'OVHcloud 匿名视觉链共 {count} 个模型，首选 {primary}。匿名限额为每 IP、每模型 2 次/分钟；5 个模型独立限额，理论合计约 10 次/分钟，实际以 OVH 限流为准。它固定在上面用户模型之后尝试，免注册、免 Key。',
       chainLabel: '视觉后端链（给识图工具用）',
-      chainHint: '上面每一行只选择一个你在「设置 → 模型」中已经配置、且明确支持 image 输入的用户模型；从上到下依次尝试。可以一行都不填，下方内置 OVH 免费兜底仍会工作。',
+      chainHint: '上面每一行只选择一个你在「设置 → 模型」中已经配置的用户视觉模型（声明支持图片、按名称识别、或在下方「额外视觉模型」里手动指定）；从上到下依次尝试。可以一行都不填，下方内置 OVH 免费兜底仍会工作。',
       addFallback: '+ 添加备用视觉模型',
       remove: '移除',
       removeTitle: '移除这一行',
@@ -76,14 +76,14 @@ window.__ModuleLoader__.load({
       catalogFallback: '），模型字段已退回手动输入。',
       visionCapsLoading: '正在验证哪些模型真正支持图片输入…',
       visionCapsError: '视觉能力元数据暂时不可用；为防止误选，暂不提供用户视觉模型下拉。内置 OVH 免费兜底仍可用。',
-      visionCapsFiltered: '视觉后端下拉只显示明确声明 image 输入的模型。',
+      visionCapsFiltered: '视觉后端下拉只显示声明支持图片、或按名称/手动指定被识别为视觉的模型。',
       visionCapsEmptyTitle: '没有可选的用户视觉模型',
       visionCapsEmptyBody: '检测到 {count} 个用户模型，但它们都没有被 DSH 明确标记为支持图片，因此已被安全隐藏。',
       visionCapsHiddenPrefix: '被隐藏的模型：',
       visionCapsReasonMissingImage: '未声明 image',
       visionCapsReasonUnverified: '无法验证图片能力',
       visionCapsHiddenMore: '另有 {count} 个模型未显示',
-      visionCapsMissingImageHint: '如果这里有你刚在「设置 → 模型 → 添加自定义提供方」中添加的视觉模型，请在 $DSH_HOME/settings.yaml 为该模型补上 input: [text, image]，或为整个提供方补上 defaultInput: [text, image]。DSH 当前 Web 表单不会写入这个字段。',
+      visionCapsMissingImageHint: '如果这里有你刚在「设置 → 模型 → 添加自定义提供方」中添加的视觉模型：可以在高级设置「额外视觉模型」的下拉里选中它直接启用；或按 DSH 的方式在 $DSH_HOME/settings.yaml 为该模型补上 input: [text, image]（或为整个提供方补 defaultInput: [text, image]）。DSH 当前 Web 表单不会写入这个字段。',
       visionCapsRetry: '重新检测模型',
       chainInvalidCurrent: '当前保存的视觉后端不支持图片或无法验证，已从下拉列表隐藏，运行时也会跳过：',
       retryCatalog: '重试加载目录',
@@ -94,6 +94,12 @@ window.__ModuleLoader__.load({
         '「图片轮整轮自动路由」且会话入口为视觉路由时，作为文字轮的回退模型。',
       groupBehavior: '行为开关',
       groupParams: '参数',
+      groupVisionOverrides: '视觉模型识别',
+      extraVisionModelsLabel: '额外视觉模型（强制按视觉模型处理）',
+      extraVisionModelsHint:
+        '下拉里列出的是能力过滤时被排除的模型（目录未声明图片输入或无法验证），例如智谱官方渠道（open.bigmodel.cn）的模型。' +
+        '选中的模型会被强制按视觉模型处理：出现在上面的视觉后端下拉里并被识别工具接受；渠道适配器拒绝图片时插件会直连其 OpenAI 兼容端点。' +
+        '留空恢复默认。常见视觉模型（如 glm-4.6v、qwen-vl、gpt-4o 等）已按名称自动识别，无需在此选择。',
       groupRoutes: '路由名',
       groupProxy: '代理',
       proxyLabel: '代理地址',
@@ -240,7 +246,7 @@ window.__ModuleLoader__.load({
       builtinFallbackDisabled: 'Disabled',
       builtinFallbackBody: 'The anonymous OVHcloud vision chain contains {count} models, starting with {primary}. Anonymous limits are 2 requests/minute per IP per model; five independent model buckets are about 10 RPM in theory, subject to OVH rate limiting. It always runs after your user models and needs no signup or API key.',
       chainLabel: 'Vision backend chain (used by the vision tools)',
-      chainHint: 'Each row selects one user model already configured under Settings → Models and explicitly declaring image input. Rows are tried top to bottom. You may leave them all empty; the built-in OVH fallback below still works.',
+      chainHint: 'Each row selects one user vision model already configured under Settings → Models (declaring image input, recognized by name, or listed in “Extra vision models” below). Rows are tried top to bottom. You may leave them all empty; the built-in OVH fallback below still works.',
       addFallback: '+ Add vision fallback',
       remove: 'Remove',
       removeTitle: 'Remove this row',
@@ -257,14 +263,14 @@ window.__ModuleLoader__.load({
       catalogFallback: '); model fields fell back to free-text input.',
       visionCapsLoading: 'Checking which models genuinely accept image input…',
       visionCapsError: 'Vision capability metadata is unavailable; user vision-model choices are hidden to prevent bad selections. The built-in OVH fallback still works.',
-      visionCapsFiltered: 'The vision-backend dropdown only shows models that explicitly declare image input.',
+      visionCapsFiltered: 'The vision-backend dropdown shows only models that declare image input or are recognized as vision models by name / manual override.',
       visionCapsEmptyTitle: 'No selectable user vision models',
       visionCapsEmptyBody: 'DSH reported {count} user models, but none are explicitly marked as accepting images, so Vision Router hid them safely.',
       visionCapsHiddenPrefix: 'Hidden models:',
       visionCapsReasonMissingImage: 'image input not declared',
       visionCapsReasonUnverified: 'image capability could not be verified',
       visionCapsHiddenMore: '{count} more models not shown',
-      visionCapsMissingImageHint: 'If one of these is a vision model you just added through Settings → Models → Add custom provider, add input: [text, image] to that model in $DSH_HOME/settings.yaml, or defaultInput: [text, image] to the provider. The current DSH Web form does not write this field.',
+      visionCapsMissingImageHint: 'If one of these is a vision model you just added through Settings → Models → Add custom provider: select it in the “Extra vision models” dropdown under Advanced to enable it directly; or follow the DSH way and add input: [text, image] to that model in $DSH_HOME/settings.yaml (or defaultInput: [text, image] to the provider). The current DSH Web form does not write this field.',
       visionCapsRetry: 'Re-detect models',
       chainInvalidCurrent: 'This saved vision backend does not support images or could not be verified. It is hidden from the dropdown and skipped at runtime: ',
       retryCatalog: 'Retry catalog',
@@ -275,6 +281,15 @@ window.__ModuleLoader__.load({
         'text-turn fallback when whole-turn routing is on and the session entry is a vision route.',
       groupBehavior: 'Behavior',
       groupParams: 'Parameters',
+      groupVisionOverrides: 'Vision model recognition',
+      extraVisionModelsLabel: 'Extra vision models (force-treat as vision)',
+      extraVisionModelsHint:
+        'The dropdown lists the models the capability filter excluded (image input not declared or not verifiable) — ' +
+        'e.g. channels like the Zhipu official API at open.bigmodel.cn. Selected models are force-treated as vision ' +
+        'backends: they appear in the dropdown above, are accepted by the vision tools, and when the channel adapter ' +
+        'refuses images the plugin calls the channel\'s OpenAI-compatible endpoint directly. Leave empty to restore the ' +
+        'default. Well-known vision models (glm-4.6v, qwen-vl, gpt-4o, …) are recognized by name automatically and ' +
+        'need no selection here.',
       groupRoutes: 'Route names',
       groupProxy: 'Proxy',
       proxyLabel: 'Proxy URL',
@@ -977,6 +992,7 @@ window.__ModuleLoader__.load({
       cacheMaxEntries: 'numCacheMaxEntries',
       wrapperRoute: 'textWrapperRoute',
       chainRoute: 'textChainRoute',
+      extraVisionModels: 'extraVisionModelsLabel',
     }
     const HINT_KEY = {
       routing: 'hintRouting',
@@ -994,6 +1010,7 @@ window.__ModuleLoader__.load({
       cacheMaxEntries: 'numHintCacheMaxEntries',
       wrapperRoute: 'textHintWrapperRoute',
       chainRoute: 'textHintChainRoute',
+      extraVisionModels: 'extraVisionModelsHint',
     }
 
     function VisionRouterCard(props) {
@@ -1033,8 +1050,32 @@ window.__ModuleLoader__.load({
       const [visionCaps, setVisionCaps] = useState({ status: 'idle', capabilities: {}, builtinFallback: [], anonymousRpmPerModel: 2, error: undefined })
       const catalogReady = catalog.status === 'ready' && catalog.groups.length > 0
       const visionGroups = filterVisionBackendGroups(catalog.groups, visionCaps.capabilities)
-      const hiddenVisionBackends =
-        visionCaps.status === 'ready' ? collectFilteredVisionBackends(catalog.groups, visionCaps.capabilities) : []
+      // Memoized: recomputing this on every render (draft keystrokes,
+      // scroll-adjacent re-renders) walks every group × model of the catalog —
+      // hundreds of entries — and regressed the settings card's smoothness.
+      const hiddenVisionBackends = useMemo(
+        () =>
+          visionCaps.status === 'ready'
+            ? collectFilteredVisionBackends(catalog.groups, visionCaps.capabilities)
+            : [],
+        [catalog.groups, visionCaps.status, visionCaps.capabilities],
+      )
+      // Hooks must live at the component top level — the editor below is a
+      // conditionally rendered plain function, so it must NOT call hooks
+      // (a changing hook count across renders crashes React and takes the
+      // whole settings card down). Derive the editor's option sets here.
+      const hiddenVisionProviders = useMemo(
+        () => [...new Set(hiddenVisionBackends.map((entry) => entry.provider))].sort(),
+        [hiddenVisionBackends],
+      )
+      const hiddenVisionModelsOf = useMemo(() => {
+        const byProvider = new Map()
+        for (const entry of hiddenVisionBackends) {
+          if (!byProvider.has(entry.provider)) byProvider.set(entry.provider, [])
+          byProvider.get(entry.provider).push(entry.model)
+        }
+        return byProvider
+      }, [hiddenVisionBackends])
       const visionModelsFor = (providerId) => {
         const group = visionGroups.find((entry) => entry.id === providerId)
         return group && Array.isArray(group.models) ? group.models : []
@@ -1111,9 +1152,16 @@ window.__ModuleLoader__.load({
           })
         }
       }
-      const loadVisionCapabilities = (force = false) => {
+      const loadVisionCapabilities = (force = false, silent = false) => {
         if (!force && (visionCaps.status === 'loading' || visionCaps.status === 'ready')) return
-        setVisionCaps({ status: 'loading', capabilities: {}, builtinFallback: [], anonymousRpmPerModel: 2, error: undefined })
+        // Silent refresh (after saving/resetting the extraVisionModels
+        // override) keeps the current capabilities on screen while the new
+        // snapshot is fetched — a visible loading state here blanks the
+        // dropdown and the hidden-models panel, which reads as a full page
+        // refresh and churns the scroll.
+        if (!silent) {
+          setVisionCaps({ status: 'loading', capabilities: {}, builtinFallback: [], anonymousRpmPerModel: 2, error: undefined })
+        }
         fetch('/_dsh/vision-router/model-capabilities')
           .then(async (response) => {
             const body = await response.json().catch(() => undefined)
@@ -1238,6 +1286,19 @@ window.__ModuleLoader__.load({
           return textProviderToText(value)
         }
         if (key === 'proxyHosts') return Array.isArray(value) ? value.join('\n') : ''
+        if (key === 'extraVisionModels') {
+          if (!Array.isArray(value)) return ''
+          return value
+            .map((entry) =>
+              entry && typeof entry === 'object'
+                ? entry.provider && entry.model
+                  ? `${entry.provider}/${entry.model}`
+                  : ''
+                : String(entry ?? '').trim(),
+            )
+            .filter((entry) => entry !== '')
+            .join('\n')
+        }
         if (key === 'wrappedProviders') {
           if (catalogReady) {
             // Expand the persisted { provider, models[] } entries into one
@@ -1298,6 +1359,32 @@ window.__ModuleLoader__.load({
             .split('\n')
             .map((host) => host.trim())
             .filter((host) => host !== '')
+          return list.length > 0 ? { value: list } : { clear: true }
+        }
+        if (key === 'extraVisionModels') {
+          // The dropdown editor drafts rows of { provider, model } objects
+          // (an incomplete row stays visible until the user picks both);
+          // string entries are the legacy/free-text shape. Both are accepted.
+          if (Array.isArray(text)) {
+            const half = text.some((row) => {
+              if (!row || typeof row !== 'object') return false
+              return row.provider ? !row.model : !!row.model
+            })
+            if (half) return undefined
+            const list = text
+              .map((row) => {
+                if (row && typeof row === 'object') {
+                  return row.provider && row.model ? `${row.provider}/${row.model}` : ''
+                }
+                return String(row ?? '').trim()
+              })
+              .filter((entry) => entry !== '')
+            return list.length > 0 ? { value: list } : { clear: true }
+          }
+          const list = String(text ?? '')
+            .split(/[\n,]+/)
+            .map((entry) => entry.trim())
+            .filter((entry) => entry !== '')
           return list.length > 0 ? { value: list } : { clear: true }
         }
         if (key === 'wrappedProviders') {
@@ -1383,6 +1470,10 @@ window.__ModuleLoader__.load({
         if (landed) setDrafts({})
         setSaving(false)
         setFailed(!landed)
+        // The extraVisionModels override changes which models count as vision
+        // backends: refresh the capability map so the dropdown reflects the
+        // saved override immediately.
+        if (landed && plan.some((item) => item.key === 'extraVisionModels')) loadVisionCapabilities(true, true)
       }
       const resetField = (key) => {
         setFailed(false)
@@ -1392,6 +1483,11 @@ window.__ModuleLoader__.load({
           return next
         })
         scope.unset(key)
+        // Resetting the override changes capability decisions; the unset
+        // round-trips asynchronously, so refresh shortly after it lands.
+        if (key === 'extraVisionModels' && typeof window !== 'undefined') {
+          window.setTimeout(() => loadVisionCapabilities(true, true), 400)
+        }
       }
 
       const runTestConnection = async () => {
@@ -1616,6 +1712,118 @@ window.__ModuleLoader__.load({
               onClick: retryVisionModels,
             }, t('visionCapsRetry')),
           ),
+        )
+      }
+      const extraVisionModelsEditor = () => {
+        const raw = 'extraVisionModels' in drafts
+          ? drafts['extraVisionModels']
+          : readValue(snapshot, 'extraVisionModels')
+        // Rows persist as { provider, model } objects while editing — an
+        // incomplete row (provider picked, model pending) stays visible
+        // instead of collapsing, which is what made the provider dropdown
+        // feel unselectable before. Like the vision backend chain above, an
+        // empty configuration still renders one blank row ready to fill.
+        const rows = (Array.isArray(raw) && raw.length > 0 ? raw : [{ provider: '', model: '' }]).map(
+          (entry) => {
+            if (entry && typeof entry === 'object') {
+              return {
+                provider: String(entry.provider ?? '').trim(),
+                model: String(entry.model ?? '').trim(),
+              }
+            }
+            const text = String(entry ?? '').trim()
+            const slash = text.indexOf('/')
+            return slash === -1
+              ? { provider: '', model: text }
+              : { provider: text.slice(0, slash), model: text.slice(slash + 1) }
+          },
+        )
+        // Same two-select row shape as the vision backend chain above: a
+        // provider dropdown (providers that have excluded models) and a model
+        // dropdown (that provider's excluded models). A row the user already
+        // selected elsewhere stays disabled in the other rows. Option sets
+        // come from the memoized top-level hooks (this function is plain
+        // render code and must stay hook-free).
+        const hiddenProviders = hiddenVisionProviders
+        const hiddenModelsOf = hiddenVisionModelsOf
+        const used = new Set(
+          rows
+            .filter((row) => row.provider !== '' && row.model !== '')
+            .map((row) => `${row.provider}/${row.model}`),
+        )
+        // Never merge the empty current value into the option list: that
+        // produced a duplicate blank option right below the placeholder.
+        const providerOptions = (current) => {
+          const options =
+            current !== '' && !hiddenProviders.includes(current)
+              ? [...hiddenProviders, current].sort()
+              : hiddenProviders
+          return options.map((provider) => h('option', { value: provider, key: provider }, provider))
+        }
+        const modelOptions = (row) => {
+          const listed = hiddenModelsOf.get(row.provider) ?? []
+          const options =
+            row.model !== '' && !listed.includes(row.model)
+              ? [...listed, row.model].sort()
+              : listed
+          return options.map((model) => {
+            const key = `${row.provider}/${model}`
+            return h('option', {
+              value: model,
+              key,
+              disabled: key !== `${row.provider}/${row.model}` && used.has(key),
+            }, model)
+          })
+        }
+        const update = (index, next) => {
+          const list = rows.map((row, i) => (i === index ? next : row))
+          setDraft('extraVisionModels', list)
+        }
+        const removeRow = (index) => {
+          const list = rows.filter((_row, i) => i !== index)
+          setDraft('extraVisionModels', list)
+        }
+        // A half-filled row (provider picked, model pending) keeps the field
+        // invalid — same rule as the vision backend chain above.
+        const hasHalfRow = rows.some((row) => (row.provider ? !row.model : !!row.model))
+        return h('div', { className: 'vr-field' },
+          h('div', { className: 'vr-field-head' },
+            h('label', { className: 'vr-label' }, t('extraVisionModelsLabel')),
+            overriddenBadge('extraVisionModels'),
+          ),
+          rows.map((row, index) =>
+            h('div', { className: 'vr-chain-row', key: index },
+              h('select', {
+                className: 'vr-input vr-select',
+                value: row.provider,
+                disabled: !writable,
+                onChange: (event) => update(index, { provider: event.target.value, model: '' }),
+              },
+                h('option', { value: '' }, t('selectProvider')),
+                providerOptions(row.provider),
+              ),
+              h('select', {
+                className: 'vr-input vr-select',
+                value: row.model,
+                disabled: !writable || row.provider === '',
+                onChange: (event) => update(index, { provider: row.provider, model: event.target.value }),
+              },
+                h('option', { value: '' }, row.provider === '' ? t('pickProviderFirst') : t('selectModel')),
+                modelOptions(row),
+              ),
+              h('button', {
+                type: 'button', className: 'vr-reset', disabled: !writable, title: t('removeTitle'),
+                onClick: () => removeRow(index),
+              }, t('remove')),
+            ),
+          ),
+          h('button', {
+            type: 'button', className: 'vr-btn', disabled: !writable || hiddenProviders.length === 0,
+            onClick: () => setDraft('extraVisionModels', [...rows, { provider: '', model: '' }]),
+          }, t('addFallback')),
+          hasHalfRow
+            ? h('p', { className: 'vr-invalid' }, t('invalidGeneric'))
+            : h('p', { className: 'vr-hint' }, t('extraVisionModelsHint')),
         )
       }
       const builtinFallbackPanel = () => {
@@ -1963,6 +2171,12 @@ window.__ModuleLoader__.load({
                     h('div', { className: 'vr-group' },
                       h('p', { className: 'vr-group-title' }, t('groupParams')),
                       NUMBER_KEYS.map((key) => textField(key, t(LABEL_KEY[key]), t(HINT_KEY[key]), false)),
+                    ),
+                    h('div', { className: 'vr-group' },
+                      h('p', { className: 'vr-group-title' }, t('groupVisionOverrides')),
+                      catalogReady && hiddenVisionBackends.length > 0
+                        ? extraVisionModelsEditor()
+                        : textField('extraVisionModels', t('extraVisionModelsLabel'), t('extraVisionModelsHint'), true),
                     ),
                     h('div', { className: 'vr-group' },
                       h('p', { className: 'vr-group-title' }, t('groupRoutes')),

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -179,7 +179,6 @@ test('the settings card skips offscreen paint and rebuilds model options once', 
   assert.equal(source.includes('inject: () => cardInject'), true)
 })
 
-
 test('empty vision dropdown diagnostics identify undeclared image models and support re-detection', () => {
   const bundle = loadClientBundle()
   const groups = [
@@ -219,4 +218,51 @@ test('toolview cards use a non-default priority so other vision plugins can coex
   // while coexisting with plugins that use the default priority 0.
   assert.equal(source.includes("key: 'vision_present', priority: -10"), true)
   assert.equal(source.includes("key, priority: -10, inject"), true)
+})
+
+test('the vision-backend override editor mirrors the chain rows with two selects', () => {
+  const source = readFileSync(new URL('../lib/client.js', import.meta.url), 'utf8')
+  // The extraVisionModels setting is rendered as the same two-select row
+  // shape as the vision backend chain: a provider select (providers with
+  // excluded models) and a model select (that provider's excluded models).
+  assert.equal(source.includes("extraVisionModels: 'extraVisionModelsLabel'"), true)
+  assert.equal(source.includes("extraVisionModels: 'extraVisionModelsHint'"), true)
+  assert.equal(source.includes('const extraVisionModelsEditor = () => {'), true)
+  // Option sets are derived by unconditional top-level hooks; the editor
+  // itself is plain render code and must stay hook-free (a changing hook
+  // count across renders crashes React and blanks the whole settings card).
+  assert.equal(source.includes('const hiddenVisionProviders = useMemo('), true)
+  assert.equal(source.includes('hiddenVisionBackends.map((entry) => entry.provider)'), true)
+  assert.equal(source.includes('const hiddenVisionModelsOf = useMemo(() => {'), true)
+  assert.equal(source.includes('hiddenModelsOf.get(row.provider) ?? []'), true)
+  assert.equal(source.includes("t('pickProviderFirst')"), true)
+  // Rows are drafted as { provider, model } objects so a half-picked row
+  // (provider selected, model pending) stays visible instead of collapsing.
+  assert.equal(source.includes("setDraft('extraVisionModels', [...rows, { provider: '', model: '' }])"), true)
+  assert.equal(source.includes('const hasHalfRow = rows.some('), true)
+  // An empty configuration still renders one blank row, like the chain above.
+  assert.equal(source.includes("raw.length > 0 ? raw : [{ provider: '', model: '' }]"), true)
+  // The current empty value is never merged into the option list (no
+  // duplicate blank option under the placeholder).
+  assert.equal(source.includes("current !== '' && !hiddenProviders.includes(current)"), true)
+  // parse accepts both the object-row drafts and the legacy string shapes.
+  assert.equal(source.includes('row && typeof row === \'object\''), true)
+  const editorBlock = source.slice(source.indexOf('const extraVisionModelsEditor = () => {'), source.indexOf('const builtinFallbackPanel = () => {'))
+  assert.equal(editorBlock.includes('useMemo('), false)
+  assert.equal(editorBlock.includes('useState('), false)
+  // The editor drafts an array; the free-text fallback stays for when no
+  // hidden models / no catalog is available.
+  assert.equal(source.includes("textField('extraVisionModels', t('extraVisionModelsLabel'), t('extraVisionModelsHint'), true)"), true)
+  assert.equal(source.includes('Array.isArray(text)'), true)
+  // Saving the override refreshes the capability map silently (no loading
+  // flash / apparent page refresh).
+  assert.equal(source.includes("plan.some((item) => item.key === 'extraVisionModels')"), true)
+  assert.equal(source.includes('loadVisionCapabilities(true, true)'), true)
+  // The capability notice reflects name-based / manual recognition.
+  assert.equal(source.includes('or are recognized as vision models by name / manual override'), true)
+  // The hidden-models panel points at the override editor.
+  assert.equal(source.includes('select it in the “Extra vision models” dropdown under Advanced'), true)
+  // The hidden-models list is memoized so per-render catalog walks cannot
+  // regress the settings card's scroll smoothness.
+  assert.equal(source.includes('collectFilteredVisionBackends(catalog.groups, visionCaps.capabilities)'), true)
 })

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -29,6 +29,8 @@ import {
   collectEventAttachmentRefs,
   parseVersionParts,
   versionSatisfies,
+  looksLikeVisionModel,
+  decideVisionBackendCapability,
   renderVisionPresent,
   extractJson,
   createCache,
@@ -2249,4 +2251,76 @@ test('versionSatisfies evaluates the plugin peer range shape', () => {
   assert.equal(versionSatisfies('0.34.5', ''), false)
   assert.equal(versionSatisfies('0.34.5', undefined), false)
   assert.equal(versionSatisfies(undefined, range), false)
+})
+
+// ── vision-backend capability recognition (Zhipu feedback) ──────────────────
+
+test('looksLikeVisionModel recognizes well-known multimodal families conservatively', () => {
+  // Zhipu VLM family — the reported case.
+  assert.equal(looksLikeVisionModel('glm-4.6v'), true)
+  assert.equal(looksLikeVisionModel('glm-4.6v-flash'), true)
+  assert.equal(looksLikeVisionModel('glm-4v-plus'), true)
+  assert.equal(looksLikeVisionModel('glm-4.5v-plus'), true)
+  // Plain glm-4.6 is NOT in the VLM family: no image-input evidence.
+  assert.equal(looksLikeVisionModel('glm-4.6'), false)
+  assert.equal(looksLikeVisionModel('glm-4.5'), false)
+  // Other well-known families.
+  assert.equal(looksLikeVisionModel('qwen2.5-vl-72b-instruct'), true)
+  assert.equal(looksLikeVisionModel('qvq-72b'), true)
+  assert.equal(looksLikeVisionModel('gpt-4o-mini'), true)
+  assert.equal(looksLikeVisionModel('gpt-4.1'), true)
+  assert.equal(looksLikeVisionModel('gpt-5.1'), true)
+  assert.equal(looksLikeVisionModel('gemini-2.0-flash'), true)
+  assert.equal(looksLikeVisionModel('claude-3-5-sonnet'), true)
+  assert.equal(looksLikeVisionModel('internvl3-38b'), true)
+  assert.equal(looksLikeVisionModel('doubao-1.5-vision-pro'), true)
+  assert.equal(looksLikeVisionModel('step-1v-8k'), true)
+  // Text-only names must not match.
+  assert.equal(looksLikeVisionModel('deepseek-v4-pro'), false)
+  assert.equal(looksLikeVisionModel('qwen3-14b'), false)
+  assert.equal(looksLikeVisionModel('glm-4-plus'), false)
+  assert.equal(looksLikeVisionModel('gpt-4-mini'), false)
+  assert.equal(looksLikeVisionModel('claude-2'), false)
+  assert.equal(looksLikeVisionModel(''), false)
+  assert.equal(looksLikeVisionModel(undefined), false)
+  // Provider-prefixed ids match on the last segment.
+  assert.equal(looksLikeVisionModel('openrouter/zhipu/glm-4.6v'), true)
+})
+
+test('decideVisionBackendCapability honors declarations, overrides and inference', () => {
+  const declared = { inputModalities: ['text', 'image'] }
+  assert.deepEqual(decideVisionBackendCapability(declared, 'zhipu-glm', 'glm-4.6v', []), {
+    image: true,
+    inputModalities: ['text', 'image'],
+    inferred: false,
+    reason: undefined,
+  })
+  // Undeclared glm-4.6v: recognized by name.
+  assert.deepEqual(decideVisionBackendCapability({ inputModalities: ['text'] }, 'zhipu-glm', 'glm-4.6v', []), {
+    image: true,
+    inputModalities: ['text', 'image'],
+    inferred: 'name',
+    reason: undefined,
+  })
+  // Undeclared plain glm-4.6: forced via the override list (bare model id).
+  assert.deepEqual(
+    decideVisionBackendCapability({ inputModalities: ['text'] }, 'zhipu-glm', 'glm-4.6', ['glm-4.6']),
+    { image: true, inputModalities: ['text', 'image'], inferred: 'override', reason: undefined },
+  )
+  // "provider/model" override entries match too.
+  assert.equal(
+    decideVisionBackendCapability(undefined, 'zhipu-glm', 'glm-4.6', ['zhipu-glm/glm-4.6']).image,
+    true,
+  )
+  // Metadata lookup failure still falls back to inference.
+  assert.equal(decideVisionBackendCapability(undefined, 'zhipu-glm', 'glm-4.6v', []).image, true)
+  // Truly text-only model stays text-only.
+  assert.deepEqual(decideVisionBackendCapability({ inputModalities: ['text'] }, 'zhipu-glm', 'glm-4.6', []), {
+    image: false,
+    inputModalities: ['text'],
+    inferred: false,
+    reason: 'model metadata does not declare image input',
+  })
+  // Missing inputModalities metadata is treated as text-only unless inferred.
+  assert.equal(decideVisionBackendCapability({}, 'zhipu-glm', 'glm-4.6', []).image, false)
 })


### PR DESCRIPTION
## 背景 / Background

用户反馈：智谱官方渠道（open.bigmodel.cn，自定义模型列表）的模型（如 glm-4.6v / glm-4.6）在 DSH 目录里没有声明 `image` 输入，此前被视觉后端下拉「安全隐藏」，即使模型本身支持看图也无法使用；渠道适配器在未声明时还会直接拒绝图片请求。

## 改动 / Changes

1. **按名称自动识别**（服务端 `looksLikeVisionModel` + `decideVisionBackendCapability`）：对保守整理的常见多模态命名（glm-4.6v/-flash、qwen-vl/qvq、gpt-4o/4.1/5、gemini、claude-3+、internvl、doubao-vision、step-v、grok-4、pixtral、llama-vision、florence 等）在目录未声明 `image` 时按名称识别为视觉后端；下拉、工具链、视觉链共用同一判定。
2. **「额外视觉模型」下拉编辑器**：高级设置新增两列下拉（与视觉后端链同款交互）——选项即能力过滤中被排除的模型（`collectFilteredVisionBackends` 同源），按 provider → model 选择、防重复、空配置默认渲染空白行、半填行标红阻止保存；服务端 schema 新增 `extraVisionModels` 字符串数组（支持裸模型名与 provider/model）。
3. **渠道直连兜底**：被识别/强制的模型在渠道适配器因未声明图片输入而拒绝请求时，插件读取该渠道自身的 `llm-pi-ai` 配置（baseURL + 凭据）直接以 OpenAI 兼容接口调用，无需手改 settings.yaml 的 `input` 声明；解析失败时安全回落，报适配器原始错误。
4. **性能/稳定性**：隐藏模型列表 memo 化（此前每次渲染全量遍历目录），保存/重置覆盖项后能力地图静默刷新（不再闪白像页面刷新）；编辑器函数保持无 hook（此前条件调用 useMemo 导致 hook 数量变化、卡片崩溃的问题已修并有回归断言）。

## 测试 / Tests

- `looksLikeVisionModel` / `decideVisionBackendCapability` 单元用例（含 glm-4.6v 识别、glm-4.6 不自动识别、override 生效、provider/model 形式）；
- 客户端源码断言：两列下拉编辑器、默认空行、无空白选项合并、hook 安全、静默刷新、被隐藏面板指向该编辑器；
- 全套 175 项：173 通过（2 项为 macOS `/private/var` 路径的既有环境失败，Linux CI 矩阵不受影响）。

版本号、CHANGELOG 与 README 公告条将随后单独发 release 准备 PR（v1.3.1）。