### PR TITLE
fix: verify one-click update result and install the confirmed version explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,16 +329,17 @@ Set it back to `false` to re-enable. Unloading removes the wrapper routes, tools
 ### Upgrade
 
 ```sh
-# normal npm/npx install
-npx @deepseek-ai/dsh plugin --profile web update dsh-vision-router
+# normal npm/npx install — install the version you want explicitly; a bare
+# `update` is silently held back for releases younger than 24h (pnpm v11)
+npx @deepseek-ai/dsh plugin --profile web add dsh-vision-router@<version>
 
 # DeepSeek Harness source checkout
-pnpm dsh plugin --profile web update dsh-vision-router
+pnpm dsh plugin --profile web add dsh-vision-router@<version>
 ```
 
-Settings live in the profile's settings provider and survive upgrades.
+Settings live in the profile's settings provider and survive upgrades. The settings card's one-click update installs the registry-confirmed version explicitly and verifies the installed manifest afterwards — it never reports success on a package-manager exit code alone.
 
-> **A fresh release does not take effect (`downloaded 0` / `added 0`):** pnpm v11 holds versions younger than 24h back; `npx dsh-vision-router repair` fixes the stale version-pinned profile exemption so updates take effect immediately.
+> **A fresh release does not take effect (`downloaded 0` / `added 0`):** pnpm v11 holds versions younger than 24h back; install the target version explicitly as above (pnpm auto-exempts it), or `npx dsh-vision-router repair` fixes the stale version-pinned profile exemption so updates take effect immediately.
 
 > **Upgrading from a pre-bundle-patch install (v0.x):** the package now mounts
 > itself through its own bundle patch, so a leftover manual row in

--- a/README.zh.md
+++ b/README.zh.md
@@ -329,16 +329,17 @@ npx @deepseek-ai/dsh --profile web --dump-config | grep vision-router
 ### 升级
 
 ```sh
-# 普通 npm / npx 安装
-npx @deepseek-ai/dsh plugin --profile web update dsh-vision-router
+# 普通 npm / npx 安装 —— 显式安装目标版本；裸 `update` 会被 pnpm v11
+# 静默拦下发布不足 24 小时的新版本
+npx @deepseek-ai/dsh plugin --profile web add dsh-vision-router@<版本号>
 
 # DeepSeek Harness 源码仓库
-pnpm dsh plugin --profile web update dsh-vision-router
+pnpm dsh plugin --profile web add dsh-vision-router@<版本号>
 ```
 
-设置存放在 profile 的设置提供方里，升级不丢失。
+设置存放在 profile 的设置提供方里，升级不丢失。设置卡里的一键更新会自动显式安装 registry 已确认的版本，并在命令结束后核对实际安装版本——绝不只凭包管理器退出码就报成功。
 
-> **新版本一直不生效（`downloaded 0` / `added 0`）：** pnpm v11 会拦下发布不足 24 小时的版本；运行 `npx dsh-vision-router repair` 修复过期的带版本号豁免条目后，更新立即生效。
+> **新版本一直不生效（`downloaded 0` / `added 0`）：** pnpm v11 会拦下发布不足 24 小时的版本；按上面方式显式安装目标版本（pnpm 会自动写入豁免），或运行 `npx dsh-vision-router repair` 修复过期的带版本号豁免条目后，更新立即生效。
 
 > **从 bundle 补丁之前（v0.x）升级：** 现在插件由自带的 bundle 补丁自动挂载，
 > 若 `~/.dsh/profiles/<profile>/cordis.patch.yml` 里还残留旧版手动行，会与之

--- a/docs/update-check.md
+++ b/docs/update-check.md
@@ -18,25 +18,27 @@ DSH and the plugin may have been launched through different paths, including `np
 When an update is available, the plugin inspects the CLI entry of the current process. One-click update is enabled only when that entry can be traced to a real `@deepseek-ai/dsh` package and can be executed safely by the current Node runtime. In that case Vision Router runs the documented DSH updater through the **same DSH CLI that is already hosting the plugin**:
 
 ```sh
-dsh plugin --profile <current-profile> update dsh-vision-router
+dsh plugin --profile <current-profile> add dsh-vision-router@<latest>
 ```
 
-The subprocess uses `execFile` with `shell: false`; no shell command is constructed from browser input. The update endpoint also requires a process-local token returned by the same-origin update-check endpoint. After the updater exits successfully, the settings card asks the user to restart DSH so the new plugin bundle is loaded.
+The registry-confirmed target version is installed explicitly rather than through a bare `update`. This matters because pnpm 11 applies `minimumReleaseAge` (default 1440 minutes): a plain `pnpm update` silently keeps the current version while every candidate release is younger than 24h and still exits 0 ("Already up to date") — a false-success update that leaves the old version running after restart. `add <name>@<version>` installs the confirmed release (pnpm auto-exempts the requested version from the policy when needed). For non-registry installs (git/file/link/workspace specs) the updater keeps `update` semantics and only verifies the result.
+
+The subprocess uses `execFile` with `shell: false`; no shell command is constructed from browser input. The update endpoint also requires a process-local token returned by the same-origin update-check endpoint. After the updater exits, the plugin reads the `dsh-vision-router` manifest under the profile's `node_modules` and verifies that the installed version actually reached the target — **a zero exit code alone is never reported as success**. Only a verified update asks the user to restart DSH so the new plugin bundle is loaded.
 
 If the CLI cannot be verified — for example a raw TypeScript source entry that needs a workspace-specific loader — the one-click button is not offered. This commonly applies to a DSH source checkout launched with `pnpm dsh`: version checking still works, but updating remains under the source workspace's own pnpm workflow. The card keeps the version information and release-notes link and tells the user to update through their original DSH installation path instead.
 
 ## Manual recovery
 
-If automatic update is unavailable, the version check fails, or a one-click update fails, the settings card still shows direct Project/Releases links and a manual command. For a DeepSeek Harness source checkout run:
+If automatic update is unavailable, the version check fails, or a one-click update fails, the settings card still shows direct Project/Releases links and a manual command. When a newer version is known, the shown commands install that version explicitly, which bypasses the release-age withholding described above. For a DeepSeek Harness source checkout run:
 
 ```sh
-pnpm dsh plugin --profile web update dsh-vision-router
+pnpm dsh plugin --profile web add dsh-vision-router@<latest>
 ```
 
 For normal npm/npx DSH usage run:
 
 ```sh
-npx @deepseek-ai/dsh plugin --profile web update dsh-vision-router
+npx @deepseek-ai/dsh plugin --profile web add dsh-vision-router@<latest>
 ```
 
-The settings card substitutes the active profile when it can determine one.
+The settings card substitutes the active profile when it can determine one. If the version still does not change after an update command, check the profile's `pnpm-workspace.yaml` for a version-pinned `minimumReleaseAgeExclude` entry — `npx dsh-vision-router repair` rewrites stale pins to bare names so future releases resolve again (see `docs/doctor.md`).

--- a/docs/update-check.zh-CN.md
+++ b/docs/update-check.zh-CN.md
@@ -18,25 +18,27 @@ Vision Router 会检查是否有新的已发布版本；当当前运行中的 DS
 发现新版本后，插件会检查当前进程真正使用的 DSH CLI 入口。只有该入口能够向上验证到真实的 `@deepseek-ai/dsh` 包，并且可以由当前 Node 运行时安全执行时，设置卡才显示“一键更新”。此时调用的不是某个猜出来的包管理器，而是**当前正在托管插件的同一套 DSH CLI**：
 
 ```sh
-dsh plugin --profile <当前 profile> update dsh-vision-router
+dsh plugin --profile <当前 profile> add dsh-vision-router@<最新版>
 ```
 
-子进程通过 `execFile` 且 `shell: false` 启动，不会把浏览器输入拼成 shell 命令。更新接口还要求由同源更新检查接口返回的本进程临时 token，避免网页跨站请求直接触发更新。更新命令成功后，设置卡会提示用户重启 DSH，让新插件 bundle 真正加载。
+这里会**显式安装 registry 已确认的目标版本**，而不是裸 `update`。原因是 pnpm 11 默认启用 `minimumReleaseAge`（1440 分钟）：当候选新版本发布不足 24 小时时，裸 `pnpm update` 会静默保留当前版本并仍然以退出码 0 结束（输出 “Already up to date”）——这就是“点了更新、提示成功、重启后版本没变”的假成功。`add <包名>@<版本>` 会安装确认过的发布版（pnpm 需要时会自动为新版本写入策略豁免）。对于非 registry 安装（git / file / link / workspace 规格），更新器保持 `update` 语义、只校验结果。
+
+子进程通过 `execFile` 且 `shell: false` 启动，不会把浏览器输入拼成 shell 命令。更新接口还要求由同源更新检查接口返回的本进程临时 token，避免网页跨站请求直接触发更新。更新命令退出后，插件会读取 profile `node_modules` 下 `dsh-vision-router` 的清单并核对安装版本确实达到目标——**仅凭退出码 0 永远不会被当作成功**。只有校验通过的更新才会提示用户重启 DSH，让新插件 bundle 真正加载。
 
 若无法可靠验证当前 CLI——例如直接运行需要 workspace 专用 loader 的 TypeScript 源码入口——就不会显示一键更新按钮。**源码仓库里通过 `pnpm dsh` 启动通常属于这种情况：版本检查仍然可以正常工作，只是一键更新继续交给源码工作区自己的 pnpm 流程。** 此时仍会显示当前/最新版本和 Release Notes，并提示用户沿用原来的 DSH 安装方式手动更新。
 
 ## 手动兜底
 
-如果自动更新不可用、版本检查失败，或一键更新失败，设置卡仍会直接显示项目主页 / Releases 入口和可执行的手动命令。DeepSeek Harness 源码仓库通过 pnpm 启动时使用：
+如果自动更新不可用、版本检查失败，或一键更新失败，设置卡仍会直接显示项目主页 / Releases 入口和可执行的手动命令。发现新版本时，显示的命令会带版本号显式安装，从而绕过上面描述的发布龄拦截。DeepSeek Harness 源码仓库通过 pnpm 启动时使用：
 
 ```sh
-pnpm dsh plugin --profile web update dsh-vision-router
+pnpm dsh plugin --profile web add dsh-vision-router@<最新版>
 ```
 
 普通 npm / npx DSH 使用：
 
 ```sh
-npx @deepseek-ai/dsh plugin --profile web update dsh-vision-router
+npx @deepseek-ai/dsh plugin --profile web add dsh-vision-router@<最新版>
 ```
 
-如果插件能识别当前 profile，设置页会把命令里的 `web` 自动替换成实际 profile。
+如果插件能识别当前 profile，设置页会把命令里的 `web` 自动替换成实际 profile。若执行后版本仍未变化，请检查 profile 的 `pnpm-workspace.yaml` 里是否有版本钉住的 `minimumReleaseAgeExclude` 条目——`npx dsh-vision-router repair` 会把过期的钉住条目改写为裸名，让后续新版本恢复正常解析（见 `docs/doctor.md`）。

--- a/index.js
+++ b/index.js
@@ -5159,8 +5159,14 @@ export function apply(ctx, config = {}) {
                 return
               }
               if (!selfUpdateInFlight) {
-                const pending = runDshPluginUpdate(selfUpdatePlan)
-                  .then((result) => ({ ...result, targetVersion: fresh.latestVersion }))
+                // Pass the registry-confirmed version in: the updater installs
+                // it explicitly (`add <name>@<target>`) and verifies the
+                // installed manifest afterwards, so a pnpm release-age policy
+                // silently keeping the old version is reported as a failure
+                // instead of a false success.
+                const pending = runDshPluginUpdate(selfUpdatePlan, {
+                  targetVersion: fresh.latestVersion,
+                })
                 selfUpdateInFlight = pending
                 void pending.then(
                   () => {

--- a/lib/client.js
+++ b/lib/client.js
@@ -128,12 +128,14 @@ window.__ModuleLoader__.load({
       updateRunning: '正在更新…',
       updateConfirm: '将通过当前正在运行的 DSH 更新 Vision Router。更新完成后需要重启 DSH。继续吗？',
       updateSuccess: '更新命令已完成（目标 v{latest}）。请重启 DSH；重启后新版本才会生效。',
+      updateSuccessVerified: '更新命令已完成（目标 v{latest}，已确认安装 v{installed}）。请重启 DSH；重启后新版本才会生效。',
       updateActionFailed: '一键更新失败：{error}',
       updateReleaseNotes: '查看更新说明',
       updateRegistryFallback: '当前配置的 registry 不可用，已自动改用 npm 官方源完成检查。',
       updateManualTitle: '手动更新',
       updateManualSource: '源码仓库 / pnpm DSH：',
       updateManualNpx: '普通 npm / npx DSH：',
+      updateManualAgeHint: '若执行后版本仍未变化：pnpm 11 默认在新版本发布 24 小时内静默拦截更新（minimumReleaseAge 策略，但命令仍显示成功）。请使用上方带版本号的安装命令，或运行 npx dsh-vision-router repair 清理过期的版本钉住豁免后重试。',
       updateProject: '项目主页',
       updateReleases: 'Releases',
       save: '保存',
@@ -319,12 +321,14 @@ window.__ModuleLoader__.load({
       updateRunning: 'Updating…',
       updateConfirm: 'Vision Router will update through the DSH CLI that is currently running. You will need to restart DSH afterward. Continue?',
       updateSuccess: 'The update command completed (target v{latest}). Restart DSH to load the new version.',
+      updateSuccessVerified: 'The update command completed (target v{latest}, installed v{installed} verified). Restart DSH to load the new version.',
       updateActionFailed: 'One-click update failed: {error}',
       updateReleaseNotes: 'View release notes',
       updateRegistryFallback: 'The configured registry failed; the check succeeded through the official npm registry.',
       updateManualTitle: 'Manual update',
       updateManualSource: 'DSH source checkout / pnpm:',
       updateManualNpx: 'Normal npm / npx DSH:',
+      updateManualAgeHint: 'If the version still has not changed after running this: pnpm 11 silently withholds releases younger than 24h (minimumReleaseAge policy, default 1440 minutes) while the command still reports success. Use the versioned install command above, or run npx dsh-vision-router repair to clean up a stale version-pinned exemption, then retry.',
       updateProject: 'Project',
       updateReleases: 'Releases',
       save: 'Save',
@@ -2492,8 +2496,15 @@ window.__ModuleLoader__.load({
           result && typeof result.releasesUrl === 'string' && result.releasesUrl
             ? result.releasesUrl
             : projectUrl + '/releases/latest'
-        const pnpmCommand = 'pnpm dsh plugin --profile ' + profile + ' update dsh-vision-router'
-        const npxCommand = 'npx @deepseek-ai/dsh plugin --profile ' + profile + ' update dsh-vision-router'
+        // When a newer version is known, the manual commands install it
+        // explicitly: plain `update` can be silently withheld by pnpm 11's
+        // minimumReleaseAge policy while still reporting success.
+        const manualAction =
+          result && typeof result.latestVersion === 'string' && result.latestVersion
+            ? 'add dsh-vision-router@' + result.latestVersion
+            : 'update dsh-vision-router'
+        const pnpmCommand = 'pnpm dsh plugin --profile ' + profile + ' ' + manualAction
+        const npxCommand = 'npx @deepseek-ai/dsh plugin --profile ' + profile + ' ' + manualAction
         let status
         let failedUpdate = false
         if (updateState.status === 'running') {
@@ -2515,9 +2526,16 @@ window.__ModuleLoader__.load({
         if (selfUpdateState.status === 'running') {
           selfUpdateStatus = t('updateRunning')
         } else if (selfUpdateState.status === 'done' && selfUpdateState.result && selfUpdateState.result.ok === true) {
-          selfUpdateStatus = t('updateSuccess', {
-            latest: selfUpdateState.result.targetVersion || (result && result.latestVersion) || '',
-          })
+          const updateResult = selfUpdateState.result
+          const latest = updateResult.targetVersion || (result && result.latestVersion) || ''
+          if (updateResult.installedVersion) {
+            selfUpdateStatus = t('updateSuccessVerified', {
+              latest,
+              installed: updateResult.installedVersion,
+            })
+          } else {
+            selfUpdateStatus = t('updateSuccess', { latest })
+          }
         } else if (selfUpdateState.status === 'error') {
           selfUpdateFailed = true
           selfUpdateStatus = t('updateActionFailed', {
@@ -2549,6 +2567,7 @@ window.__ModuleLoader__.load({
                 : null,
               h('p', { className: 'vr-hint' }, t('updateManualNpx')),
               h('code', { style: commandStyle }, npxCommand),
+              h('p', { className: 'vr-hint' }, t('updateManualAgeHint')),
               h('div', { style: { display: 'flex', gap: 8, flexWrap: 'wrap', marginTop: 8 } },
                 h('button', {
                   type: 'button', className: 'vr-btn',

--- a/lib/self-update.js
+++ b/lib/self-update.js
@@ -2,10 +2,16 @@ import { execFile } from 'node:child_process'
 import { existsSync, readFileSync, realpathSync } from 'node:fs'
 import path from 'node:path'
 import { promisify } from 'node:util'
-import { PACKAGE_NAME } from './update-check.js'
+import { resolveDshHome } from './doctor.js'
+import { CURRENT_VERSION, PACKAGE_NAME, compareSemver, parseSemver } from './update-check.js'
 
 const DSH_PACKAGE_NAME = '@deepseek-ai/dsh'
 const PROFILE_RE = /^[A-Za-z0-9._-]+$/
+
+// Specifiers pnpm resolves outside the npm registry: git/hosted repos, local
+// paths, workspace links and tarballs. Those must keep `update` semantics;
+// only plain registry specs are safe to re-install explicitly.
+const NON_REGISTRY_SPEC_RE = /^(?:git\+|github:|gitlab:|bitbucket:|file:|link:|workspace:|https?:|[./\\])/
 
 function safeRealpath(value) {
   try {
@@ -121,45 +127,162 @@ function outputDetail(error) {
   return (parts[0] || 'unknown update error').slice(0, 1200)
 }
 
+function profileDirOf(dshHome, profile) {
+  return path.join(dshHome, 'profiles', profile)
+}
+
+/** Version of the plugin manifest pnpm actually materialized under the profile. */
+function readInstalledPluginVersion({ dshHome, profile }) {
+  const manifestPath = path.join(
+    profileDirOf(dshHome, profile),
+    'node_modules',
+    PACKAGE_NAME,
+    'package.json',
+  )
+  const manifest = readPackageJson(manifestPath)
+  return manifest && typeof manifest.version === 'string' ? manifest.version : undefined
+}
+
+/** How the profile declares this plugin (e.g. `^1.2.0` or a git/file spec). */
+function readProfilePluginSpec({ dshHome, profile }) {
+  const manifest = readPackageJson(path.join(profileDirOf(dshHome, profile), 'package.json'))
+  const spec = manifest?.dependencies?.[PACKAGE_NAME]
+  return typeof spec === 'string' ? spec : undefined
+}
+
+/**
+ * Whether the update actually moved the installed version. A package-manager
+ * exit code of 0 proves nothing: pnpm >= 11 silently keeps the current
+ * version when the target release is younger than `minimumReleaseAge` and
+ * still exits 0 ("Already up to date").
+ */
+export function updateTookEffect({
+  installedVersion,
+  targetVersion,
+  currentVersion = CURRENT_VERSION,
+} = {}) {
+  if (!installedVersion || parseSemver(installedVersion) === undefined) {
+    return { effect: false, reason: 'unreadable-installed-version' }
+  }
+  if (targetVersion && parseSemver(targetVersion) !== undefined) {
+    const precedence = compareSemver(installedVersion, targetVersion)
+    if (precedence === undefined || precedence < 0) {
+      return { effect: false, reason: 'installed-version-behind-target' }
+    }
+    return { effect: true }
+  }
+  const precedence = compareSemver(installedVersion, currentVersion)
+  if (precedence === undefined || precedence <= 0) {
+    return { effect: false, reason: 'installed-version-unchanged' }
+  }
+  return { effect: true }
+}
+
+function releaseAgeHint({ profile, targetVersion }) {
+  const target = targetVersion && parseSemver(targetVersion) !== undefined
+    ? targetVersion
+    : '<latest>'
+  return (
+    'pnpm 11 withholds releases younger than 24h via its `minimumReleaseAge` policy ' +
+    '(default 1440 minutes) while still exiting 0, which looks like a successful update. ' +
+    'Retry once the release has aged past the policy window, or run ' +
+    `\`npx @deepseek-ai/dsh plugin --profile ${profile} add ${PACKAGE_NAME}@${target}\` ` +
+    'to install the version explicitly (pnpm auto-exempts it). If the profile carries a ' +
+    'version-pinned `minimumReleaseAgeExclude` entry, `npx dsh-vision-router repair` rewrites ' +
+    'it to a bare name so future releases resolve again.'
+  )
+}
+
 /**
  * Run the documented DSH plugin updater through the exact DSH CLI entry that
  * is already hosting this plugin. No shell is involved and no package-manager
  * command is guessed.
+ *
+ * When the registry-confirmed `targetVersion` is given (the settings-card
+ * flow always provides one) and the profile declares this plugin with a plain
+ * registry spec, the update installs that version explicitly —
+ * `add <name>@<target>` — instead of `update <name>`. This is the reliable
+ * path across pnpm >= 11's `minimumReleaseAge` policy, which makes plain
+ * `update` silently keep the current version for releases younger than 24h.
+ * Non-registry installs (git/file/link/workspace specs) keep `update`
+ * semantics. Either way the installed manifest is verified afterwards: a zero
+ * exit code alone is never reported as success.
  */
 export async function runDshPluginUpdate(plan, {
   execFileImpl,
   timeoutMs = 180000,
   env = process.env,
+  targetVersion,
+  currentVersion = CURRENT_VERSION,
+  dshHome = resolveDshHome(env),
 } = {}) {
   if (!plan || plan.available !== true) {
     throw new Error(`automatic update unavailable (${plan?.reason || 'unknown reason'})`)
   }
   const runner = execFileImpl || promisify(execFile)
+  const target = typeof targetVersion === 'string' && parseSemver(targetVersion) !== undefined
+    ? targetVersion.trim()
+    : undefined
+
+  const profileSpec = readProfilePluginSpec({ dshHome, profile: plan.profile })
+  const explicit = target !== undefined
+    && (profileSpec === undefined || !NON_REGISTRY_SPEC_RE.test(profileSpec))
+  const verb = explicit ? 'add' : 'update'
+  const packageSpec = explicit ? `${PACKAGE_NAME}@${target}` : PACKAGE_NAME
   const args = [
     plan.cliEntry,
     'plugin',
     '--profile',
     plan.profile,
-    'update',
-    PACKAGE_NAME,
+    verb,
+    packageSpec,
   ]
+
+  let result
   try {
-    const result = await runner(plan.execPath, args, {
+    result = await runner(plan.execPath, args, {
       env,
       timeout: timeoutMs,
       maxBuffer: 2 * 1024 * 1024,
       windowsHide: true,
       shell: false,
     })
-    return {
-      ok: true,
-      method: plan.method,
-      profile: plan.profile,
-      stdout: typeof result?.stdout === 'string' ? result.stdout.trim().slice(-2000) : '',
-      stderr: typeof result?.stderr === 'string' ? result.stderr.trim().slice(-2000) : '',
-      restartRequired: true,
-    }
   } catch (error) {
     throw new Error(`DSH plugin update failed: ${outputDetail(error)}`)
+  }
+
+  const stdout = typeof result?.stdout === 'string' ? result.stdout.trim() : ''
+  const stderr = typeof result?.stderr === 'string' ? result.stderr.trim() : ''
+
+  // Exit code 0 does not prove the version moved (see above): verify the
+  // manifest pnpm actually materialized under the profile.
+  const installedVersion = readInstalledPluginVersion({ dshHome, profile: plan.profile })
+  const verification = updateTookEffect({
+    installedVersion,
+    targetVersion: target,
+    currentVersion,
+  })
+  if (!verification.effect) {
+    const tail = (stdout || stderr).slice(-400)
+    const output = tail ? ` Package manager output tail: ${tail}` : ''
+    throw new Error(
+      'update did not take effect: installed version is ' +
+      `${installedVersion || 'unreadable'} (target ${target || `newer than ${currentVersion}`}).` +
+      output +
+      ' ' +
+      releaseAgeHint({ profile: plan.profile, targetVersion: target }),
+    )
+  }
+
+  return {
+    ok: true,
+    method: plan.method,
+    profile: plan.profile,
+    targetVersion: target,
+    installedVersion,
+    verified: true,
+    stdout: stdout.slice(-2000),
+    stderr: stderr.slice(-2000),
+    restartRequired: true,
   }
 }

--- a/tests/self-update.test.js
+++ b/tests/self-update.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, mkdirSync, realpathSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import {
@@ -8,6 +8,7 @@ import {
   findDshPackageRoot,
   profileFromArgv,
   runDshPluginUpdate,
+  updateTookEffect,
 } from '../lib/self-update.js'
 
 function fixture({ entry = 'bin/dsh.mjs', packageName = '@deepseek-ai/dsh' } = {}) {
@@ -22,6 +23,43 @@ function fixture({ entry = 'bin/dsh.mjs', packageName = '@deepseek-ai/dsh' } = {
   return { root, cliEntry }
 }
 
+// A fake $DSH_HOME with a profile whose node_modules already materializes the
+// plugin at `installedVersion`, declared by the profile with `dependencySpec`.
+function profileFixture({
+  profile = 'web',
+  installedVersion = '1.4.0',
+  dependencySpec = '^1.2.0',
+  withInstalledManifest = true,
+} = {}) {
+  const dshHome = mkdtempSync(path.join(tmpdir(), 'vision-router-home-'))
+  const profileDir = path.join(dshHome, 'profiles', profile)
+  mkdirSync(profileDir, { recursive: true })
+  writeFileSync(
+    path.join(profileDir, 'package.json'),
+    JSON.stringify({ dependencies: { 'dsh-vision-router': dependencySpec } }),
+  )
+  if (withInstalledManifest) {
+    mkdirSync(path.join(profileDir, 'node_modules', 'dsh-vision-router'), { recursive: true })
+    writeFileSync(
+      path.join(profileDir, 'node_modules', 'dsh-vision-router', 'package.json'),
+      JSON.stringify({ name: 'dsh-vision-router', version: installedVersion }),
+    )
+  }
+  return { dshHome }
+}
+
+function planFor(cliEntry, profile = 'web') {
+  return {
+    available: true,
+    method: 'current-dsh-cli',
+    execPath: '/opt/node/bin/node',
+    cliEntry,
+    profile,
+  }
+}
+
+const exitZero = async (_file, _args, _options) => ({ stdout: 'downloaded 0 / added 0\n', stderr: '' })
+
 test('profileFromArgv honors explicit profiles and defaults Web hosts to web', () => {
   assert.equal(profileFromArgv(['node', 'dsh', 'web']), 'web')
   assert.equal(profileFromArgv(['node', 'dsh', '--profile', 'custom-web', 'web']), 'custom-web')
@@ -31,7 +69,9 @@ test('profileFromArgv honors explicit profiles and defaults Web hosts to web', (
 
 test('findDshPackageRoot only trusts an owning @deepseek-ai/dsh manifest', () => {
   const trusted = fixture()
-  assert.equal(findDshPackageRoot(trusted.cliEntry)?.packageRoot, trusted.root)
+  // macOS symlinks /var -> /private/var: the walk realpaths the entry, so
+  // compare against the realpath'd root (identical on Linux CI).
+  assert.equal(findDshPackageRoot(trusted.cliEntry)?.packageRoot, realpathSync(trusted.root))
   const unrelated = fixture({ packageName: 'not-dsh' })
   assert.equal(findDshPackageRoot(unrelated.cliEntry), undefined)
 })
@@ -44,8 +84,8 @@ test('detectDshSelfUpdatePlan reuses a verified packaged DSH CLI', () => {
   })
   assert.equal(plan.available, true)
   assert.equal(plan.method, 'current-dsh-cli')
-  assert.equal(plan.cliEntry, cliEntry)
-  assert.equal(plan.packageRoot, root)
+  assert.equal(plan.cliEntry, realpathSync(cliEntry))
+  assert.equal(plan.packageRoot, realpathSync(root))
   assert.equal(plan.profile, 'web')
   assert.equal(plan.dshVersion, '0.1.0-rc.6')
 })
@@ -64,21 +104,29 @@ test('detectDshSelfUpdatePlan refuses unverified or loader-dependent CLI entries
   )
 })
 
-test('runDshPluginUpdate invokes the current DSH CLI without a shell', async () => {
+test('updateTookEffect requires the installed version to reach the target', () => {
+  assert.equal(updateTookEffect({ installedVersion: '1.4.0', targetVersion: '1.4.0' }).effect, true)
+  assert.equal(updateTookEffect({ installedVersion: '1.5.0', targetVersion: '1.4.0' }).effect, true)
+  assert.equal(updateTookEffect({ installedVersion: '1.2.0', targetVersion: '1.4.0' }).effect, false)
+  assert.equal(updateTookEffect({ installedVersion: undefined, targetVersion: '1.4.0' }).effect, false)
+  // Without a target the installed version must be strictly newer than the
+  // running bundle: staying equal is exactly the false-success case.
+  assert.equal(updateTookEffect({ installedVersion: '1.3.0', currentVersion: '1.2.0' }).effect, true)
+  assert.equal(updateTookEffect({ installedVersion: '1.2.0', currentVersion: '1.2.0' }).effect, false)
+})
+
+test('runDshPluginUpdate installs the confirmed target explicitly and verifies it', async () => {
   const { cliEntry } = fixture()
-  const plan = {
-    available: true,
-    method: 'current-dsh-cli',
-    execPath: '/opt/node/bin/node',
-    cliEntry,
-    profile: 'custom-web',
-  }
+  const { dshHome } = profileFixture({ profile: 'custom-web', installedVersion: '1.4.0' })
+  const plan = planFor(cliEntry, 'custom-web')
   let invocation
   const result = await runDshPluginUpdate(plan, {
+    targetVersion: '1.4.0',
+    dshHome,
     env: { TEST_ENV: '1' },
     execFileImpl: async (file, args, options) => {
       invocation = { file, args, options }
-      return { stdout: 'updated\n', stderr: '' }
+      return { stdout: 'added dsh-vision-router@1.4.0\n', stderr: '' }
     },
   })
 
@@ -88,14 +136,93 @@ test('runDshPluginUpdate invokes the current DSH CLI without a shell', async () 
     'plugin',
     '--profile',
     'custom-web',
-    'update',
-    'dsh-vision-router',
+    'add',
+    'dsh-vision-router@1.4.0',
   ])
   assert.equal(invocation.options.shell, false)
   assert.equal(invocation.options.windowsHide, true)
   assert.equal(invocation.options.env.TEST_ENV, '1')
   assert.equal(result.ok, true)
+  assert.equal(result.installedVersion, '1.4.0')
+  assert.equal(result.verified, true)
   assert.equal(result.restartRequired, true)
+})
+
+test('runDshPluginUpdate keeps update semantics without a target and verifies the move', async () => {
+  const { cliEntry } = fixture()
+  const { dshHome } = profileFixture({ installedVersion: '1.3.0' })
+  let invocation
+  const result = await runDshPluginUpdate(planFor(cliEntry), {
+    currentVersion: '1.2.0',
+    dshHome,
+    execFileImpl: async (file, args, options) => {
+      invocation = { file, args, options }
+      return { stdout: 'updated\n', stderr: '' }
+    },
+  })
+
+  assert.deepEqual(invocation.args.slice(4), ['update', 'dsh-vision-router'])
+  assert.equal(result.ok, true)
+  assert.equal(result.installedVersion, '1.3.0')
+})
+
+test('runDshPluginUpdate falls back to update for non-registry specs', async () => {
+  const { cliEntry } = fixture()
+  const { dshHome } = profileFixture({
+    installedVersion: '1.4.0',
+    dependencySpec: 'github:ysr666/dsh-vision-router',
+  })
+  let invocation
+  const result = await runDshPluginUpdate(planFor(cliEntry), {
+    targetVersion: '1.4.0',
+    currentVersion: '1.2.0',
+    dshHome,
+    execFileImpl: async (file, args, options) => {
+      invocation = { file, args, options }
+      return { stdout: 'updated\n', stderr: '' }
+    },
+  })
+
+  assert.deepEqual(invocation.args.slice(4), ['update', 'dsh-vision-router'])
+  assert.equal(result.ok, true)
+  assert.equal(result.installedVersion, '1.4.0')
+})
+
+test('runDshPluginUpdate rejects a false-success update that kept the old version', async () => {
+  const { cliEntry } = fixture()
+  const { dshHome } = profileFixture({ installedVersion: '1.2.0' })
+  let message = ''
+  try {
+    await runDshPluginUpdate(planFor(cliEntry), {
+      targetVersion: '1.4.0',
+      currentVersion: '1.2.0',
+      dshHome,
+      execFileImpl: exitZero,
+    })
+  } catch (error) {
+    message = error instanceof Error ? error.message : String(error)
+  }
+
+  assert.match(message, /update did not take effect/)
+  assert.match(message, /1\.2\.0/)
+  assert.match(message, /minimumReleaseAge/)
+  assert.match(message, /downloaded 0 \/ added 0/)
+  assert.match(message, /add dsh-vision-router@1\.4\.0/)
+})
+
+test('runDshPluginUpdate rejects an update that leaves no readable installed manifest', async () => {
+  const { cliEntry } = fixture()
+  const { dshHome } = profileFixture({ withInstalledManifest: false })
+  await assert.rejects(
+    () =>
+      runDshPluginUpdate(planFor(cliEntry), {
+        targetVersion: '1.4.0',
+        currentVersion: '1.2.0',
+        dshHome,
+        execFileImpl: exitZero,
+      }),
+    /installed version is unreadable/,
+  )
 })
 
 test('runDshPluginUpdate surfaces bounded updater output on failure', async () => {


### PR DESCRIPTION
## Problem

Users on v1.2.0 report that both one-click and manual updates "succeed" but the version never changes after restart. Root cause: the one-click updater forwards to `pnpm update`, and pnpm 11's `minimumReleaseAge` policy (default 1440 minutes) silently keeps the current version for releases younger than 24h while still exiting 0 ("Already up to date"). The plugin treated the exit code as success and never verified the installed result — a false-success update.

## Changes

- The one-click updater now installs the registry-confirmed target explicitly (`add dsh-vision-router@<target>`) through the same DSH CLI; pnpm auto-exempts explicit installs from the release-age policy. Non-registry specs (git/file/link/workspace) keep `update` semantics.
- After the updater exits, the plugin reads the installed manifest under the profile and verifies the version actually reached the target; a zero exit code alone is never reported as success. Failures explain the release-age policy and point to the manual `add <name>@<version>` command and `npx dsh-vision-router repair` for stale pinned exemptions.
- The settings card's manual fallback commands install the known latest version explicitly, success messages show the verified installed version, and the manual section explains the release-age hold.
- Docs (update-check EN/ZH, README EN/ZH) document the hold and the explicit install path.
- Tests cover explicit install arguments, no-target fallback, non-registry fallback, false-success rejection, and unreadable-manifest rejection.

## Notes

- Users currently stuck on v1.2.0/v1.3.0 run the old updater: they need one manual versioned install to get unstuck; from the next release onward one-click updates bypass and verify.
- Fresh installs are unaffected (pnpm auto-exempts when the only matching version is immature).
