### PR TITLE
release: prepare v1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 每个版本的中英双语发布说明（GitHub Release 工作流从这里取对应版本的段落，发布前必须先写好本节）｜
 Bilingual (Chinese + English) release notes for every version — the GitHub Release workflow pulls the matching section from this file, so it must be filled in before tagging.
 
+## v1.4.1
+
+### 修复 / Fixed
+
+- **视觉失败链不再拖垮文本对话（#117）**：单个视觉后端的配置错误 / 401 / 429 / 临时故障此前会被放大成数分钟的重复视觉工具调用——超时逐层叠加（120s×N）、429 盲等 30–60s 重试、无熔断、无同轮失败记忆，后端失败以异常形式抛给模型，诱导其反复改问法重试直至 `tool call aborted`。现在引入统一韧性机制：AUTH 按凭据指纹熔断（换 Key 自动解除）、429 按 Retry-After 冷却、INVALID_REQUEST 本轮跳过；同一轮全部后端失败后，后续视觉调用零网络快速返回 `VISION_BACKEND_UNAVAILABLE_THIS_TURN`。单次视觉任务共享一个总预算（新增 `visionTaskTimeoutMs`，默认 45s），OCR 由 tesseract（≤12s）与视觉模型回退共享另一个预算（新增 `ocrTimeoutMs`，默认 30s），不再把两层超时相加。后端失败以结构化结果（`ok:false + code + retryable:false + attemptedProviders`）返回而非抛异常；401 时附带 Qwen Token Plan Key/端点不匹配提示；`vision_describe` / `vision_ground` / `vision_detect` / `vision_ocr` 工具描述、自动挂载提醒、wrapper 图片标记与 vision-tools skill 统一写明失败语义与「OCR 只读文字、绝不当识别重试」边界。新增 22 个回归测试覆盖 401/429 熔断、同轮防重打、总 deadline、OCR 预算、凭据更新解除熔断、wrapper/twin 委托一致性等全部场景。
+- **Vision failure chains can no longer stall text turns (#117)**: one misconfigured/broken vision backend (401 / 429 / outage) used to cascade into minutes of repeated vision tool calls — stacked per-request timeouts (120s × N), blind 30–60s 429 retry waits, no circuit breaking, no same-turn failure memory, and backend failures surfaced as exceptions that invited the model to rephrase and retry until `tool call aborted`. A unified resilience layer now trips AUTH backends per credential fingerprint (auto-released when the key changes), applies Retry-After cooldowns for 429s, skips INVALID_REQUEST backends for the turn, and answers instantly with `VISION_BACKEND_UNAVAILABLE_THIS_TURN` once every backend failed this turn — zero further network attempts. One vision task shares a wall-clock budget (new `visionTaskTimeoutMs`, default 45s); OCR shares one budget between tesseract (≤12s cap) and the vision-model fallback (new `ocrTimeoutMs`, default 30s) instead of stacking the two timeouts. Backend failures return structured results (`ok:false + code + retryable:false + attemptedProviders`) instead of throwing; 401s carry a Qwen Token Plan key/endpoint mismatch hint; and the `vision_describe` / `vision_ground` / `vision_detect` / `vision_ocr` descriptions, the auto-mount reminder, the wrapper image marker and the vision-tools skill all state the failure semantics and that OCR is text-only, never a recognition retry. 22 new regression tests cover the full matrix: 401/429 trips, same-turn no-rehit, shared deadlines, OCR budget, credential-change release, and wrapper/twin delegation parity.
+
 ## v1.4.0
 
 ### 改进 / Changed

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/ysr666/dsh-vision-router/releases/tag/v1.4.0"><img src="https://img.shields.io/badge/release-v1.4.0-5B4CF0?style=flat-square" alt="Release v1.4.0" /></a>
+  <a href="https://github.com/ysr666/dsh-vision-router/releases/tag/v1.4.1"><img src="https://img.shields.io/badge/release-v1.4.1-5B4CF0?style=flat-square" alt="Release v1.4.1" /></a>
   <a href="tests"><img src="https://img.shields.io/badge/verified-149%20tests-2EA44F?style=flat-square" alt="Verified: 149 tests" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-2EA44F?style=flat-square" alt="License: MIT" /></a>
   <a href="package.json"><img src="https://img.shields.io/badge/Node.js-%3E%3D22-339933?style=flat-square&amp;logo=nodedotjs&amp;logoColor=white" alt="Node.js >=22" /></a>
@@ -28,9 +28,9 @@
 <p align="center">💬 <strong>QQ community group: 1105463028</strong></p>
 
 > [!WARNING]
-> 📌 **Announcement (v1.4.0)**
+> 📌 **Announcement (v1.4.1)**
 >
-> **v1.4.0 now supports** automatic recognition and direct-channel bridging of undeclared vision models, doctor repair of stale version-pinned exemptions, and a spotlight-guided onboarding walkthrough — plus hardened settings-save verification and vision-backend compatibility.
+> **v1.4.1 now supports** hardened vision failure handling — a single broken vision backend (401 / 429 / outage) can no longer stall a text turn: circuit breaking, shared task budgets and structured failure results keep DeepSeek conversations moving.
 
 <p align="center">
   <img src="assets/vision-demo.gif" width="640" alt="Demo: paste an image, the agent locates the send button with vision_ground / vision_crop / vision_pixel_diff and answers with coordinates" />

--- a/README.zh.md
+++ b/README.zh.md
@@ -15,7 +15,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/ysr666/dsh-vision-router/releases/tag/v1.4.0"><img src="https://img.shields.io/badge/release-v1.4.0-5B4CF0?style=flat-square" alt="Release v1.4.0" /></a>
+  <a href="https://github.com/ysr666/dsh-vision-router/releases/tag/v1.4.1"><img src="https://img.shields.io/badge/release-v1.4.1-5B4CF0?style=flat-square" alt="Release v1.4.1" /></a>
   <a href="tests"><img src="https://img.shields.io/badge/verified-149%20tests-2EA44F?style=flat-square" alt="Verified: 149 tests" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-2EA44F?style=flat-square" alt="License: MIT" /></a>
   <a href="package.json"><img src="https://img.shields.io/badge/Node.js-%3E%3D22-339933?style=flat-square&amp;logo=nodedotjs&amp;logoColor=white" alt="Node.js >=22" /></a>
@@ -28,9 +28,9 @@
 <p align="center">💬 <strong>QQ 用户交流群：1105463028</strong></p>
 
 > [!WARNING]
-> 📌 **公告（v1.4.0）**
+> 📌 **公告（v1.4.1）**
 >
-> **v1.4.0 现已支持**：未声明视觉模型的自动识别与直连桥接、doctor 修复过期版本钉住豁免、引导流程聚光灯高亮——并增强设置保存校验与视觉后端兼容性。
+> **v1.4.1 现已支持**：视觉失败链加固——单个视觉后端（401 / 429 / 故障）不再拖垮文本对话；熔断、共享任务预算与结构化失败结果让对话始终顺畅继续。
 
 <p align="center">
   <img src="assets/vision-demo.gif" width="640" alt="演示：粘贴图片，Agent 用 vision_ground / vision_crop / vision_pixel_diff 定位发送按钮并给出坐标" />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-vision-router",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Eyes for text-only DeepSeek Harness agents: built-in free vision chain (no key) + pixel-level vision tools (Q&A, grounding, crop, pixel diff, colors, OCR, SVG trace, cutout, screenshots). One-command install, no Python, image turns work like ordinary tool-calling turns.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
准备 v1.4.1 发版：

- package.json 版本号 1.4.0 → 1.4.1
- CHANGELOG 新增双语 v1.4.1 段：视觉失败链加固（#117）——AUTH/429 熔断、同轮失败记忆、视觉任务与 OCR 共享预算、结构化失败结果、Qwen Token Plan 401 提示与失败语义文案
- README.md / README.zh.md 顶部公告条与 release 徽章更新为 v1.4.1（工作流校验通过）

---

Prepare v1.4.1:

- package.json version 1.4.0 → 1.4.1
- Bilingual v1.4.1 CHANGELOG section covering the vision failure chain hardening (#117) — AUTH/429 circuit breaking, same-turn failure memory, shared vision/OCR task budgets, structured failure results, the Qwen Token Plan 401 hint, and the failure-semantics prompt updates
- README.md / README.zh.md announcement banners and release badges updated to v1.4.1 (workflow validation passes)