### PR TITLE
fix: verify settings persistence before clearing drafts

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -106,7 +106,7 @@ window.__ModuleLoader__.load({
       proxyHint: '如 http://127.0.0.1:10808 或 socks5h://127.0.0.1:10808；留空关闭。修改即时生效。',
       proxyHostsLabel: '走代理的域名（每行一个）',
       proxyHostsHint: '仅这些域名经代理，其余直连；留空清除覆盖。修改即时生效。',
-      saveFailed: '保存失败：宿主拒绝了本次写入，请重试。',
+      saveFailed: '保存失败：部分配置未写入。未写入的修改已保留，请重试。',
       discard: '放弃修改',
       testConnection: '测试连接',
       testConnecting: '测试中…',
@@ -296,7 +296,7 @@ window.__ModuleLoader__.load({
       proxyHint: 'e.g. http://127.0.0.1:10808 or socks5h://127.0.0.1:10808; empty disables. Applies immediately.',
       proxyHostsLabel: 'Proxied hosts (one per line)',
       proxyHostsHint: 'Only these hosts go through the proxy; everything else stays direct. Empty clears the override. Applies immediately.',
-      saveFailed: 'Save failed: the host rejected this write, please retry.',
+      saveFailed: 'Save failed: some changes were not written. Unwritten changes were kept; please retry.',
       discard: 'Discard',
       testConnection: 'Test connection',
       testConnecting: 'Testing…',
@@ -474,7 +474,109 @@ window.__ModuleLoader__.load({
     }
     function userHas(snapshot, key) {
       const user = snapshot && snapshot.user
-      return user && typeof user === 'object' && key in user
+      return !!user && typeof user === 'object' && Object.prototype.hasOwnProperty.call(user, key)
+    }
+
+    /** Compare the JSON-shaped values accepted by SettingsScope. */
+    function jsonValueEqual(left, right) {
+      if (left === right) return true
+      if (left === null || right === null || typeof left !== 'object' || typeof right !== 'object') return false
+      if (Array.isArray(left) || Array.isArray(right)) {
+        if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length) return false
+        return left.every((value, index) => jsonValueEqual(value, right[index]))
+      }
+      const leftKeys = Object.keys(left)
+      const rightKeys = Object.keys(right)
+      if (leftKeys.length !== rightKeys.length) return false
+      return leftKeys.every(
+        (key) => Object.prototype.hasOwnProperty.call(right, key) && jsonValueEqual(left[key], right[key]),
+      )
+    }
+
+    function settingsSaveErrorMessage(error) {
+      return error && error.message ? error.message : String(error)
+    }
+
+    /**
+     * Write a settings plan and verify the raw user layer after every settled
+     * operation. SettingsScope intentionally resolves after a rejected Host
+     * mutation once its recovery read finishes, so Promise settlement alone is
+     * not evidence that a write landed.
+     */
+    async function commitSettingsPlan(scope, plan, drafts = {}) {
+      const failures = []
+      const landedFields = []
+      for (const item of plan) {
+        const operation = item.run.clear ? 'unset' : 'set'
+        try {
+          if (item.run.clear) await scope.unset(item.key)
+          else await scope.set(item.key, item.run.value)
+        } catch (error) {
+          failures.push({
+            field: item.key,
+            operation,
+            reason: 'write-error',
+            detail: settingsSaveErrorMessage(error),
+          })
+          continue
+        }
+
+        let snapshot
+        try {
+          snapshot = scope.getSnapshot()
+        } catch (error) {
+          failures.push({
+            field: item.key,
+            operation,
+            reason: 'readback-error',
+            detail: settingsSaveErrorMessage(error),
+          })
+          continue
+        }
+
+        const user = snapshot && snapshot.user
+        const stored = !!user && typeof user === 'object' && Object.prototype.hasOwnProperty.call(user, item.key)
+        const landed = item.run.clear
+          ? !stored
+          : stored && jsonValueEqual(user[item.key], item.run.value)
+        if (!landed) {
+          failures.push({
+            field: item.key,
+            operation,
+            reason: 'readback-mismatch',
+            detail: item.run.clear
+              ? 'field remained present in the user layer'
+              : stored
+                ? 'stored user-layer value differs from the requested value'
+                : 'field is absent from the user layer',
+          })
+        } else {
+          landedFields.push(item.key)
+        }
+      }
+      const landed = failures.length === 0
+      const nextDrafts = landedFields.length === 0 ? drafts : { ...drafts }
+      for (const field of landedFields) delete nextDrafts[field]
+      return {
+        landed,
+        failed: !landed,
+        landedFields,
+        nextDrafts,
+        failures,
+      }
+    }
+
+    function reportSettingsSaveFailures(failures) {
+      if (!Array.isArray(failures) || failures.length === 0 || typeof fetch !== 'function') return
+      try {
+        void fetch('/_dsh/vision-router/settings-save-diagnostics', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ failures }),
+        }).catch(() => {})
+      } catch {
+        // Diagnostics are best-effort and must never mask the visible failure.
+      }
     }
 
     function providersToText(value) {
@@ -1271,6 +1373,7 @@ window.__ModuleLoader__.load({
         return null
       }
       const writable = snapshot.writable
+      const editBlocked = !writable || saving
 
       const format = (key) => {
         if (key in drafts) return drafts[key]
@@ -1457,36 +1560,56 @@ window.__ModuleLoader__.load({
         if (blocked) return
         setSaving(true)
         setFailed(false)
-        let landed = true
-        for (const item of plan) {
-          if (item.run.clear) {
-            const ok = await scope.unset(item.key).then(() => true, () => false)
-            landed = ok && landed
-          } else {
-            const ok = await scope.set(item.key, item.run.value).then(() => true, () => false)
-            landed = ok && landed
+        try {
+          const outcome = await commitSettingsPlan(scope, plan, drafts)
+          if (outcome.landedFields.length > 0) setDrafts(outcome.nextDrafts)
+          if (outcome.failed) reportSettingsSaveFailures(outcome.failures)
+          setFailed(outcome.failed)
+          // The extraVisionModels override changes which models count as vision
+          // backends: refresh the capability map so the dropdown reflects the
+          // saved override immediately.
+          if (outcome.landedFields.includes('extraVisionModels')) {
+            loadVisionCapabilities(true, true)
           }
+        } catch (error) {
+          reportSettingsSaveFailures([{
+            field: 'settings-plan',
+            operation: 'set',
+            reason: 'write-error',
+            detail: settingsSaveErrorMessage(error),
+          }])
+          setFailed(true)
+        } finally {
+          setSaving(false)
         }
-        if (landed) setDrafts({})
-        setSaving(false)
-        setFailed(!landed)
-        // The extraVisionModels override changes which models count as vision
-        // backends: refresh the capability map so the dropdown reflects the
-        // saved override immediately.
-        if (landed && plan.some((item) => item.key === 'extraVisionModels')) loadVisionCapabilities(true, true)
       }
-      const resetField = (key) => {
+      const resetField = async (key) => {
+        if (editBlocked) return
         setFailed(false)
-        setDrafts((prev) => {
-          const next = { ...prev }
-          delete next[key]
-          return next
-        })
-        scope.unset(key)
-        // Resetting the override changes capability decisions; the unset
-        // round-trips asynchronously, so refresh shortly after it lands.
-        if (key === 'extraVisionModels' && typeof window !== 'undefined') {
-          window.setTimeout(() => loadVisionCapabilities(true, true), 400)
+        setSaving(true)
+        try {
+          const outcome = await commitSettingsPlan(scope, [{ key, run: { clear: true } }], drafts)
+          if (!outcome.landed) {
+            reportSettingsSaveFailures(outcome.failures)
+            setFailed(true)
+            return
+          }
+          setDrafts((prev) => {
+            const next = { ...prev }
+            delete next[key]
+            return next
+          })
+          if (key === 'extraVisionModels') loadVisionCapabilities(true, true)
+        } catch (error) {
+          reportSettingsSaveFailures([{
+            field: key,
+            operation: 'unset',
+            reason: 'write-error',
+            detail: settingsSaveErrorMessage(error),
+          }])
+          setFailed(true)
+        } finally {
+          setSaving(false)
         }
       }
 
@@ -1557,7 +1680,7 @@ window.__ModuleLoader__.load({
           ? h('span', { className: 'vr-badges' },
               h('span', { className: 'vr-badge' }, t('overridden')),
               h('button', {
-                type: 'button', className: 'vr-reset', disabled: !writable,
+                type: 'button', className: 'vr-reset', disabled: editBlocked,
                 onClick: () => resetField(key),
               }, t('reset')))
           : null
@@ -1568,7 +1691,7 @@ window.__ModuleLoader__.load({
               h('span', { className: 'vr-label' }, t(LABEL_KEY[key])),
               h('input', {
                 type: 'checkbox', className: 'vr-check', checked: format(key),
-                disabled: !writable,
+                disabled: editBlocked,
                 onChange: (event) => setDraft(key, event.target.checked),
               }),
             ),
@@ -1587,7 +1710,7 @@ window.__ModuleLoader__.load({
           ),
           h(multi ? 'textarea' : 'input', {
             className: 'vr-input' + (multi ? ' vr-area' : '') + (invalidField ? ' vr-input-invalid' : ''),
-            value: format(key), disabled: !writable,
+            value: format(key), disabled: editBlocked,
             placeholder: '',
             onChange: (event) => setDraft(key, event.target.value),
           }),
@@ -1652,7 +1775,7 @@ window.__ModuleLoader__.load({
           rows.map((row, index) =>
             h('div', { className: 'vr-chain-row', key: index },
               h('select', {
-                className: 'vr-input vr-select', value: visionProviderVisible(row.provider) ? row.provider : '', disabled: !writable,
+                className: 'vr-input vr-select', value: visionProviderVisible(row.provider) ? row.provider : '', disabled: editBlocked,
                 onChange: (event) => updateChain(index, { provider: event.target.value, model: '' }),
               },
                 h('option', { value: '' }, t('selectProvider')),
@@ -1660,14 +1783,14 @@ window.__ModuleLoader__.load({
               ),
               h('select', {
                 className: 'vr-input vr-select', value: visionModelVisible(row.provider, row.model) ? row.model : '',
-                disabled: !writable || !visionProviderVisible(row.provider),
+                disabled: editBlocked || !visionProviderVisible(row.provider),
                 onChange: (event) => updateChain(index, { provider: row.provider, model: event.target.value }),
               },
                 h('option', { value: '' }, visionProviderVisible(row.provider) ? t('selectModel') : t('pickProviderFirst')),
                 modelOptionsOf(visionModelsFor(row.provider)),
               ),
               h('button', {
-                type: 'button', className: 'vr-reset', disabled: !writable, title: t('removeTitle'),
+                type: 'button', className: 'vr-reset', disabled: editBlocked, title: t('removeTitle'),
                 onClick: () => removeChain(index),
               }, t('remove')),
             ),
@@ -1677,7 +1800,7 @@ window.__ModuleLoader__.load({
                 t('chainInvalidCurrent') + ' ' + invalidRows.map((row) => row.provider + '/' + row.model).join('、'))
             : null,
           h('button', {
-            type: 'button', className: 'vr-btn', disabled: !writable,
+            type: 'button', className: 'vr-btn', disabled: editBlocked,
             onClick: () => setDraft('providers', [...rows, { provider: '', model: '' }]),
           }, t('addFallback')),
           h('p', { className: 'vr-hint' }, t('chainHint')),
@@ -1796,7 +1919,7 @@ window.__ModuleLoader__.load({
               h('select', {
                 className: 'vr-input vr-select',
                 value: row.provider,
-                disabled: !writable,
+                disabled: editBlocked,
                 onChange: (event) => update(index, { provider: event.target.value, model: '' }),
               },
                 h('option', { value: '' }, t('selectProvider')),
@@ -1805,20 +1928,20 @@ window.__ModuleLoader__.load({
               h('select', {
                 className: 'vr-input vr-select',
                 value: row.model,
-                disabled: !writable || row.provider === '',
+                disabled: editBlocked || row.provider === '',
                 onChange: (event) => update(index, { provider: row.provider, model: event.target.value }),
               },
                 h('option', { value: '' }, row.provider === '' ? t('pickProviderFirst') : t('selectModel')),
                 modelOptions(row),
               ),
               h('button', {
-                type: 'button', className: 'vr-reset', disabled: !writable, title: t('removeTitle'),
+                type: 'button', className: 'vr-reset', disabled: editBlocked, title: t('removeTitle'),
                 onClick: () => removeRow(index),
               }, t('remove')),
             ),
           ),
           h('button', {
-            type: 'button', className: 'vr-btn', disabled: !writable || hiddenProviders.length === 0,
+            type: 'button', className: 'vr-btn', disabled: editBlocked || hiddenProviders.length === 0,
             onClick: () => setDraft('extraVisionModels', [...rows, { provider: '', model: '' }]),
           }, t('addFallback')),
           hasHalfRow
@@ -1850,7 +1973,7 @@ window.__ModuleLoader__.load({
           ),
           h('div', { className: 'vr-chain-row' },
             h('select', {
-              className: 'vr-input vr-select', value: pair.provider ?? '', disabled: !writable,
+              className: 'vr-input vr-select', value: pair.provider ?? '', disabled: editBlocked,
               onChange: (event) => setPair({ provider: event.target.value, model: '' }),
             },
               h('option', { value: '' }, t('selectProvider')),
@@ -1858,7 +1981,7 @@ window.__ModuleLoader__.load({
             ),
             h('select', {
               className: 'vr-input vr-select', value: pair.model ?? '',
-              disabled: !writable || !pair.provider,
+              disabled: editBlocked || !pair.provider,
               onChange: (event) => setPair({ provider: pair.provider, model: event.target.value }),
             },
               h('option', { value: '' }, pair.provider ? t('selectModel') : t('pickProviderFirst')),
@@ -1888,7 +2011,7 @@ window.__ModuleLoader__.load({
           rows.map((row, index) =>
             h('div', { className: 'vr-chain-row', key: index },
               h('select', {
-                className: 'vr-input vr-select', value: row.provider ?? '', disabled: !writable,
+                className: 'vr-input vr-select', value: row.provider ?? '', disabled: editBlocked,
                 onChange: (event) => updateWrap(index, { provider: event.target.value, model: '' }),
               },
                 h('option', { value: '' }, t('selectProvider')),
@@ -1896,20 +2019,20 @@ window.__ModuleLoader__.load({
               ),
               h('select', {
                 className: 'vr-input vr-select', value: row.model ?? '',
-                disabled: !writable || !row.provider,
+                disabled: editBlocked || !row.provider,
                 onChange: (event) => updateWrap(index, { provider: row.provider, model: event.target.value }),
               },
                 h('option', { value: '' }, row.provider ? t('wrapAllModels') : t('pickProviderFirst')),
                 modelOptionsOf(modelsOf(row.provider)),
               ),
               h('button', {
-                type: 'button', className: 'vr-reset', disabled: !writable, title: t('removeTitle'),
+                type: 'button', className: 'vr-reset', disabled: editBlocked, title: t('removeTitle'),
                 onClick: () => removeWrap(index),
               }, t('remove')),
             ),
           ),
           h('button', {
-            type: 'button', className: 'vr-btn', disabled: !writable,
+            type: 'button', className: 'vr-btn', disabled: editBlocked,
             onClick: () => setDraft('wrappedProviders', [...rows, { provider: '', model: '' }]),
           }, t('addWrapper')),
           h('p', { className: 'vr-hint' }, t('wrapHint')),
@@ -2227,7 +2350,7 @@ window.__ModuleLoader__.load({
                   type: 'button', className: 'vr-btn', disabled: testState.status === 'running',
                   onClick: runTestConnection,
                 }, t('testConnection')),
-                failed ? h('p', { className: 'vr-failed' }, t('saveFailed')) : null,
+                failed ? h('p', { className: 'vr-failed', role: 'alert' }, t('saveFailed')) : null,
                 h('button', {
                   type: 'button', className: 'vr-btn', disabled: !dirty || saving,
                   onClick: clearDrafts,
@@ -2484,6 +2607,8 @@ window.__ModuleLoader__.load({
     exports.unwrapModelsResult = unwrapModelsResult
     exports.filterVisionBackendGroups = filterVisionBackendGroups
     exports.collectFilteredVisionBackends = collectFilteredVisionBackends
+    exports.jsonValueEqual = jsonValueEqual
+    exports.commitSettingsPlan = commitSettingsPlan
     return module.exports
   },
 })

--- a/lib/file-logger.js
+++ b/lib/file-logger.js
@@ -12,6 +12,8 @@ export const DEFAULT_LOG_MAX_BYTES = 2 * 1024 * 1024
 
 const execFileAsync = promisify(execFile)
 const installs = new WeakMap()
+const SETTINGS_SAVE_DIAGNOSTICS_PATH = '/_dsh/vision-router/settings-save-diagnostics'
+const MAX_DIAGNOSTICS_BODY_BYTES = 16 * 1024
 
 export function resolveVisionRouterLogPaths(dshHome = resolveDshHome()) {
   const directory = path.join(dshHome, 'logs', 'vision-router')
@@ -187,6 +189,46 @@ function sameOrigin(req) {
   }
 }
 
+function compactDiagnosticText(value, maxLength) {
+  return sanitizeLogText(value)
+    .replace(/[\u0000-\u001f\u007f-\u009f\u2028\u2029]+/g, ' ')
+    .trim()
+    .slice(0, maxLength)
+}
+
+/** Keep client diagnostics bounded and free of settings values before logging. */
+export function normalizeSettingsSaveDiagnostics(payload) {
+  const operations = new Set(['set', 'unset'])
+  const reasons = new Set(['write-error', 'readback-error', 'readback-mismatch'])
+  const failures = payload && Array.isArray(payload.failures) ? payload.failures : []
+  return failures.slice(0, 16).flatMap((failure) => {
+    if (!failure || typeof failure !== 'object') return []
+    const field = compactDiagnosticText(failure.field, 80)
+    if (field === '') return []
+    const operation = operations.has(failure.operation) ? failure.operation : 'unknown'
+    const reason = reasons.has(failure.reason) ? failure.reason : 'unknown'
+    const detail = compactDiagnosticText(failure.detail, 400)
+    return [{ field, operation, reason, detail }]
+  })
+}
+
+async function readJsonBody(req) {
+  const chunks = []
+  let size = 0
+  for await (const chunk of req) {
+    const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+    size += bytes.length
+    if (size > MAX_DIAGNOSTICS_BODY_BYTES) {
+      const error = new Error('request body too large')
+      error.code = 'BODY_TOO_LARGE'
+      throw error
+    }
+    chunks.push(bytes)
+  }
+  const text = Buffer.concat(chunks).toString('utf8')
+  return text === '' ? {} : JSON.parse(text)
+}
+
 function sendJson(res, status, body) {
   res.writeHead(status, {
     'content-type': 'application/json; charset=utf-8',
@@ -195,7 +237,7 @@ function sendJson(res, status, body) {
   res.end(JSON.stringify(body))
 }
 
-function installLogRoute(ctx, paths) {
+function installLogRoute(ctx, paths, logger) {
   ctx.inject(['webServer'], (webCtx) => {
     webCtx.effect(() => webCtx.webServer.register({
       kind: 'exact',
@@ -227,6 +269,43 @@ function installLogRoute(ctx, paths) {
         }
       },
     }), 'vision-router: diagnostics log route')
+    webCtx.effect(() => webCtx.webServer.register({
+      kind: 'exact',
+      path: SETTINGS_SAVE_DIAGNOSTICS_PATH,
+      handler: async (req, res) => {
+        if (req.method !== 'POST') {
+          res.setHeader('Allow', 'POST')
+          sendJson(res, 405, { ok: false, error: 'method not allowed' })
+          return
+        }
+        if (!sameOrigin(req)) {
+          sendJson(res, 403, { ok: false, error: 'cross-origin request rejected' })
+          return
+        }
+        try {
+          const failures = normalizeSettingsSaveDiagnostics(await readJsonBody(req))
+          if (failures.length === 0) {
+            sendJson(res, 400, { ok: false, error: 'no valid diagnostics' })
+            return
+          }
+          for (const failure of failures) {
+            logger.warn(
+              'vision-router: settings save failed field=%s operation=%s reason=%s detail=%s',
+              failure.field,
+              failure.operation,
+              failure.reason,
+              failure.detail || 'none',
+            )
+          }
+          sendJson(res, 200, { ok: true, count: failures.length })
+        } catch (error) {
+          sendJson(res, error && error.code === 'BODY_TOO_LARGE' ? 413 : 400, {
+            ok: false,
+            error: error && error.message ? error.message : String(error),
+          })
+        }
+      },
+    }), 'vision-router: settings save diagnostics route')
   })
 }
 
@@ -260,7 +339,7 @@ export function installVisionRouterFileLogging(ctx, options = {}) {
   const installed = { ctx: wrappedCtx, logger, sink, ...paths }
   if (ctx && typeof ctx === 'object') installs.set(ctx, installed)
 
-  installLogRoute(ctx, paths)
+  installLogRoute(ctx, paths, logger)
   logger.info(
     'vision-router: diagnostics log enabled at %s (plugin=%s node=%s platform=%s/%s)',
     paths.file,

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -66,6 +66,147 @@ test('the client bundle still loads and registers with the proven injects', () =
   assert.equal(typeof bundle.apply, 'function')
 })
 
+test('commitSettingsPlan keeps drafts when a resolved set did not land in the user layer', async () => {
+  const bundle = loadClientBundle()
+  const requested = [{ provider: 'zhipu', model: 'glm-4.6v-flash' }]
+  const drafts = { providers: requested }
+  const calls = []
+  const scope = {
+    async set(field, value) {
+      calls.push([field, value])
+      // SettingsScope resolves after its recovery read even when the Host
+      // rejected the mutation. Deliberately leave the old user layer intact.
+    },
+    getSnapshot() {
+      return { status: 'ready', writable: true, user: { providers: [] } }
+    },
+  }
+
+  const outcome = await bundle.commitSettingsPlan(scope, [
+    { key: 'providers', run: { value: requested } },
+  ], drafts)
+
+  assert.deepEqual(calls, [['providers', requested]])
+  assert.equal(outcome.landed, false)
+  assert.equal(outcome.failed, true)
+  assert.equal(outcome.nextDrafts, drafts)
+  assert.deepEqual(outcome.failures.map(({ field, operation, reason }) => ({ field, operation, reason })), [{
+    field: 'providers',
+    operation: 'set',
+    reason: 'readback-mismatch',
+  }])
+})
+
+test('commitSettingsPlan accepts structurally equal JSON readback and clears drafts', async () => {
+  const bundle = loadClientBundle()
+  const requested = [{ provider: 'zhipu', model: 'glm-4.6v-flash' }]
+  const snapshot = { status: 'ready', writable: true, user: {} }
+  const scope = {
+    async set(field, value) {
+      snapshot.user[field] = structuredClone(value)
+    },
+    getSnapshot() {
+      return snapshot
+    },
+  }
+
+  const outcome = await bundle.commitSettingsPlan(scope, [
+    { key: 'providers', run: { value: requested } },
+  ], { providers: requested })
+
+  assert.equal(outcome.landed, true)
+  assert.equal(outcome.failed, false)
+  assert.deepEqual(outcome.nextDrafts, {})
+  assert.deepEqual(outcome.failures, [])
+  assert.equal(bundle.jsonValueEqual({ a: 1, b: [2] }, { b: [2], a: 1 }), true)
+  assert.equal(bundle.jsonValueEqual(-0, 0), true)
+})
+
+test('commitSettingsPlan clears only fields that landed during a partial save', async () => {
+  const bundle = loadClientBundle()
+  const providers = [{ provider: 'zhipu', model: 'glm-4.6v-flash' }]
+  const drafts = { routing: true, providers }
+  const snapshot = { status: 'ready', writable: true, user: { providers: [] } }
+  const outcome = await bundle.commitSettingsPlan({
+    async set(field, value) {
+      if (field === 'routing') snapshot.user[field] = value
+      // The providers write resolves after a rejected Host mutation and its
+      // recovery read, leaving the old user-layer value in place.
+    },
+    getSnapshot() { return snapshot },
+  }, [
+    { key: 'routing', run: { value: true } },
+    { key: 'providers', run: { value: providers } },
+  ], drafts)
+
+  assert.equal(outcome.landed, false)
+  assert.deepEqual(outcome.landedFields, ['routing'])
+  assert.deepEqual(outcome.nextDrafts, { providers })
+  assert.deepEqual(outcome.failures.map(({ field, reason }) => [field, reason]), [
+    ['providers', 'readback-mismatch'],
+  ])
+})
+
+test('commitSettingsPlan requires unset to remove the user-layer own property', async () => {
+  const bundle = loadClientBundle()
+  const plan = [{ key: 'proxyHosts', run: { clear: true } }]
+  const drafts = { proxyHosts: '' }
+  const rejectedSnapshot = { status: 'ready', writable: true, user: { proxyHosts: ['example.test'] } }
+  const rejected = await bundle.commitSettingsPlan({
+    async unset() {},
+    getSnapshot() { return rejectedSnapshot },
+  }, plan, drafts)
+  assert.equal(rejected.landed, false)
+  assert.equal(rejected.nextDrafts, drafts)
+  assert.equal(rejected.failures[0].reason, 'readback-mismatch')
+
+  const acceptedSnapshot = { status: 'ready', writable: true, user: { proxyHosts: ['example.test'] } }
+  const accepted = await bundle.commitSettingsPlan({
+    async unset(field) { delete acceptedSnapshot.user[field] },
+    getSnapshot() { return acceptedSnapshot },
+  }, plan, drafts)
+  assert.equal(accepted.landed, true)
+  assert.deepEqual(accepted.nextDrafts, {})
+})
+
+test('commitSettingsPlan classifies write and readback errors without dropping drafts', async () => {
+  const bundle = loadClientBundle()
+  const drafts = { routing: true, tool: true }
+  const outcome = await bundle.commitSettingsPlan({
+    async set(field) {
+      if (field === 'routing') throw new Error('transport failed')
+    },
+    getSnapshot() {
+      throw new Error('snapshot failed')
+    },
+  }, [
+    { key: 'routing', run: { value: true } },
+    { key: 'tool', run: { value: true } },
+  ], drafts)
+
+  assert.equal(outcome.landed, false)
+  assert.equal(outcome.nextDrafts, drafts)
+  assert.deepEqual(outcome.failures.map(({ field, reason }) => [field, reason]), [
+    ['routing', 'write-error'],
+    ['tool', 'readback-error'],
+  ])
+})
+
+test('settings save failure copy says unwritten drafts were kept', () => {
+  const source = readFileSync(new URL('../lib/client.js', import.meta.url), 'utf8')
+  assert.equal(source.includes('保存失败：部分配置未写入。未写入的修改已保留，请重试。'), true)
+  assert.equal(source.includes('Save failed: some changes were not written. Unwritten changes were kept; please retry.'), true)
+  assert.equal(source.includes("className: 'vr-failed', role: 'alert'"), true)
+  // One-click field resets share the same verified write path, and all
+  // editors are frozen during the round-trip so a successful save cannot
+  // discard a newer in-flight edit.
+  assert.equal(source.includes('const resetField = async (key) => {'), true)
+  assert.equal(source.includes("commitSettingsPlan(scope, [{ key, run: { clear: true } }], drafts)"), true)
+  assert.equal(source.includes('const editBlocked = !writable || saving'), true)
+  assert.equal(source.includes('if (outcome.landedFields.length > 0) setDrafts(outcome.nextDrafts)'), true)
+  assert.equal(source.includes("if (outcome.landedFields.includes('extraVisionModels'))"), true)
+})
+
 
 test('model-selection guide separates session and vision models and targets the vision chain', () => {
   const source = readFileSync(new URL('../lib/client.js', import.meta.url), 'utf8')
@@ -256,7 +397,7 @@ test('the vision-backend override editor mirrors the chain rows with two selects
   assert.equal(source.includes('Array.isArray(text)'), true)
   // Saving the override refreshes the capability map silently (no loading
   // flash / apparent page refresh).
-  assert.equal(source.includes("plan.some((item) => item.key === 'extraVisionModels')"), true)
+  assert.equal(source.includes("outcome.landedFields.includes('extraVisionModels')"), true)
   assert.equal(source.includes('loadVisionCapabilities(true, true)'), true)
   // The capability notice reflects name-based / manual recognition.
   assert.equal(source.includes('or are recognized as vision models by name / manual override'), true)

--- a/tests/file-logger.test.js
+++ b/tests/file-logger.test.js
@@ -3,8 +3,11 @@ import assert from 'node:assert/strict'
 import { mkdtemp, readFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
+import { Readable } from 'node:stream'
 import {
   createFileLogSink,
+  installVisionRouterFileLogging,
+  normalizeSettingsSaveDiagnostics,
   openLogDirectory,
   resolveVisionRouterLogPaths,
   sanitizeLogText,
@@ -28,6 +31,129 @@ test('sanitizeLogText redacts common credential shapes', () => {
   assert.equal(output.includes('abcdefghijklmnopqrstuvwxyz'), false)
   assert.equal(output.includes('super-secret-value'), false)
   assert.match(output, /\[REDACTED/)
+})
+
+test('settings-save diagnostics are bounded, single-line, and redacted', () => {
+  const oversized = Array.from({ length: 20 }, (_value, index) => ({
+    field: `field-${index}-` + 'x'.repeat(100),
+    operation: 'set',
+    reason: 'readback-mismatch',
+    detail: 'y'.repeat(500),
+  }))
+  const diagnostics = normalizeSettingsSaveDiagnostics({
+    failures: [
+      {
+        field: 'extraVisionModels\nforged',
+        operation: 'set',
+        reason: 'readback-mismatch',
+        detail: 'Authorization: Bearer abcdefghijklmnopqrstuvwxyz\u0000\u001b\u0085\u2028second line',
+      },
+      null,
+      { field: '', operation: 'unset', reason: 'write-error', detail: 'ignored' },
+      ...oversized,
+    ],
+  })
+  assert.deepEqual(diagnostics.slice(0, 1).map(({ field, operation, reason }) => ({ field, operation, reason })), [{
+    field: 'extraVisionModels forged',
+    operation: 'set',
+    reason: 'readback-mismatch',
+  }])
+  assert.equal(diagnostics[0].detail.includes('abcdefghijklmnopqrstuvwxyz'), false)
+  assert.doesNotMatch(diagnostics[0].detail, /[\u0000-\u001f\u007f-\u009f\u2028\u2029]/)
+  assert.equal(diagnostics.length, 14)
+  assert.equal(diagnostics.every(({ field, detail }) => field.length <= 80 && detail.length <= 400), true)
+
+  const exactlyBounded = normalizeSettingsSaveDiagnostics({ failures: oversized })
+  assert.equal(exactlyBounded.length, 16)
+  assert.equal(exactlyBounded.every(({ field, detail }) => field.length === 80 && detail.length === 400), true)
+})
+
+test('settings-save diagnostic route enforces request boundaries and writes the plugin log', async () => {
+  const root = await mkdtemp(path.join(tmpdir(), 'vision-router-client-log-'))
+  const routes = new Map()
+  const hostLogs = []
+  const ctx = {
+    logger: {
+      info(...args) { hostLogs.push(['info', ...args]) },
+      warn(...args) { hostLogs.push(['warn', ...args]) },
+    },
+    inject(_services, install) {
+      install({
+        webServer: {
+          register(route) {
+            routes.set(route.path, route.handler)
+            return () => routes.delete(route.path)
+          },
+        },
+        effect(effect) { return effect() },
+      })
+    },
+  }
+  const response = () => ({
+    status: undefined,
+    headers: {},
+    body: '',
+    setHeader(name, value) { this.headers[name] = value },
+    writeHead(status, headers) {
+      this.status = status
+      Object.assign(this.headers, headers)
+    },
+    end(body) { this.body = String(body ?? '') },
+  })
+  const request = (method, body = '', headers = {}) => {
+    const req = Readable.from(body === '' ? [] : [body])
+    req.method = method
+    req.headers = headers
+    return req
+  }
+
+  try {
+    const installed = installVisionRouterFileLogging(ctx, { dshHome: root })
+    const handler = routes.get('/_dsh/vision-router/settings-save-diagnostics')
+    assert.equal(typeof handler, 'function')
+
+    let res = response()
+    await handler(request('GET'), res)
+    assert.equal(res.status, 405)
+
+    res = response()
+    await handler(request('POST', '{}', {
+      host: 'localhost:3000',
+      origin: 'https://attacker.test',
+      'sec-fetch-site': 'cross-site',
+    }), res)
+    assert.equal(res.status, 403)
+
+    res = response()
+    await handler(request('POST', 'x'.repeat(17 * 1024)), res)
+    assert.equal(res.status, 413)
+
+    res = response()
+    await handler(request('POST', '{'), res)
+    assert.equal(res.status, 400)
+
+    res = response()
+    await handler(request('POST', JSON.stringify({ failures: [{
+      field: 'providers',
+      operation: 'set',
+      reason: 'readback-mismatch',
+      detail: 'Bearer abcdefghijklmnopqrstuvwxyz',
+    }] }), {
+      host: 'localhost:3000',
+      origin: 'http://localhost:3000',
+      'sec-fetch-site': 'same-origin',
+    }), res)
+    assert.equal(res.status, 200)
+    assert.deepEqual(JSON.parse(res.body), { ok: true, count: 1 })
+
+    await installed.sink.flush()
+    const log = await readFile(installed.file, 'utf8')
+    assert.match(log, /settings save failed field=providers operation=set reason=readback-mismatch/)
+    assert.equal(log.includes('abcdefghijklmnopqrstuvwxyz'), false)
+    assert.equal(JSON.stringify(hostLogs).includes('abcdefghijklmnopqrstuvwxyz'), false)
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
 })
 
 test('file log sink writes formatted diagnostics and rotates bounded logs', async () => {

--- a/tests/logging-ui.test.js
+++ b/tests/logging-ui.test.js
@@ -9,3 +9,11 @@ test('settings card exposes a one-click logs-folder action', () => {
   assert.equal(source.includes("fetch('/_dsh/vision-router/logs'"), true)
   assert.equal(source.includes("method: 'POST'"), true)
 })
+
+test('settings save failures are forwarded to the bounded server diagnostic route', () => {
+  const clientSource = readFileSync(new URL('../lib/client.js', import.meta.url), 'utf8')
+  const serverSource = readFileSync(new URL('../lib/file-logger.js', import.meta.url), 'utf8')
+  assert.equal(clientSource.includes("fetch('/_dsh/vision-router/settings-save-diagnostics'"), true)
+  assert.equal(serverSource.includes("const SETTINGS_SAVE_DIAGNOSTICS_PATH = '/_dsh/vision-router/settings-save-diagnostics'"), true)
+  assert.equal(serverSource.includes("'vision-router: settings save failed field=%s operation=%s reason=%s detail=%s'"), true)
+})


### PR DESCRIPTION
## Summary

- Verify every settings `set` and `unset` operation against the raw user layer before treating it as persisted.
- Clear only drafts whose values actually landed, while retaining unwritten changes and showing an explicit failure alert.
- Apply the same read-back verification to field resets and freeze editors during save operations.
- Persist bounded, redacted settings-save diagnostics through a same-origin endpoint without logging configuration values.

## Root cause

DSH's `SettingsScopeController` intentionally resolves `set()` and `unset()` after recovering from a rejected Host write and reloading the previous configuration. Vision Router treated Promise resolution as proof of success, cleared the frontend drafts, and then rendered the unchanged Host snapshot. This made a newly selected fallback vision model appear to disappear immediately after saving.

## User impact

Successful fields now lose their unsaved marker only after their user-layer values are verified. Rejected fields remain visible and editable, with a clear message explaining that the configuration was not written. Partial multi-field saves retain only the fields that failed.

## Validation

- Added regression coverage for a resolved `scope.set()` whose user-layer value did not change.
- Covered structural JSON read-back, partial saves, failed unsets, write errors, and snapshot errors.
- Covered diagnostic redaction, request limits, same-origin enforcement, and persistent logging.
- Full test suite: 189 passed.

## Upstream follow-up

The separate macOS “Open configuration file” failure belongs to DeepSeek Harness and has been reported upstream:

https://github.com/deepseek-ai/deepseek-harness/discussions/2344