### PR TITLE
fix(doctor): run the CLI when invoked through a symlinked bin (npx shim)

### DIFF
--- a/lib/doctor-cli.js
+++ b/lib/doctor-cli.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
-import { pathToFileURL } from 'node:url'
+import { realpathSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
 import { doctorProfiles, resolveDshHome } from './doctor.js'
 
 function usage() {
@@ -116,7 +117,26 @@ export function run(argv = process.argv.slice(2), io = console, env = process.en
   return report.ok ? 0 : 1
 }
 
+/**
+ * Whether `argv[1]` points at this module. npm's npx shim on POSIX invokes
+ * the bin through a symlink in `node_modules/.bin`, so `argv[1]` carries the
+ * shim path while the module loader realpaths the file and `import.meta.url`
+ * carries the real target path — a plain string comparison never matches and
+ * the CLI silently does nothing. Compare realpaths instead.
+ */
+export function isCliEntry(entry, moduleUrl = import.meta.url) {
+  if (typeof entry !== 'string' || entry.trim() === '') return false
+  const real = (value) => {
+    try {
+      return realpathSync(value.startsWith('file:') ? fileURLToPath(value) : value)
+    } catch {
+      return value
+    }
+  }
+  return real(entry) === real(moduleUrl)
+}
+
 const entry = process.argv[1]
-if (entry && import.meta.url === pathToFileURL(entry).href) {
+if (isCliEntry(entry)) {
   process.exitCode = run()
 }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "sharp": "^0.35.3"
   },
   "scripts": {
-    "test": "node --test tests/core.test.js tests/client.test.js tests/http-compat.test.js tests/update-check.test.js tests/self-update.test.js tests/doctor.test.js tests/bundle-defaults.test.js tests/file-logger.test.js tests/logging-ui.test.js tests/manifest-dependencies.test.js"
+    "test": "node --test tests/core.test.js tests/client.test.js tests/http-compat.test.js tests/update-check.test.js tests/self-update.test.js tests/doctor.test.js tests/doctor-cli.test.js tests/bundle-defaults.test.js tests/file-logger.test.js tests/logging-ui.test.js tests/manifest-dependencies.test.js"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/tests/doctor-cli.test.js
+++ b/tests/doctor-cli.test.js
@@ -1,0 +1,38 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import { isCliEntry } from '../lib/doctor-cli.js'
+
+const modulePath = fileURLToPath(new URL('../lib/doctor-cli.js', import.meta.url))
+const moduleUrl = pathToFileURL(modulePath).href
+
+test('isCliEntry matches direct invocation paths only', () => {
+  assert.equal(isCliEntry(modulePath, moduleUrl), true)
+  assert.equal(isCliEntry(path.join(path.dirname(modulePath), 'other.js'), moduleUrl), false)
+  assert.equal(isCliEntry('', moduleUrl), false)
+  assert.equal(isCliEntry(undefined, moduleUrl), false)
+})
+
+test('doctor CLI prints a report when invoked through a symlinked bin (npx shim shape)', { skip: process.platform === 'win32' }, () => {
+  const home = mkdtempSync(path.join(tmpdir(), 'dsh-cli-'))
+  const profileDir = path.join(home, 'profiles', 'web')
+  mkdirSync(profileDir, { recursive: true })
+  writeFileSync(path.join(profileDir, 'package.json'), '{}\n')
+
+  const binDir = mkdtempSync(path.join(tmpdir(), 'dsh-bin-'))
+  const link = path.join(binDir, 'dsh-vision-router')
+  symlinkSync(modulePath, link)
+
+  const result = spawnSync(process.execPath, [link, 'doctor'], {
+    encoding: 'utf8',
+    env: { ...process.env, DSH_HOME: home },
+  })
+  assert.equal(result.status, 0)
+  assert.match(result.stdout, /DSH home:/)
+  assert.match(result.stdout, /✓ web/)
+  rmSync(binDir, { recursive: true, force: true })
+})


### PR DESCRIPTION
## Why

`npx dsh-vision-router doctor` prints nothing and exits 0 on macOS/Linux, even though the command installs and the bin exists.

The bin entry guard compared `import.meta.url` against `pathToFileURL(argv[1]).href`. npm's npx shim on POSIX invokes the bin through a symlink in `node_modules/.bin`, so `argv[1]` carries the shim path while the module loader realpaths the file and `import.meta.url` carries the real target path. The strings never match, so `run()` is never called — the CLI has silently done nothing on POSIX shims since the bin shipped. Windows `.cmd` shims pass the real path directly, which is why it worked there.

## Changes

- `lib/doctor-cli.js`: `isCliEntry` compares realpaths of `argv[1]` and the module URL, so direct and symlinked invocation both run the CLI.
- `tests/doctor-cli.test.js` (new, wired into the test script): unit coverage for `isCliEntry` plus a spawn regression test that invokes the CLI through a symlinked bin — the exact npx shim shape.

## Tests

Full suite 180/182; the two remaining failures are a pre-existing macOS tmpdir-path quirk in the self-update tests and reproduce unchanged on `main`.
