### PR TITLE
fix: finish the vision walkthrough on save, model pick, or settings close

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -840,6 +840,11 @@ window.__ModuleLoader__.load({
     let onboardingSeenMemory = false
     let visionGuideStepMemory
     let visionGuideMemoryAuthoritative = false
+    // Whether the app-owned settings modal has been seen open during this
+    // walkthrough round, plus a grace timer so a host re-render that rebuilds
+    // the dialog in place is not mistaken for the user closing it.
+    let visionGuidePanelSeen = false
+    let visionGuidePanelCloseTimer
     // Installed by apply(): a narrow, defensive view of the settings scope.
     // { get, set, unset } never throw, and subscribe returns a disposer (or
     // undefined when the scope is unavailable — the legacy paths take over).
@@ -1067,6 +1072,11 @@ window.__ModuleLoader__.load({
       if (typeof document === 'undefined') return undefined
       const dialogs = Array.from(document.querySelectorAll('[role="dialog"][aria-modal="true"]'))
       return dialogs.find((dialog) => !dialog.closest || !dialog.closest('.vr-onboarding-dialog'))
+    }
+    // The settings modal can close by unmounting or by the host hiding it in
+    // place; a panel that is gone or not visibly rendered counts as closed.
+    function guideSettingsPanelOpen() {
+      return guideElementUsable(guideSettingsPanel())
     }
     function guideElementUsable(el) {
       if (!el || typeof el.getBoundingClientRect !== 'function') return false
@@ -1322,6 +1332,32 @@ window.__ModuleLoader__.load({
     function syncVisionGuidePrompt(t) {
       if (typeof document === 'undefined' || typeof window === 'undefined' || !document.body) return
       const step = readVisionGuideStep()
+      const panelOpen = guideSettingsPanelOpen()
+      if (step !== undefined && visionGuidePanelSeen && !panelOpen) {
+        // The settings panel was open during this walkthrough round and the
+        // user has just closed it: honor the close by ending the round
+        // instead of re-pointing the prompt at the gear and nagging again.
+        // A short grace period absorbs SPA re-renders that rebuild the dialog
+        // in place; if the panel is still gone afterwards, the guide finishes
+        // for good and can never pop back up for this round.
+        clearGuidePromptUI()
+        if (visionGuidePanelCloseTimer === undefined) {
+          visionGuidePanelCloseTimer = window.setTimeout(() => {
+            visionGuidePanelCloseTimer = undefined
+            if (readVisionGuideStep() !== undefined && !guideSettingsPanelOpen()) {
+              finishVisionSettingsGuide()
+            }
+          }, 400)
+        }
+        return
+      }
+      if (panelOpen) {
+        visionGuidePanelSeen = true
+        if (visionGuidePanelCloseTimer !== undefined) {
+          window.clearTimeout(visionGuidePanelCloseTimer)
+          visionGuidePanelCloseTimer = undefined
+        }
+      }
       const phase = guidePhase(step)
       if (phase === 'none' || phase === 'done' || phase === 'suspend') {
         // No floating layer: the walkthrough is over, the in-card callout
@@ -1359,11 +1395,21 @@ window.__ModuleLoader__.load({
       anchorGuidePrompt(visionGuidePrompt, step, phase, rect, menuOpen)
     }
     function startVisionSettingsGuide(t) {
+      visionGuidePanelSeen = false
+      if (visionGuidePanelCloseTimer !== undefined) {
+        window.clearTimeout(visionGuidePanelCloseTimer)
+        visionGuidePanelCloseTimer = undefined
+      }
       writeVisionGuideStep('step1')
       syncVisionGuidePrompt(t)
       notifyVisionGuideChanged()
     }
     function finishVisionSettingsGuide() {
+      visionGuidePanelSeen = false
+      if (visionGuidePanelCloseTimer !== undefined) {
+        window.clearTimeout(visionGuidePanelCloseTimer)
+        visionGuidePanelCloseTimer = undefined
+      }
       writeVisionGuideStep(undefined)
       removeVisionGuidePrompt()
       notifyVisionGuideChanged()
@@ -2002,6 +2048,10 @@ window.__ModuleLoader__.load({
       }
       const save = async () => {
         if (blocked) return
+        // Saving ends the walkthrough: the user has reached the settings card
+        // and acted, so the guide must never nag again afterwards — even when
+        // a hidden write is rejected (dismissal stays page-authoritative).
+        finishGuide()
         setSaving(true)
         setFailed(false)
         setFailedFields([])
@@ -2234,7 +2284,14 @@ window.__ModuleLoader__.load({
               h('select', {
                 className: 'vr-input vr-select', value: visionModelVisible(row.provider, row.model) ? row.model : '',
                 disabled: editBlocked || !visionProviderVisible(row.provider),
-                onChange: (event) => updateChain(index, { provider: row.provider, model: event.target.value }),
+                onChange: (event) => {
+                  updateChain(index, { provider: row.provider, model: event.target.value })
+                  // Picking a real vision model is an active backend choice:
+                  // the walkthrough has done its job, so end it right away
+                  // instead of waiting for the in-card button. Picking only a
+                  // provider (model still empty) does not finish it.
+                  if (row.provider && event.target.value) finishGuide()
+                },
               },
                 h('option', { value: '' }, visionProviderVisible(row.provider) ? t('selectModel') : t('pickProviderFirst')),
                 modelOptionsOf(visionModelsFor(row.provider)),

--- a/lib/client.js
+++ b/lib/client.js
@@ -1429,6 +1429,11 @@ window.__ModuleLoader__.load({
       // snapshot changes (e.g. the first read resolves after page load).
       const unsubscribe = settingsPersistence && settingsPersistence.subscribe(sync)
       return () => {
+        visionGuidePanelSeen = false
+        if (visionGuidePanelCloseTimer !== undefined) {
+          window.clearTimeout(visionGuidePanelCloseTimer)
+          visionGuidePanelCloseTimer = undefined
+        }
         window.removeEventListener(VISION_GUIDE_EVENT, sync)
         window.removeEventListener('popstate', sync)
         window.removeEventListener('resize', sync)

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -298,6 +298,25 @@ test('re-viewing the model guide replays the overview instead of skipping to ste
   assert.equal(source.includes('if (!readOnboardingSeen()) showOnboarding(t)'), true)
 })
 
+test('walkthrough ends on save, on picking a vision model, or when the settings panel closes', () => {
+  const source = readFileSync(new URL('../lib/client.js', import.meta.url), 'utf8')
+  // Closing the app-owned settings modal ends the round instead of demoting
+  // the floating prompt back to the "find the vision model in settings"
+  // phase: a grace timer absorbs host re-renders that rebuild the dialog.
+  assert.equal(source.includes('let visionGuidePanelSeen = false'), true)
+  assert.equal(source.includes('let visionGuidePanelCloseTimer'), true)
+  assert.equal(source.includes('function guideSettingsPanelOpen()'), true)
+  assert.equal(source.includes('step !== undefined && visionGuidePanelSeen && !panelOpen'), true)
+  assert.equal(source.includes('if (readVisionGuideStep() !== undefined && !guideSettingsPanelOpen())'), true)
+  // Saving the settings card completes the walkthrough, even when a hidden
+  // write is later rejected — dismissal stays page-authoritative.
+  assert.equal(source.includes('Saving ends the walkthrough'), true)
+  assert.equal(source.includes('finishGuide()'), true)
+  // Picking a real vision model completes it too; picking only a provider
+  // (model still empty) keeps the guide alive.
+  assert.equal(source.includes('if (row.provider && event.target.value) finishGuide()'), true)
+})
+
 test('onboarding and guide durability live in the settings section, not origin-scoped localStorage (#78)', () => {
   const source = readFileSync(new URL('../lib/client.js', import.meta.url), 'utf8')
   // DSH Desktop re-randomizes the Web UI port on every launch, so


### PR DESCRIPTION
The step-3 walkthrough had exactly one exit: the in-card "Done" button. Picking
a vision backend, saving the settings, or closing the settings panel all left
the stored step at `step2`, so closing the panel removed the highlighted chain
from the DOM and `guidePhase()` demoted the walkthrough back to the "find the
vision model in settings" phase — the floating prompt popped up again, over and
over, whether or not a backend was chosen.

Endings are now driven by the user's real actions:

- **Save completes the walkthrough** — clicking Save in the settings card
  finishes the guide, even when a hidden write is later rejected (dismissal
  stays page-authoritative, as in #114).
- **Picking a vision backend completes it** — selecting a concrete model
  finishes the guide immediately; picking only a provider keeps it alive.
- **Closing the settings panel ends the round** — a panel that was seen open
  during the walkthrough and then disappears suppresses the prompt and
  finishes the guide after a 400 ms grace period, so a host re-render that
  rebuilds the dialog in place is not mistaken for a close.
- **Leaving the chain empty stays valid** — no forced selection: the built-in
  free fallback still works, and Save/close both count as a normal end.

A regression test asserts the new behaviors; the full suite passes (230 tests).