### PR TITLE
feat: spotlight highlights for every onboarding walkthrough step

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1153,32 +1153,47 @@ window.__ModuleLoader__.load({
       // The gear sits at the bottom-left: land above it first. Everywhere
       // else prefer the side so the card reads naturally left-to-right.
       const prefer = phase === 'gear' ? ['top', 'right', 'bottom', 'left'] : ['right', 'top', 'bottom', 'left']
+      const clampX = (value) => Math.min(Math.max(value, margin), Math.max(margin, vw - pw - margin))
+      const clampY = (value) => Math.min(Math.max(value, margin), Math.max(margin, vh - ph - margin))
+      // Keep a small halo around the target clear so the prompt never sits
+      // flush against (or on top of) the highlighted control.
+      const halo = 10
+      const hx = rect.x - halo
+      const hy = rect.y - halo
+      const hw = rect.width + halo * 2
+      const hh = rect.height + halo * 2
       let picked
       for (const side of prefer) {
         const candidate = guideAnchorCandidate(side, rect, pw, ph, gap)
-        const covers =
-          candidate.left < rect.x + rect.width &&
-          candidate.left + pw > rect.x &&
-          candidate.top < rect.y + rect.height &&
-          candidate.top + ph > rect.y
+        const left = clampX(candidate.left)
+        const top = clampY(candidate.top)
+        // Judge coverage on the CLAMPED box: clamping next to a viewport edge
+        // can push a prompt back over the target, which is exactly how step 1
+        // used to hide the model selector.
+        const covers = left < hx + hw && left + pw > hx && top < hy + hh && top + ph > hy
         if (!covers) {
-          picked = candidate
+          picked = { side, left, top }
           break
         }
       }
-      if (!picked) picked = guideAnchorCandidate(prefer[0], rect, pw, ph, gap)
-      const left = Math.min(Math.max(picked.left, margin), Math.max(margin, vw - pw - margin))
-      const top = Math.min(Math.max(picked.top, margin), Math.max(margin, vh - ph - margin))
-      prompt.style.left = left + 'px'
-      prompt.style.top = top + 'px'
+      if (!picked) {
+        const fallback = guideAnchorCandidate(prefer[0], rect, pw, ph, gap)
+        picked = { side: fallback.side, left: clampX(fallback.left), top: clampY(fallback.top) }
+      }
+      prompt.style.left = picked.left + 'px'
+      prompt.style.top = picked.top + 'px'
       prompt.style.right = 'auto'
       prompt.style.bottom = 'auto'
       if (arrow) {
-        arrow.classList.add('vr-guide-arrow-' + picked.side)
+        // The arrow lives on the prompt's edge that FACES the target: a
+        // prompt placed above the target shows a bottom arrow pointing down,
+        // a prompt to the right of the target shows a left arrow, and so on.
+        const arrowSide = { top: 'bottom', bottom: 'top', left: 'right', right: 'left' }[picked.side]
+        arrow.classList.add('vr-guide-arrow-' + arrowSide)
         const pos =
           picked.side === 'top' || picked.side === 'bottom'
-            ? Math.min(Math.max(rect.x + rect.width / 2 - left, 16), pw - 16)
-            : Math.min(Math.max(rect.y + rect.height / 2 - top, 16), ph - 16)
+            ? Math.min(Math.max(rect.x + rect.width / 2 - picked.left, 16), pw - 16)
+            : Math.min(Math.max(rect.y + rect.height / 2 - picked.top, 16), ph - 16)
         arrow.style.setProperty('--vr-arrow-pos', pos + 'px')
       }
     }

--- a/lib/client.js
+++ b/lib/client.js
@@ -36,8 +36,8 @@ window.__ModuleLoader__.load({
       guideStep1Body: '聊天页右下角、输入框旁的模型选择器已经被高亮圈出。发图片时请选带「+ 自动识图」的模型组；组里的模型仍负责聊天、思考和调用工具。选好后点击「下一步」。',
       guideStepNext: '下一步',
       guidePromptTitle: '第 2 步 · 视觉模型',
-      guidePromptGearBody: '点击侧边栏左下角被高亮圈出的「设置」齿轮，打开设置面板。',
-      guidePromptNavBody: '在设置面板左侧的导航里，点击被高亮的「插件」入口。进入插件页后，我会自动展开 Vision Router 并定位到「视觉后端链」。',
+      guidePromptGearBody: '点击侧边栏左下角被高亮圈出的「设置」齿轮打开设置面板；也可以直接点「下一步」帮你打开。',
+      guidePromptNavBody: '在设置面板左侧的导航里，点击被高亮的「插件」入口（或点「下一步」自动进入）。进入插件页后，我会自动展开 Vision Router 并定位到「视觉后端链」。',
       guidePromptCancel: '结束引导',
       guideChainTitle: '第 3 步 · 这里就是视觉模型',
       guideChainBody: '上面的每一行都是你自己的视觉模型，从上到下依次尝试；可以全部留空。内置 OVH 免费链固定在最后自动兜底。这里不会修改聊天页右下角的会话/文字模型。选好后点击页面底部「保存」。',
@@ -224,8 +224,8 @@ window.__ModuleLoader__.load({
       guideStep1Body: 'The model selector next to the chat input in the lower-right corner is now highlighted. For image turns, pick a group marked “+ Auto Vision”; the model inside still handles chat, reasoning, and tool calls. Click “Next” when done.',
       guideStepNext: 'Next',
       guidePromptTitle: 'Step 2 · Vision model',
-      guidePromptGearBody: 'Click the highlighted Settings gear at the bottom-left of the sidebar to open the settings panel.',
-      guidePromptNavBody: 'In the settings panel’s left navigation, click the highlighted “Plugins” entry. Once that page is open, I will expand Vision Router and take you to “Vision backend chain”.',
+      guidePromptGearBody: 'Click the highlighted Settings gear at the bottom-left of the sidebar, or press “Next” and I will open it for you.',
+      guidePromptNavBody: 'In the settings panel’s left navigation, click the highlighted “Plugins” entry (or press “Next”). Once that page is open, I will expand Vision Router and take you to “Vision backend chain”.',
       guidePromptCancel: 'End guide',
       guideChainTitle: 'Step 3 · This is the vision model',
       guideChainBody: 'Each row above is one of your own vision models, tried top to bottom; you may leave them all empty. The built-in OVH chain remains the automatic final fallback. This does not change the session/text model in the lower-right chat selector. Click “Save” after choosing.',
@@ -1074,19 +1074,34 @@ window.__ModuleLoader__.load({
         finishVisionSettingsGuide()
       })
       actions.append(cancel)
-      if (step === 'step1') {
-        const next = document.createElement('button')
-        next.type = 'button'
-        next.className = 'vr-btn vr-btn-save'
-        next.textContent = t('guideStepNext')
-        next.addEventListener('click', () => {
+      // Every step that is not the last one gets a Next button, so the two
+      // floating prompts stay symmetric. Step 1's Next advances the stored
+      // step; step 2's Next performs the current phase's action for the
+      // user — opening the settings panel, then entering the Plugins
+      // section — so the walkthrough can be driven entirely from the prompt
+      // without touching the real controls.
+      const next = document.createElement('button')
+      next.type = 'button'
+      next.className = 'vr-btn vr-btn-save'
+      next.textContent = t('guideStepNext')
+      next.addEventListener('click', () => {
+        if (step === 'step1') {
           writeVisionGuideStep('step2')
-          clearGuidePromptUI()
-          syncVisionGuidePrompt(t)
-          notifyVisionGuideChanged()
-        })
-        actions.append(next)
-      }
+        } else {
+          const currentPhase = guidePhase('step2')
+          if (currentPhase === 'gear') {
+            const gear = guideGearButton()
+            if (gear && typeof gear.click === 'function') gear.click()
+          } else if (currentPhase === 'nav') {
+            const row = guidePluginsNav()
+            if (row && row.tagName === 'BUTTON' && typeof row.click === 'function') row.click()
+          }
+        }
+        clearGuidePromptUI()
+        syncVisionGuidePrompt(t)
+        notifyVisionGuideChanged()
+      })
+      actions.append(next)
       const arrow = document.createElement('div')
       arrow.className = 'vr-guide-arrow'
       arrow.setAttribute('aria-hidden', 'true')

--- a/lib/client.js
+++ b/lib/client.js
@@ -33,10 +33,11 @@ window.__ModuleLoader__.load({
       onboardingLater: '稍后',
       onboardingClose: '关闭',
       guideStep1Title: '第 1 步 · 会话 / 文字模型',
-      guideStep1Body: '在聊天页右下角的模型选择器里选择会话/文字模型。发图片时，请选带「+ 自动识图」的模型组；组里的模型仍负责聊天、思考和调用工具。选好后点击「下一步」。',
+      guideStep1Body: '聊天页右下角、输入框旁的模型选择器已经被高亮圈出。发图片时请选带「+ 自动识图」的模型组；组里的模型仍负责聊天、思考和调用工具。选好后点击「下一步」。',
       guideStepNext: '下一步',
       guidePromptTitle: '第 2 步 · 视觉模型',
-      guidePromptBody: '请打开 DSH 的「设置 → 插件」。进入插件页后，我会自动展开 Vision Router，并定位到「视觉后端链」。',
+      guidePromptGearBody: '点击侧边栏左下角被高亮圈出的「设置」齿轮，打开设置面板。',
+      guidePromptNavBody: '在设置面板左侧的导航里，点击被高亮的「插件」入口。进入插件页后，我会自动展开 Vision Router 并定位到「视觉后端链」。',
       guidePromptCancel: '结束引导',
       guideChainTitle: '第 3 步 · 这里就是视觉模型',
       guideChainBody: '上面的每一行都是你自己的视觉模型，从上到下依次尝试；可以全部留空。内置 OVH 免费链固定在最后自动兜底。这里不会修改聊天页右下角的会话/文字模型。选好后点击页面底部「保存」。',
@@ -220,10 +221,11 @@ window.__ModuleLoader__.load({
       onboardingLater: 'Later',
       onboardingClose: 'Close',
       guideStep1Title: 'Step 1 · Session / text model',
-      guideStep1Body: 'Choose it from the lower-right chat selector. For image turns, use a group marked “+ Auto Vision”; the model inside still handles chat, reasoning, and tool calls. Click “Next” when done.',
+      guideStep1Body: 'The model selector next to the chat input in the lower-right corner is now highlighted. For image turns, pick a group marked “+ Auto Vision”; the model inside still handles chat, reasoning, and tool calls. Click “Next” when done.',
       guideStepNext: 'Next',
       guidePromptTitle: 'Step 2 · Vision model',
-      guidePromptBody: 'Open DSH Settings → Plugins. Once that page is open, I will expand Vision Router and take you to “Vision backend chain”.',
+      guidePromptGearBody: 'Click the highlighted Settings gear at the bottom-left of the sidebar to open the settings panel.',
+      guidePromptNavBody: 'In the settings panel’s left navigation, click the highlighted “Plugins” entry. Once that page is open, I will expand Vision Router and take you to “Vision backend chain”.',
       guidePromptCancel: 'End guide',
       guideChainTitle: 'Step 3 · This is the vision model',
       guideChainBody: 'Each row above is one of your own vision models, tried top to bottom; you may leave them all empty. The built-in OVH chain remains the automatic final fallback. This does not change the session/text model in the lower-right chat selector. Click “Save” after choosing.',
@@ -692,16 +694,41 @@ window.__ModuleLoader__.load({
       '.vr-onboarding-primary{border:0;background:var(--dsw-alias-label-primary);color:var(--dsw-alias-bg-layer-3)}' +
       '.vr-onboarding-secondary{border:1px solid var(--dsw-alias-border-l2);background:transparent;color:var(--dsw-alias-label-secondary)}' +
       '.vr-onboarding-primary:focus-visible,.vr-onboarding-secondary:focus-visible,.vr-onboarding-close:focus-visible{outline:2px solid var(--dsw-alias-brand-primary);outline-offset:2px}' +
-      '.vr-guide-prompt{position:fixed;right:20px;bottom:20px;z-index:9999;width:min(360px,calc(100vw - 32px));box-sizing:border-box;border:1px solid var(--dsw-alias-brand-primary);border-radius:12px;background:var(--dsw-alias-bg-layer-2);box-shadow:0 12px 40px #0004;padding:14px;display:flex;flex-direction:column;gap:7px;color:var(--dsw-alias-label-primary)}' +
+      '.vr-guide-prompt{position:fixed;z-index:10002;width:min(360px,calc(100vw - 24px));box-sizing:border-box;border:1px solid var(--dsw-alias-brand-primary);border-radius:12px;background:var(--dsw-alias-bg-layer-2);box-shadow:0 12px 40px #0006;padding:14px;display:flex;flex-direction:column;gap:7px;color:var(--dsw-alias-label-primary);transition:left .22s ease,top .22s ease,opacity .18s ease,transform .18s ease}' +
       '.vr-guide-prompt-title{font-size:13px;font-weight:700;line-height:1.5}' +
       '.vr-guide-prompt-body{margin:0;color:var(--dsw-alias-label-secondary);font-size:12px;line-height:1.6}' +
       '.vr-guide-prompt-actions{display:flex;justify-content:flex-end;align-items:center;gap:8px;flex-wrap:wrap}' +
-      '.vr-guide-prompt-left{right:auto;left:20px}' +
-      '.vr-guide-target{border:2px solid var(--dsw-alias-brand-primary)!important;border-radius:12px;padding:12px!important;margin:8px -12px!important;background:var(--dsw-alias-bg-module-platform);box-shadow:0 0 0 4px color-mix(in srgb,var(--dsw-alias-brand-primary) 12%,transparent)}' +
+      '.vr-guide-prompt-veiled{opacity:0;transform:translateY(10px);pointer-events:none}' +
+      '.vr-guide-arrow{position:absolute;width:20px;height:20px;pointer-events:none}' +
+      '.vr-guide-arrow::before{content:"";position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);border:9px solid #0000}' +
+      '.vr-guide-arrow::after{content:"";position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);border:8px solid #0000}' +
+      '.vr-guide-arrow-bottom{bottom:-11px;left:var(--vr-arrow-pos)}' +
+      '.vr-guide-arrow-bottom::before{border-bottom-width:0;border-top-color:var(--dsw-alias-brand-primary)}' +
+      '.vr-guide-arrow-bottom::after{border-bottom-width:0;border-top-color:var(--dsw-alias-bg-layer-2);margin-top:1px}' +
+      '.vr-guide-arrow-top{top:-11px;left:var(--vr-arrow-pos)}' +
+      '.vr-guide-arrow-top::before{border-top-width:0;border-bottom-color:var(--dsw-alias-brand-primary)}' +
+      '.vr-guide-arrow-top::after{border-top-width:0;border-bottom-color:var(--dsw-alias-bg-layer-2);margin-top:-1px}' +
+      '.vr-guide-arrow-left{left:-11px;top:var(--vr-arrow-pos)}' +
+      '.vr-guide-arrow-left::before{border-left-width:0;border-right-color:var(--dsw-alias-brand-primary)}' +
+      '.vr-guide-arrow-left::after{border-left-width:0;border-right-color:var(--dsw-alias-bg-layer-2);margin-left:1px}' +
+      '.vr-guide-arrow-right{right:-11px;top:var(--vr-arrow-pos)}' +
+      '.vr-guide-arrow-right::before{border-right-width:0;border-left-color:var(--dsw-alias-brand-primary)}' +
+      '.vr-guide-arrow-right::after{border-right-width:0;border-left-color:var(--dsw-alias-bg-layer-2);margin-left:-1px}' +
+      '.vr-guide-arrow-corner-se{bottom:-10px;right:0;transform:rotate(-45deg)}' +
+      '.vr-guide-arrow-corner-sw{bottom:-10px;left:0;transform:rotate(45deg)}' +
+      '.vr-guide-arrow-corner-se::before,.vr-guide-arrow-corner-sw::before{border-bottom-width:0;border-top-color:var(--dsw-alias-brand-primary)}' +
+      '.vr-guide-arrow-corner-se::after,.vr-guide-arrow-corner-sw::after{border-bottom-width:0;border-top-color:var(--dsw-alias-bg-layer-2);margin-top:1px}' +
+      '.vr-guide-spot{position:fixed;inset:0;z-index:10000;pointer-events:none}' +
+      '.vr-guide-spot-hole{position:fixed;border-radius:14px;box-shadow:0 0 0 9999px #10101499;transition:left .22s ease,top .22s ease,width .22s ease,height .22s ease}' +
+      '.vr-guide-spot-ring{position:fixed;border:2px solid var(--dsw-alias-brand-primary);border-radius:16px;animation:vr-guide-pulse 1.6s ease-in-out infinite;transition:left .22s ease,top .22s ease,width .22s ease,height .22s ease}' +
+      '@keyframes vr-guide-pulse{0%,100%{box-shadow:0 0 0 4px color-mix(in srgb,var(--dsw-alias-brand-primary) 16%,#0000),0 0 18px color-mix(in srgb,var(--dsw-alias-brand-primary) 30%,#0000)}50%{box-shadow:0 0 0 9px color-mix(in srgb,var(--dsw-alias-brand-primary) 26%,#0000),0 0 30px color-mix(in srgb,var(--dsw-alias-brand-primary) 55%,#0000)}}' +
+      '.vr-guide-target{border:2px solid var(--dsw-alias-brand-primary)!important;border-radius:12px;padding:12px!important;margin:8px -12px!important;background:var(--dsw-alias-bg-module-platform);animation:vr-guide-target-pulse 1.6s ease-in-out infinite}' +
+      '@keyframes vr-guide-target-pulse{0%,100%{box-shadow:0 0 0 4px color-mix(in srgb,var(--dsw-alias-brand-primary) 12%,#0000)}50%{box-shadow:0 0 0 9px color-mix(in srgb,var(--dsw-alias-brand-primary) 24%,#0000)}}' +
       '.vr-guide-callout{border-radius:9px;background:var(--dsw-alias-bg-layer-3);padding:10px 12px;display:flex;flex-direction:column;align-items:flex-start;gap:5px;margin-bottom:4px}' +
       '.vr-guide-callout-title{font-size:13px;font-weight:700;color:var(--dsw-alias-brand-primary)}' +
       '.vr-guide-callout-body{margin:0;font-size:12px;line-height:1.6;color:var(--dsw-alias-label-secondary)}' +
-      '@media(max-width:640px){.vr-onboarding-backdrop{align-items:flex-end;padding:0}.vr-onboarding-dialog{width:100%;border-radius:16px 16px 0 0;padding:20px 18px max(20px,env(safe-area-inset-bottom))}.vr-guide-prompt{left:12px;right:12px;bottom:max(12px,env(safe-area-inset-bottom));width:auto}}'
+      '@media(prefers-reduced-motion:reduce){.vr-guide-spot-ring,.vr-guide-target{animation:none}.vr-guide-prompt{transition:none}}' +
+      '@media(max-width:640px){.vr-onboarding-backdrop{align-items:flex-end;padding:0}.vr-onboarding-dialog{width:100%;border-radius:16px 16px 0 0;padding:20px 18px max(20px,env(safe-area-inset-bottom))}.vr-guide-arrow{display:none}.vr-guide-prompt{left:12px!important;right:12px!important;bottom:max(12px,env(safe-area-inset-bottom))!important;top:auto!important;width:auto}}'
 
     let stylesInstalled = false
     function installStyles() {
@@ -736,6 +763,8 @@ window.__ModuleLoader__.load({
     const VISION_GUIDE_SETTINGS_KEY = 'visionGuideStep'
     const VISION_GUIDE_EVENT = 'dsh-vision-router:vision-settings-guide'
     let visionGuidePrompt
+    let visionGuideSpotlight
+    let visionGuideSyncTimer
     let visionGuideStepMemory
     // Installed by apply(): a narrow, defensive view of the settings scope.
     // { get, set, unset } never throw, and subscribe returns a disposer (or
@@ -852,12 +881,26 @@ window.__ModuleLoader__.load({
         // Page-memory state still keeps the guide functional for this load.
       }
     }
-    function readVisionGuideActive() {
-      return readVisionGuideStep() !== undefined
-    }
-    function removeVisionGuidePrompt() {
+    function clearGuidePromptUI() {
       if (visionGuidePrompt) visionGuidePrompt.remove()
       visionGuidePrompt = undefined
+      removeGuideSpotlight()
+    }
+    function removeVisionGuidePrompt() {
+      clearGuidePromptUI()
+      stopGuideSync()
+    }
+    function removeGuideSpotlight() {
+      if (visionGuideSpotlight) {
+        visionGuideSpotlight.root.remove()
+        visionGuideSpotlight = undefined
+      }
+    }
+    function stopGuideSync() {
+      if (visionGuideSyncTimer !== undefined) {
+        window.clearInterval(visionGuideSyncTimer)
+        visionGuideSyncTimer = undefined
+      }
     }
     function notifyVisionGuideChanged() {
       if (typeof window === 'undefined' || typeof window.dispatchEvent !== 'function') return
@@ -878,31 +921,149 @@ window.__ModuleLoader__.load({
         // KeyboardEvent constructor unavailable: degrade to staying put.
       }
     }
-    function syncVisionGuidePrompt(t) {
-      if (typeof document === 'undefined' || typeof window === 'undefined') return
-      const step = readVisionGuideStep()
-      if (step === undefined) {
-        removeVisionGuidePrompt()
+
+    // ── walkthrough spotlight: highlight the real UI targets ────────────────
+    // The walkthrough overlays are plain DOM: a dimmed backdrop with a "hole"
+    // over the current target (classic box-shadow spotlight), a pulsing ring
+    // around it, and the prompt card anchored beside the target with an arrow
+    // pointing at it. Everything is pointer-events:none except the prompt, so
+    // the real controls stay clickable the whole time.
+    //
+    // DSH web hashes its CSS-module class names (unstable across builds), so
+    // the targets are addressed through the stable surface instead: slot
+    // wrappers (data-slot), data-composer-card and aria-haspopup/aria-label
+    // attributes. Each step keeps a fallback chain, and when nothing matches
+    // the prompt degrades to a corner card with a directional arrow.
+    const GUIDE_SELECTOR_TARGETS = [
+      '[data-slot="conversation.input.model"] button[aria-haspopup="menu"]',
+      '[aria-label^="选择模型"], [aria-label^="Select model"]',
+      '[data-composer-card] button[aria-haspopup="menu"]',
+    ]
+    // Settings is a modal, not a URL route: detect it purely by DOM. Exclude
+    // our own onboarding dialog (also aria-modal) from the panel lookup.
+    function guideSettingsPanel() {
+      if (typeof document === 'undefined') return undefined
+      const dialogs = Array.from(document.querySelectorAll('[role="dialog"][aria-modal="true"]'))
+      return dialogs.find((dialog) => !dialog.closest || !dialog.closest('.vr-onboarding-dialog'))
+    }
+    function guideElementUsable(el) {
+      if (!el || typeof el.getBoundingClientRect !== 'function') return false
+      const rect = el.getBoundingClientRect()
+      if (!rect || rect.width < 6 || rect.height < 6) return false
+      const vw = window.innerWidth || 1
+      const vh = window.innerHeight || 1
+      return rect.right > 0 && rect.bottom > 0 && rect.left < vw && rect.top < vh
+    }
+    function guideFindFirstUsable(selectors) {
+      if (typeof document === 'undefined') return undefined
+      for (const selector of selectors) {
+        let list
+        try {
+          list = Array.from(document.querySelectorAll(selector))
+        } catch {
+          continue
+        }
+        // Walk backwards: among ambiguous matches (e.g. several menu buttons
+        // inside the composer) the trailing row holds the model seat and is
+        // the safest pick.
+        for (let index = list.length - 1; index >= 0; index--) {
+          if (guideElementUsable(list[index])) return list[index]
+        }
+      }
+      return undefined
+    }
+    // The sidebar settings gear: aria-haspopup="dialog" also appears on the
+    // composer's context meter, so exclude anything inside the composer card.
+    function guideGearButton() {
+      if (typeof document === 'undefined') return undefined
+      const list = Array.from(document.querySelectorAll('button[aria-haspopup="dialog"]')).filter(
+        (el) => !el.closest || !el.closest('[data-composer-card]'),
+      )
+      return list.find(guideElementUsable)
+    }
+    // The settings panel's "Plugins" nav row; when the row label is in a
+    // locale we don't match, degrade to the whole nav column.
+    function guidePluginsNav() {
+      const panel = guideSettingsPanel()
+      if (!panel) return undefined
+      const nav = panel.querySelector('nav')
+      if (!nav) return undefined
+      const rows = Array.from(nav.querySelectorAll('button'))
+      const match = rows.find((row) => /^(插件|Plugins)$/.test((row.textContent || '').trim()))
+      return match || nav
+    }
+    // step1 phases: 'selector' (composer model seat found) or 'corner'
+    // (fallback). step2 phases: 'gear' (sidebar), 'nav' (plugins row inside
+    // the panel), 'done' (the vision chain target exists — the in-card step-3
+    // callout takes over). 'suspend' hides the floating layer while our own
+    // onboarding overview dialog is open.
+    function guidePhase(step) {
+      if (step === undefined) return 'none'
+      if (onboardingOverlay) return 'suspend'
+      if (step === 'step1') return guideFindFirstUsable(GUIDE_SELECTOR_TARGETS) ? 'selector' : 'corner'
+      if (typeof document === 'undefined') return 'gear'
+      if (document.querySelector('[data-vr-guide-target="vision-backend"]')) return 'done'
+      if (guideSettingsPanel()) return 'nav'
+      return 'gear'
+    }
+    function guideTarget(step, phase) {
+      if (step === 'step1') return guideFindFirstUsable(GUIDE_SELECTOR_TARGETS)
+      if (phase === 'nav') return guidePluginsNav()
+      return guideGearButton()
+    }
+    function ensureGuideSpotlight() {
+      if (visionGuideSpotlight) return visionGuideSpotlight
+      if (typeof document === 'undefined' || !document.body) return undefined
+      const root = document.createElement('div')
+      root.className = 'vr-guide-spot'
+      root.setAttribute('aria-hidden', 'true')
+      const hole = document.createElement('div')
+      hole.className = 'vr-guide-spot-hole'
+      const ring = document.createElement('div')
+      ring.className = 'vr-guide-spot-ring'
+      root.append(hole, ring)
+      document.body.appendChild(root)
+      visionGuideSpotlight = { root, hole, ring }
+      return visionGuideSpotlight
+    }
+    function applyGuideSpotlight(rect) {
+      const spot = ensureGuideSpotlight()
+      if (!spot) return
+      if (!rect) {
+        spot.root.style.display = 'none'
         return
       }
-      if (step === 'step2' && document.querySelector('[data-vr-guide-target="vision-backend"]')) {
-        // Step 2 is done once the card is on screen; the in-card callout
-        // (step 3) takes over from here.
-        removeVisionGuidePrompt()
-        return
+      spot.root.style.display = ''
+      const parts = [
+        [spot.hole, 9, 14],
+        [spot.ring, 5, 16],
+      ]
+      for (const [el, pad, radius] of parts) {
+        el.style.left = Math.max(0, rect.x - pad) + 'px'
+        el.style.top = Math.max(0, rect.y - pad) + 'px'
+        el.style.width = rect.width + pad * 2 + 'px'
+        el.style.height = rect.height + pad * 2 + 'px'
+        el.style.borderRadius = radius + 'px'
       }
-      if (visionGuidePrompt || !document.body) return
+    }
+    function guidePromptText(t, step, phase) {
+      if (step === 'step1') return { title: t('guideStep1Title'), body: t('guideStep1Body') }
+      return {
+        title: t('guidePromptTitle'),
+        body: phase === 'nav' ? t('guidePromptNavBody') : t('guidePromptGearBody'),
+      }
+    }
+    function buildGuidePrompt(t, step, phase) {
       const prompt = document.createElement('div')
-      // Step 1 talks about the chat page's lower-right model selector, so
-      // park the prompt on the LEFT side and keep the selector usable.
-      prompt.className = 'vr-guide-prompt' + (step === 'step1' ? ' vr-guide-prompt-left' : '')
-      prompt.setAttribute('role', 'status')
+      prompt.className = 'vr-guide-prompt'
+      prompt.setAttribute('role', 'dialog')
+      prompt.setAttribute('aria-modal', 'false')
+      prompt.dataset.vrStep = step
+      prompt.dataset.vrPhase = phase
       const title = document.createElement('div')
       title.className = 'vr-guide-prompt-title'
-      title.textContent = step === 'step1' ? t('guideStep1Title') : t('guidePromptTitle')
       const body = document.createElement('p')
       body.className = 'vr-guide-prompt-body'
-      body.textContent = step === 'step1' ? t('guideStep1Body') : t('guidePromptBody')
       const actions = document.createElement('div')
       actions.className = 'vr-guide-prompt-actions'
       const cancel = document.createElement('button')
@@ -920,15 +1081,130 @@ window.__ModuleLoader__.load({
         next.textContent = t('guideStepNext')
         next.addEventListener('click', () => {
           writeVisionGuideStep('step2')
-          removeVisionGuidePrompt()
+          clearGuidePromptUI()
           syncVisionGuidePrompt(t)
           notifyVisionGuideChanged()
         })
         actions.append(next)
       }
-      prompt.append(title, body, actions)
-      document.body.appendChild(prompt)
-      visionGuidePrompt = prompt
+      const arrow = document.createElement('div')
+      arrow.className = 'vr-guide-arrow'
+      arrow.setAttribute('aria-hidden', 'true')
+      const text = guidePromptText(t, step, phase)
+      title.textContent = text.title
+      body.textContent = text.body
+      prompt.append(title, body, actions, arrow)
+      return prompt
+    }
+    function updateGuidePrompt(prompt, t, step, phase) {
+      const text = guidePromptText(t, step, phase)
+      const title = prompt.querySelector('.vr-guide-prompt-title')
+      const body = prompt.querySelector('.vr-guide-prompt-body')
+      if (title) title.textContent = text.title
+      if (body) body.textContent = text.body
+      prompt.dataset.vrStep = step
+      prompt.dataset.vrPhase = phase
+    }
+    function guideAnchorCandidate(side, rect, pw, ph, gap) {
+      if (side === 'top') return { side, left: rect.x + rect.width / 2 - pw / 2, top: rect.y - ph - gap }
+      if (side === 'bottom') return { side, left: rect.x + rect.width / 2 - pw / 2, top: rect.y + rect.height + gap }
+      if (side === 'right') return { side, left: rect.x + rect.width + gap, top: rect.y + rect.height / 2 - ph / 2 }
+      return { side, left: rect.x - pw - gap, top: rect.y + rect.height / 2 - ph / 2 }
+    }
+    function anchorGuidePrompt(prompt, step, phase, rect, veil) {
+      prompt.classList.toggle('vr-guide-prompt-veiled', !!veil)
+      const arrow = prompt.querySelector('.vr-guide-arrow')
+      const arrowSides = ['vr-guide-arrow-bottom', 'vr-guide-arrow-top', 'vr-guide-arrow-left', 'vr-guide-arrow-right', 'vr-guide-arrow-corner-se', 'vr-guide-arrow-corner-sw']
+      if (arrow) {
+        for (const cls of arrowSides) arrow.classList.remove(cls)
+        arrow.style.removeProperty('--vr-arrow-pos')
+      }
+      const margin = 12
+      const gap = 16
+      const vw = window.innerWidth || 1
+      const vh = window.innerHeight || 1
+      const pw = prompt.offsetWidth || 360
+      const ph = prompt.offsetHeight || 160
+      if (!rect) {
+        // No target found: park the prompt in a corner with an arrow pointing
+        // toward where the control normally lives.
+        prompt.style.left = step === 'step1' ? margin + 'px' : 'auto'
+        prompt.style.right = step === 'step1' ? 'auto' : margin + 'px'
+        prompt.style.top = 'auto'
+        prompt.style.bottom = margin + 'px'
+        if (arrow) arrow.classList.add(step === 'step1' ? 'vr-guide-arrow-corner-se' : 'vr-guide-arrow-corner-sw')
+        return
+      }
+      // The gear sits at the bottom-left: land above it first. Everywhere
+      // else prefer the side so the card reads naturally left-to-right.
+      const prefer = phase === 'gear' ? ['top', 'right', 'bottom', 'left'] : ['right', 'top', 'bottom', 'left']
+      let picked
+      for (const side of prefer) {
+        const candidate = guideAnchorCandidate(side, rect, pw, ph, gap)
+        const covers =
+          candidate.left < rect.x + rect.width &&
+          candidate.left + pw > rect.x &&
+          candidate.top < rect.y + rect.height &&
+          candidate.top + ph > rect.y
+        if (!covers) {
+          picked = candidate
+          break
+        }
+      }
+      if (!picked) picked = guideAnchorCandidate(prefer[0], rect, pw, ph, gap)
+      const left = Math.min(Math.max(picked.left, margin), Math.max(margin, vw - pw - margin))
+      const top = Math.min(Math.max(picked.top, margin), Math.max(margin, vh - ph - margin))
+      prompt.style.left = left + 'px'
+      prompt.style.top = top + 'px'
+      prompt.style.right = 'auto'
+      prompt.style.bottom = 'auto'
+      if (arrow) {
+        arrow.classList.add('vr-guide-arrow-' + picked.side)
+        const pos =
+          picked.side === 'top' || picked.side === 'bottom'
+            ? Math.min(Math.max(rect.x + rect.width / 2 - left, 16), pw - 16)
+            : Math.min(Math.max(rect.y + rect.height / 2 - top, 16), ph - 16)
+        arrow.style.setProperty('--vr-arrow-pos', pos + 'px')
+      }
+    }
+    function syncVisionGuidePrompt(t) {
+      if (typeof document === 'undefined' || typeof window === 'undefined' || !document.body) return
+      const step = readVisionGuideStep()
+      const phase = guidePhase(step)
+      if (phase === 'none' || phase === 'done' || phase === 'suspend') {
+        // No floating layer: the walkthrough is over, the in-card callout
+        // (step 3) has taken over, or the onboarding overview dialog covers
+        // the page.
+        clearGuidePromptUI()
+        if (phase === 'none') stopGuideSync()
+        return
+      }
+      // Keep the light re-sync tick alive while any step is active; it is the
+      // only thing that follows targets through SPA renders and menus.
+      if (visionGuideSyncTimer === undefined) {
+        visionGuideSyncTimer = window.setInterval(() => syncVisionGuidePrompt(t), 600)
+      }
+      if (!visionGuidePrompt || visionGuidePrompt.dataset.vrStep !== step) {
+        if (visionGuidePrompt) visionGuidePrompt.remove()
+        removeGuideSpotlight()
+        visionGuidePrompt = buildGuidePrompt(t, step, phase)
+        document.body.appendChild(visionGuidePrompt)
+      } else if (visionGuidePrompt.dataset.vrPhase !== phase) {
+        updateGuidePrompt(visionGuidePrompt, t, step, phase)
+      }
+      const target = guideTarget(step, phase)
+      const rect =
+        target && typeof target.getBoundingClientRect === 'function' ? target.getBoundingClientRect() : undefined
+      applyGuideSpotlight(rect)
+      // Step 1's menu opens right over the spot where the prompt sits: veil
+      // the prompt while the user picks, and bring it back when they close
+      // the menu.
+      const menuOpen =
+        phase === 'selector' &&
+        typeof target !== 'undefined' &&
+        typeof target.getAttribute === 'function' &&
+        target.getAttribute('aria-expanded') === 'true'
+      anchorGuidePrompt(visionGuidePrompt, step, phase, rect, menuOpen)
     }
     function startVisionSettingsGuide(t) {
       writeVisionGuideStep('step1')
@@ -946,12 +1222,20 @@ window.__ModuleLoader__.load({
       syncVisionGuidePrompt(t)
       window.addEventListener(VISION_GUIDE_EVENT, sync)
       window.addEventListener('popstate', sync)
+      window.addEventListener('resize', sync)
+      // Inner scrollers (message list, settings content) don't bubble;
+      // capture keeps the spotlight glued to its target while anything
+      // scrolls. The interval below covers the rest (menus, SPA renders).
+      document.addEventListener('scroll', sync, true)
       // The durable step now lives in the settings section; re-sync when its
       // snapshot changes (e.g. the first read resolves after page load).
       const unsubscribe = settingsPersistence && settingsPersistence.subscribe(sync)
       return () => {
         window.removeEventListener(VISION_GUIDE_EVENT, sync)
         window.removeEventListener('popstate', sync)
+        window.removeEventListener('resize', sync)
+        document.removeEventListener('scroll', sync, true)
+        stopGuideSync()
         if (typeof unsubscribe === 'function') unsubscribe()
         removeVisionGuidePrompt()
       }
@@ -1146,7 +1430,8 @@ window.__ModuleLoader__.load({
       const [testState, setTestState] = useState({ status: 'idle' })
       const [updateState, setUpdateState] = useState({ status: 'idle', result: undefined })
       const [selfUpdateState, setSelfUpdateState] = useState({ status: 'idle', result: undefined })
-      const [guideActive, setGuideActive] = useState(() => readVisionGuideActive())
+      const [guideStep, setGuideStep] = useState(() => readVisionGuideStep())
+      const guideActive = guideStep !== undefined
       const [showAdvanced, setShowAdvanced] = useState(false)
       const [catalog, setCatalog] = useState({ status: 'idle', groups: [], error: undefined })
       const [visionCaps, setVisionCaps] = useState({ status: 'idle', capabilities: {}, builtinFallback: [], anonymousRpmPerModel: 2, error: undefined })
@@ -1187,7 +1472,7 @@ window.__ModuleLoader__.load({
       const visionModelVisible = (providerId, modelId) =>
         typeof modelId === 'string' && visionModelsFor(providerId).some((entry) => entry.id === modelId)
       React.useEffect(() => {
-        const refreshGuide = () => setGuideActive(readVisionGuideActive())
+        const refreshGuide = () => setGuideStep(readVisionGuideStep())
         window.addEventListener(VISION_GUIDE_EVENT, refreshGuide)
         refreshGuide()
         return () => window.removeEventListener(VISION_GUIDE_EVENT, refreshGuide)
@@ -1735,10 +2020,10 @@ window.__ModuleLoader__.load({
       }
       const finishGuide = () => {
         finishVisionSettingsGuide()
-        setGuideActive(false)
+        setGuideStep(undefined)
       }
       const guideCallout = () =>
-        guideActive
+        guideStep === 'step2'
           ? h('div', { className: 'vr-guide-callout' },
               h('div', { className: 'vr-guide-callout-title' }, t('guideChainTitle')),
               h('p', { className: 'vr-guide-callout-body' }, t('guideChainBody')),
@@ -1762,10 +2047,10 @@ window.__ModuleLoader__.load({
           setDraft('providers', list.length > 0 ? list : [{ provider: '', model: '' }])
         }
         return h('div', {
-          className: 'vr-field' + (guideActive ? ' vr-guide-target' : ''),
+          className: 'vr-field' + (guideStep === 'step2' ? ' vr-guide-target' : ''),
           id: 'vr-vision-backend-chain',
           'data-vr-guide-target': 'vision-backend',
-          tabIndex: guideActive ? -1 : undefined,
+          tabIndex: guideStep === 'step2' ? -1 : undefined,
         },
           guideCallout(),
           h('div', { className: 'vr-field-head' },
@@ -2248,10 +2533,10 @@ window.__ModuleLoader__.load({
               catalogReady
                 ? chainEditor()
                 : h('div', {
-                    className: guideActive ? 'vr-guide-target' : '',
+                    className: guideStep === 'step2' ? 'vr-guide-target' : '',
                     id: 'vr-vision-backend-chain',
                     'data-vr-guide-target': 'vision-backend',
-                    tabIndex: guideActive ? -1 : undefined,
+                    tabIndex: guideStep === 'step2' ? -1 : undefined,
                   },
                     guideCallout(),
                     textField('providers', t('textProviders'), t('textProvidersHint'), true),

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -315,6 +315,14 @@ test('the walkthrough walks step 1 (session model), step 2 (open settings), step
   // stays clickable, and animations respect reduced motion.
   assert.equal(source.includes('vr-guide-prompt-veiled'), true)
   assert.equal(source.includes('prefers-reduced-motion'), true)
+  // Step 2 also carries a Next button: it performs the current phase's
+  // action for the user (open the settings panel, then enter Plugins), so
+  // every non-final step can be driven entirely from the prompt.
+  assert.equal(source.includes("const currentPhase = guidePhase('step2')"), true)
+  assert.equal(source.includes('gear.click()'), true)
+  assert.equal(source.includes("row.tagName === 'BUTTON'"), true)
+  assert.equal(source.includes('也可以直接点「下一步」帮你打开'), true)
+  assert.equal(source.includes(', or press “Next” and I will open it for you'), true)
 })
 
 test('the settings card skips offscreen paint and rebuilds model options once', () => {

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -295,8 +295,26 @@ test('the walkthrough walks step 1 (session model), step 2 (open settings), step
   assert.equal(source.includes("guideStepNext: 'Next'"), true)
   assert.equal(source.includes("guidePromptTitle: 'Step 2 · Vision model'"), true)
   assert.equal(source.includes("guideChainTitle: 'Step 3 · This is the vision model'"), true)
-  // Step 1 parks the prompt on the left so the chat selector stays usable.
-  assert.equal(source.includes('vr-guide-prompt-left'), true)
+  // Every step now carries a visual target, not just step 3: the prompt is
+  // anchored to a highlighted element (spotlight hole + pulsing ring + arrow),
+  // and step 2's copy differs between the sidebar gear phase and the settings
+  // panel's Plugins nav row.
+  assert.equal(source.includes('vr-guide-spot-hole'), true)
+  assert.equal(source.includes('vr-guide-spot-ring'), true)
+  assert.equal(source.includes('vr-guide-arrow'), true)
+  assert.equal(source.includes("guidePromptGearBody: '点击侧边栏左下角被高亮圈出的「设置」齿轮"), true)
+  assert.equal(source.includes("guidePromptNavBody: '在设置面板左侧的导航里，点击被高亮的「插件」入口"), true)
+  assert.equal(source.includes("guidePromptGearBody: 'Click the highlighted Settings gear"), true)
+  assert.equal(source.includes("guidePromptNavBody: 'In the settings panel’s left navigation"), true)
+  // Stable DOM anchors: DSH web hashes its CSS-module class names, so targets
+  // are addressed via data-slot / aria attributes instead of class names.
+  assert.equal(source.includes('[data-slot="conversation.input.model"] button[aria-haspopup="menu"]'), true)
+  assert.equal(source.includes('button[aria-haspopup="dialog"]'), true)
+  assert.equal(source.includes('[role="dialog"][aria-modal="true"]'), true)
+  // The prompt veils itself while the step-1 model menu is open so the menu
+  // stays clickable, and animations respect reduced motion.
+  assert.equal(source.includes('vr-guide-prompt-veiled'), true)
+  assert.equal(source.includes('prefers-reduced-motion'), true)
 })
 
 test('the settings card skips offscreen paint and rebuilds model options once', () => {

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -323,6 +323,13 @@ test('the walkthrough walks step 1 (session model), step 2 (open settings), step
   assert.equal(source.includes("row.tagName === 'BUTTON'"), true)
   assert.equal(source.includes('也可以直接点「下一步」帮你打开'), true)
   assert.equal(source.includes(', or press “Next” and I will open it for you'), true)
+  // Anchoring correctness: the prompt must never cover the highlighted
+  // target (coverage is judged on the viewport-clamped box, with a small
+  // halo around the target), and the arrow must sit on the prompt's edge
+  // that faces the target — above the target means a bottom arrow, etc.
+  assert.equal(source.includes('Judge coverage on the CLAMPED box'), true)
+  assert.equal(source.includes('const halo = 10'), true)
+  assert.equal(source.includes("{ top: 'bottom', bottom: 'top', left: 'right', right: 'left' }"), true)
 })
 
 test('the settings card skips offscreen paint and rebuilds model options once', () => {


### PR DESCRIPTION
首次引导的三步走之前只有第 3 步（卡片内高亮）有清晰的视觉指引；第 1、2 步只是角落文字卡片，与真实 UI 没有视觉关联。本次把每一步都变成聚光灯引导：

- 第 1 步：暗色聚光灯 + 呼吸光环圈出聊天页右下角模型选择器，提示卡带箭头锚定在旁且绝不遮挡目标；打开模型菜单时提示卡自动淡出让路，菜单关闭后恢复。
- 第 2 步：先圈出侧边栏「设置」齿轮；设置面板打开后光环自动移到左侧导航的「插件」入口，文案随之切换。
- 第 2 步的提示卡同样提供「下一步」按钮：齿轮阶段自动打开设置面板，导航阶段自动进入插件页，整个引导可完全从提示卡一键推进（第 3 步以「完成引导」收尾）。
- 第 3 步：沿用卡片内高亮 + 说明框，高亮改为同款脉冲动画。

目标定位使用稳定锚点（data-slot / aria-* / data-composer-card），不依赖会随构建变化的哈希 CSS 类名，每步带降级链；遮罩不拦截点击，滚动/缩放/SPA 渲染下持续跟随；动效遵循 prefers-reduced-motion。

---

Before this change only step 3 (the in-card highlight) gave clear visual guidance; steps 1–2 were floating text cards with no visual link to the real UI. Now every step is a spotlight tour:

- Step 1: dimmed spotlight + pulsing ring around the chat composer's model selector, prompt anchored beside it with an arrow that never covers the target; the prompt veils while the model menu is open.
- Step 2: highlights the sidebar Settings gear first, then moves the ring onto the Plugins nav row once the settings panel opens, switching the copy accordingly.
- Step 2's prompt also carries a Next button: it opens the settings panel and then enters the Plugins section automatically, so the whole walkthrough can be driven from the prompt (step 3 finishes with the existing button).
- Step 3: keeps the in-card callout; the chain highlight now pulses in the same accent.

Targets are addressed via stable anchors (data-slot / aria-* / data-composer-card) instead of hashed CSS-module classes, with per-step fallback chains; overlays never intercept clicks, follow scroll/resize/SPA renders, and honor prefers-reduced-motion.