### PR TITLE
fix: harden vision backend compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -2019,6 +2019,21 @@ export function modelInfoAcceptsImages(info) {
 // perfectly usable vision backends. The conservative, curated name patterns
 // below recognize well-known multimodal model families as a fallback; models
 // that still do not match can be forced via the `extraVisionModels` setting.
+// A vision-looking name does not necessarily identify a generative chat model.
+// Embedding and reranker endpoints often share the same VL family prefix but
+// cannot answer vision_describe. Keep them out of the automatic candidate
+// set; an explicit extraVisionModels override remains the expert escape hatch.
+const NON_GENERATIVE_VISION_MODEL_HINTS = [
+  /(^|[\/_.-])(embedding|embeddings|embed)(?=$|[\/_.-])/i,
+  /(^|[\/_.-])(rerank|reranker|reranking)(?=$|[\/_.-])/i,
+]
+
+export function looksLikeNonGenerativeVisionModel(modelId) {
+  const id = String(modelId ?? '').trim()
+  if (id === '') return false
+  return NON_GENERATIVE_VISION_MODEL_HINTS.some((pattern) => pattern.test(id))
+}
+
 const VISION_MODEL_NAME_HINTS = [
   // Zhipu VLM family: glm-4.6v, glm-4.6v-flash, glm-4v-plus, glm-4.5v(-plus)…
   /(^|\/)glm-4[\w.-]*v(?=$|[-/])/i,
@@ -2051,14 +2066,14 @@ const VISION_MODEL_NAME_HINTS = [
  */
 export function looksLikeVisionModel(modelId) {
   const id = String(modelId ?? '').trim()
-  if (id === '') return false
+  if (id === '' || looksLikeNonGenerativeVisionModel(id)) return false
   return VISION_MODEL_NAME_HINTS.some((pattern) => pattern.test(id))
 }
 
 /**
- * Pure capability decision for a vision backend: explicit metadata first,
- * then the user's `extraVisionModels` override list, then the name-based
- * inference, and finally a text-only verdict.
+ * Pure capability decision for a vision backend: an explicit user override
+ * wins first, known non-generative endpoint roles are excluded next, then
+ * declared image metadata and conservative name inference are considered.
  *
  * @param info - resolved model metadata (may be undefined when the lookup failed).
  * @param provider - provider id, used to match "provider/model" override entries.
@@ -2073,31 +2088,78 @@ export function decideVisionBackendCapability(info, provider, model, extraVision
     ? info.inputModalities.filter((item) => typeof item === 'string')
     : []
   const modelId = String(model ?? '').trim()
-  if (inputModalities.includes('image')) {
-    return { image: true, inputModalities, inferred: false, reason: undefined }
-  }
+  const providerId = String(provider ?? '').trim()
   const extras = Array.isArray(extraVisionModels)
     ? extraVisionModels.map((entry) => String(entry ?? '').trim()).filter((entry) => entry !== '')
     : []
-  if (modelId !== '' && extras.some((entry) => entry === modelId)) {
-    return { image: true, inputModalities: [...inputModalities, 'image'], inferred: 'override', reason: undefined }
-  }
-  const providerId = String(provider ?? '').trim()
-  if (
+  const forced =
     modelId !== '' &&
-    providerId !== '' &&
-    extras.some((entry) => entry === `${providerId}/${modelId}`)
-  ) {
-    return { image: true, inputModalities: [...inputModalities, 'image'], inferred: 'override', reason: undefined }
+    extras.some((entry) => entry === modelId || (providerId !== '' && entry === `${providerId}/${modelId}`))
+  // Manual override is deliberately strongest: advanced users can still
+  // force an unusual endpoint that our role/name heuristics reject.
+  if (forced) {
+    return { image: true, inputModalities: [...new Set([...inputModalities, 'image'])], inferred: 'override', reason: undefined }
+  }
+  // A model can consume images and still be the wrong KIND of endpoint
+  // for this plugin: embedding/reranking produces no assistant answer.
+  if (modelId !== '' && looksLikeNonGenerativeVisionModel(modelId)) {
+    return {
+      image: false,
+      inputModalities,
+      inferred: false,
+      reason: 'model name indicates an embedding/reranker endpoint, not a generative vision backend',
+    }
+  }
+  if (inputModalities.includes('image')) {
+    return { image: true, inputModalities, inferred: false, reason: undefined }
   }
   if (modelId !== '' && looksLikeVisionModel(modelId)) {
-    return { image: true, inputModalities: [...inputModalities, 'image'], inferred: 'name', reason: undefined }
+    return { image: true, inputModalities: [...new Set([...inputModalities, 'image'])], inferred: 'name', reason: undefined }
   }
   return {
     image: false,
     inputModalities,
     inferred: false,
     reason: 'model metadata does not declare image input',
+  }
+}
+
+/**
+ * Resolve transport facts for the direct channel compatibility bridge.
+ * Raw llm-pi-ai settings commonly omit baseURL/api for built-in catalog
+ * providers; the materialized pi-ai model carries the effective values.
+ */
+export function resolveChannelBridgeTransport(rawProfile, resolvedProfile, modelId) {
+  let resolvedModel
+  try {
+    const getModels = resolvedProfile && resolvedProfile.piProvider && resolvedProfile.piProvider.getModels
+    const models = typeof getModels === 'function'
+      ? getModels.call(resolvedProfile.piProvider)
+      : []
+    resolvedModel = Array.isArray(models)
+      ? models.find((entry) => entry && String(entry.id) === String(modelId))
+      : undefined
+  } catch {
+    resolvedModel = undefined
+  }
+  const firstString = (...values) =>
+    values.find((value) => typeof value === 'string' && value.trim() !== '')
+  return {
+    baseURL: firstString(
+      resolvedModel && resolvedModel.baseUrl,
+      rawProfile && rawProfile.baseURL,
+      resolvedProfile && resolvedProfile.baseURL,
+      resolvedProfile && resolvedProfile.piProvider && resolvedProfile.piProvider.baseUrl,
+    ),
+    api: firstString(
+      resolvedModel && resolvedModel.api,
+      rawProfile && rawProfile.api,
+      resolvedProfile && resolvedProfile.api,
+    ),
+    apiKeyEnv: firstString(
+      rawProfile && rawProfile.apiKeyEnv,
+      resolvedProfile && resolvedProfile.apiKeyEnv,
+    ),
   }
 }
 
@@ -2764,52 +2826,105 @@ export function apply(ctx, config = {}) {
   // reads only: if the channel settings section, the baseURL, or the
   // credential cannot be resolved, the bridge is simply unavailable and the
   // adapter's own error is reported.
-  const channelProfileOf = (provider) => {
+  const rawChannelProfileOf = (provider) => {
     try {
       const settings = ctx.get('settings')
       const section =
         settings && typeof settings.get === 'function' ? settings.get('llm-pi-ai') : undefined
-      const profile = section && section.providers ? section.providers[provider] : undefined
-      if (!profile || typeof profile.baseURL !== 'string' || profile.baseURL === '') return undefined
-      return profile
+      return section && section.providers ? section.providers[provider] : undefined
     } catch {
       return undefined
     }
   }
-  const resolveChannelApiKey = async (provider, profile) => {
-    const ref =
-      profile && typeof profile.apiKeyEnv === 'string' && profile.apiKeyEnv !== ''
-        ? profile.apiKeyEnv
-        : undefined
-    if (ref === undefined) return undefined
+  // DSH's public model metadata intentionally omits endpoint/protocol
+  // details. PiAiAdapter has already materialized those facts in its
+  // resolved profile, so feature-detect that shape as a compatibility
+  // shim. If upstream changes it, this fails closed to the normal chain.
+  const resolvedPiAiProfileOf = (provider) => {
     try {
-      const credentials = ctx.get('credentials')
-      if (credentials !== undefined) {
-        const hit = await credentials.resolve(ref)
-        if (hit && typeof hit.value === 'string' && hit.value.length > 0) return hit.value
+      const registration = ctx.llm.registration(provider)
+      const adapter = registration && registration.adapter
+      const config = adapter && adapter.config
+      const profiles = config && typeof config.profiles === 'function' ? config.profiles() : undefined
+      return profiles && typeof profiles.get === 'function' ? profiles.get(provider) : undefined
+    } catch {
+      return undefined
+    }
+  }
+  const channelBridgePlan = (provider, model) => {
+    const rawProfile = rawChannelProfileOf(provider)
+    const resolvedProfile = resolvedPiAiProfileOf(provider)
+    const transport = resolveChannelBridgeTransport(rawProfile, resolvedProfile, model)
+    if (!transport.baseURL) {
+      return { ok: false, reason: 'no resolved channel baseURL', rawProfile, resolvedProfile, transport }
+    }
+    // callOpenAICompatible speaks Chat Completions. Never send another
+    // provider protocol through this bridge just because its name looks visual.
+    if (transport.api !== 'openai-completions') {
+      return {
+        ok: false,
+        reason: `channel protocol ${transport.api || 'unknown'} is not OpenAI Chat Completions`,
+        rawProfile,
+        resolvedProfile,
+        transport,
+      }
+    }
+    return { ok: true, rawProfile, resolvedProfile, transport }
+  }
+  const resolveChannelApiKey = async (plan) => {
+    const ref = plan && plan.transport && plan.transport.apiKeyEnv
+    if (typeof ref === 'string' && ref !== '') {
+      try {
+        const credentials = ctx.get('credentials')
+        if (credentials !== undefined) {
+          const hit = await credentials.resolve(ref)
+          if (hit && typeof hit.value === 'string' && hit.value.length > 0) return hit.value
+        }
+      } catch {
+        /* fall through to the ambient environment */
+      }
+      if (typeof process !== 'undefined' && process.env && typeof process.env[ref] === 'string') {
+        return process.env[ref]
+      }
+    }
+    // Catalog routes may use provider-native environment discovery and
+    // therefore carry no explicit Harness credential reference.
+    try {
+      const auth = plan && plan.resolvedProfile && plan.resolvedProfile.piProvider
+        && plan.resolvedProfile.piProvider.auth && plan.resolvedProfile.piProvider.auth.apiKey
+      if (auth && typeof auth.resolve === 'function') {
+        const hit = await auth.resolve({ credential: undefined })
+        const value = hit && hit.auth && hit.auth.apiKey
+        if (typeof value === 'string' && value.length > 0) return value
       }
     } catch {
-      /* fall through to the ambient environment */
-    }
-    if (typeof process !== 'undefined' && process.env && typeof process.env[ref] === 'string') {
-      return process.env[ref]
+      /* unavailable native auth */
     }
     return undefined
   }
   const directChannelVisionAnswer = async (provider, model, blocks, instruction, signal) => {
-    const profile = channelProfileOf(provider)
-    if (profile === undefined) return undefined
-    const apiKey = await resolveChannelApiKey(provider, profile)
-    if (apiKey === undefined || apiKey === '') return undefined
+    const plan = channelBridgePlan(provider, model)
+    if (!plan.ok) throw new Error(`vision bridge unavailable: ${plan.reason}`)
+    const apiKey = await resolveChannelApiKey(plan)
+    if (apiKey === undefined || apiKey === '') {
+      throw new Error('vision bridge unavailable: channel credential could not be resolved')
+    }
     const attachments = ctx.get('attachments')
-    if (attachments === undefined) return undefined
+    if (attachments === undefined) {
+      throw new Error('vision bridge unavailable: attachment service is not registered')
+    }
     const content = []
     for (const block of blocks) {
       const stored = await attachments.readImage(block.attachment)
       content.push(...toOpenAIContent([block], () => stored.data))
     }
     return callOpenAICompatible(
-      { name: provider, baseURL: profile.baseURL, model, apiKeyEnv: '__vision-router-channel__' },
+      {
+        name: provider,
+        baseURL: plan.transport.baseURL,
+        model,
+        apiKeyEnv: '__vision-router-channel__',
+      },
       [{ role: 'user', content: [...content, { type: 'text', text: instruction }] }],
       { maxTokens: 4096, signal, resolveCredential: () => apiKey },
     )
@@ -3942,6 +4057,16 @@ export function apply(ctx, config = {}) {
         }
       }
       for (const pair of usablePairs) {
+        // usablePairs also contains auto-discovered models. Before this fix the
+        // map was populated only from explicit config rows, so inferred
+        // SiliconFlow models failed pi-ai image admission and never reached
+        // the direct channel bridge that was meant to rescue them.
+        const pairKey = `${pair.provider}/${pair.model}`
+        let pairCapability = pairCapabilities.get(pairKey)
+        if (pairCapability === undefined) {
+          pairCapability = await resolveVisionBackendCapability(pair.provider, pair.model)
+          pairCapabilities.set(pairKey, pairCapability)
+        }
         try {
           const text = await visionAnswer(ctx.llm, {
             provider: pair.provider,

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -407,3 +407,12 @@ test('the vision-backend override editor mirrors the chain rows with two selects
   // regress the settings card's scroll smoothness.
   assert.equal(source.includes('collectFilteredVisionBackends(catalog.groups, visionCaps.capabilities)'), true)
 })
+
+
+test('auto-discovered inferred vision models retain bridge capability state', () => {
+  const source = readFileSync(new URL('../index.js', import.meta.url), 'utf8')
+  assert.equal(source.includes('const pairKey = `${pair.provider}/${pair.model}`'), true)
+  assert.equal(source.includes('pairCapabilities.set(pairKey, pairCapability)'), true)
+  assert.equal(source.includes('resolvedPiAiProfileOf'), true)
+  assert.equal(source.includes("transport.api !== 'openai-completions'"), true)
+})

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -30,7 +30,9 @@ import {
   parseVersionParts,
   versionSatisfies,
   looksLikeVisionModel,
+  looksLikeNonGenerativeVisionModel,
   decideVisionBackendCapability,
+  resolveChannelBridgeTransport,
   renderVisionPresent,
   extractJson,
   createCache,
@@ -2266,6 +2268,11 @@ test('looksLikeVisionModel recognizes well-known multimodal families conservativ
   assert.equal(looksLikeVisionModel('glm-4.5'), false)
   // Other well-known families.
   assert.equal(looksLikeVisionModel('qwen2.5-vl-72b-instruct'), true)
+  assert.equal(looksLikeVisionModel('Qwen/Qwen3-VL-32B-Instruct'), true)
+  assert.equal(looksLikeVisionModel('Qwen/Qwen3-VL-Embedding-8B'), false)
+  assert.equal(looksLikeVisionModel('Qwen/Qwen3-VL-Reranker-8B'), false)
+  assert.equal(looksLikeNonGenerativeVisionModel('Qwen3-VL-Embedding-8B'), true)
+  assert.equal(looksLikeNonGenerativeVisionModel('Qwen3-VL-Reranker-8B'), true)
   assert.equal(looksLikeVisionModel('qvq-72b'), true)
   assert.equal(looksLikeVisionModel('gpt-4o-mini'), true)
   assert.equal(looksLikeVisionModel('gpt-4.1'), true)
@@ -2323,4 +2330,65 @@ test('decideVisionBackendCapability honors declarations, overrides and inference
   })
   // Missing inputModalities metadata is treated as text-only unless inferred.
   assert.equal(decideVisionBackendCapability({}, 'zhipu-glm', 'glm-4.6', []).image, false)
+})
+
+
+test('non-generative VL endpoints stay hidden unless explicitly forced', () => {
+  const metadata = { inputModalities: ['text', 'image'] }
+  const rejected = decideVisionBackendCapability(
+    metadata,
+    'siliconflow',
+    'Qwen/Qwen3-VL-Embedding-8B',
+    [],
+  )
+  assert.equal(rejected.image, false)
+  assert.match(rejected.reason, /embedding\/reranker/)
+  const forced = decideVisionBackendCapability(
+    { inputModalities: ['text'] },
+    'siliconflow',
+    'Qwen/Qwen3-VL-Reranker-8B',
+    ['siliconflow/Qwen/Qwen3-VL-Reranker-8B'],
+  )
+  assert.equal(forced.image, true)
+  assert.equal(forced.inferred, 'override')
+})
+
+test('channel bridge transport uses resolved pi-ai catalog model facts', () => {
+  const resolved = {
+    apiKeyEnv: 'SILICONFLOW_API_KEY',
+    piProvider: {
+      baseUrl: 'https://provider.example/v1',
+      getModels: () => [
+        {
+          id: 'Qwen/Qwen3-VL-32B-Instruct',
+          api: 'openai-completions',
+          baseUrl: 'https://model.example/v1',
+        },
+      ],
+    },
+  }
+  assert.deepEqual(
+    resolveChannelBridgeTransport(
+      { apiKeyEnv: 'RAW_KEY_ONLY' },
+      resolved,
+      'Qwen/Qwen3-VL-32B-Instruct',
+    ),
+    {
+      baseURL: 'https://model.example/v1',
+      api: 'openai-completions',
+      apiKeyEnv: 'RAW_KEY_ONLY',
+    },
+  )
+  assert.deepEqual(
+    resolveChannelBridgeTransport(
+      { baseURL: 'https://raw.example/v1', api: 'anthropic-messages' },
+      undefined,
+      'claude-4-sonnet',
+    ),
+    {
+      baseURL: 'https://raw.example/v1',
+      api: 'anthropic-messages',
+      apiKeyEnv: undefined,
+    },
+  )
 })


### PR DESCRIPTION
## Summary

- exclude VL embedding/reranker endpoints from automatic vision-backend inference, while keeping `extraVisionModels` as an explicit expert override
- make the #99 direct vision bridge work for auto-discovered inferred models, not only explicitly configured backend rows
- resolve effective `baseURL` / protocol from catalog-backed `pi-ai` model descriptors, covering providers such as SiliconFlow whose raw profile can omit catalog defaults
- fail closed when the resolved channel is not OpenAI Chat Completions, and surface clearer bridge-unavailable diagnostics

## Why

A user configured SiliconFlow after the new visual-model filter landed. Qwen3-VL chat models were correctly recognized by name, but `pi-ai` still rejected image input because its model metadata was text-only. The auto-discovered models then skipped the direct bridge because the capability cache had only been populated for explicit rows. At the same time, `Qwen3-VL-Embedding-8B` and `Qwen3-VL-Reranker-8B` were false positives because the old heuristic matched any `VL` name.

The direct bridge also depended on a raw `llm-pi-ai` `baseURL`, which catalog-backed routes may legitimately omit. This patch feature-detects the already-resolved pi-ai profile/model to recover the effective transport facts, while falling back safely if upstream internals change.

## Regression coverage

- Qwen3-VL Instruct remains recognized
- Qwen3-VL Embedding/Reranker are excluded automatically
- explicit `extraVisionModels` can still force an unusual endpoint
- catalog-resolved model `baseUrl` / `api` feed the compatibility bridge
- auto-discovered inferred models populate the runtime capability cache before adapter failure handling
- non-OpenAI-Chat-Completions routes are not sent through the OpenAI compatibility bridge

## Verification

- full `pnpm test`
- `node --check index.js`
- `git diff --check`

Built on the current `main`, including the latest settings-save and doctor fixes.