### PR TITLE
fix: preserve picker-chosen reasoningEffort across twin turns (issue #103)

### DIFF
--- a/index.js
+++ b/index.js
@@ -293,6 +293,11 @@ export const Config = z.object({
   // Text-provider routes the user wants wrapped as image-capable twins
   // (e.g. opencode-go): each entry registers a "<provider>-vision" route
   // whose catalog mirrors the original models but declares image input.
+  // `reasoningEffort` (issue #103): some source routes advertise no
+  // reasoning.defaultEffort (pi-ai only emits one when the provider profile
+  // sets `reasoning`), which makes the host drop the persisted effort every
+  // time the twin is picked — only the first step of a turn thinks. Set it
+  // here to force a default for the twin's catalog entries.
   // 开箱预置一条 deepseek-official（与视觉模型链预置 vision-http 内置免费
   // 端点同理）：新用户在卡片里第一眼就能看到官方 DeepSeek 行可发图。该路由
   // 由插件内置包装（deepseek-vision）服务，syncTwins 跳过 ownRoutes，这条
@@ -302,6 +307,7 @@ export const Config = z.object({
       z.object({
         provider: z.string(),
         models: z.array(z.string()).default([]),
+        reasoningEffort: z.string().default(''),
       }),
     )
     .default([{ provider: 'deepseek-official', models: [] }]),
@@ -1951,7 +1957,16 @@ export function createNativeDeepSeekAdapter(ctx) {
  * vision_ground / ... itself, so image turns stay ordinary tool-calling text
  * turns with continuous multi-step operations.
  */
-export function createWrapperStreamBody(ctx, { imageMemory, delegateProvider, preserveImageInput }) {
+export function createWrapperStreamBody(ctx, { imageMemory, delegateProvider, preserveImageInput, defaultReasoningEffort }) {
+  // issue #103 (defense in depth): when the twin metadata lacks a reasoning
+  // default, the host can drop reasoningEffort from the later steps of a
+  // multi-step turn (only step 1 thinks). Remember the last explicitly seen
+  // effort per delegate and re-inject it when a later call arrives without
+  // one, so every step keeps reasoning. The vision chain never flows through
+  // this body and keeps its own reasoningEffort: undefined.
+  const lastReasoningEffort = new Map() // delegate provider -> last explicit effort
+  const fallbackReasoningEffort = () =>
+    typeof defaultReasoningEffort === 'function' ? defaultReasoningEffort() : defaultReasoningEffort
   return {
     async *stream(options) {
       const messages = options.messages ?? []
@@ -2006,8 +2021,20 @@ export function createWrapperStreamBody(ctx, { imageMemory, delegateProvider, pr
         })
         return result.changed ? { ...message, content: result.content } : message
       })
+      let effort = typeof options.reasoningEffort === 'string' && options.reasoningEffort !== ''
+        ? options.reasoningEffort
+        : undefined
+      if (effort !== undefined) {
+        lastReasoningEffort.set(delegateProvider, effort)
+      } else {
+        effort = lastReasoningEffort.get(delegateProvider)
+      }
+      if (effort === undefined) {
+        const fallback = fallbackReasoningEffort()
+        if (typeof fallback === 'string' && fallback !== '') effort = fallback
+      }
       yield* ctx.llm.stream({
-        ...options,
+        ...(effort === undefined ? options : { ...options, reasoningEffort: effort }),
         provider: delegateProvider,
         messages: rewritten,
       })
@@ -2817,6 +2844,30 @@ export function apply(ctx, config = {}) {
         return false
       }
     }
+    // issue #103: the twin mirrors the source metadata, and pi-ai routes only
+    // advertise reasoning.defaultEffort when the provider profile sets
+    // `reasoning`. Without a default the picker rebuild and the agent request
+    // hook drop the persisted effort whenever the twin is selected, so only
+    // the first step of a turn thinks. The twin therefore exposes a
+    // defaultEffort: the source's own when present, or the per-entry
+    // wrappedProviders[].reasoningEffort override when configured.
+    const configuredReasoningEffort = () => {
+      const entry = wrappedProviders().find((candidate) => candidate.provider === provider)
+      return entry && typeof entry.reasoningEffort === 'string' ? entry.reasoningEffort.trim() : ''
+    }
+    const withDefaultEffort = (model) => {
+      const configured = configuredReasoningEffort()
+      if (configured === '') return model
+      const reasoning = model && typeof model === 'object' ? model.reasoning : undefined
+      const efforts = reasoning && Array.isArray(reasoning.efforts) ? reasoning.efforts : []
+      if (efforts.length === 0) {
+        return { ...model, reasoning: { efforts: [configured], defaultEffort: configured } }
+      }
+      if (efforts.includes(configured)) {
+        return { ...model, reasoning: { ...reasoning, defaultEffort: configured } }
+      }
+      return { ...model, reasoning: { ...reasoning, efforts: [configured, ...efforts], defaultEffort: configured } }
+    }
     return {
       providerInfo() {
         const original = originalAdapter()
@@ -2845,7 +2896,9 @@ export function apply(ctx, config = {}) {
           const listed = await original.listModels(provider)
           return listed
             .filter((model) => models.length === 0 || models.includes(model.id))
-            .map((model) => ({ ...model, provider: twinRoute, inputModalities: ['text', 'image'] }))
+            .map((model) =>
+              withDefaultEffort({ ...model, provider: twinRoute, inputModalities: ['text', 'image'] }),
+            )
         } catch {
           return []
         }
@@ -2856,7 +2909,7 @@ export function apply(ctx, config = {}) {
           throw new Error(`vision-router: wrapped provider "${provider}" has no adapter registered yet`)
         }
         const base = await original.resolveModel(provider, model)
-        return { ...base, provider: twinRoute, inputModalities: ['text', 'image'] }
+        return withDefaultEffort({ ...base, provider: twinRoute, inputModalities: ['text', 'image'] })
       },
       ...createWrapperStreamBody(ctx, {
         imageMemory,
@@ -2865,6 +2918,9 @@ export function apply(ctx, config = {}) {
         // Keep that direct path intact and expose vision-router as optional
         // precision tools instead of forcing an image -> text detour.
         preserveImageInput: (options) => sourceAcceptsImages(options.model),
+        // issue #103 (defense in depth): even when the agent drops the effort
+        // between steps, re-inject the configured default for this twin.
+        defaultReasoningEffort: () => configuredReasoningEffort(),
       }),
     }
   }

--- a/index.js
+++ b/index.js
@@ -1965,8 +1965,11 @@ export function createWrapperStreamBody(ctx, { imageMemory, delegateProvider, pr
   // one, so every step keeps reasoning. The vision chain never flows through
   // this body and keeps its own reasoningEffort: undefined.
   const lastReasoningEffort = new Map() // delegate provider -> last explicit effort
-  const fallbackReasoningEffort = () =>
-    typeof defaultReasoningEffort === 'function' ? defaultReasoningEffort() : defaultReasoningEffort
+  const fallbackReasoningEffort = async (options) => {
+    if (defaultReasoningEffort === undefined) return ''
+    const raw = typeof defaultReasoningEffort === 'function' ? await defaultReasoningEffort(options) : defaultReasoningEffort
+    return typeof raw === 'string' && raw !== '' ? raw : ''
+  }
   return {
     async *stream(options) {
       const messages = options.messages ?? []
@@ -2030,7 +2033,7 @@ export function createWrapperStreamBody(ctx, { imageMemory, delegateProvider, pr
         effort = lastReasoningEffort.get(delegateProvider)
       }
       if (effort === undefined) {
-        const fallback = fallbackReasoningEffort()
+        const fallback = await fallbackReasoningEffort(options)
         if (typeof fallback === 'string' && fallback !== '') effort = fallback
       }
       yield* ctx.llm.stream({
@@ -2860,13 +2863,12 @@ export function apply(ctx, config = {}) {
       if (configured === '') return model
       const reasoning = model && typeof model === 'object' ? model.reasoning : undefined
       const efforts = reasoning && Array.isArray(reasoning.efforts) ? reasoning.efforts : []
-      if (efforts.length === 0) {
-        return { ...model, reasoning: { efforts: [configured], defaultEffort: configured } }
+      if (!efforts.includes(configured)) {
+        // Not supported by the source route: never advertise or inject it.
+        // The host falls back to the source's own metadata and behavior.
+        return model
       }
-      if (efforts.includes(configured)) {
-        return { ...model, reasoning: { ...reasoning, defaultEffort: configured } }
-      }
-      return { ...model, reasoning: { ...reasoning, efforts: [configured, ...efforts], defaultEffort: configured } }
+      return { ...model, reasoning: { ...reasoning, defaultEffort: configured } }
     }
     return {
       providerInfo() {
@@ -2919,8 +2921,25 @@ export function apply(ctx, config = {}) {
         // precision tools instead of forcing an image -> text detour.
         preserveImageInput: (options) => sourceAcceptsImages(options.model),
         // issue #103 (defense in depth): even when the agent drops the effort
-        // between steps, re-inject the configured default for this twin.
-        defaultReasoningEffort: () => configuredReasoningEffort(),
+        // between steps, re-inject the configured default for this twin — but
+        // only when the source route actually advertises that effort, so an
+        // unsupported level is ignored instead of being forced upstream.
+        defaultReasoningEffort: async (options) => {
+          const configured = configuredReasoningEffort()
+          if (configured === '') return ''
+          const original = originalAdapter()
+          try {
+            const info =
+              original && typeof original.resolveModel === 'function'
+                ? await original.resolveModel(provider, options && options.model)
+                : undefined
+            const efforts =
+              info && info.reasoning && Array.isArray(info.reasoning.efforts) ? info.reasoning.efforts : []
+            return efforts.includes(configured) ? configured : ''
+          } catch {
+            return ''
+          }
+        },
       }),
     }
   }

--- a/index.js
+++ b/index.js
@@ -293,11 +293,6 @@ export const Config = z.object({
   // Text-provider routes the user wants wrapped as image-capable twins
   // (e.g. opencode-go): each entry registers a "<provider>-vision" route
   // whose catalog mirrors the original models but declares image input.
-  // `reasoningEffort` (issue #103): some source routes advertise no
-  // reasoning.defaultEffort (pi-ai only emits one when the provider profile
-  // sets `reasoning`), which makes the host drop the persisted effort every
-  // time the twin is picked — only the first step of a turn thinks. Set it
-  // here to force a default for the twin's catalog entries.
   // 开箱预置一条 deepseek-official（与视觉模型链预置 vision-http 内置免费
   // 端点同理）：新用户在卡片里第一眼就能看到官方 DeepSeek 行可发图。该路由
   // 由插件内置包装（deepseek-vision）服务，syncTwins 跳过 ownRoutes，这条
@@ -307,7 +302,6 @@ export const Config = z.object({
       z.object({
         provider: z.string(),
         models: z.array(z.string()).default([]),
-        reasoningEffort: z.string().default(''),
       }),
     )
     .default([{ provider: 'deepseek-official', models: [] }]),
@@ -1957,19 +1951,16 @@ export function createNativeDeepSeekAdapter(ctx) {
  * vision_ground / ... itself, so image turns stay ordinary tool-calling text
  * turns with continuous multi-step operations.
  */
-export function createWrapperStreamBody(ctx, { imageMemory, delegateProvider, preserveImageInput, defaultReasoningEffort }) {
-  // issue #103 (defense in depth): when the twin metadata lacks a reasoning
-  // default, the host can drop reasoningEffort from the later steps of a
-  // multi-step turn (only step 1 thinks). Remember the last explicitly seen
-  // effort per delegate and re-inject it when a later call arrives without
-  // one, so every step keeps reasoning. The vision chain never flows through
-  // this body and keeps its own reasoningEffort: undefined.
+export function createWrapperStreamBody(ctx, { imageMemory, delegateProvider, preserveImageInput }) {
+  // issue #103: the reasoning level is a per-session picker choice (the chat
+  // page's bottom-right selector), but the host can drop reasoningEffort from
+  // the later steps of a multi-step turn once the twin metadata lacks a
+  // reasoning.defaultEffort (only step 1 thinks). Remember the last explicit
+  // effort seen per delegate — whatever the user actually picked — and
+  // re-inject it when a later call arrives without one, so every step keeps
+  // the user's chosen level. The vision chain never flows through this body
+  // and keeps its own reasoningEffort: undefined.
   const lastReasoningEffort = new Map() // delegate provider -> last explicit effort
-  const fallbackReasoningEffort = async (options) => {
-    if (defaultReasoningEffort === undefined) return ''
-    const raw = typeof defaultReasoningEffort === 'function' ? await defaultReasoningEffort(options) : defaultReasoningEffort
-    return typeof raw === 'string' && raw !== '' ? raw : ''
-  }
   return {
     async *stream(options) {
       const messages = options.messages ?? []
@@ -2031,10 +2022,6 @@ export function createWrapperStreamBody(ctx, { imageMemory, delegateProvider, pr
         lastReasoningEffort.set(delegateProvider, effort)
       } else {
         effort = lastReasoningEffort.get(delegateProvider)
-      }
-      if (effort === undefined) {
-        const fallback = await fallbackReasoningEffort(options)
-        if (typeof fallback === 'string' && fallback !== '') effort = fallback
       }
       yield* ctx.llm.stream({
         ...(effort === undefined ? options : { ...options, reasoningEffort: effort }),
@@ -2850,29 +2837,12 @@ export function apply(ctx, config = {}) {
         return false
       }
     }
-    // issue #103: the twin mirrors the source metadata, and pi-ai routes only
-    // advertise reasoning.defaultEffort when the provider profile sets
-    // `reasoning`. Without a default the picker rebuild and the agent request
-    // hook drop the persisted effort whenever the twin is selected, so only
-    // the first step of a turn thinks. The twin therefore exposes a
-    // defaultEffort: the source's own when present, or the per-entry
-    // wrappedProviders[].reasoningEffort override when configured.
-    const configuredReasoningEffort = () => {
-      const entry = wrappedProviders().find((candidate) => candidate.provider === provider)
-      return entry && typeof entry.reasoningEffort === 'string' ? entry.reasoningEffort.trim() : ''
-    }
-    const withDefaultEffort = (model) => {
-      const configured = configuredReasoningEffort()
-      if (configured === '') return model
-      const reasoning = model && typeof model === 'object' ? model.reasoning : undefined
-      const efforts = reasoning && Array.isArray(reasoning.efforts) ? reasoning.efforts : []
-      if (!efforts.includes(configured)) {
-        // Not supported by the source route: never advertise or inject it.
-        // The host falls back to the source's own metadata and behavior.
-        return model
-      }
-      return { ...model, reasoning: { ...reasoning, defaultEffort: configured } }
-    }
+    // issue #103: the twin mirrors the source metadata one-to-one, so any
+    // reasoning.defaultEffort the source advertises is inherited as-is. The
+    // reasoning LEVEL itself stays a per-session picker choice (bottom-right
+    // selector): the wrapper body below preserves it across the twin switch
+    // by remembering the last explicit effort and re-injecting it on the
+    // later steps that arrive without one.
     return {
       providerInfo() {
         const original = originalAdapter()
@@ -2901,9 +2871,7 @@ export function apply(ctx, config = {}) {
           const listed = await original.listModels(provider)
           return listed
             .filter((model) => models.length === 0 || models.includes(model.id))
-            .map((model) =>
-              withDefaultEffort({ ...model, provider: twinRoute, inputModalities: ['text', 'image'] }),
-            )
+            .map((model) => ({ ...model, provider: twinRoute, inputModalities: ['text', 'image'] }))
         } catch {
           return []
         }
@@ -2914,7 +2882,7 @@ export function apply(ctx, config = {}) {
           throw new Error(`vision-router: wrapped provider "${provider}" has no adapter registered yet`)
         }
         const base = await original.resolveModel(provider, model)
-        return withDefaultEffort({ ...base, provider: twinRoute, inputModalities: ['text', 'image'] })
+        return { ...base, provider: twinRoute, inputModalities: ['text', 'image'] }
       },
       ...createWrapperStreamBody(ctx, {
         imageMemory,
@@ -2923,26 +2891,6 @@ export function apply(ctx, config = {}) {
         // Keep that direct path intact and expose vision-router as optional
         // precision tools instead of forcing an image -> text detour.
         preserveImageInput: (options) => sourceAcceptsImages(options.model),
-        // issue #103 (defense in depth): even when the agent drops the effort
-        // between steps, re-inject the configured default for this twin — but
-        // only when the source route actually advertises that effort, so an
-        // unsupported level is ignored instead of being forced upstream.
-        defaultReasoningEffort: async (options) => {
-          const configured = configuredReasoningEffort()
-          if (configured === '') return ''
-          const original = originalAdapter()
-          try {
-            const info =
-              original && typeof original.resolveModel === 'function'
-                ? await original.resolveModel(provider, options && options.model)
-                : undefined
-            const efforts =
-              info && info.reasoning && Array.isArray(info.reasoning.efforts) ? info.reasoning.efforts : []
-            return efforts.includes(configured) ? configured : ''
-          } catch {
-            return ''
-          }
-        },
       }),
     }
   }

--- a/index.js
+++ b/index.js
@@ -2672,7 +2672,13 @@ export function apply(ctx, config = {}) {
   // declares image input so the admission passes, shows up in the model
   // picker as "DeepSeek + 自动识图", and delegates to the real text-provider
   // adapter for anything the waterfalls did not rewrite.
-  if (wrapperRoute() !== undefined) {
+  //
+  // The adapter is built unconditionally; whether (and under which name) it
+  // mounts is reconciled reactively against the resolved settings document by
+  // syncRoutingMounts() below, so the card's wrapperRoute/routing switches
+  // take effect without a restart.
+  let wrapperAdapter
+  {
     const WRAPPER_MODEL_IDS = ['deepseek-v4-pro', 'deepseek-v4-flash']
     const wrapName = (name) => name ?? 'DeepSeek'
     const textProviderRoute = () => (stealthActive ? nativeRoute : textProvider().provider)
@@ -2683,7 +2689,7 @@ export function apply(ctx, config = {}) {
         return undefined
       }
     }
-    const wrapperAdapter = {
+    wrapperAdapter = {
       providerInfo(provider) {
         return { id: provider, name: 'DeepSeek + 自动识图' }
       },
@@ -2772,9 +2778,6 @@ export function apply(ctx, config = {}) {
         delegateProvider: textProviderRoute(),
       }),
     }
-    const handle = ctx.llm.registerAdapter([wrapperRoute()], wrapperAdapter)
-    wrapperRegistered = true
-    ctx.effect(() => handle, 'vision-router: wrapper route')
   }
 
 
@@ -3218,8 +3221,13 @@ export function apply(ctx, config = {}) {
   // model-switch retry. To make fallback reliable, image turns are routed to
   // this chain adapter instead; it walks the configured providers itself and
   // only surfaces a failure once every model has failed.
-  if (chainRoute() !== undefined && routingEnabled()) {
-    const chainAdapter = {
+  //
+  // Built unconditionally; syncRoutingMounts() below mounts it whenever the
+  // resolved settings enable routing, so the card's routing switch takes
+  // effect without a restart.
+  let chainAdapter
+  {
+    chainAdapter = {
       providerInfo(provider) {
         return { id: provider, name: 'Vision Chain' }
       },
@@ -3392,9 +3400,79 @@ export function apply(ctx, config = {}) {
         }
       },
     }
-    const handle = ctx.llm.registerAdapter([chainRoute()], chainAdapter)
-    ctx.effect(() => handle, 'vision-router: chain route')
   }
+
+  // ── reactive routing mounts ────────────────────────────────────────────────
+  //
+  // Legacy routing used to be composition-gated at apply time while the
+  // settings card exposes the same switches — flipping them mid-session left
+  // the flow half-wired (hooks reading the settings document against mounts
+  // registered from the composition). The wrapper route, the chain route and
+  // the agent/request hook now reconcile against the resolved settings
+  // document: the settings seam below runs one initial sync and re-syncs on
+  // every document change, so toggles take effect immediately.
+  let wrapperRouteHandle
+  let wrapperRouteMounted
+  let chainRouteHandle
+  let chainRouteMounted
+  const syncRoutingMounts = () => {
+    const wantWrapper = wrapperRoute()
+    if (wantWrapper !== wrapperRouteMounted) {
+      if (wrapperRouteHandle) {
+        wrapperRouteHandle()
+        wrapperRouteHandle = undefined
+        wrapperRouteMounted = undefined
+      }
+      wrapperRegistered = false
+      if (wantWrapper !== undefined) {
+        try {
+          wrapperRouteHandle = ctx.llm.registerAdapter([wantWrapper], wrapperAdapter)
+          wrapperRouteMounted = wantWrapper
+          wrapperRegistered = true
+        } catch (error) {
+          if (error && error.code === 'DUPLICATE_ADAPTER') {
+            // Another layer already serves this name: adopt it and keep the
+            // flow functional instead of failing the apply.
+            wrapperRouteMounted = wantWrapper
+            wrapperRegistered = true
+          } else {
+            throw error
+          }
+        }
+      }
+    }
+    const wantChain = routingEnabled() ? chainRoute() : undefined
+    if (wantChain !== chainRouteMounted) {
+      if (chainRouteHandle) {
+        chainRouteHandle()
+        chainRouteHandle = undefined
+        chainRouteMounted = undefined
+      }
+      if (wantChain !== undefined) {
+        try {
+          chainRouteHandle = ctx.llm.registerAdapter([wantChain], chainAdapter)
+          chainRouteMounted = wantChain
+        } catch (error) {
+          if (error && error.code === 'DUPLICATE_ADAPTER') {
+            chainRouteMounted = wantChain
+          } else {
+            throw error
+          }
+        }
+      }
+    }
+  }
+  ctx.effect(
+    () => () => {
+      if (wrapperRouteHandle) wrapperRouteHandle()
+      if (chainRouteHandle) chainRouteHandle()
+      wrapperRouteHandle = undefined
+      chainRouteHandle = undefined
+      wrapperRouteMounted = undefined
+      chainRouteMounted = undefined
+    },
+    'vision-router: reactive routing mounts',
+  )
   // session -> Map<attachmentId, ref> (uploaded images visible to vision_describe)
   const sessionAttachments = new WeakMap()
   // secondary index by session id string (agent.session object identity can change across turns)
@@ -3792,52 +3870,54 @@ export function apply(ctx, config = {}) {
     return sanitizedToolResults.changed ? { ...decision, messages } : decision
   })
 
-  if (routingEnabled()) {
-    ctx.on('agent/request', async (payload, next) => {
-      const config0 = await next()
-      const session = payload.agent && payload.agent.session
-      if (!session) return config0
-      const state = turnState.get(session)
-      if (!state || state.turn !== payload.turn) return config0
-      if (!state.hasImage) {
-        const events = session.events ?? []
-        for (let i = state.startIndex; i < events.length; i++) {
-          if (eventHasImage(events[i])) {
-            state.hasImage = true
-            break
-          }
+  // Registered unconditionally and gated at runtime so the settings card's
+  // routing switch takes effect immediately (syncRoutingMounts reconciles the
+  // adapters the same way).
+  ctx.on('agent/request', async (payload, next) => {
+    const config0 = await next()
+    if (!routingEnabled()) return config0
+    const session = payload.agent && payload.agent.session
+    if (!session) return config0
+    const state = turnState.get(session)
+    if (!state || state.turn !== payload.turn) return config0
+    if (!state.hasImage) {
+    const events = session.events ?? []
+    for (let i = state.startIndex; i < events.length; i++) {
+      if (eventHasImage(events[i])) {
+        state.hasImage = true
+        break
+      }
+    }
+    }
+    if (!state.hasImage) {
+      // Reverse routing: the session's entry model is a vision provider
+      // (needed to pass the prompt admission); send text-only turns back
+      // to the text provider (DeepSeek) so daily work stays on it.
+      if (reverseRoutingEnabled()) {
+        const target = reverseRouteTarget(config0, {
+          pairs: pairs(),
+          wrapperRoute: wrapperRoute(),
+          wrapperRegistered,
+          textProvider: textProvider(),
+          hasAdapter: (provider) => adapterAvailable(ctx.llm, provider),
+        })
+        if (target !== undefined) {
+          return switchRoute(config0, target.provider, target.model)
         }
       }
-      if (!state.hasImage) {
-        // Reverse routing: the session's entry model is a vision provider
-        // (needed to pass the prompt admission); send text-only turns back
-        // to the text provider (DeepSeek) so daily work stays on it.
-        if (reverseRoutingEnabled()) {
-          const target = reverseRouteTarget(config0, {
-            pairs: pairs(),
-            wrapperRoute: wrapperRoute(),
-            wrapperRegistered,
-            textProvider: textProvider(),
-            hasAdapter: (provider) => adapterAvailable(ctx.llm, provider),
-          })
-          if (target !== undefined) {
-            return switchRoute(config0, target.provider, target.model)
-          }
-        }
-        return config0
-      }
-      // Route the image turn to the chain adapter (falls back under our own
-      // control), or directly to the first vision model when the chain route
-      // is disabled.
-      if (chainRoute() !== undefined) {
-        if (config0.provider === chainRoute()) return config0
-        return switchRoute(config0, chainRoute(), `${pairs()[0].provider}/${pairs()[0].model}`)
-      }
-      const first = pairs()[0]
-      if (first === undefined || config0.provider === first.provider) return config0
-      return switchRoute(config0, first.provider, first.model)
-    })
-  }
+      return config0
+    }
+    // Route the image turn to the chain adapter (falls back under our own
+    // control), or directly to the first vision model when the chain route
+    // is disabled.
+    if (chainRoute() !== undefined) {
+      if (config0.provider === chainRoute()) return config0
+      return switchRoute(config0, chainRoute(), `${pairs()[0].provider}/${pairs()[0].model}`)
+    }
+    const first = pairs()[0]
+    if (first === undefined || config0.provider === first.provider) return config0
+    return switchRoute(config0, first.provider, first.model)
+  })
 
   if (toolEnabled()) {
     const deepToolDefs = []
@@ -5412,6 +5492,9 @@ export function apply(ctx, config = {}) {
       base: config,
     })
     current = () => scope.get()
+    // With the settings document now visible, reconcile the routing mounts
+    // (wrapper route, chain route) against the resolved values.
+    syncRoutingMounts()
     sctx.effect(
       () => () => {
         // The settings provider went away: fall back to the composition entry.
@@ -5421,9 +5504,10 @@ export function apply(ctx, config = {}) {
     )
     scope.watch(() => {
       // Most consumers read current() per call, but the wrappedProviders
-      // twins are registered eagerly: re-sync them whenever the settings
-      // document loads or the user edits the wrappers section.
+      // twins and the routing mounts are registered eagerly: re-sync them
+      // whenever the settings document loads or the user edits the card.
       syncTwins()
+      syncRoutingMounts()
     })
   })
 

--- a/index.js
+++ b/index.js
@@ -1960,7 +1960,7 @@ export function createWrapperStreamBody(ctx, { imageMemory, delegateProvider, pr
   // re-inject it when a later call arrives without one, so every step keeps
   // the user's chosen level. The vision chain never flows through this body
   // and keeps its own reasoningEffort: undefined.
-  const lastReasoningEffort = new Map() // delegate provider -> last explicit effort
+  const lastReasoningEffort = new Map() // "provider\0model" -> last explicit effort
   return {
     async *stream(options) {
       const messages = options.messages ?? []
@@ -2015,13 +2015,18 @@ export function createWrapperStreamBody(ctx, { imageMemory, delegateProvider, pr
         })
         return result.changed ? { ...message, content: result.content } : message
       })
+      // Remember per delegate+model rather than per delegate alone: the
+      // stream boundary carries no session id, so provider+model is the
+      // narrowest scope available and keeps two concurrent sessions on the
+      // same twin from sharing one memory slot.
+      const effortKey = `${delegateProvider}\u0000${options.model ?? ''}`
       let effort = typeof options.reasoningEffort === 'string' && options.reasoningEffort !== ''
         ? options.reasoningEffort
         : undefined
       if (effort !== undefined) {
-        lastReasoningEffort.set(delegateProvider, effort)
+        lastReasoningEffort.set(effortKey, effort)
       } else {
-        effort = lastReasoningEffort.get(delegateProvider)
+        effort = lastReasoningEffort.get(effortKey)
       }
       yield* ctx.llm.stream({
         ...(effort === undefined ? options : { ...options, reasoningEffort: effort }),

--- a/lib/client.js
+++ b/lib/client.js
@@ -191,11 +191,9 @@ window.__ModuleLoader__.load({
       textHintChainRoute: '视觉链的挂载路由名（识图工具经由真实 provider 直接调用，不经过它）。',
       textWrappedProviders: '手动包装模型（可选）',
       groupWrappers: '手动限定自动识图范围（可选）',
-      textHintWrappedProviders: '通常不用配置。只有关闭自动创建，或只想让某些模型出现在「+ 自动识图」组时才使用：每行 `provider` 包装全部模型，或 `provider/model1,model2` 只包装指定模型；行尾可加 ` @ max` 指定该组的推理等级默认值（修复「只有第一步会思考」，不支持的等级自动忽略）。改动即时生效，无需重启。',
-      wrapHint: '通常无需配置：默认自动发现并包装「设置 → 模型」里已启用的模型。仅需限定范围或关闭自动创建后手动添加；模型留空 = 该路由全部模型。推理等级：源路由缺默认时补 reasoning.defaultEffort，不支持的等级自动忽略（修复「只有第一步会思考」）。原模型组保留不变，改动即时生效。',
+      textHintWrappedProviders: '通常不用配置。只有关闭自动创建，或只想让某些模型出现在「+ 自动识图」组时才使用：每行 `provider` 包装全部模型，或 `provider/model1,model2` 只包装指定模型。改动即时生效，无需重启。',
+      wrapHint: '通常无需配置：默认会自动发现并包装「设置 → 模型」里已启用的模型。只有想限制某个 provider 的自动识图范围，或关闭上方自动创建后手动指定时才在这里添加；模型留空 = 该路由全部模型。原模型组始终保留不变。改动即时生效，无需重启。',
       wrapAllModels: '全部模型（不选 = 包装全部）',
-      wrapEffortDefault: '默认等级',
-      wrapEffortTitle: '该包装组缺少 reasoning.defaultEffort 时使用的推理等级（源路由不支持的等级自动忽略）',
       addWrapper: '+ 添加手动包装',
       textProviders: '视觉后端链',
       textProvidersHint: '每行一个真正支持图片输入的「provider/model」，从上到下失败回退；不要填写纯文本模型。留空清除用户覆盖。',
@@ -393,11 +391,9 @@ window.__ModuleLoader__.load({
       textHintChainRoute: 'The fallback chain mount route (vision tools call real providers directly, not through it).',
       textWrappedProviders: 'Manual model wrappers (optional)',
       groupWrappers: 'Limit auto-vision scope manually (optional)',
-      textHintWrappedProviders: 'Usually leave this alone. Use it only after disabling automatic creation, or when only selected models should appear in a “+ Auto Vision” group: one `provider` wraps all models, while `provider/model1,model2` limits the set; append ` @ max` to set the group’s reasoning default (fixes “only the first step thinks”; unsupported levels are ignored). Applies immediately; no restart.',
-      wrapHint: 'Usually no configuration is needed: enabled models from Settings → Models are discovered and wrapped automatically. Add rows only to restrict one provider’s auto-vision scope, or after turning off automatic creation above. Empty model = every model on that route. Reasoning effort supplies reasoning.defaultEffort when the source route lacks one; unsupported levels are ignored (fixes “only the first step thinks”). The original model group stays untouched. Applies immediately; no restart.',
+      textHintWrappedProviders: 'Usually leave this alone. Use it only after disabling automatic creation, or when only selected models should appear in a “+ Auto Vision” group: one `provider` wraps all models, while `provider/model1,model2` limits the set. Applies immediately; no restart.',
+      wrapHint: 'Usually no configuration is needed: enabled models from Settings → Models are discovered and wrapped automatically. Add rows here only to restrict one provider’s auto-vision scope, or after turning off automatic creation above. Empty model = every model on that route. The original model group always remains untouched. Applies immediately; no restart.',
       wrapAllModels: 'All models (empty = wrap all)',
-      wrapEffortDefault: 'Default effort',
-      wrapEffortTitle: 'Reasoning effort used when this wrapped group lacks reasoning.defaultEffort (levels unsupported by the source route are ignored)',
       addWrapper: '+ Add manual wrapper',
       textProviders: 'Vision backend chain',
       textProvidersHint: 'One genuinely image-capable "provider/model" per line, top-down failover. Do not put text-only models here. Empty clears the override.',
@@ -742,7 +738,6 @@ window.__ModuleLoader__.load({
       '.vr-group{content-visibility:auto;contain-intrinsic-size:auto 96px;border-top:1px solid var(--dsw-alias-border-l2);padding:10px 0 2px;display:flex;flex-direction:column;gap:8px}' +
       '.vr-group-title{font-size:12px;font-weight:600;color:var(--dsw-alias-label-tertiary);margin:0}' +
       '.vr-select{flex:1;min-width:0;font:inherit}' +
-      '.vr-select-effort{flex:0 0 auto;width:104px}' +
       '.vr-invalid{color:var(--dsw-alias-label-error);margin:0;font-size:12px;line-height:1.5}' +
       '.vr-hint{color:var(--dsw-alias-label-tertiary);margin:0;font-size:12px;line-height:1.5}' +
       '.vr-toggle{display:flex;align-items:center;gap:10px;justify-content:space-between;width:100%}' +
@@ -1903,33 +1898,25 @@ window.__ModuleLoader__.load({
         if (key === 'wrappedProviders') {
           if (catalogReady) {
             // Expand the persisted { provider, models[] } entries into one
-            // editor row per selected model ('' = wrap all models). The
-            // per-provider reasoningEffort rides on every row of that
-            // provider; parse() folds the first non-empty one back.
+            // editor row per selected model ('' = wrap all models).
             const rows = []
             for (const entry of Array.isArray(value) ? value : []) {
               if (!entry || typeof entry.provider !== 'string' || entry.provider === '') continue
               const models = Array.isArray(entry.models) ? entry.models : []
-              const reasoningEffort = typeof entry.reasoningEffort === 'string' ? entry.reasoningEffort : ''
-              if (models.length === 0) rows.push({ provider: entry.provider, model: '', reasoningEffort })
-              else for (const model of models) rows.push({ provider: entry.provider, model, reasoningEffort })
+              if (models.length === 0) rows.push({ provider: entry.provider, model: '' })
+              else for (const model of models) rows.push({ provider: entry.provider, model })
             }
             return rows
           }
           if (!Array.isArray(value)) return ''
           return value
-            .map((entry) => {
-              if (!entry || !entry.provider) return ''
-              const line =
-                entry.models && entry.models.length > 0
+            .map((entry) =>
+              entry && entry.provider
+                ? entry.models && entry.models.length > 0
                   ? `${entry.provider}/${entry.models.join(',')}`
                   : entry.provider
-              const effort =
-                entry.reasoningEffort && typeof entry.reasoningEffort === 'string' && entry.reasoningEffort.trim() !== ''
-                  ? ` @ ${entry.reasoningEffort.trim()}`
-                  : ''
-              return line + effort
-            })
+                : '',
+            )
             .join('\n')
         }
         if (NUMBER_KEYS.includes(key)) return typeof value === 'number' ? String(value) : ''
@@ -2000,32 +1987,27 @@ window.__ModuleLoader__.load({
           if (catalogReady) {
             // Merge the editor rows back into { provider, models[] }: one
             // entry per provider; a row without a model means wrap all of the
-            // provider's models and wins over any specific selections. The
-            // first non-empty reasoningEffort among a provider's rows becomes
-            // the entry default.
+            // provider's models and wins over any specific selections.
             const rows = Array.isArray(text) ? text : []
-            const merged = new Map() // provider -> { models: null (all) | Set, effort }
+            const merged = new Map() // provider -> null (all) | Set(model ids)
             for (const row of rows) {
               if (row === undefined || row === null || typeof row !== 'object') return undefined
               const provider = typeof row.provider === 'string' ? row.provider.trim() : ''
               const model = typeof row.model === 'string' ? row.model.trim() : ''
-              const effort = typeof row.reasoningEffort === 'string' ? row.reasoningEffort.trim() : ''
               if (provider === '') {
-                // the empty template row is fine only without a model/effort
-                if (model !== '' || effort !== '') return undefined
+                // the empty template row is fine only without a model picked
+                if (model !== '') return undefined
                 continue
               }
-              if (!merged.has(provider)) merged.set(provider, { models: new Set(), effort: '' })
-              const entry = merged.get(provider)
-              if (entry.effort === '' && effort !== '') entry.effort = effort
-              if (entry.models === null) continue
-              if (model === '') merged.set(provider, { models: null, effort: entry.effort })
-              else entry.models.add(model)
+              if (!merged.has(provider)) merged.set(provider, new Set())
+              const set = merged.get(provider)
+              if (set === null) continue
+              if (model === '') merged.set(provider, null)
+              else set.add(model)
             }
-            const cleaned = [...merged.entries()].map(([provider, entry]) => ({
+            const cleaned = [...merged.entries()].map(([provider, set]) => ({
               provider,
-              models: entry.models === null ? [] : [...entry.models],
-              reasoningEffort: entry.effort,
+              models: set === null ? [] : [...set],
             }))
             return cleaned.length > 0 ? { value: cleaned } : { clear: true }
           }
@@ -2033,28 +2015,19 @@ window.__ModuleLoader__.load({
           for (const raw of String(text ?? '').split('\n')) {
             const line = raw.trim()
             if (line === '') continue
-            // Optional trailing ` @ effort` sets the group's reasoning
-            // default (issue #103); it applies to the whole line.
-            let body = line
-            let effort = ''
-            const at = line.lastIndexOf(' @ ')
-            if (at !== -1) {
-              body = line.slice(0, at).trim()
-              effort = line.slice(at + 3).trim()
-            }
-            const slash = body.indexOf('/')
-            const provider = (slash === -1 ? body : body.slice(0, slash)).trim()
+            const slash = line.indexOf('/')
+            const provider = (slash === -1 ? line : line.slice(0, slash)).trim()
             if (provider === '') return undefined
             const models =
               slash === -1
                 ? []
-                : body
+                : line
                     .slice(slash + 1)
                     .split(',')
                     .map((model) => model.trim())
                     .filter((model) => model !== '')
             if (slash !== -1 && models.length === 0) return undefined
-            list.push({ provider, models, reasoningEffort: effort })
+            list.push({ provider, models })
           }
           return list.length > 0 ? { value: list } : { clear: true }
         }
@@ -2532,7 +2505,7 @@ window.__ModuleLoader__.load({
       }
       const wrappersEditor = () => {
         const value = format('wrappedProviders')
-        const rows = Array.isArray(value) && value.length > 0 ? value : [{ provider: '', model: '', reasoningEffort: '' }]
+        const rows = Array.isArray(value) && value.length > 0 ? value : [{ provider: '', model: '' }]
         const updateWrap = (index, next) => {
           const list = rows.map((row) => ({ ...row }))
           list[index] = next
@@ -2540,7 +2513,7 @@ window.__ModuleLoader__.load({
         }
         const removeWrap = (index) => {
           const list = rows.filter((_row, i) => i !== index)
-          setDraft('wrappedProviders', list.length > 0 ? list : [{ provider: '', model: '', reasoningEffort: '' }])
+          setDraft('wrappedProviders', list.length > 0 ? list : [{ provider: '', model: '' }])
         }
         return h('div', { className: 'vr-field' },
           h('div', { className: 'vr-field-head' },
@@ -2551,7 +2524,7 @@ window.__ModuleLoader__.load({
             h('div', { className: 'vr-chain-row', key: index },
               h('select', {
                 className: 'vr-input vr-select', value: row.provider ?? '', disabled: editBlocked,
-                onChange: (event) => updateWrap(index, { provider: event.target.value, model: '', reasoningEffort: row.reasoningEffort ?? '' }),
+                onChange: (event) => updateWrap(index, { provider: event.target.value, model: '' }),
               },
                 h('option', { value: '' }, t('selectProvider')),
                 wrapGroupOptions,
@@ -2559,18 +2532,10 @@ window.__ModuleLoader__.load({
               h('select', {
                 className: 'vr-input vr-select', value: row.model ?? '',
                 disabled: editBlocked || !row.provider,
-                onChange: (event) => updateWrap(index, { provider: row.provider, model: event.target.value, reasoningEffort: row.reasoningEffort ?? '' }),
+                onChange: (event) => updateWrap(index, { provider: row.provider, model: event.target.value }),
               },
                 h('option', { value: '' }, row.provider ? t('wrapAllModels') : t('pickProviderFirst')),
                 modelOptionsOf(modelsOf(row.provider)),
-              ),
-              h('select', {
-                className: 'vr-input vr-select vr-select-effort', value: row.reasoningEffort ?? '',
-                disabled: editBlocked || !row.provider, title: t('wrapEffortTitle'),
-                onChange: (event) => updateWrap(index, { provider: row.provider, model: row.model, reasoningEffort: event.target.value }),
-              },
-                h('option', { value: '' }, t('wrapEffortDefault')),
-                ['off', 'low', 'medium', 'high', 'max'].map((effort) => h('option', { value: effort, key: effort }, effort)),
               ),
               h('button', {
                 type: 'button', className: 'vr-reset', disabled: editBlocked, title: t('removeTitle'),
@@ -2580,7 +2545,7 @@ window.__ModuleLoader__.load({
           ),
           h('button', {
             type: 'button', className: 'vr-btn', disabled: editBlocked,
-            onClick: () => setDraft('wrappedProviders', [...rows, { provider: '', model: '', reasoningEffort: '' }]),
+            onClick: () => setDraft('wrappedProviders', [...rows, { provider: '', model: '' }]),
           }, t('addWrapper')),
           h('p', { className: 'vr-hint' }, t('wrapHint')),
         )

--- a/lib/client.js
+++ b/lib/client.js
@@ -191,11 +191,11 @@ window.__ModuleLoader__.load({
       textHintChainRoute: '视觉链的挂载路由名（识图工具经由真实 provider 直接调用，不经过它）。',
       textWrappedProviders: '手动包装模型（可选）',
       groupWrappers: '手动限定自动识图范围（可选）',
-      textHintWrappedProviders: '通常不用配置。只有关闭自动创建，或只想让某些模型出现在「+ 自动识图」组时才使用：每行 `provider` 包装全部模型，或 `provider/model1,model2` 只包装指定模型；行尾可加 ` @ max` 指定该组的推理等级默认值（源路由缺少默认时生效，修复「只有第一步会思考」）。改动即时生效，无需重启。',
-      wrapHint: '通常无需配置：默认会自动发现并包装「设置 → 模型」里已启用的模型。只有想限制某个 provider 的自动识图范围，或关闭上方自动创建后手动指定时才在这里添加；模型留空 = 该路由全部模型。推理等级为该组补一个 reasoning.defaultEffort（源路由缺少默认时生效，修复「只有第一步会思考」）。原模型组始终保留不变。改动即时生效，无需重启。',
+      textHintWrappedProviders: '通常不用配置。只有关闭自动创建，或只想让某些模型出现在「+ 自动识图」组时才使用：每行 `provider` 包装全部模型，或 `provider/model1,model2` 只包装指定模型；行尾可加 ` @ max` 指定该组的推理等级默认值（修复「只有第一步会思考」，不支持的等级自动忽略）。改动即时生效，无需重启。',
+      wrapHint: '通常无需配置：默认自动发现并包装「设置 → 模型」里已启用的模型。仅需限定范围或关闭自动创建后手动添加；模型留空 = 该路由全部模型。推理等级：源路由缺默认时补 reasoning.defaultEffort，不支持的等级自动忽略（修复「只有第一步会思考」）。原模型组保留不变，改动即时生效。',
       wrapAllModels: '全部模型（不选 = 包装全部）',
-      wrapEffortDefault: '推理等级（默认继承）',
-      wrapEffortTitle: '该包装组缺少 reasoning.defaultEffort 时使用的推理等级',
+      wrapEffortDefault: '默认等级',
+      wrapEffortTitle: '该包装组缺少 reasoning.defaultEffort 时使用的推理等级（源路由不支持的等级自动忽略）',
       addWrapper: '+ 添加手动包装',
       textProviders: '视觉后端链',
       textProvidersHint: '每行一个真正支持图片输入的「provider/model」，从上到下失败回退；不要填写纯文本模型。留空清除用户覆盖。',
@@ -393,11 +393,11 @@ window.__ModuleLoader__.load({
       textHintChainRoute: 'The fallback chain mount route (vision tools call real providers directly, not through it).',
       textWrappedProviders: 'Manual model wrappers (optional)',
       groupWrappers: 'Limit auto-vision scope manually (optional)',
-      textHintWrappedProviders: 'Usually leave this alone. Use it only after disabling automatic creation, or when only selected models should appear in a “+ Auto Vision” group: one `provider` wraps all models, while `provider/model1,model2` limits the set; append ` @ max` to set the group’s reasoning default (used when the source route lacks one — fixes “only the first step thinks”). Applies immediately; no restart.',
-      wrapHint: 'Usually no configuration is needed: enabled models from Settings → Models are discovered and wrapped automatically. Add rows here only to restrict one provider’s auto-vision scope, or after turning off automatic creation above. Empty model = every model on that route. Reasoning effort supplies the group with a reasoning.defaultEffort when the source route lacks one (fixes “only the first step thinks”). The original model group always remains untouched. Applies immediately; no restart.',
+      textHintWrappedProviders: 'Usually leave this alone. Use it only after disabling automatic creation, or when only selected models should appear in a “+ Auto Vision” group: one `provider` wraps all models, while `provider/model1,model2` limits the set; append ` @ max` to set the group’s reasoning default (fixes “only the first step thinks”; unsupported levels are ignored). Applies immediately; no restart.',
+      wrapHint: 'Usually no configuration is needed: enabled models from Settings → Models are discovered and wrapped automatically. Add rows only to restrict one provider’s auto-vision scope, or after turning off automatic creation above. Empty model = every model on that route. Reasoning effort supplies reasoning.defaultEffort when the source route lacks one; unsupported levels are ignored (fixes “only the first step thinks”). The original model group stays untouched. Applies immediately; no restart.',
       wrapAllModels: 'All models (empty = wrap all)',
-      wrapEffortDefault: 'Reasoning effort (inherit default)',
-      wrapEffortTitle: 'Reasoning effort used when this wrapped group lacks reasoning.defaultEffort',
+      wrapEffortDefault: 'Default effort',
+      wrapEffortTitle: 'Reasoning effort used when this wrapped group lacks reasoning.defaultEffort (levels unsupported by the source route are ignored)',
       addWrapper: '+ Add manual wrapper',
       textProviders: 'Vision backend chain',
       textProvidersHint: 'One genuinely image-capable "provider/model" per line, top-down failover. Do not put text-only models here. Empty clears the override.',
@@ -742,6 +742,7 @@ window.__ModuleLoader__.load({
       '.vr-group{content-visibility:auto;contain-intrinsic-size:auto 96px;border-top:1px solid var(--dsw-alias-border-l2);padding:10px 0 2px;display:flex;flex-direction:column;gap:8px}' +
       '.vr-group-title{font-size:12px;font-weight:600;color:var(--dsw-alias-label-tertiary);margin:0}' +
       '.vr-select{flex:1;min-width:0;font:inherit}' +
+      '.vr-select-effort{flex:0 0 auto;width:104px}' +
       '.vr-invalid{color:var(--dsw-alias-label-error);margin:0;font-size:12px;line-height:1.5}' +
       '.vr-hint{color:var(--dsw-alias-label-tertiary);margin:0;font-size:12px;line-height:1.5}' +
       '.vr-toggle{display:flex;align-items:center;gap:10px;justify-content:space-between;width:100%}' +
@@ -2564,7 +2565,7 @@ window.__ModuleLoader__.load({
                 modelOptionsOf(modelsOf(row.provider)),
               ),
               h('select', {
-                className: 'vr-input vr-select', value: row.reasoningEffort ?? '',
+                className: 'vr-input vr-select vr-select-effort', value: row.reasoningEffort ?? '',
                 disabled: editBlocked || !row.provider, title: t('wrapEffortTitle'),
                 onChange: (event) => updateWrap(index, { provider: row.provider, model: row.model, reasoningEffort: event.target.value }),
               },

--- a/lib/client.js
+++ b/lib/client.js
@@ -191,9 +191,11 @@ window.__ModuleLoader__.load({
       textHintChainRoute: '视觉链的挂载路由名（识图工具经由真实 provider 直接调用，不经过它）。',
       textWrappedProviders: '手动包装模型（可选）',
       groupWrappers: '手动限定自动识图范围（可选）',
-      textHintWrappedProviders: '通常不用配置。只有关闭自动创建，或只想让某些模型出现在「+ 自动识图」组时才使用：每行 `provider` 包装全部模型，或 `provider/model1,model2` 只包装指定模型。改动即时生效，无需重启。',
-      wrapHint: '通常无需配置：默认会自动发现并包装「设置 → 模型」里已启用的模型。只有想限制某个 provider 的自动识图范围，或关闭上方自动创建后手动指定时才在这里添加；模型留空 = 该路由全部模型。原模型组始终保留不变。改动即时生效，无需重启。',
+      textHintWrappedProviders: '通常不用配置。只有关闭自动创建，或只想让某些模型出现在「+ 自动识图」组时才使用：每行 `provider` 包装全部模型，或 `provider/model1,model2` 只包装指定模型；行尾可加 ` @ max` 指定该组的推理等级默认值（源路由缺少默认时生效，修复「只有第一步会思考」）。改动即时生效，无需重启。',
+      wrapHint: '通常无需配置：默认会自动发现并包装「设置 → 模型」里已启用的模型。只有想限制某个 provider 的自动识图范围，或关闭上方自动创建后手动指定时才在这里添加；模型留空 = 该路由全部模型。推理等级为该组补一个 reasoning.defaultEffort（源路由缺少默认时生效，修复「只有第一步会思考」）。原模型组始终保留不变。改动即时生效，无需重启。',
       wrapAllModels: '全部模型（不选 = 包装全部）',
+      wrapEffortDefault: '推理等级（默认继承）',
+      wrapEffortTitle: '该包装组缺少 reasoning.defaultEffort 时使用的推理等级',
       addWrapper: '+ 添加手动包装',
       textProviders: '视觉后端链',
       textProvidersHint: '每行一个真正支持图片输入的「provider/model」，从上到下失败回退；不要填写纯文本模型。留空清除用户覆盖。',
@@ -391,9 +393,11 @@ window.__ModuleLoader__.load({
       textHintChainRoute: 'The fallback chain mount route (vision tools call real providers directly, not through it).',
       textWrappedProviders: 'Manual model wrappers (optional)',
       groupWrappers: 'Limit auto-vision scope manually (optional)',
-      textHintWrappedProviders: 'Usually leave this alone. Use it only after disabling automatic creation, or when only selected models should appear in a “+ Auto Vision” group: one `provider` wraps all models, while `provider/model1,model2` limits the set. Applies immediately; no restart.',
-      wrapHint: 'Usually no configuration is needed: enabled models from Settings → Models are discovered and wrapped automatically. Add rows here only to restrict one provider’s auto-vision scope, or after turning off automatic creation above. Empty model = every model on that route. The original model group always remains untouched. Applies immediately; no restart.',
+      textHintWrappedProviders: 'Usually leave this alone. Use it only after disabling automatic creation, or when only selected models should appear in a “+ Auto Vision” group: one `provider` wraps all models, while `provider/model1,model2` limits the set; append ` @ max` to set the group’s reasoning default (used when the source route lacks one — fixes “only the first step thinks”). Applies immediately; no restart.',
+      wrapHint: 'Usually no configuration is needed: enabled models from Settings → Models are discovered and wrapped automatically. Add rows here only to restrict one provider’s auto-vision scope, or after turning off automatic creation above. Empty model = every model on that route. Reasoning effort supplies the group with a reasoning.defaultEffort when the source route lacks one (fixes “only the first step thinks”). The original model group always remains untouched. Applies immediately; no restart.',
       wrapAllModels: 'All models (empty = wrap all)',
+      wrapEffortDefault: 'Reasoning effort (inherit default)',
+      wrapEffortTitle: 'Reasoning effort used when this wrapped group lacks reasoning.defaultEffort',
       addWrapper: '+ Add manual wrapper',
       textProviders: 'Vision backend chain',
       textProvidersHint: 'One genuinely image-capable "provider/model" per line, top-down failover. Do not put text-only models here. Empty clears the override.',
@@ -1898,25 +1902,33 @@ window.__ModuleLoader__.load({
         if (key === 'wrappedProviders') {
           if (catalogReady) {
             // Expand the persisted { provider, models[] } entries into one
-            // editor row per selected model ('' = wrap all models).
+            // editor row per selected model ('' = wrap all models). The
+            // per-provider reasoningEffort rides on every row of that
+            // provider; parse() folds the first non-empty one back.
             const rows = []
             for (const entry of Array.isArray(value) ? value : []) {
               if (!entry || typeof entry.provider !== 'string' || entry.provider === '') continue
               const models = Array.isArray(entry.models) ? entry.models : []
-              if (models.length === 0) rows.push({ provider: entry.provider, model: '' })
-              else for (const model of models) rows.push({ provider: entry.provider, model })
+              const reasoningEffort = typeof entry.reasoningEffort === 'string' ? entry.reasoningEffort : ''
+              if (models.length === 0) rows.push({ provider: entry.provider, model: '', reasoningEffort })
+              else for (const model of models) rows.push({ provider: entry.provider, model, reasoningEffort })
             }
             return rows
           }
           if (!Array.isArray(value)) return ''
           return value
-            .map((entry) =>
-              entry && entry.provider
-                ? entry.models && entry.models.length > 0
+            .map((entry) => {
+              if (!entry || !entry.provider) return ''
+              const line =
+                entry.models && entry.models.length > 0
                   ? `${entry.provider}/${entry.models.join(',')}`
                   : entry.provider
-                : '',
-            )
+              const effort =
+                entry.reasoningEffort && typeof entry.reasoningEffort === 'string' && entry.reasoningEffort.trim() !== ''
+                  ? ` @ ${entry.reasoningEffort.trim()}`
+                  : ''
+              return line + effort
+            })
             .join('\n')
         }
         if (NUMBER_KEYS.includes(key)) return typeof value === 'number' ? String(value) : ''
@@ -1987,27 +1999,32 @@ window.__ModuleLoader__.load({
           if (catalogReady) {
             // Merge the editor rows back into { provider, models[] }: one
             // entry per provider; a row without a model means wrap all of the
-            // provider's models and wins over any specific selections.
+            // provider's models and wins over any specific selections. The
+            // first non-empty reasoningEffort among a provider's rows becomes
+            // the entry default.
             const rows = Array.isArray(text) ? text : []
-            const merged = new Map() // provider -> null (all) | Set(model ids)
+            const merged = new Map() // provider -> { models: null (all) | Set, effort }
             for (const row of rows) {
               if (row === undefined || row === null || typeof row !== 'object') return undefined
               const provider = typeof row.provider === 'string' ? row.provider.trim() : ''
               const model = typeof row.model === 'string' ? row.model.trim() : ''
+              const effort = typeof row.reasoningEffort === 'string' ? row.reasoningEffort.trim() : ''
               if (provider === '') {
-                // the empty template row is fine only without a model picked
-                if (model !== '') return undefined
+                // the empty template row is fine only without a model/effort
+                if (model !== '' || effort !== '') return undefined
                 continue
               }
-              if (!merged.has(provider)) merged.set(provider, new Set())
-              const set = merged.get(provider)
-              if (set === null) continue
-              if (model === '') merged.set(provider, null)
-              else set.add(model)
+              if (!merged.has(provider)) merged.set(provider, { models: new Set(), effort: '' })
+              const entry = merged.get(provider)
+              if (entry.effort === '' && effort !== '') entry.effort = effort
+              if (entry.models === null) continue
+              if (model === '') merged.set(provider, { models: null, effort: entry.effort })
+              else entry.models.add(model)
             }
-            const cleaned = [...merged.entries()].map(([provider, set]) => ({
+            const cleaned = [...merged.entries()].map(([provider, entry]) => ({
               provider,
-              models: set === null ? [] : [...set],
+              models: entry.models === null ? [] : [...entry.models],
+              reasoningEffort: entry.effort,
             }))
             return cleaned.length > 0 ? { value: cleaned } : { clear: true }
           }
@@ -2015,19 +2032,28 @@ window.__ModuleLoader__.load({
           for (const raw of String(text ?? '').split('\n')) {
             const line = raw.trim()
             if (line === '') continue
-            const slash = line.indexOf('/')
-            const provider = (slash === -1 ? line : line.slice(0, slash)).trim()
+            // Optional trailing ` @ effort` sets the group's reasoning
+            // default (issue #103); it applies to the whole line.
+            let body = line
+            let effort = ''
+            const at = line.lastIndexOf(' @ ')
+            if (at !== -1) {
+              body = line.slice(0, at).trim()
+              effort = line.slice(at + 3).trim()
+            }
+            const slash = body.indexOf('/')
+            const provider = (slash === -1 ? body : body.slice(0, slash)).trim()
             if (provider === '') return undefined
             const models =
               slash === -1
                 ? []
-                : line
+                : body
                     .slice(slash + 1)
                     .split(',')
                     .map((model) => model.trim())
                     .filter((model) => model !== '')
             if (slash !== -1 && models.length === 0) return undefined
-            list.push({ provider, models })
+            list.push({ provider, models, reasoningEffort: effort })
           }
           return list.length > 0 ? { value: list } : { clear: true }
         }
@@ -2505,7 +2531,7 @@ window.__ModuleLoader__.load({
       }
       const wrappersEditor = () => {
         const value = format('wrappedProviders')
-        const rows = Array.isArray(value) && value.length > 0 ? value : [{ provider: '', model: '' }]
+        const rows = Array.isArray(value) && value.length > 0 ? value : [{ provider: '', model: '', reasoningEffort: '' }]
         const updateWrap = (index, next) => {
           const list = rows.map((row) => ({ ...row }))
           list[index] = next
@@ -2513,7 +2539,7 @@ window.__ModuleLoader__.load({
         }
         const removeWrap = (index) => {
           const list = rows.filter((_row, i) => i !== index)
-          setDraft('wrappedProviders', list.length > 0 ? list : [{ provider: '', model: '' }])
+          setDraft('wrappedProviders', list.length > 0 ? list : [{ provider: '', model: '', reasoningEffort: '' }])
         }
         return h('div', { className: 'vr-field' },
           h('div', { className: 'vr-field-head' },
@@ -2524,7 +2550,7 @@ window.__ModuleLoader__.load({
             h('div', { className: 'vr-chain-row', key: index },
               h('select', {
                 className: 'vr-input vr-select', value: row.provider ?? '', disabled: editBlocked,
-                onChange: (event) => updateWrap(index, { provider: event.target.value, model: '' }),
+                onChange: (event) => updateWrap(index, { provider: event.target.value, model: '', reasoningEffort: row.reasoningEffort ?? '' }),
               },
                 h('option', { value: '' }, t('selectProvider')),
                 wrapGroupOptions,
@@ -2532,10 +2558,18 @@ window.__ModuleLoader__.load({
               h('select', {
                 className: 'vr-input vr-select', value: row.model ?? '',
                 disabled: editBlocked || !row.provider,
-                onChange: (event) => updateWrap(index, { provider: row.provider, model: event.target.value }),
+                onChange: (event) => updateWrap(index, { provider: row.provider, model: event.target.value, reasoningEffort: row.reasoningEffort ?? '' }),
               },
                 h('option', { value: '' }, row.provider ? t('wrapAllModels') : t('pickProviderFirst')),
                 modelOptionsOf(modelsOf(row.provider)),
+              ),
+              h('select', {
+                className: 'vr-input vr-select', value: row.reasoningEffort ?? '',
+                disabled: editBlocked || !row.provider, title: t('wrapEffortTitle'),
+                onChange: (event) => updateWrap(index, { provider: row.provider, model: row.model, reasoningEffort: event.target.value }),
+              },
+                h('option', { value: '' }, t('wrapEffortDefault')),
+                ['off', 'low', 'medium', 'high', 'max'].map((effort) => h('option', { value: effort, key: effort }, effort)),
               ),
               h('button', {
                 type: 'button', className: 'vr-reset', disabled: editBlocked, title: t('removeTitle'),
@@ -2545,7 +2579,7 @@ window.__ModuleLoader__.load({
           ),
           h('button', {
             type: 'button', className: 'vr-btn', disabled: editBlocked,
-            onClick: () => setDraft('wrappedProviders', [...rows, { provider: '', model: '' }]),
+            onClick: () => setDraft('wrappedProviders', [...rows, { provider: '', model: '', reasoningEffort: '' }]),
           }, t('addWrapper')),
           h('p', { className: 'vr-hint' }, t('wrapHint')),
         )

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -534,9 +534,10 @@ test('the twin preserves the picker-chosen reasoningEffort across steps (issue #
   // plugin never configures or invents one. The wrapper body only remembers
   // the last explicitly seen effort per delegate and re-injects it on the
   // later steps that arrive without one, so the user's choice survives the
+  // twin switch (memory is scoped per provider+model).
   // twin switch. The vision chain keeps reasoningEffort: undefined.
   assert.equal(serverSource.includes('const lastReasoningEffort = new Map()'), true)
-  assert.equal(serverSource.includes('lastReasoningEffort.set(delegateProvider, effort)'), true)
+  assert.equal(serverSource.includes('lastReasoningEffort.set(effortKey, effort)'), true)
   assert.equal(serverSource.includes('{ ...options, reasoningEffort: effort }'), true)
   assert.equal(serverSource.includes('reasoningEffort: undefined'), true)
   assert.equal(serverSource.includes('reasoningEffort: z.string()'), false)

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -535,17 +535,22 @@ test('wrappedProviders reasoningEffort: server schema, client syntax and editor 
   // wrapper body's re-injection fallback.
   assert.equal(serverSource.includes("reasoningEffort: z.string().default('')"), true)
   assert.equal(serverSource.includes('const configuredReasoningEffort = () => {'), true)
-  assert.equal(serverSource.includes('defaultReasoningEffort: () => configuredReasoningEffort()'), true)
+  assert.equal(serverSource.includes('defaultReasoningEffort: async (options) => {'), true)
   assert.equal(serverSource.includes('lastReasoningEffort.set(delegateProvider, effort)'), true)
+  // Unsupported levels are never forced: metadata and re-injection both check
+  // the source route's advertised efforts first.
+  assert.equal(serverSource.includes('if (!efforts.includes(configured)) {'), true)
+  assert.equal(serverSource.includes('return efforts.includes(configured) ? configured : \'\''), true)
   // Client: the editor row carries the effort and folds it back per provider;
   // the free-text shape accepts a trailing ` @ effort`.
-  assert.equal(clientSource.includes("wrapEffortDefault: '推理等级（默认继承）'"), true)
-  assert.equal(clientSource.includes("wrapEffortTitle: '该包装组缺少 reasoning.defaultEffort 时使用的推理等级'"), true)
-  assert.equal(clientSource.includes("wrapEffortDefault: 'Reasoning effort (inherit default)'"), true)
+  assert.equal(clientSource.includes("wrapEffortDefault: '默认等级'"), true)
+  assert.equal(clientSource.includes("wrapEffortTitle: '该包装组缺少 reasoning.defaultEffort 时使用的推理等级（源路由不支持的等级自动忽略）'"), true)
+  assert.equal(clientSource.includes("wrapEffortDefault: 'Default effort'"), true)
   assert.equal(clientSource.includes("const at = line.lastIndexOf(' @ ')"), true)
   assert.equal(clientSource.includes("reasoningEffort: entry.effort"), true)
   assert.equal(clientSource.includes("['off', 'low', 'medium', 'high', 'max'].map((effort) => h('option'"), true)
+  assert.equal(clientSource.includes('.vr-select-effort{flex:0 0 auto;width:104px}'), true)
   // Copy documents the fix for both dictionaries.
-  assert.equal(clientSource.includes('行尾可加 ` @ max` 指定该组的推理等级默认值'), true)
+  assert.equal(clientSource.includes('不支持的等级自动忽略'), true)
   assert.equal(clientSource.includes('append ` @ max` to set the group’s reasoning default'), true)
 })

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -527,3 +527,25 @@ test('auto-discovered inferred vision models retain bridge capability state', ()
   assert.equal(source.includes('resolvedPiAiProfileOf'), true)
   assert.equal(source.includes("transport.api !== 'openai-completions'"), true)
 })
+
+test('wrappedProviders reasoningEffort: server schema, client syntax and editor (issue #103)', () => {
+  const clientSource = readFileSync(new URL('../lib/client.js', import.meta.url), 'utf8')
+  const serverSource = readFileSync(new URL('../index.js', import.meta.url), 'utf8')
+  // Server: the per-entry schema field feeds the twin's defaultEffort and the
+  // wrapper body's re-injection fallback.
+  assert.equal(serverSource.includes("reasoningEffort: z.string().default('')"), true)
+  assert.equal(serverSource.includes('const configuredReasoningEffort = () => {'), true)
+  assert.equal(serverSource.includes('defaultReasoningEffort: () => configuredReasoningEffort()'), true)
+  assert.equal(serverSource.includes('lastReasoningEffort.set(delegateProvider, effort)'), true)
+  // Client: the editor row carries the effort and folds it back per provider;
+  // the free-text shape accepts a trailing ` @ effort`.
+  assert.equal(clientSource.includes("wrapEffortDefault: '推理等级（默认继承）'"), true)
+  assert.equal(clientSource.includes("wrapEffortTitle: '该包装组缺少 reasoning.defaultEffort 时使用的推理等级'"), true)
+  assert.equal(clientSource.includes("wrapEffortDefault: 'Reasoning effort (inherit default)'"), true)
+  assert.equal(clientSource.includes("const at = line.lastIndexOf(' @ ')"), true)
+  assert.equal(clientSource.includes("reasoningEffort: entry.effort"), true)
+  assert.equal(clientSource.includes("['off', 'low', 'medium', 'high', 'max'].map((effort) => h('option'"), true)
+  // Copy documents the fix for both dictionaries.
+  assert.equal(clientSource.includes('行尾可加 ` @ max` 指定该组的推理等级默认值'), true)
+  assert.equal(clientSource.includes('append ` @ max` to set the group’s reasoning default'), true)
+})

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -528,29 +528,17 @@ test('auto-discovered inferred vision models retain bridge capability state', ()
   assert.equal(source.includes("transport.api !== 'openai-completions'"), true)
 })
 
-test('wrappedProviders reasoningEffort: server schema, client syntax and editor (issue #103)', () => {
-  const clientSource = readFileSync(new URL('../lib/client.js', import.meta.url), 'utf8')
+test('the twin preserves the picker-chosen reasoningEffort across steps (issue #103)', () => {
   const serverSource = readFileSync(new URL('../index.js', import.meta.url), 'utf8')
-  // Server: the per-entry schema field feeds the twin's defaultEffort and the
-  // wrapper body's re-injection fallback.
-  assert.equal(serverSource.includes("reasoningEffort: z.string().default('')"), true)
-  assert.equal(serverSource.includes('const configuredReasoningEffort = () => {'), true)
-  assert.equal(serverSource.includes('defaultReasoningEffort: async (options) => {'), true)
+  // The reasoning level belongs to the chat page's bottom-right picker: the
+  // plugin never configures or invents one. The wrapper body only remembers
+  // the last explicitly seen effort per delegate and re-injects it on the
+  // later steps that arrive without one, so the user's choice survives the
+  // twin switch. The vision chain keeps reasoningEffort: undefined.
+  assert.equal(serverSource.includes('const lastReasoningEffort = new Map()'), true)
   assert.equal(serverSource.includes('lastReasoningEffort.set(delegateProvider, effort)'), true)
-  // Unsupported levels are never forced: metadata and re-injection both check
-  // the source route's advertised efforts first.
-  assert.equal(serverSource.includes('if (!efforts.includes(configured)) {'), true)
-  assert.equal(serverSource.includes('return efforts.includes(configured) ? configured : \'\''), true)
-  // Client: the editor row carries the effort and folds it back per provider;
-  // the free-text shape accepts a trailing ` @ effort`.
-  assert.equal(clientSource.includes("wrapEffortDefault: '默认等级'"), true)
-  assert.equal(clientSource.includes("wrapEffortTitle: '该包装组缺少 reasoning.defaultEffort 时使用的推理等级（源路由不支持的等级自动忽略）'"), true)
-  assert.equal(clientSource.includes("wrapEffortDefault: 'Default effort'"), true)
-  assert.equal(clientSource.includes("const at = line.lastIndexOf(' @ ')"), true)
-  assert.equal(clientSource.includes("reasoningEffort: entry.effort"), true)
-  assert.equal(clientSource.includes("['off', 'low', 'medium', 'high', 'max'].map((effort) => h('option'"), true)
-  assert.equal(clientSource.includes('.vr-select-effort{flex:0 0 auto;width:104px}'), true)
-  // Copy documents the fix for both dictionaries.
-  assert.equal(clientSource.includes('不支持的等级自动忽略'), true)
-  assert.equal(clientSource.includes('append ` @ max` to set the group’s reasoning default'), true)
+  assert.equal(serverSource.includes('{ ...options, reasoningEffort: effort }'), true)
+  assert.equal(serverSource.includes('reasoningEffort: undefined'), true)
+  assert.equal(serverSource.includes('reasoningEffort: z.string()'), false)
+  assert.equal(serverSource.includes('wrappedProviders[].reasoningEffort'), false)
 })

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -1216,7 +1216,9 @@ test('stealth defaults to false (issue #34: explicit opt-in, no stealth takeover
 test('wrappedProviders pre-fills the stock deepseek-official row out of the box', () => {
   // like the vision chain pre-fills vision-http, the wrappers section ships
   // one visible default row so users see the built-in wrapper at first glance
-  assert.deepEqual(Config({}).wrappedProviders, [{ provider: 'deepseek-official', models: [] }])
+  assert.deepEqual(Config({}).wrappedProviders, [
+    { provider: 'deepseek-official', models: [], reasoningEffort: '' },
+  ])
 })
 
 
@@ -1502,6 +1504,173 @@ test('apply registers an image-capable twin route for wrappedProviders', async (
   assert.equal(delegateCall.provider, 'opencode-go')
   assert.equal(delegateCall.messages[0].content.filter((b) => b.type === 'image').length, 0)
   assert.ok(delegateCall.messages[0].content[0].text.includes('img-1'))
+})
+
+test('wrappedProviders reasoningEffort gives the twin a reasoning defaultEffort (issue #103)', async () => {
+  const { ctx, adapters } = mockHarnessCtx({
+    config0: {
+      wrappedProviders: [{ provider: 'opencode-go', models: ['deepseek-v4-flash'], reasoningEffort: 'max' }],
+    },
+  })
+  // pi-ai routes advertise efforts without a default when the provider
+  // profile does not set `reasoning` — the exact #103 trigger.
+  const piAiLike = {
+    providerInfo: (p) => ({ id: p, name: 'Opencode' }),
+    providerRetryPolicy: () => 'retry',
+    listModels: async (p) => [
+      {
+        provider: p, id: 'deepseek-v4-flash', name: 'DeepSeek-V4-Flash', inputModalities: ['text'],
+        reasoning: { efforts: ['off', 'high', 'max'] },
+      },
+    ],
+    resolveModel: async (p, m) => ({
+      provider: p, id: m, name: m, inputModalities: ['text'], context: { contextWindow: 100000 },
+      reasoning: { efforts: ['off', 'high', 'max'] },
+    }),
+    stream: async function* () {
+      yield { type: 'finish', reason: { kind: 'stop' } }
+    },
+  }
+  ctx.llm.registerAdapter(['opencode-go'], piAiLike)
+  apply(ctx, Config({}))
+  const twin = adapters.get('opencode-go-vision')
+  const listed = await twin.listModels('opencode-go-vision')
+  assert.deepEqual(listed[0].reasoning, { efforts: ['off', 'high', 'max'], defaultEffort: 'max' })
+  const resolved = await twin.resolveModel('opencode-go-vision', 'deepseek-v4-flash')
+  assert.equal(resolved.reasoning.defaultEffort, 'max')
+  assert.deepEqual(resolved.reasoning.efforts, ['off', 'high', 'max'])
+})
+
+test('twin inherits the source defaultEffort when no reasoningEffort override is set', async () => {
+  const { ctx, adapters } = mockHarnessCtx({
+    config0: { wrappedProviders: [{ provider: 'opencode-go', models: [] }] },
+  })
+  const source = {
+    providerInfo: (p) => ({ id: p, name: 'Opencode' }),
+    providerRetryPolicy: () => 'retry',
+    listModels: async (p) => [
+      {
+        provider: p, id: 'deepseek-v4-flash', name: 'DeepSeek-V4-Flash', inputModalities: ['text'],
+        reasoning: { efforts: ['low', 'high', 'max'], defaultEffort: 'high' },
+      },
+    ],
+    resolveModel: async (p, m) => ({
+      provider: p, id: m, name: m, inputModalities: ['text'], context: { contextWindow: 100000 },
+      reasoning: { efforts: ['low', 'high', 'max'], defaultEffort: 'high' },
+    }),
+    stream: async function* () {
+      yield { type: 'finish', reason: { kind: 'stop' } }
+    },
+  }
+  ctx.llm.registerAdapter(['opencode-go'], source)
+  apply(ctx, Config({}))
+  const twin = adapters.get('opencode-go-vision')
+  const listed = await twin.listModels('opencode-go-vision')
+  assert.equal(listed[0].reasoning.defaultEffort, 'high')
+  assert.deepEqual(listed[0].reasoning.efforts, ['low', 'high', 'max'])
+  const resolved = await twin.resolveModel('opencode-go-vision', 'deepseek-v4-flash')
+  assert.equal(resolved.reasoning.defaultEffort, 'high')
+})
+
+test('twin wrapper re-injects the last explicit reasoningEffort on later steps (issue #103)', async () => {
+  const { ctx, adapters } = mockHarnessCtx({
+    config0: { wrappedProviders: [{ provider: 'opencode-go', models: [] }] },
+  })
+  const source = {
+    providerInfo: (p) => ({ id: p, name: 'Opencode' }),
+    providerRetryPolicy: () => 'retry',
+    listModels: async (p) => [
+      { provider: p, id: 'm', name: 'M', inputModalities: ['text'] },
+    ],
+    resolveModel: async (p, m) => ({
+      provider: p, id: m, name: m, inputModalities: ['text'], context: { contextWindow: 100000 },
+    }),
+    stream: async function* () {
+      yield { type: 'finish', reason: { kind: 'stop' } }
+    },
+  }
+  ctx.llm.registerAdapter(['opencode-go'], source)
+  apply(ctx, Config({}))
+  const twin = adapters.get('opencode-go-vision')
+  const calls = []
+  ctx.llm.stream = async function* (options) {
+    calls.push({ ...options })
+    yield { type: 'finish', reason: { kind: 'stop' } }
+  }
+  const drain = async (options) => {
+    for await (const _c of twin.stream(options)) {
+      /* drain */
+    }
+  }
+  // step 1 carries the effort explicitly; the later steps arrive without it
+  // (the agent drops it once the twin metadata lacks a default) and must
+  // inherit the remembered value so every step keeps thinking.
+  await drain({ provider: 'opencode-go-vision', model: 'm', messages: [], reasoningEffort: 'max' })
+  await drain({ provider: 'opencode-go-vision', model: 'm', messages: [] })
+  await drain({ provider: 'opencode-go-vision', model: 'm', messages: [], reasoningEffort: 'off' })
+  await drain({ provider: 'opencode-go-vision', model: 'm', messages: [] })
+  assert.equal(calls[0].reasoningEffort, 'max')
+  assert.equal(calls[1].reasoningEffort, 'max')
+  assert.equal(calls[2].reasoningEffort, 'off')
+  assert.equal(calls[3].reasoningEffort, 'off')
+})
+
+test('twin wrapper uses the configured default when no effort was ever seen', async () => {
+  const { ctx, adapters } = mockHarnessCtx({
+    config0: { wrappedProviders: [{ provider: 'opencode-go', models: [], reasoningEffort: 'high' }] },
+  })
+  const source = {
+    providerInfo: (p) => ({ id: p, name: 'Opencode' }),
+    providerRetryPolicy: () => 'retry',
+    listModels: async (p) => [{ provider: p, id: 'm', name: 'M', inputModalities: ['text'] }],
+    resolveModel: async (p, m) => ({
+      provider: p, id: m, name: m, inputModalities: ['text'], context: { contextWindow: 100000 },
+    }),
+    stream: async function* () {
+      yield { type: 'finish', reason: { kind: 'stop' } }
+    },
+  }
+  ctx.llm.registerAdapter(['opencode-go'], source)
+  apply(ctx, Config({}))
+  const twin = adapters.get('opencode-go-vision')
+  const calls = []
+  ctx.llm.stream = async function* (options) {
+    calls.push({ ...options })
+    yield { type: 'finish', reason: { kind: 'stop' } }
+  }
+  for await (const _c of twin.stream({ provider: 'opencode-go-vision', model: 'm', messages: [] })) {
+    /* drain */
+  }
+  assert.equal(calls[0].reasoningEffort, 'high')
+})
+
+test('twin wrapper leaves the effort untouched when nothing was seen or configured', async () => {
+  const { ctx, adapters } = mockHarnessCtx({
+    config0: { wrappedProviders: [{ provider: 'opencode-go', models: [] }] },
+  })
+  const source = {
+    providerInfo: (p) => ({ id: p, name: 'Opencode' }),
+    providerRetryPolicy: () => 'retry',
+    listModels: async (p) => [{ provider: p, id: 'm', name: 'M', inputModalities: ['text'] }],
+    resolveModel: async (p, m) => ({
+      provider: p, id: m, name: m, inputModalities: ['text'], context: { contextWindow: 100000 },
+    }),
+    stream: async function* () {
+      yield { type: 'finish', reason: { kind: 'stop' } }
+    },
+  }
+  ctx.llm.registerAdapter(['opencode-go'], source)
+  apply(ctx, Config({}))
+  const twin = adapters.get('opencode-go-vision')
+  const calls = []
+  ctx.llm.stream = async function* (options) {
+    calls.push({ ...options })
+    yield { type: 'finish', reason: { kind: 'stop' } }
+  }
+  for await (const _c of twin.stream({ provider: 'opencode-go-vision', model: 'm', messages: [] })) {
+    /* drain */
+  }
+  assert.equal(calls[0].reasoningEffort, undefined)
 })
 
 test('twin route registers before its source adapter appears (live provider registration)', async () => {

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -1602,6 +1602,10 @@ test('twin wrapper re-injects the last explicit reasoningEffort on later steps (
   assert.equal(calls[1].reasoningEffort, 'max')
   assert.equal(calls[2].reasoningEffort, 'off')
   assert.equal(calls[3].reasoningEffort, 'off')
+  // the memory is scoped per provider+model: a second model on the same
+  // twin must not inherit the first model's remembered effort
+  await drain({ provider: 'opencode-go-vision', model: 'other', messages: [] })
+  assert.equal(calls[4].reasoningEffort, undefined)
 })
 
 test('twin wrapper leaves the effort untouched when nothing was seen or configured', async () => {

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -1061,6 +1061,10 @@ function mockHarnessCtx({ stockRoute = false, config0 = {}, skills = false } = {
   const adapters = new Map() // provider -> adapter
   const registrations = new Map() // provider -> { adapter, retryPolicy }
   const captured = { skills: [], on: new Map() }
+  // The mutable user document and the watch seam: tests flip config0 fields
+  // and fire the watchers to simulate a settings-card save.
+  const userDoc = config0
+  const settingsWatchers = []
   if (stockRoute) {
     const stock = {
       providerInfo: (p) => ({ id: p, name: 'DeepSeek' }),
@@ -1103,13 +1107,21 @@ function mockHarnessCtx({ stockRoute = false, config0 = {}, skills = false } = {
     },
     inject(_deps, callback) {
       // settings seam: run synchronously against a mock settings service that
-      // resolves the composition entry through the Config schema defaults.
+      // mirrors the real one — schema defaults over the composition entry
+      // (apply's `config`, passed as `base`) over the user document (userDoc).
       const scope = {
-        get: () => ({ ...Config({}), ...config0 }),
-        watch: () => {},
+        get: () => ({ ...Config({}), ...userDoc }),
+        watch: (fn) => {
+          settingsWatchers.push(fn)
+        },
       }
       const sctx = {
-        settings: { register: () => scope },
+        settings: {
+          register: (_name, _schema, options) => {
+            const base = options && options.base ? options.base : {}
+            return { ...scope, get: () => ({ ...Config({}), ...base, ...userDoc }) }
+          },
+        },
         effect: () => () => {},
       }
       callback(sctx)
@@ -1128,8 +1140,15 @@ function mockHarnessCtx({ stockRoute = false, config0 = {}, skills = false } = {
           adapters.set(provider, adapter)
           registrations.set(provider, { adapter, retryPolicy: adapter.providerRetryPolicy(provider) })
         }
-        // mirror the real handle: callable disposer with a replace() sidecar
-        const handle = () => {}
+        // mirror the real handle: calling it disposes the registration
+        const handle = () => {
+          for (const provider of providers) {
+            if (adapters.get(provider) === adapter) adapters.delete(provider)
+            if (registrations.get(provider) && registrations.get(provider).adapter === adapter) {
+              registrations.delete(provider)
+            }
+          }
+        }
         handle.replace = () => {}
         return handle
       },
@@ -1167,7 +1186,7 @@ function mockHarnessCtx({ stockRoute = false, config0 = {}, skills = false } = {
       },
     },
   }
-  return { ctx, adapters, captured }
+  return { ctx, adapters, captured, userDoc, settingsWatchers }
 }
 
 test('apply registers the stealth deepseek-official route with the stock catalog', async () => {
@@ -1880,6 +1899,16 @@ test('apply falls back to the visible wrapper when the stock route is still acti
 
 test('wrapper lists the vision-chain pairs only when whole-turn routing is on', async () => {
   const { ctx, adapters } = mockHarnessCtx({ stockRoute: true, config0: { routing: true } })
+  ctx.llm.registerAdapter(['openrouter'], {
+    providerInfo: (p) => ({ id: p, name: 'OpenRouter' }),
+    providerRetryPolicy: () => 'retry',
+    listModels: async (p) => [
+      { provider: p, id: 'qwen/qwen3-vl-235b-a22b-instruct', name: 'Qwen3-VL', inputModalities: ['text', 'image'] },
+    ],
+    resolveModel: async (p, m) => ({
+      provider: p, id: m, name: m, inputModalities: ['text', 'image'], context: { contextWindow: 100000 },
+    }),
+  })
   apply(ctx, Config({
     provider: 'openrouter',
     providers: [{ provider: 'openrouter', model: 'qwen/qwen3-vl-235b-a22b-instruct' }],
@@ -1890,16 +1919,16 @@ test('wrapper lists the vision-chain pairs only when whole-turn routing is on', 
   assert.deepEqual(wrapped.map((m) => m.id), [
     'deepseek-v4-flash',
     'deepseek-v4-pro',
-    'vision-http/ovh/Qwen3.5-397B-A17B',
+    'openrouter/qwen/qwen3-vl-235b-a22b-instruct',
   ])
-  const visionEntry = wrapped.find((m) => m.id === 'vision-http/ovh/Qwen3.5-397B-A17B')
+  const visionEntry = wrapped.find((m) => m.id === 'openrouter/qwen/qwen3-vl-235b-a22b-instruct')
   assert.ok(visionEntry)
   assert.deepEqual(visionEntry.inputModalities, ['text', 'image'])
   assert.ok(String(visionEntry.name).includes('视觉'))
   // resolving a vision-pair entry still returns image-capable metadata
-  const resolved = await wrapper.resolveModel('deepseek-vision', 'vision-http/ovh/Qwen3.5-397B-A17B')
+  const resolved = await wrapper.resolveModel('deepseek-vision', 'openrouter/qwen/qwen3-vl-235b-a22b-instruct')
   assert.deepEqual(resolved.inputModalities, ['text', 'image'])
-  assert.equal(resolved.id, 'vision-http/ovh/Qwen3.5-397B-A17B')
+  assert.equal(resolved.id, 'openrouter/qwen/qwen3-vl-235b-a22b-instruct')
 })
 test('floodFillBackground clears border-connected background pixels', () => {
   // 4x4: white background, black 2x2 square in the middle
@@ -2786,4 +2815,39 @@ test('strict upstream: vision chain fails over when a forced extraVisionModels b
   assert.deepEqual(calls, ['forced', 'good'])
   assert.equal(chunks[chunks.length - 1].type, 'finish')
   assert.equal(chunks[chunks.length - 1].reason.kind, 'stop')
+})
+
+test('legacy routing mounts follow the settings document without a restart', async () => {
+  const { ctx, adapters, captured, userDoc, settingsWatchers } = mockHarnessCtx({
+    config0: { routing: false },
+  })
+  apply(ctx, Config({}))
+  // The agent/request hook is registered unconditionally and gates at
+  // runtime, so the settings switch reaches it immediately.
+  assert.equal(typeof captured.on.get('agent/request'), 'function')
+  assert.equal(adapters.has('vision-chain'), false, 'chain route off while routing is disabled')
+  // the user flips the routing switch in the settings card
+  userDoc.routing = true
+  for (const watch of settingsWatchers) watch()
+  assert.ok(adapters.has('vision-chain'), 'chain route mounts when routing turns on')
+  // and off again
+  userDoc.routing = false
+  for (const watch of settingsWatchers) watch()
+  assert.equal(adapters.has('vision-chain'), false, 'chain route unmounts when routing turns off')
+})
+
+test('wrapper route mount follows the settings wrapperRoute name', async () => {
+  const { ctx, adapters, userDoc, settingsWatchers } = mockHarnessCtx({
+    stockRoute: true,
+    config0: { wrapperRoute: '' },
+  })
+  apply(ctx, Config({}))
+  assert.equal(adapters.has('deepseek-vision'), false, 'no wrapper while the name is empty')
+  userDoc.wrapperRoute = 'deepseek-vision'
+  for (const watch of settingsWatchers) watch()
+  assert.ok(adapters.has('deepseek-vision'), 'wrapper mounts under the configured name')
+  userDoc.wrapperRoute = 'my-wrapper'
+  for (const watch of settingsWatchers) watch()
+  assert.equal(adapters.has('deepseek-vision'), false, 'old name is disposed')
+  assert.ok(adapters.has('my-wrapper'), 'wrapper re-mounts under the new name')
 })

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -1155,6 +1155,13 @@ function mockHarnessCtx({ stockRoute = false, config0 = {}, skills = false } = {
         if (hit === undefined || typeof hit.adapter.listModels !== 'function') return []
         return hit.adapter.listModels(provider)
       },
+      async resolveModelInfo(provider, model) {
+        const hit = registrations.get(provider)
+        if (hit === undefined || typeof hit.adapter.resolveModel !== 'function') {
+          throw new Error(`no adapter registered for provider "${provider}"`)
+        }
+        return hit.adapter.resolveModel(provider, model)
+      },
       stream: async function* () {
         yield { type: 'finish', reason: { kind: 'stop' } }
       },
@@ -2607,4 +2614,176 @@ test('channel bridge transport uses resolved pi-ai catalog model facts', () => {
       apiKeyEnv: undefined,
     },
   )
+})
+
+// ── strict-upstream audit (#103 follow-up) ─────────────────────────────────
+// The plugin fabricates capability hints (twin reasoning defaults, image
+// declarations on wrapper routes, extraVisionModels overrides). These tests
+// run a STRICT upstream that throws on anything it cannot actually handle,
+// proving nothing fabricated is ever forwarded unsafely.
+
+test('strict upstream: twin forwards only supported reasoning efforts', async () => {
+  const supported = new Set(['off', 'high', 'max'])
+  const { ctx, adapters } = mockHarnessCtx({
+    config0: { wrappedProviders: [{ provider: 'opencode-go', models: [], reasoningEffort: 'max' }] },
+  })
+  const strict = {
+    providerInfo: (p) => ({ id: p, name: 'Opencode' }),
+    providerRetryPolicy: () => 'retry',
+    listModels: async (p) => [
+      { provider: p, id: 'm', name: 'M', inputModalities: ['text'], reasoning: { efforts: [...supported] } },
+    ],
+    resolveModel: async (p, m) => ({
+      provider: p, id: m, name: m, inputModalities: ['text'], context: { contextWindow: 100000 },
+      reasoning: { efforts: [...supported] },
+    }),
+  }
+  ctx.llm.registerAdapter(['opencode-go'], strict)
+  apply(ctx, Config({}))
+  const twin = adapters.get('opencode-go-vision')
+  const seen = []
+  ctx.llm.stream = async function* (options) {
+    if (options.reasoningEffort !== undefined && !supported.has(options.reasoningEffort)) {
+      throw new Error(`strict upstream rejects reasoningEffort "${options.reasoningEffort}"`)
+    }
+    seen.push(options.reasoningEffort)
+    yield { type: 'finish', reason: { kind: 'stop' } }
+  }
+  const drain = async (options) => {
+    for await (const _c of twin.stream(options)) {
+      /* drain */
+    }
+  }
+  // configured default, explicit selection, and the remembered re-injection
+  // must all resolve to the supported 'max'
+  await drain({ provider: 'opencode-go-vision', model: 'm', messages: [] })
+  await drain({ provider: 'opencode-go-vision', model: 'm', messages: [], reasoningEffort: 'max' })
+  await drain({ provider: 'opencode-go-vision', model: 'm', messages: [] })
+  assert.deepEqual(seen, ['max', 'max', 'max'])
+})
+
+test('strict upstream: an unsupported configured effort is never forwarded', async () => {
+  const supported = new Set(['off', 'high', 'max'])
+  const { ctx, adapters } = mockHarnessCtx({
+    config0: { wrappedProviders: [{ provider: 'opencode-go', models: [], reasoningEffort: 'medium' }] },
+  })
+  const strict = {
+    providerInfo: (p) => ({ id: p, name: 'Opencode' }),
+    providerRetryPolicy: () => 'retry',
+    listModels: async (p) => [
+      { provider: p, id: 'm', name: 'M', inputModalities: ['text'], reasoning: { efforts: [...supported] } },
+    ],
+    resolveModel: async (p, m) => ({
+      provider: p, id: m, name: m, inputModalities: ['text'], context: { contextWindow: 100000 },
+      reasoning: { efforts: [...supported] },
+    }),
+  }
+  ctx.llm.registerAdapter(['opencode-go'], strict)
+  apply(ctx, Config({}))
+  const twin = adapters.get('opencode-go-vision')
+  const seen = []
+  ctx.llm.stream = async function* (options) {
+    if (options.reasoningEffort !== undefined && !supported.has(options.reasoningEffort)) {
+      throw new Error(`strict upstream rejects reasoningEffort "${options.reasoningEffort}"`)
+    }
+    seen.push(options.reasoningEffort)
+    yield { type: 'finish', reason: { kind: 'stop' } }
+  }
+  for await (const _c of twin.stream({ provider: 'opencode-go-vision', model: 'm', messages: [] })) {
+    /* drain */
+  }
+  assert.deepEqual(seen, [undefined])
+})
+
+test('strict upstream: twin never leaks image blocks to a text-only source', async () => {
+  const { ctx, adapters } = mockHarnessCtx({
+    config0: { wrappedProviders: [{ provider: 'opencode-go', models: [] }] },
+  })
+  const strict = {
+    providerInfo: (p) => ({ id: p, name: 'Opencode' }),
+    providerRetryPolicy: () => 'retry',
+    listModels: async (p) => [
+      { provider: p, id: 'm', name: 'M', inputModalities: ['text'] },
+    ],
+    resolveModel: async (p, m) => ({
+      provider: p, id: m, name: m, inputModalities: ['text'], context: { contextWindow: 100000 },
+    }),
+  }
+  ctx.llm.registerAdapter(['opencode-go'], strict)
+  apply(ctx, Config({}))
+  const twin = adapters.get('opencode-go-vision')
+  const seen = []
+  ctx.llm.stream = async function* (options) {
+    const flattened = JSON.stringify(options.messages)
+    if (flattened.includes('"type":"image"')) {
+      throw new Error('strict upstream rejects image blocks')
+    }
+    seen.push(options)
+    yield { type: 'finish', reason: { kind: 'stop' } }
+  }
+  const messages = [
+    { role: 'user', content: [{ type: 'image', attachment: { attachmentId: 'img-1', name: 'a.png' } }, { type: 'text', text: '看这张图' }] },
+  ]
+  for await (const _c of twin.stream({ provider: 'opencode-go-vision', model: 'm', messages })) {
+    /* drain */
+  }
+  assert.equal(seen.length, 1)
+  assert.equal(seen[0].messages[0].content.filter((b) => b.type === 'image').length, 0)
+})
+
+test('strict upstream: vision chain fails over when a forced extraVisionModels backend rejects the image', async () => {
+  // The chain route is an eager composition-level opt-in (registered while
+  // apply() still reads the composition config), while its pair list is read
+  // lazily from the settings scope — supply both layers.
+  const chainConfig = {
+    routing: true,
+    chainRoute: 'vision-chain',
+    providers: [
+      { provider: 'forced', model: 'fake-vl' },
+      { provider: 'good', model: 'qwen-vl' },
+    ],
+    // The expert escape hatch forces a text-only model into the chain —
+    // the strict upstream rejects it, and the chain must fall through to
+    // the genuinely image-capable backend.
+    extraVisionModels: ['forced/fake-vl'],
+  }
+  const { ctx, adapters } = mockHarnessCtx({ config0: chainConfig })
+  const forced = {
+    providerInfo: (p) => ({ id: p, name: 'Forced' }),
+    providerRetryPolicy: () => 'retry',
+    listModels: async (p) => [{ provider: p, id: 'fake-vl', name: 'Fake-VL', inputModalities: ['text'] }],
+    resolveModel: async (p, m) => ({
+      provider: p, id: m, name: m, inputModalities: ['text'], context: { contextWindow: 100000 },
+    }),
+  }
+  const good = {
+    providerInfo: (p) => ({ id: p, name: 'Good' }),
+    providerRetryPolicy: () => 'retry',
+    listModels: async (p) => [{ provider: p, id: 'qwen-vl', name: 'Qwen-VL', inputModalities: ['text', 'image'] }],
+    resolveModel: async (p, m) => ({
+      provider: p, id: m, name: m, inputModalities: ['text', 'image'], context: { contextWindow: 100000 },
+    }),
+  }
+  ctx.llm.registerAdapter(['forced'], forced)
+  ctx.llm.registerAdapter(['good'], good)
+  apply(ctx, Config(chainConfig))
+  const chain = adapters.get('vision-chain')
+  assert.ok(chain, 'expected the vision chain route')
+  const calls = []
+  ctx.llm.stream = async function* (options) {
+    calls.push(options.provider)
+    if (options.provider === 'forced') throw new Error('forced backend rejects images')
+    yield { type: 'text', text: 'ok' }
+    yield { type: 'finish', reason: { kind: 'stop' } }
+  }
+  const messages = [
+    { role: 'user', content: [{ type: 'image', attachment: { attachmentId: 'img-1', name: 'a.png' } }, { type: 'text', text: '看' }] },
+  ]
+  const chunks = []
+  for await (const chunk of chain.stream({ provider: 'vision-chain', model: 'forced/fake-vl', messages })) {
+    chunks.push(chunk)
+  }
+  assert.deepEqual(calls, ['forced', 'good'])
+  assert.equal(chunks[chunks.length - 1].type, 'finish')
+  assert.equal(chunks[chunks.length - 1].reason.kind, 'stop')
 })

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -1242,9 +1242,7 @@ test('stealth defaults to false (issue #34: explicit opt-in, no stealth takeover
 test('wrappedProviders pre-fills the stock deepseek-official row out of the box', () => {
   // like the vision chain pre-fills vision-http, the wrappers section ships
   // one visible default row so users see the built-in wrapper at first glance
-  assert.deepEqual(Config({}).wrappedProviders, [
-    { provider: 'deepseek-official', models: [], reasoningEffort: '' },
-  ])
+  assert.deepEqual(Config({}).wrappedProviders, [{ provider: 'deepseek-official', models: [] }])
 })
 
 
@@ -1532,42 +1530,7 @@ test('apply registers an image-capable twin route for wrappedProviders', async (
   assert.ok(delegateCall.messages[0].content[0].text.includes('img-1'))
 })
 
-test('wrappedProviders reasoningEffort gives the twin a reasoning defaultEffort (issue #103)', async () => {
-  const { ctx, adapters } = mockHarnessCtx({
-    config0: {
-      wrappedProviders: [{ provider: 'opencode-go', models: ['deepseek-v4-flash'], reasoningEffort: 'max' }],
-    },
-  })
-  // pi-ai routes advertise efforts without a default when the provider
-  // profile does not set `reasoning` — the exact #103 trigger.
-  const piAiLike = {
-    providerInfo: (p) => ({ id: p, name: 'Opencode' }),
-    providerRetryPolicy: () => 'retry',
-    listModels: async (p) => [
-      {
-        provider: p, id: 'deepseek-v4-flash', name: 'DeepSeek-V4-Flash', inputModalities: ['text'],
-        reasoning: { efforts: ['off', 'high', 'max'] },
-      },
-    ],
-    resolveModel: async (p, m) => ({
-      provider: p, id: m, name: m, inputModalities: ['text'], context: { contextWindow: 100000 },
-      reasoning: { efforts: ['off', 'high', 'max'] },
-    }),
-    stream: async function* () {
-      yield { type: 'finish', reason: { kind: 'stop' } }
-    },
-  }
-  ctx.llm.registerAdapter(['opencode-go'], piAiLike)
-  apply(ctx, Config({}))
-  const twin = adapters.get('opencode-go-vision')
-  const listed = await twin.listModels('opencode-go-vision')
-  assert.deepEqual(listed[0].reasoning, { efforts: ['off', 'high', 'max'], defaultEffort: 'max' })
-  const resolved = await twin.resolveModel('opencode-go-vision', 'deepseek-v4-flash')
-  assert.equal(resolved.reasoning.defaultEffort, 'max')
-  assert.deepEqual(resolved.reasoning.efforts, ['off', 'high', 'max'])
-})
-
-test('twin inherits the source defaultEffort when no reasoningEffort override is set', async () => {
+test('twin mirrors the source reasoning metadata one-to-one (defaultEffort inheritance)', async () => {
   const { ctx, adapters } = mockHarnessCtx({
     config0: { wrappedProviders: [{ provider: 'opencode-go', models: [] }] },
   })
@@ -1639,79 +1602,6 @@ test('twin wrapper re-injects the last explicit reasoningEffort on later steps (
   assert.equal(calls[1].reasoningEffort, 'max')
   assert.equal(calls[2].reasoningEffort, 'off')
   assert.equal(calls[3].reasoningEffort, 'off')
-})
-
-test('twin wrapper uses the configured default when no effort was ever seen', async () => {
-  const { ctx, adapters } = mockHarnessCtx({
-    config0: { wrappedProviders: [{ provider: 'opencode-go', models: [], reasoningEffort: 'high' }] },
-  })
-  const source = {
-    providerInfo: (p) => ({ id: p, name: 'Opencode' }),
-    providerRetryPolicy: () => 'retry',
-    listModels: async (p) => [{ provider: p, id: 'm', name: 'M', inputModalities: ['text'] }],
-    resolveModel: async (p, m) => ({
-      provider: p, id: m, name: m, inputModalities: ['text'], context: { contextWindow: 100000 },
-      reasoning: { efforts: ['off', 'high', 'max'] },
-    }),
-    stream: async function* () {
-      yield { type: 'finish', reason: { kind: 'stop' } }
-    },
-  }
-  ctx.llm.registerAdapter(['opencode-go'], source)
-  apply(ctx, Config({}))
-  const twin = adapters.get('opencode-go-vision')
-  const calls = []
-  ctx.llm.stream = async function* (options) {
-    calls.push({ ...options })
-    yield { type: 'finish', reason: { kind: 'stop' } }
-  }
-  for await (const _c of twin.stream({ provider: 'opencode-go-vision', model: 'm', messages: [] })) {
-    /* drain */
-  }
-  assert.equal(calls[0].reasoningEffort, 'high')
-})
-
-test('unsupported configured effort is ignored: metadata stays untouched and no injection', async () => {
-  const { ctx, adapters } = mockHarnessCtx({
-    config0: { wrappedProviders: [{ provider: 'opencode-go', models: [], reasoningEffort: 'medium' }] },
-  })
-  const source = {
-    providerInfo: (p) => ({ id: p, name: 'Opencode' }),
-    providerRetryPolicy: () => 'retry',
-    listModels: async (p) => [
-      {
-        provider: p, id: 'm', name: 'M', inputModalities: ['text'],
-        reasoning: { efforts: ['off', 'high', 'max'] },
-      },
-    ],
-    resolveModel: async (p, m) => ({
-      provider: p, id: m, name: m, inputModalities: ['text'], context: { contextWindow: 100000 },
-      reasoning: { efforts: ['off', 'high', 'max'] },
-    }),
-    stream: async function* () {
-      yield { type: 'finish', reason: { kind: 'stop' } }
-    },
-  }
-  ctx.llm.registerAdapter(['opencode-go'], source)
-  apply(ctx, Config({}))
-  const twin = adapters.get('opencode-go-vision')
-  // Metadata: 'medium' is not advertised by the route, so the twin must not
-  // force it into the efforts list or set it as default — the host falls
-  // back to the source's own metadata.
-  const listed = await twin.listModels('opencode-go-vision')
-  assert.deepEqual(listed[0].reasoning, { efforts: ['off', 'high', 'max'] })
-  const resolved = await twin.resolveModel('opencode-go-vision', 'm')
-  assert.equal(resolved.reasoning.defaultEffort, undefined)
-  // Wrapper fallback: an unsupported configured effort is never injected.
-  const calls = []
-  ctx.llm.stream = async function* (options) {
-    calls.push({ ...options })
-    yield { type: 'finish', reason: { kind: 'stop' } }
-  }
-  for await (const _c of twin.stream({ provider: 'opencode-go-vision', model: 'm', messages: [] })) {
-    /* drain */
-  }
-  assert.equal(calls[0].reasoningEffort, undefined)
 })
 
 test('twin wrapper leaves the effort untouched when nothing was seen or configured', async () => {
@@ -2651,10 +2541,10 @@ test('channel bridge transport uses resolved pi-ai catalog model facts', () => {
 // run a STRICT upstream that throws on anything it cannot actually handle,
 // proving nothing fabricated is ever forwarded unsafely.
 
-test('strict upstream: twin forwards only supported reasoning efforts', async () => {
+test('strict upstream: twin forwards only what the picker explicitly sent', async () => {
   const supported = new Set(['off', 'high', 'max'])
   const { ctx, adapters } = mockHarnessCtx({
-    config0: { wrappedProviders: [{ provider: 'opencode-go', models: [], reasoningEffort: 'max' }] },
+    config0: { wrappedProviders: [{ provider: 'opencode-go', models: [] }] },
   })
   const strict = {
     providerInfo: (p) => ({ id: p, name: 'Opencode' }),
@@ -2683,45 +2573,11 @@ test('strict upstream: twin forwards only supported reasoning efforts', async ()
       /* drain */
     }
   }
-  // configured default, explicit selection, and the remembered re-injection
-  // must all resolve to the supported 'max'
-  await drain({ provider: 'opencode-go-vision', model: 'm', messages: [] })
+  // the user picked 'max' in the bottom-right selector: the first step
+  // carries it, and the wrapper remembers it for the steps that follow
   await drain({ provider: 'opencode-go-vision', model: 'm', messages: [], reasoningEffort: 'max' })
   await drain({ provider: 'opencode-go-vision', model: 'm', messages: [] })
-  assert.deepEqual(seen, ['max', 'max', 'max'])
-})
-
-test('strict upstream: an unsupported configured effort is never forwarded', async () => {
-  const supported = new Set(['off', 'high', 'max'])
-  const { ctx, adapters } = mockHarnessCtx({
-    config0: { wrappedProviders: [{ provider: 'opencode-go', models: [], reasoningEffort: 'medium' }] },
-  })
-  const strict = {
-    providerInfo: (p) => ({ id: p, name: 'Opencode' }),
-    providerRetryPolicy: () => 'retry',
-    listModels: async (p) => [
-      { provider: p, id: 'm', name: 'M', inputModalities: ['text'], reasoning: { efforts: [...supported] } },
-    ],
-    resolveModel: async (p, m) => ({
-      provider: p, id: m, name: m, inputModalities: ['text'], context: { contextWindow: 100000 },
-      reasoning: { efforts: [...supported] },
-    }),
-  }
-  ctx.llm.registerAdapter(['opencode-go'], strict)
-  apply(ctx, Config({}))
-  const twin = adapters.get('opencode-go-vision')
-  const seen = []
-  ctx.llm.stream = async function* (options) {
-    if (options.reasoningEffort !== undefined && !supported.has(options.reasoningEffort)) {
-      throw new Error(`strict upstream rejects reasoningEffort "${options.reasoningEffort}"`)
-    }
-    seen.push(options.reasoningEffort)
-    yield { type: 'finish', reason: { kind: 'stop' } }
-  }
-  for await (const _c of twin.stream({ provider: 'opencode-go-vision', model: 'm', messages: [] })) {
-    /* drain */
-  }
-  assert.deepEqual(seen, [undefined])
+  assert.deepEqual(seen, ['max', 'max'])
 })
 
 test('strict upstream: twin never leaks image blocks to a text-only source', async () => {

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -1625,6 +1625,7 @@ test('twin wrapper uses the configured default when no effort was ever seen', as
     listModels: async (p) => [{ provider: p, id: 'm', name: 'M', inputModalities: ['text'] }],
     resolveModel: async (p, m) => ({
       provider: p, id: m, name: m, inputModalities: ['text'], context: { contextWindow: 100000 },
+      reasoning: { efforts: ['off', 'high', 'max'] },
     }),
     stream: async function* () {
       yield { type: 'finish', reason: { kind: 'stop' } }
@@ -1642,6 +1643,49 @@ test('twin wrapper uses the configured default when no effort was ever seen', as
     /* drain */
   }
   assert.equal(calls[0].reasoningEffort, 'high')
+})
+
+test('unsupported configured effort is ignored: metadata stays untouched and no injection', async () => {
+  const { ctx, adapters } = mockHarnessCtx({
+    config0: { wrappedProviders: [{ provider: 'opencode-go', models: [], reasoningEffort: 'medium' }] },
+  })
+  const source = {
+    providerInfo: (p) => ({ id: p, name: 'Opencode' }),
+    providerRetryPolicy: () => 'retry',
+    listModels: async (p) => [
+      {
+        provider: p, id: 'm', name: 'M', inputModalities: ['text'],
+        reasoning: { efforts: ['off', 'high', 'max'] },
+      },
+    ],
+    resolveModel: async (p, m) => ({
+      provider: p, id: m, name: m, inputModalities: ['text'], context: { contextWindow: 100000 },
+      reasoning: { efforts: ['off', 'high', 'max'] },
+    }),
+    stream: async function* () {
+      yield { type: 'finish', reason: { kind: 'stop' } }
+    },
+  }
+  ctx.llm.registerAdapter(['opencode-go'], source)
+  apply(ctx, Config({}))
+  const twin = adapters.get('opencode-go-vision')
+  // Metadata: 'medium' is not advertised by the route, so the twin must not
+  // force it into the efforts list or set it as default — the host falls
+  // back to the source's own metadata.
+  const listed = await twin.listModels('opencode-go-vision')
+  assert.deepEqual(listed[0].reasoning, { efforts: ['off', 'high', 'max'] })
+  const resolved = await twin.resolveModel('opencode-go-vision', 'm')
+  assert.equal(resolved.reasoning.defaultEffort, undefined)
+  // Wrapper fallback: an unsupported configured effort is never injected.
+  const calls = []
+  ctx.llm.stream = async function* (options) {
+    calls.push({ ...options })
+    yield { type: 'finish', reason: { kind: 'stop' } }
+  }
+  for await (const _c of twin.stream({ provider: 'opencode-go-vision', model: 'm', messages: [] })) {
+    /* drain */
+  }
+  assert.equal(calls[0].reasoningEffort, undefined)
 })
 
 test('twin wrapper leaves the effort untouched when nothing was seen or configured', async () => {


### PR DESCRIPTION
修复 #103：切到「+ 自动识图」twin 组后，宿主会把选择器里选好的
reasoningEffort 丢掉——多步 turn 只有第一步会思考。

- 推理等级完全归会话右下角选择器管：插件不再配置/发明任何等级，twin
  元数据一比一镜像源路由（源模型声明的默认值照常继承）
- createWrapperStreamBody 按「委托 provider + 模型」记忆最近一次显式出现的
  reasoningEffort，后续步骤缺失时自动补上——选 max 就一直是 max，选 off
  就忠实跟随 off
- 视觉链保持 reasoningEffort: undefined（视觉模型只看图，不烧推理预算）

顺带修复审计发现的配置层不一致：wrapper 路由、视觉链路由与 agent/request
钩子此前在 apply 时只读 composition 配置，而设置卡片暴露同样的开关——
中途切换只起一半作用。现在由 syncRoutingMounts() 按解析后的 settings
文档做响应式挂载/卸载，卡片开关即时生效。

验证：195 项测试全过（含严格上游模拟：上游对不支持的等级/图片块抛错，
证明插件从不转发伪造值；twin 不泄漏图片；视觉链 failover；挂载跟随设置
变化）。真实环境实测：twin 组选 Max 发送带图多步任务，会话日志 4 步全部
产生推理块（3/7/3/2），#103 症状不复现。

---

Fix #103: switching to a "+ Auto Vision" twin makes the host drop the
picker-chosen reasoningEffort — only the first step of a multi-step turn
thinks.

- The reasoning level stays a picker concern: the plugin never configures
  or invents one; twin metadata mirrors the source one-to-one (inheriting
  any default the source declares)
- createWrapperStreamBody remembers the last explicit reasoningEffort per
  delegate provider + model and re-injects it on later steps that arrive
  without one — Max stays Max, off stays off
- The vision chain keeps reasoningEffort: undefined (vision models only
  look)

Also fixes a config-layer inconsistency found during the audit: the wrapper
route, the chain route and the agent/request hook mounted from the
composition config evaluated at apply, while the settings card exposes the
same switches — flipping them mid-session only half-worked. syncRoutingMounts()
now reconciles the mounts against the resolved settings document, so the
card switches take effect immediately.

Verification: 195 tests pass (strict-upstream simulations where an upstream
throws on unsupported efforts/image blocks prove nothing fabricated is ever
forwarded; no image leaks to text-only sources; chain failover; mounts
follow settings edits). Real-environment run: a Max-effort image turn on the
twin produced reasoning blocks on all 4 steps (3/7/3/2) — the #103 symptom
no longer reproduces.

Closes #103