### PR TITLE
feat(doctor): detect and repair stale version-pinned release-age exemptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,8 @@ pnpm dsh plugin --profile web update dsh-vision-router
 
 Settings live in the profile's settings provider and survive upgrades.
 
+> **A fresh release does not take effect (`downloaded 0` / `added 0`):** pnpm v11 holds versions younger than 24h back; `npx dsh-vision-router repair` fixes the stale version-pinned profile exemption so updates take effect immediately.
+
 > **Upgrading from a pre-bundle-patch install (v0.x):** the package now mounts
 > itself through its own bundle patch, so a leftover manual row in
 > `~/.dsh/profiles/<profile>/cordis.patch.yml` duplicates it and `dsh web`

--- a/README.zh.md
+++ b/README.zh.md
@@ -337,6 +337,8 @@ pnpm dsh plugin --profile web update dsh-vision-router
 
 设置存放在 profile 的设置提供方里，升级不丢失。
 
+> **新版本一直不生效（`downloaded 0` / `added 0`）：** pnpm v11 会拦下发布不足 24 小时的版本；运行 `npx dsh-vision-router repair` 修复过期的带版本号豁免条目后，更新立即生效。
+
 > **从 bundle 补丁之前（v0.x）升级：** 现在插件由自带的 bundle 补丁自动挂载，
 > 若 `~/.dsh/profiles/<profile>/cordis.patch.yml` 里还残留旧版手动行，会与之
 > 重复，`dsh web` 启动即报 `duplicate loader entry id: vision-router`。删除

--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -32,7 +32,7 @@ To inspect only the Web profile:
 npx dsh-vision-router doctor --profile web
 ```
 
-The command locates the DSH home (`$DSH_HOME` when set, otherwise `~/.dsh`), scans profile `package.json` files, reports UTF-8 BOM bytes, validates the JSON after ignoring a leading BOM for diagnosis, and reports whether `dsh-vision-router` is present as a profile dependency and bundle layer.
+The command locates the DSH home (`$DSH_HOME` when set, otherwise `~/.dsh`), scans profile `package.json` files, reports UTF-8 BOM bytes, validates the JSON after ignoring a leading BOM for diagnosis, reports whether `dsh-vision-router` is present as a profile dependency and bundle layer, and flags version-pinned `minimumReleaseAgeExclude` entries in the profile's `pnpm-workspace.yaml` that would hold back the next release.
 
 ## Repair the UTF-8 BOM startup failure
 
@@ -50,3 +50,21 @@ npx dsh-vision-router repair --profile web
 ```
 
 `repair` removes only the three-byte UTF-8 BOM prefix (`EF BB BF`) when it is present, then validates the remaining JSON. It does not reformat, regenerate, or otherwise rewrite the profile contents. If JSON is still invalid for another reason, the command reports that and stops rather than guessing a repair.
+
+## Repair a stale release-age exemption (the "update does nothing" gate)
+
+pnpm v11 defaults `minimumReleaseAge` to 1440 minutes: a version published less than 24 hours ago is not resolved, so `dsh plugin update` silently keeps the previous version and prints `downloaded 0 / added 0`. An exemption entry that pins a version — `dsh-vision-router@1.2.0` — only exempts that one version and goes stale on the next release, which is why "a new release is out but the update does nothing" keeps recurring.
+
+The doctor flags version-pinned entries for `dsh-vision-router` and the `@deepseek-ai/*` host packages:
+
+```text
+✗ web — … — release-age exemption version-pinned (dsh-vision-router@1.2.0) — releases younger than 24h will not be picked up
+```
+
+Run:
+
+```sh
+npx dsh-vision-router repair --profile web
+```
+
+to rewrite them to bare names (`dsh-vision-router`, `@deepseek-ai/*`), which exempt every future version, so upgrades take effect immediately again. Unrelated entries and the rest of the file are left untouched.

--- a/lib/doctor-cli.js
+++ b/lib/doctor-cli.js
@@ -4,7 +4,7 @@ import { pathToFileURL } from 'node:url'
 import { doctorProfiles, resolveDshHome } from './doctor.js'
 
 function usage() {
-  return `dsh-vision-router doctor [--profile <name>] [--fix]\ndsh-vision-router repair [--profile <name>]\n\nChecks DSH profile manifests even when DSH itself cannot boot.\n\nCommands:\n  doctor   Diagnose profile package.json files.\n  repair   Diagnose and safely remove a leading UTF-8 BOM.\n\nOptions:\n  --profile <name>  Check only one profile (for example: web).\n  --fix             With doctor, remove a leading UTF-8 BOM when found.\n  --help            Show this help.\n`
+  return `dsh-vision-router doctor [--profile <name>] [--fix]\ndsh-vision-router repair [--profile <name>]\n\nChecks DSH profile manifests even when DSH itself cannot boot.\n\nCommands:\n  doctor   Diagnose profile package.json files and the pnpm v11 release-age update gate.\n  repair   Diagnose and safely repair: remove a leading UTF-8 BOM, and rewrite version-pinned minimumReleaseAgeExclude entries to bare names.\n\nOptions:\n  --profile <name>  Check only one profile (for example: web).\n  --fix             With doctor, remove a leading UTF-8 BOM and rewrite version-pinned release-age exemptions when found.\n  --help            Show this help.\n`
 }
 
 function parseArgs(argv) {
@@ -61,6 +61,13 @@ function statusLine(profile) {
     parts.push(profile.pluginDependency ? `dependency ${profile.pluginDependency}` : 'Vision Router dependency not present')
     parts.push(profile.pluginBundle ? 'bundle registered' : 'bundle not registered')
   }
+  const workspace = profile.workspace
+  if (workspace?.exists && workspace.pinned.length > 0) {
+    const listed = workspace.pinned.slice(0, 3).join(', ')
+    parts.push(workspace.rewritten
+      ? `release-age exemption rewritten to bare name (${listed})`
+      : `release-age exemption version-pinned (${listed}) — releases younger than 24h will not be picked up`)
+  }
   return parts.join(' — ')
 }
 
@@ -97,9 +104,11 @@ export function run(argv = process.argv.slice(2), io = console, env = process.en
 
   for (const profile of report.profiles) io.log(statusLine(profile))
 
-  const pendingBom = report.profiles.some((profile) => profile.hasBom && !profile.repaired)
-  if (pendingBom) {
-    io.log('Run `npx dsh-vision-router repair` to remove detected UTF-8 BOM bytes safely.')
+  const pendingFix = report.profiles.some((profile) =>
+    (profile.hasBom && !profile.repaired)
+    || (profile.workspace?.pinned.length > 0 && !profile.workspace.rewritten))
+  if (pendingFix) {
+    io.log('Run `npx dsh-vision-router repair` to fix the detected issues safely.')
   }
   if (report.profiles.some((profile) => !profile.validJson)) {
     io.error('At least one profile is still invalid JSON. The repair command only removes a leading UTF-8 BOM; it does not rewrite other JSON content.')

--- a/lib/doctor.js
+++ b/lib/doctor.js
@@ -3,6 +3,9 @@ import { homedir } from 'node:os'
 import path from 'node:path'
 
 const UTF8_BOM = Buffer.from([0xef, 0xbb, 0xbf])
+const PLUGIN_NAME = 'dsh-vision-router'
+const HOST_PATTERN = /^@deepseek-ai\/.+/
+const WORKSPACE_FILENAME = 'pnpm-workspace.yaml'
 
 function expandHome(value, home = homedir()) {
   if (value === '~') return home
@@ -63,11 +66,105 @@ export function inspectProfileManifest(manifestPath, { fix = false } = {}) {
   }
 }
 
+/**
+ * Check a profile's pnpm-workspace.yaml for version-pinned
+ * `minimumReleaseAgeExclude` entries. pnpm v11 defaults `minimumReleaseAge`
+ * to 1440 minutes, so versions published less than 24h ago are not resolved
+ * and `update` silently keeps the previous version. An exemption entry with a
+ * pinned version (`dsh-vision-router@1.2.0`) only exempts that one version
+ * and goes stale on the next release; a bare name or org pattern exempts
+ * every future version. With `fix`, version-pinned entries for this plugin
+ * and the `@deepseek-ai/*` host packages are rewritten to the bare name or
+ * org pattern (duplicates are dropped); every other line is left untouched.
+ */
+export function inspectProfileWorkspace(workspacePath, { fix = false } = {}) {
+  if (!existsSync(workspacePath)) {
+    return { path: workspacePath, exists: false, pinned: [], rewritten: false }
+  }
+  const original = readFileSync(workspacePath, 'utf8')
+  const lines = original.split('\n')
+  const items = []
+  let blockIndent = -1
+  let inBlock = false
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index]
+    const keyMatch = /^(\s*)minimumReleaseAgeExclude\s*:\s*$/.exec(line)
+    if (keyMatch) {
+      blockIndent = keyMatch[1].length
+      inBlock = true
+      continue
+    }
+    if (!inBlock) continue
+    if (/^\s*$/.test(line) || /^\s*#/.test(line)) continue
+    if (/^(\s*)/.exec(line)[1].length <= blockIndent) {
+      inBlock = false
+      continue
+    }
+    const itemMatch = /^(\s*)-\s+(.+?)\s*$/.exec(line)
+    if (!itemMatch) continue
+    const raw = itemMatch[2].replace(/\s+#.*$/, '')
+    const value = raw.replace(/^(['"])(.*)\1$/, '$2').trim()
+    const spec = /^(@?[^@\s]+)(?:@(.+))?$/.exec(value)
+    items.push({
+      line: index,
+      indent: itemMatch[1],
+      raw,
+      name: spec?.[1],
+      version: spec?.[2],
+    })
+  }
+
+  const targetFor = (name) => {
+    if (name === PLUGIN_NAME) return PLUGIN_NAME
+    if (HOST_PATTERN.test(name)) return '@deepseek-ai/*'
+    return undefined
+  }
+  const pinned = items.filter((item) =>
+    item.version !== undefined && targetFor(item.name) !== undefined)
+  const existingTargets = new Set(items
+    .filter((item) => item.version === undefined)
+    .map((item) => targetFor(item.name))
+    .filter((target) => target !== undefined))
+
+  let rewritten = false
+  if (fix && pinned.length > 0) {
+    const claimed = new Set(existingTargets)
+    const removals = new Set()
+    for (const item of pinned) {
+      const target = targetFor(item.name)
+      if (claimed.has(target)) {
+        removals.add(item.line)
+      } else {
+        claimed.add(target)
+        const quote = /^(['"])/.test(item.raw) ? item.raw[0] : ''
+        lines[item.line] = `${item.indent}- ${quote}${target}${quote}`
+      }
+    }
+    if (removals.size > 0 || claimed.size > existingTargets.size) {
+      writeFileSync(workspacePath, lines
+        .filter((_, index) => !removals.has(index))
+        .join('\n'))
+      rewritten = true
+    }
+  }
+
+  return {
+    path: workspacePath,
+    exists: true,
+    pinned: pinned.map((item) => item.name && item.version !== undefined
+      ? `${item.name}@${item.version}`
+      : String(item.raw)).filter((value) => value !== undefined),
+    rewritten,
+  }
+}
+
 export function listProfileNames(dshHome, requestedProfile) {
   if (requestedProfile) return [requestedProfile]
   const profilesDir = path.join(dshHome, 'profiles')
   if (!existsSync(profilesDir)) return []
   return readdirSync(profilesDir)
+    .filter((name) => name !== 'node_modules')
     .filter((name) => {
       const full = path.join(profilesDir, name)
       try {
@@ -89,6 +186,7 @@ export function doctorProfiles({
 
   for (const name of names) {
     const manifestPath = path.join(dshHome, 'profiles', name, 'package.json')
+    const workspacePath = path.join(dshHome, 'profiles', name, WORKSPACE_FILENAME)
     if (!existsSync(manifestPath)) {
       profiles.push({
         name,
@@ -99,7 +197,12 @@ export function doctorProfiles({
       })
       continue
     }
-    profiles.push({ name, exists: true, ...inspectProfileManifest(manifestPath, { fix }) })
+    profiles.push({
+      name,
+      exists: true,
+      ...inspectProfileManifest(manifestPath, { fix }),
+      workspace: inspectProfileWorkspace(workspacePath, { fix }),
+    })
   }
 
   return {
@@ -108,6 +211,7 @@ export function doctorProfiles({
     fix,
     profiles,
     ok: profiles.length > 0 && profiles.every((item) =>
-      item.exists && item.validJson && (!item.hasBom || item.repaired)),
+      item.exists && item.validJson && (!item.hasBom || item.repaired)
+      && (!item.workspace || item.workspace.pinned.length === 0 || item.workspace.rewritten)),
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,17 +1,8 @@
 allowBuilds:
   sharp: true
+# pnpm v11 defaults minimumReleaseAge to 1440 minutes: freshly published
+# versions are not resolved for 24h, so dev installs silently keep old ones.
+# Bare names / org patterns exempt every future version; a `name@x.y.z` entry
+# exempts only that one version and goes stale on the next release.
 minimumReleaseAgeExclude:
-  - '@deepseek-ai/cosmokit@1.8.2'
-  - '@deepseek-ai/schemastery@3.18.1'
-  - '@deepseek-ai/cordis@4.0.1'
-  - '@deepseek-ai/dsh-anonymous-user-id@0.1.0-rc.6'
-  - '@deepseek-ai/dsh-attachment@0.1.0-rc.6'
-  - '@deepseek-ai/dsh-brand@0.1.0-rc.6'
-  - '@deepseek-ai/dsh-credentials@0.1.0-rc.6'
-  - '@deepseek-ai/dsh-home-paths@0.1.0-rc.6'
-  - '@deepseek-ai/dsh-invariants@0.1.0-rc.6'
-  - '@deepseek-ai/dsh-launch-environment@0.1.0-rc.6'
-  - '@deepseek-ai/dsh-llm-deepseek@0.1.0-rc.6'
-  - '@deepseek-ai/dsh-llm@0.1.0-rc.6'
-  - '@deepseek-ai/dsh-settings@0.1.0-rc.6'
-  - '@deepseek-ai/dsh-timeout@0.1.0-rc.6'
+  - '@deepseek-ai/*'

--- a/tests/doctor.test.js
+++ b/tests/doctor.test.js
@@ -3,15 +3,17 @@ import assert from 'node:assert/strict'
 import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
-import { doctorProfiles, hasUtf8Bom, inspectProfileManifest, resolveDshHome } from '../lib/doctor.js'
+import { doctorProfiles, hasUtf8Bom, inspectProfileManifest, inspectProfileWorkspace, resolveDshHome } from '../lib/doctor.js'
 
-function fixture(manifestText, { profile = 'web' } = {}) {
+function fixture(manifestText, { profile = 'web', workspace } = {}) {
   const home = mkdtempSync(path.join(tmpdir(), 'dsh-doctor-'))
   const dir = path.join(home, 'profiles', profile)
   mkdirSync(dir, { recursive: true })
   const manifestPath = path.join(dir, 'package.json')
   writeFileSync(manifestPath, manifestText)
-  return { home, dir, manifestPath }
+  const workspacePath = path.join(dir, 'pnpm-workspace.yaml')
+  if (workspace !== undefined) writeFileSync(workspacePath, workspace)
+  return { home, dir, manifestPath, workspacePath }
 }
 
 const validManifest = JSON.stringify({
@@ -82,6 +84,7 @@ test('doctorProfiles can scan all profiles or a requested profile', () => {
   const secondDir = path.join(first.home, 'profiles', 'headless')
   mkdirSync(secondDir, { recursive: true })
   writeFileSync(path.join(secondDir, 'package.json'), '{}\n')
+  mkdirSync(path.join(first.home, 'profiles', 'node_modules'), { recursive: true })
 
   const all = doctorProfiles({ dshHome: first.home })
   assert.deepEqual(all.profiles.map((item) => item.name), ['headless', 'web'])
@@ -95,4 +98,93 @@ test('resolveDshHome respects DSH_HOME and expands tilde', () => {
   const fakeHome = path.join(tmpdir(), 'doctor-home')
   assert.equal(resolveDshHome({}, fakeHome), path.resolve(fakeHome, '.dsh'))
   assert.equal(resolveDshHome({ DSH_HOME: '~/custom-dsh' }, fakeHome), path.resolve(fakeHome, 'custom-dsh'))
+})
+
+const pinnedWorkspace = [
+  'packages:',
+  '  - .',
+  '',
+  'minimumReleaseAgeExclude:',
+  "  - '@deepseek-ai/cosmokit@1.8.2'",
+  '  - dsh-vision-router@1.2.0',
+  '  - unrelated-pkg@0.0.1',
+  '',
+].join('\n')
+
+test('inspectProfileWorkspace flags version-pinned exemptions without mutating', () => {
+  const { workspacePath } = fixture(validManifest, { workspace: pinnedWorkspace })
+  const result = inspectProfileWorkspace(workspacePath)
+  assert.equal(result.exists, true)
+  assert.deepEqual(result.pinned, ['@deepseek-ai/cosmokit@1.8.2', 'dsh-vision-router@1.2.0'])
+  assert.equal(result.rewritten, false)
+  assert.equal(readFileSync(workspacePath, 'utf8'), pinnedWorkspace)
+})
+
+test('inspectProfileWorkspace fix rewrites pinned entries to bare names and keeps the rest', () => {
+  const { workspacePath } = fixture(validManifest, { workspace: pinnedWorkspace })
+  const result = inspectProfileWorkspace(workspacePath, { fix: true })
+  assert.equal(result.rewritten, true)
+  assert.equal(readFileSync(workspacePath, 'utf8'), [
+    'packages:',
+    '  - .',
+    '',
+    'minimumReleaseAgeExclude:',
+    "  - '@deepseek-ai/*'",
+    '  - dsh-vision-router',
+    '  - unrelated-pkg@0.0.1',
+    '',
+  ].join('\n'))
+})
+
+test('inspectProfileWorkspace drops a pinned entry that duplicates an existing bare name', () => {
+  const workspace = [
+    'packages:',
+    '  - .',
+    '',
+    'minimumReleaseAgeExclude:',
+    '  - dsh-vision-router',
+    '  - dsh-vision-router@1.2.0',
+    '',
+  ].join('\n')
+  const { workspacePath } = fixture(validManifest, { workspace })
+  const result = inspectProfileWorkspace(workspacePath, { fix: true })
+  assert.equal(result.rewritten, true)
+  assert.equal(readFileSync(workspacePath, 'utf8'), [
+    'packages:',
+    '  - .',
+    '',
+    'minimumReleaseAgeExclude:',
+    '  - dsh-vision-router',
+    '',
+  ].join('\n'))
+})
+
+test('doctorProfiles treats a version-pinned exemption as unhealthy until repaired', () => {
+  const { home } = fixture(validManifest, { workspace: pinnedWorkspace })
+  const before = doctorProfiles({ dshHome: home, profile: 'web' })
+  assert.equal(before.ok, false)
+  assert.deepEqual(before.profiles[0].workspace.pinned, ['@deepseek-ai/cosmokit@1.8.2', 'dsh-vision-router@1.2.0'])
+
+  const after = doctorProfiles({ dshHome: home, profile: 'web', fix: true })
+  assert.equal(after.ok, true)
+  assert.equal(after.profiles[0].workspace.rewritten, true)
+})
+
+test('doctorProfiles stays healthy with bare names or no workspace file', () => {
+  const bare = fixture(validManifest, {
+    workspace: [
+      'packages:',
+      '  - .',
+      '',
+      'minimumReleaseAgeExclude:',
+      "  - '@deepseek-ai/*'",
+      '  - dsh-vision-router',
+      '',
+    ].join('\n'),
+  })
+  assert.equal(doctorProfiles({ dshHome: bare.home, profile: 'web' }).ok, true)
+
+  const none = fixture(validManifest)
+  assert.equal(doctorProfiles({ dshHome: none.home, profile: 'web' }).ok, true)
+  assert.equal(doctorProfiles({ dshHome: none.home, profile: 'web' }).profiles[0].workspace.exists, false)
 })


### PR DESCRIPTION
## Why

Users report that `dsh plugin --profile web update dsh-vision-router` prints `downloaded 0 / added 0` right after a release and keeps the old version — "a new release is out but the update does nothing".

pnpm v11 defaults `minimumReleaseAge` to 1440 minutes, so versions published less than 24 hours ago are not resolved and the update silently keeps the newest compliant one. The earlier workaround pinned exact versions, which pnpm persists as version-scoped `minimumReleaseAgeExclude` entries such as `dsh-vision-router@1.2.0` — those exempt only that one version and go stale on the next release, so the problem recurs on every release.

## Changes

- **Doctor check + repair** (`lib/doctor.js`, `lib/doctor-cli.js`): the doctor now flags version-pinned `minimumReleaseAgeExclude` entries for `dsh-vision-router` and the `@deepseek-ai/*` host packages in each profile's `pnpm-workspace.yaml`; `npx dsh-vision-router repair` rewrites them to bare names / the org pattern (duplicates dropped, unrelated lines untouched), so every future release installs immediately. A stray `node_modules` directory under the profiles dir is skipped so a full scan exits cleanly.
- **`docs/doctor.md`**: documents the new check and the repair.
- **README.md / README.zh.md**: the upgrade sections point at the doctor for the `downloaded 0 / added 0` symptom instead of carrying a config recipe.
- **Dev `pnpm-workspace.yaml`**: replaces the 14 stale version-pinned entries with a single `@deepseek-ai/*` org pattern.

## Tests

12 doctor tests (5 new) pass. Full suite 178/180; the two remaining failures are a pre-existing macOS tmpdir-path quirk in the self-update tests and reproduce unchanged on `main`.
