### PR TITLE
fix: preserve reasoning replay across Auto Vision wrapper delegation

### DIFF
--- a/entry.js
+++ b/entry.js
@@ -9,6 +9,7 @@
 import z from '@deepseek-ai/schemastery'
 import * as core from './index.js'
 import { installVisionRouterFileLogging } from './lib/file-logger.js'
+import { contextWithDelegatedReplay } from './lib/replay-delegation.js'
 
 // Schemastery object schemas expose set() as the supported way to replace a
 // field schema. This mutates the Config object that index.js itself later uses
@@ -21,13 +22,14 @@ export const Config = core.Config
 
 // Defense in depth for direct/programmatic callers that invoke apply() without
 // first running the Cordis Config resolver: only an explicit true enables the
-// schema-changing progressive mode. The wrapped context changes only logger:
-// every existing vision-router diagnostic still reaches the host logger and is
-// also persisted to ~/.dsh/logs/vision-router/vision-router.log.
+// schema-changing progressive mode. The wrapped context changes logger plus a
+// private llm view used only by Vision Router: wrapper -> delegate calls can
+// restore adapter-owned replay identity without mutating the host LLM service.
 export function apply(ctx, config = {}) {
   const logging = installVisionRouterFileLogging(ctx)
+  const runtimeCtx = contextWithDelegatedReplay(logging.ctx)
   try {
-    const result = core.apply(logging.ctx, {
+    const result = core.apply(runtimeCtx, {
       ...config,
       progressiveTools: config.progressiveTools === true,
     })

--- a/lib/replay-delegation.js
+++ b/lib/replay-delegation.js
@@ -1,0 +1,90 @@
+const wrappedContexts = new WeakMap()
+const wrappedLlmServices = new WeakMap()
+
+function isNonEmptyString(value) {
+  return typeof value === 'string' && value.length > 0
+}
+
+/**
+ * Rebind assistant source identity only when replay metadata proves that the
+ * response was produced by the provider currently receiving this delegated
+ * call. Vision Router wrapper routes persist their public route as
+ * source.provider while the adapter-owned replayState keeps the real delegate
+ * provider. DSH otherwise treats that state as foreign and strips it before
+ * the delegate adapter can replay reasoning/tool metadata.
+ */
+export function rebindDelegatedReplaySources(messages, delegateProvider) {
+  if (!Array.isArray(messages) || !isNonEmptyString(delegateProvider)) return messages
+
+  let changed = false
+  const rebound = messages.map((message) => {
+    if (!message || message.role !== 'assistant') return message
+    const source = message.source
+    if (!source || source.kind !== 'model') return message
+    if (!isNonEmptyString(source.provider) || source.provider === delegateProvider) return message
+    if (!isNonEmptyString(source.model)) return message
+
+    const replayState = source.replayState
+    if (!replayState || typeof replayState !== 'object' || Array.isArray(replayState)) return message
+    if (replayState.provider !== delegateProvider || replayState.model !== source.model) return message
+
+    changed = true
+    return {
+      ...message,
+      source: {
+        ...source,
+        provider: delegateProvider,
+      },
+    }
+  })
+
+  return changed ? rebound : messages
+}
+
+export function rebindDelegatedReplayOptions(options) {
+  if (!options || typeof options !== 'object') return options
+  const messages = rebindDelegatedReplaySources(options.messages, options.provider)
+  return messages === options.messages ? options : { ...options, messages }
+}
+
+function llmWithDelegatedReplay(llm) {
+  if (!llm || (typeof llm !== 'object' && typeof llm !== 'function')) return llm
+  const cached = wrappedLlmServices.get(llm)
+  if (cached) return cached
+
+  const wrapped = new Proxy(llm, {
+    get(target, property) {
+      if (property === 'stream') {
+        const stream = Reflect.get(target, property, target)
+        if (typeof stream !== 'function') return stream
+        return (options) => stream.call(target, rebindDelegatedReplayOptions(options))
+      }
+      const value = Reflect.get(target, property, target)
+      return typeof value === 'function' ? value.bind(target) : value
+    },
+  })
+  wrappedLlmServices.set(llm, wrapped)
+  return wrapped
+}
+
+/**
+ * Give Vision Router a private context view whose llm.stream preserves replay
+ * identity across wrapper -> delegate calls. The host service itself is never
+ * mutated, so unrelated plugins and direct DSH calls keep their native rules.
+ */
+export function contextWithDelegatedReplay(ctx) {
+  if (!ctx || typeof ctx !== 'object') return ctx
+  const cached = wrappedContexts.get(ctx)
+  if (cached) return cached
+
+  const llm = llmWithDelegatedReplay(ctx.llm)
+  const wrapped = new Proxy(ctx, {
+    get(target, property) {
+      if (property === 'llm') return llm
+      const value = Reflect.get(target, property, target)
+      return typeof value === 'function' ? value.bind(target) : value
+    },
+  })
+  wrappedContexts.set(ctx, wrapped)
+  return wrapped
+}

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "sharp": "^0.35.3"
   },
   "scripts": {
-    "test": "node --test tests/core.test.js tests/client.test.js tests/http-compat.test.js tests/update-check.test.js tests/self-update.test.js tests/doctor.test.js tests/doctor-cli.test.js tests/bundle-defaults.test.js tests/file-logger.test.js tests/logging-ui.test.js tests/manifest-dependencies.test.js"
+    "test": "node --test tests/core.test.js tests/client.test.js tests/http-compat.test.js tests/update-check.test.js tests/self-update.test.js tests/doctor.test.js tests/doctor-cli.test.js tests/bundle-defaults.test.js tests/file-logger.test.js tests/replay-delegation.test.js tests/logging-ui.test.js tests/manifest-dependencies.test.js"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/tests/replay-delegation.test.js
+++ b/tests/replay-delegation.test.js
@@ -1,0 +1,127 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  contextWithDelegatedReplay,
+  rebindDelegatedReplayOptions,
+  rebindDelegatedReplaySources,
+} from '../lib/replay-delegation.js'
+
+function assistant({
+  sourceProvider = 'opencodex-vision',
+  sourceModel = 'deepseek-v4-flash',
+  replayProvider = 'opencodex',
+  replayModel = sourceModel,
+  replay = true,
+} = {}) {
+  return {
+    role: 'assistant',
+    content: [
+      { type: 'reasoning', text: 'hidden' },
+      { type: 'tool-call', id: 't1', name: 'vision_describe', arguments: '{}' },
+    ],
+    source: {
+      kind: 'model',
+      provider: sourceProvider,
+      model: sourceModel,
+      ...(replay
+        ? {
+            replayState: {
+              kind: 'pi-ai',
+              provider: replayProvider,
+              model: replayModel,
+              blocks: [{ type: 'reasoning' }],
+            },
+          }
+        : {}),
+    },
+  }
+}
+
+test('rebindDelegatedReplaySources restores the delegate provider without mutating replay metadata', () => {
+  const input = assistant()
+  const state = input.source.replayState
+  const messages = [input]
+  const output = rebindDelegatedReplaySources(messages, 'opencodex')
+
+  assert.notEqual(output, messages)
+  assert.notEqual(output[0], input)
+  assert.notEqual(output[0].source, input.source)
+  assert.equal(output[0].source.provider, 'opencodex')
+  assert.equal(output[0].source.replayState, state)
+  assert.equal(input.source.provider, 'opencodex-vision')
+})
+
+test('rebindDelegatedReplaySources rejects foreign, model-mismatched, replay-less and non-assistant history', () => {
+  const cases = [
+    assistant({ replayProvider: 'another-provider' }),
+    assistant({ replayModel: 'another-model' }),
+    assistant({ replay: false }),
+    assistant({ sourceProvider: 'opencodex' }),
+    {
+      role: 'user',
+      content: [{ type: 'text', text: 'hello' }],
+      source: {
+        kind: 'model',
+        provider: 'opencodex-vision',
+        model: 'deepseek-v4-flash',
+        replayState: { provider: 'opencodex', model: 'deepseek-v4-flash' },
+      },
+    },
+  ]
+  for (const input of cases) {
+    const messages = [input]
+    assert.equal(rebindDelegatedReplaySources(messages, 'opencodex'), messages)
+  }
+})
+
+test('rebindDelegatedReplayOptions only clones request options when a source is actually rebound', () => {
+  const unchanged = { provider: 'opencodex', messages: [{ role: 'user', content: [] }] }
+  assert.equal(rebindDelegatedReplayOptions(unchanged), unchanged)
+
+  const changed = { provider: 'opencodex', messages: [assistant()], reasoningEffort: 'high' }
+  const output = rebindDelegatedReplayOptions(changed)
+  assert.notEqual(output, changed)
+  assert.equal(output.provider, 'opencodex')
+  assert.equal(output.reasoningEffort, 'high')
+  assert.equal(output.messages[0].source.provider, 'opencodex')
+})
+
+test('contextWithDelegatedReplay scopes rebinding to the context view and preserves llm method receivers', async () => {
+  let seen
+  const llm = {
+    marker: 'original',
+    registerAdapter() {
+      assert.equal(this, llm)
+      return 'registered'
+    },
+    async *stream(options) {
+      assert.equal(this, llm)
+      seen = options
+      yield { type: 'finish', reason: { kind: 'stop' } }
+    },
+  }
+  const ctx = {
+    llm,
+    ping() {
+      assert.equal(this, ctx)
+      return 'pong'
+    },
+  }
+  const wrapped = contextWithDelegatedReplay(ctx)
+  assert.notEqual(wrapped, ctx)
+  assert.equal(wrapped.ping(), 'pong')
+  assert.equal(wrapped.llm.registerAdapter(), 'registered')
+
+  const input = assistant()
+  for await (const _chunk of wrapped.llm.stream({
+    provider: 'opencodex',
+    model: 'deepseek-v4-flash',
+    messages: [input],
+  })) {
+    // drain
+  }
+  assert.equal(seen.messages[0].source.provider, 'opencodex')
+  assert.equal(input.source.provider, 'opencodex-vision')
+  assert.equal(ctx.llm, llm)
+  assert.equal(contextWithDelegatedReplay(ctx), wrapped)
+})


### PR DESCRIPTION
## What changed

Fixes the Vision Router side of #83 without fabricating or rewriting `reasoning_content`.

Auto Vision wrapper routes persist the public wrapper route (for example `opencodex-vision`) in `message.source.provider`, while the adapter-owned `replayState` correctly identifies the real delegate provider (for example `opencodex`). On the next tool step, the wrapper delegates through `ctx.llm.stream({ provider: delegateProvider, ... })`; DSH then sees the historical source as belonging to another adapter and strips the otherwise valid replay state.

This PR adds a private LLM context view used only inside Vision Router. Before Vision Router-internal delegated `llm.stream()` calls, it rebinds `source.provider` to the current delegate provider **only when the replay metadata proves the identity**:

- assistant model message;
- source provider differs from the current delegate;
- `replayState.provider === delegateProvider`;
- `replayState.model === source.model`.

The original message and replay state are not mutated. Foreign-provider, model-mismatched, replay-less, user/tool history is left untouched. The host LLM service is not monkey-patched, so other plugins/direct DSH calls keep native behavior.

## Files

- `lib/replay-delegation.js` — strict replay source rebinding + private Context/LLM proxies.
- `entry.js` — passes the replay-safe private context into `core.apply()`.
- `tests/replay-delegation.test.js` — regression coverage.
- `package.json` — includes the new regression test in `pnpm test`.

## Validation

- Local dependency-free regression run: 4/4 tests passed, plus syntax check for the new helper.
- GitHub CI: Node 22 `pnpm test` ✅
- GitHub CI: Node 24 `pnpm test` ✅
- DSH-like packaged host / shared sharp: Ubuntu ✅ macOS ✅ Windows ✅

Addresses #83. Runtime verification by the original reporter is still requested before the issue is considered fully confirmed.