### PR TITLE
feat(vision_html_screenshot): fullPage full-page capture + pageHeight result

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Default `progressiveTools: false`: all eleven deep tools stay registered from pl
 | `vision_ocr` | Text transcription: local tesseract (chi_sim+eng) first, vision model fallback | — |
 | `vision_trace` | SVG vectorization (potrace posterization; icons/logos) | SVG |
 | `vision_extract_foreground` | Cutout via border flood fill (uniform backgrounds) | transparent PNG |
-| `vision_html_screenshot` | Screenshot a local HTML file (headless system Chrome) | PNG |
+| `vision_html_screenshot` | Screenshot a local HTML file (headless system Chrome); `fullPage: true` captures the whole page and reports `pageHeight` | PNG |
 | `vision_long_screenshot_ocr` | Long-screenshot transcription: overlapping chunks, tesseract first / vision model fallback, stitched Markdown | chunk PNGs + Markdown + manifest |
 
 Formats are sniffed from magic bytes, so extensionless content-addressed attachment files work everywhere (no `.png` renaming needed).
@@ -194,6 +194,7 @@ vision_colors image="ref.png" top=8
 vision_trace image="icon.png" steps=4
 vision_extract_foreground image="logo.png"
 vision_html_screenshot source="page.html" width=1200 height=720
+vision_html_screenshot source="page.html" width=1200 height=720 fullPage=true
 vision_long_screenshot_ocr image="chat-log.png" chunkHeight=1200 overlap=120
 ```
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -176,7 +176,7 @@ Agent 仅根据参考图复刻 UI，再用 `vision_pixel_diff` 验证最终结�
 | `vision_ocr` | 文字转写：本地 tesseract（中英）优先，视觉模型兜底 | — |
 | `vision_trace` | SVG 矢量化（potrace 分色；图标/logo） | SVG |
 | `vision_extract_foreground` | 边界洪泛抠图（纯色背景） | 透明 PNG |
-| `vision_html_screenshot` | 给本地 HTML 文件截图（无头系统 Chrome） | PNG |
+| `vision_html_screenshot` | 给本地 HTML 文件截图（无头系统 Chrome）；`fullPage: true` 截整页并返回 `pageHeight` | PNG |
 | `vision_long_screenshot_ocr` | 长截图转写：重叠分片，tesseract 优先 / 视觉模型回退，按序拼接 Markdown | 分片 PNG + Markdown + manifest |
 
 图片格式按**魔数识别**，无扩展名的内容寻址附件文件也能直接用（不用再复制成 `.png`）。
@@ -194,6 +194,7 @@ vision_colors image="ref.png" top=8
 vision_trace image="icon.png" steps=4
 vision_extract_foreground image="logo.png"
 vision_html_screenshot source="page.html" width=1200 height=720
+vision_html_screenshot source="page.html" width=1200 height=720 fullPage=true
 vision_long_screenshot_ocr image="chat-log.png" chunkHeight=1200 overlap=120
 ```
 

--- a/index.js
+++ b/index.js
@@ -1594,6 +1594,49 @@ export function chromiumCandidates(env = {}, platform = typeof process !== 'unde
   return out
 }
 
+/**
+ * Wake lazy/revealed content before a full-page capture so the PNG does not
+ * miss anything below the initial viewport:
+ *
+ * 1. Force instant scrolling — a page-level `scroll-behavior: smooth` turns
+ *    every scrollTo into an animation that cancels the previous one, so a
+ *    step-by-step sweep would barely move.
+ * 2. Sweep top → bottom in viewport-sized steps, pausing briefly at each stop
+ *    so IntersectionObserver callbacks fire and scroll-triggered reveals
+ *    (e.g. `opacity: 0` until visible) actually render.
+ * 3. Scroll back to the top, then wait for reveal CSS transitions (commonly
+ *    0.5–0.8s) to settle before the screenshot is taken.
+ *
+ * Lazy images are handled separately at launch time via
+ * `--blink-settings=imagesLazyLoadingEnabled=false`.
+ */
+export async function wakePageForFullCapture(page, viewportHeight) {
+  const step = Number.isInteger(viewportHeight) && viewportHeight > 0 ? viewportHeight : 720
+  await page.evaluate(() => {
+    document.documentElement.style.scrollBehavior = 'auto'
+  })
+  const total = await page.evaluate(() =>
+    Math.max(document.documentElement.scrollHeight, document.body ? document.body.scrollHeight : 0),
+  )
+  for (let y = 0; y < total; y += step) {
+    await page.evaluate((yy) => window.scrollTo(0, yy), y)
+    await new Promise((resolve) => setTimeout(resolve, 60))
+  }
+  await page.evaluate(() => window.scrollTo(0, 0))
+  await new Promise((resolve) => setTimeout(resolve, 800))
+}
+
+/** Full scrollable page height (CSS px), measured after reveals have woken. */
+export async function fullPageHeightOf(page) {
+  return await page.evaluate(() =>
+    Math.max(
+      document.documentElement.scrollHeight,
+      document.body ? document.body.scrollHeight : 0,
+      window.innerHeight,
+    ),
+  )
+}
+
 /** Downscale bytes whose intrinsic pixel count exceeds maxPixels; returns original bytes on failure. */
 export async function downscaleImage(bytes, maxPixels) {
   try {
@@ -4748,13 +4791,23 @@ export function apply(ctx, config = {}) {
       description:
         'Render a local .html/.htm file in the system Chrome (headless, network disabled by ' +
         'default) and save a PNG screenshot as an artifact — the verify step of the ' +
-        'reference -> implementation -> screenshot -> pixel-diff loop.',
+        'reference -> implementation -> screenshot -> pixel-diff loop. With fullPage: true the ' +
+        'page keeps the requested viewport but the whole scrollable height is captured and the ' +
+        'result JSON reports pageHeight (CSS px).',
       parameters: {
         type: 'object',
         properties: {
           source: { type: 'string', description: 'Local .html or .htm file path' },
           width: { type: 'number', description: 'Viewport width, default 1200' },
           height: { type: 'number', description: 'Viewport height, default 720' },
+          fullPage: {
+            type: 'boolean',
+            description:
+              'Capture the complete scrollable page height at the requested viewport width ' +
+              'instead of just the viewport (default false). Lazy-loaded images and ' +
+              'scroll-triggered reveals are woken first; the result JSON then includes ' +
+              'pageHeight (CSS px).',
+          },
         },
         required: ['source'],
         additionalProperties: false,
@@ -4795,18 +4848,37 @@ export function apply(ctx, config = {}) {
         }
         const width = Number.isInteger(args.width) && args.width > 0 ? args.width : 1200
         const height = Number.isInteger(args.height) && args.height > 0 ? args.height : 720
+        const fullPage = args.fullPage === true
+        const launchArgs = ['--no-sandbox', '--disable-gpu', '--hide-scrollbars', '--incognito']
+        if (fullPage) {
+          // `loading="lazy"` images below the initial viewport never load
+          // during a full-page capture; disable lazy loading so they do.
+          launchArgs.push('--blink-settings=imagesLazyLoadingEnabled=false')
+        }
         const browser = await puppeteer.default.launch({
           executablePath,
           headless: true,
-          args: ['--no-sandbox', '--disable-gpu', '--hide-scrollbars', '--incognito'],
+          args: launchArgs,
         })
         try {
           const page = await browser.newPage()
           await page.setViewport({ width, height })
           await page.goto(pathToFileURL(targetPath).href, { waitUntil: 'networkidle0', timeout: 30000 })
-          const png = await page.screenshot({ type: 'png' })
-          const target = await saveArtifact(exec, `${artifactStem(source, `shot-${width}x${height}`)}.png`, png)
-          return JSON.stringify({ path: target, width, height, bytes: png.length })
+          let pageHeight
+          if (fullPage) {
+            await wakePageForFullCapture(page, height)
+            pageHeight = await fullPageHeightOf(page)
+          }
+          const png = fullPage
+            ? await page.screenshot({ type: 'png', fullPage: true })
+            : await page.screenshot({ type: 'png' })
+          const stem = fullPage ? `shot-${width}x${height}-fullpage` : `shot-${width}x${height}`
+          const target = await saveArtifact(exec, `${artifactStem(source, stem)}.png`, png)
+          const result = { path: target, width, height, bytes: png.length }
+          if (fullPage) {
+            result.pageHeight = pageHeight
+          }
+          return JSON.stringify(result)
         } finally {
           await browser.close()
         }
@@ -4864,8 +4936,8 @@ export function apply(ctx, config = {}) {
                 '图片消息会自动挂载它们；纯文字任务需要时可调用 `vision_activate`（只需一次）。\n' +
                 'Use these tools for pixel-level vision work. They auto-mount on image turns; on text-only turns call `vision_activate` once if needed.\n\n' +
                 '1. 定位与细看：`vision_ground` 定位 → `vision_crop` 裁剪放大 → `vision_describe` 细看；盘点页面元素用 `vision_detect`（编号清单+框，可引用“元素 #n”）；\n' +
-                '2. 还原验证循环（本插件招牌流程）：参考图 → 实现 → `vision_html_screenshot` 截图 → `vision_pixel_diff` 度量差异 → 修复 → 再截图，迭代到差异收敛（0% 是常见终点）；\n' +
-                '3. 其余按需取用：配色用 `vision_colors`，文字用 `vision_ocr`，图标矢量化用 `vision_trace`，纯色背景抠图用 `vision_extract_foreground`，本地 HTML 截图用 `vision_html_screenshot`；\n' +
+                '2. 还原验证循环（本插件招牌流程）：参考图 → 实现 → `vision_html_screenshot` 截图 → `vision_pixel_diff` 度量差异 → 修复 → 再截图，迭代到差异收敛（0% 是常见终点）；长页面用 `fullPage: true` 一次截整页并拿到 `pageHeight`；\n' +
+                '3. 其余按需取用：配色用 `vision_colors`，文字用 `vision_ocr`，图标矢量化用 `vision_trace`，纯色背景抠图用 `vision_extract_foreground`，本地 HTML 截图用 `vision_html_screenshot`（长页面加 `fullPage: true` 截整页）；\n' +
                 '4. 展示规则（必须遵守）：当你生成、编辑、截图或导出一张图片，并希望用户看到它时，必须调用 `vision_present`。' +
                 '`read_image` 仅用于你自己读取或检查图片内容，绝不能把 `read_image` 当成向用户展示或发送图片的方法。\n' +
                 '   MANDATORY PRESENTATION RULE: when you generate, edit, screenshot, or export an image and want the user to see it, ' +


### PR DESCRIPTION
## What

Add `fullPage: true` to `vision_html_screenshot` (default false, non-fullPage behavior unchanged):

- Layout stays at the requested viewport; Puppeteer's native `page.screenshot({ fullPage: true })` (CDP `captureBeyondViewport` + clip) captures the full scrollable height in one shot — `min-height: 100svh` sections keep the viewport height instead of diverging.
- The result JSON gains `pageHeight` (CSS px), so agents no longer guess ever-taller viewports.
- Content below the fold is woken before capture, so nothing is missing from the PNG:
  - fullPage launches add `--blink-settings=imagesLazyLoadingEnabled=false`, otherwise `loading="lazy"` images outside the viewport never load;
  - page-level `scroll-behavior: smooth` is overridden to `auto` (smooth scroll makes successive `scrollTo` calls cancel each other), then a viewport-stepped sweep top → bottom → top fires IntersectionObserver reveals, followed by a 0.8 s wait for reveal CSS transitions.

Closes #109

## Verification

- A local test page exercising every pitfall (2 lazy images, 2 IO reveals, a `min-height: 100svh` hero, page-level `scroll-behavior: smooth`) passed 15 pixel-level assertions: PNG width equals the requested viewport, PNG height equals `pageHeight` equals the document height, the hero stays 720 px, reveals are opaque, lazy images are present.
- Negative control: a naive fullPage capture without the wake logic on the same page does reproduce the pitfalls (transparent reveals, blank lazy images), confirming the fix addresses the real failure modes.
- The non-fullPage path still returns a viewport-sized PNG with the same result fields.
- Existing test suite: 196/198 pass; the 2 failures are a pre-existing macOS path-canonicalization issue that also fails on a clean `origin/main`, unrelated to this change.
