### PR TITLE
docs: fact-check comparison table against the six plugins' current READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,21 +76,21 @@ Most DSH vision plugins bridge images to DeepSeek as *text descriptions* — los
 | Free out-of-the-box | ❌ | ❌ | ✅ built-in keyless endpoint |
 | Fits dsh composition | — | external server | ✅ one plugin row |
 
-**Difference from existing dsh community projects** (all excellent, each with its own focus):
+**Difference from existing dsh community projects** (all excellent, each with its own focus; descriptions reflect their READMEs as of 2026-08):
 
 | Project | Approach | What this plugin adds |
 |---|---|---|
-| [dsh-vision-sidecar](https://github.com/121103qwq/dsh-vision-sidecar) | Pre-describes images with an external VLM; the description joins the session as a message to DeepSeek; OVHcloud anonymous endpoint by default | Description bridge; this plugin adds raw-image routing, with `vision_describe` covering descriptions on demand |
+| [dsh-vision-sidecar](https://github.com/121103qwq/dsh-vision-sidecar) | Pre-describes images with an external VLM; the description joins the session as a message to DeepSeek; LLM7.io anonymous endpoint by default (OVHcloud listed as a no-key alternative) | Description bridge; this plugin adds raw-image routing, with `vision_describe` covering descriptions on demand |
 | [dsh-vision-proxy](https://github.com/Flyvhidbwo/dsh-vision-proxy) | Wraps a provider route and transcribes images into text in the request stream | Transcription bridge; this plugin wraps no provider — it rewrites routing through `agent/request` waterfalls |
-| [dsh-vision-provider](https://github.com/libinyam/dsh-vision-provider) | Config-only bundle registering an OpenAI-compatible multimodal route | Same config-layer idea; this plugin adds automatic routing, fallback chains and tools on top |
-| [modlens](https://github.com/liustack/modlens) | The first dsh vision plugin; reuses local Codex/OpenCode/Pi logins as vision engines | Engine-reuse idea; this plugin ships its own provider chain and depends on no other local CLI |
-| [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | Ten intent-aware visual tools (Q&A/OCR/pixel verification/UI restoration) | Broader tool set; this plugin focuses on routing + one general comparison tool, lighter |
-| [dsh-tool-vision](https://github.com/Scorp1o117/dsh-tool-vision) | An `inspect_image` tool plus an `llm/stream` waterfall image bridge | Similar waterfall bridge; this plugin adds turn routing, fallback chains, caching and the free endpoint |
+| [dsh-vision-provider](https://github.com/libinyam/dsh-vision-provider) | Registers `DeepSeek + Vision` combined routes: images are described by the chosen vision model before reaching DeepSeek | Two-model bridge idea; this plugin adds automatic routing, fallback chains and tools on top |
+| [modlens](https://github.com/liustack/modlens) | The first dsh vision plugin; reuses local Claude Code/Codex/OpenCode/Pi logins as vision engines | Engine-reuse idea; this plugin ships its own provider chain and depends on no other local CLI |
+| [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | Ten intent-aware visual tools (Q&A/OCR/pixel verification/UI restoration), called explicitly on demand | Broader tool set; this plugin adds whole-turn auto-routing and a keyless free fallback |
+| [dsh-tool-vision](https://github.com/Scorp1o117/dsh-tool-vision) | An `inspect_image` tool plus an `agent/pre-step` waterfall bridge (pasted images become tool hints before entering the log) | Similar waterfall bridge; this plugin adds turn routing, fallback chains, caching and the free endpoint |
 
 ## Acknowledgements
 
 This project borrows ideas from all of the above — especially the keyless free-endpoint
-discovery (OVHcloud AI Endpoints anonymous tier) by
+exploration (LLM7.io and OVHcloud anonymous tiers) by
 [dsh-vision-sidecar](https://github.com/121103qwq/dsh-vision-sidecar). Thanks to the authors of
 [dsh-vision-proxy](https://github.com/Flyvhidbwo/dsh-vision-proxy),
 [dsh-vision-provider](https://github.com/libinyam/dsh-vision-provider),

--- a/README.zh.md
+++ b/README.zh.md
@@ -75,21 +75,21 @@
 | 免费开箱即用 | ❌ | ❌ | ✅ 内置免 Key 免费端点 |
 | 贴合 dsh 组合体系 | — | 外部服务器 | ✅ 一行插件行 |
 
-**与现有 dsh 社区方案的差异**（均为优秀项目，各有侧重）：
+**与现有 dsh 社区方案的差异**（均为优秀项目，各有侧重；描述以各家 README 2026-08 状态为准）：
 
 | 项目 | 思路 | 本插件的差异 |
 |---|---|---|
-| [dsh-vision-sidecar](https://github.com/121103qwq/dsh-vision-sidecar) | 图片先经外部 VLM 做 OCR/描述，描述作为会话消息交给 DeepSeek；默认 OVHcloud 匿名端点 | 描述桥方案；本插件提供"原图直看"路由，描述能力由 `vision_describe` 按需替代 |
+| [dsh-vision-sidecar](https://github.com/121103qwq/dsh-vision-sidecar) | 图片先经外部 VLM 做 OCR/描述，描述作为会话消息交给 DeepSeek；默认 LLM7.io 匿名端点（OVHcloud 为无 Key 备选） | 描述桥方案；本插件提供"原图直看"路由，描述能力由 `vision_describe` 按需替代 |
 | [dsh-vision-proxy](https://github.com/Flyvhidbwo/dsh-vision-proxy) | 包装 provider 路由，请求流里把图片转译成文本再交给 DeepSeek | 转译桥方案；本插件不包装 provider，通过 `agent/request` 瀑布改写路由 |
-| [dsh-vision-provider](https://github.com/libinyam/dsh-vision-provider) | 纯配置 bundle，注册一个 OpenAI 兼容多模态路由 | 配置层思路相同；本插件在此基础上增加自动路由、降级链与工具 |
-| [modlens](https://github.com/liustack/modlens) | 最早的 dsh 视觉插件；复用本机 Codex/OpenCode/Pi 等登录态作为视觉引擎 | 引擎复用思路；本插件自带供应商链，不依赖本机其他 CLI |
-| [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 10 个意图化视觉工具（Q&A/OCR/像素校验/UI 还原） | 工具集更全；本插件聚焦"路由 + 一个通用对比工具"，更轻 |
-| [dsh-tool-vision](https://github.com/Scorp1o117/dsh-tool-vision) | `inspect_image` 工具 + `llm/stream` 瀑布图片桥 | 瀑布桥思路相近；本插件多出轮次路由、降级链、缓存与免费端点 |
+| [dsh-vision-provider](https://github.com/libinyam/dsh-vision-provider) | 注册 `DeepSeek + Vision` 组合路由：图片先经所选视觉模型转成描述，再交给 DeepSeek | 双模型桥思路；本插件在此基础上增加自动路由、降级链与工具 |
+| [modlens](https://github.com/liustack/modlens) | 最早的 dsh 视觉插件；复用本机 Claude Code/Codex/OpenCode/Pi 等登录态作为视觉引擎 | 引擎复用思路；本插件自带供应商链，不依赖本机其他 CLI |
+| [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 10 个意图化视觉工具（Q&A/OCR/像素校验/UI 还原），按需显式调用 | 工具集更全；本插件多出整轮自动路由与免 Key 免费兜底 |
+| [dsh-tool-vision](https://github.com/Scorp1o117/dsh-tool-vision) | `inspect_image` 工具 + `agent/pre-step` 瀑布图片桥（粘贴图入日志前转成工具提示） | 瀑布桥思路相近；本插件多出轮次路由、降级链、缓存与免费端点 |
 
 ## 致谢
 
 本插件借鉴了以上全部社区项目的思路，特别是 [dsh-vision-sidecar](https://github.com/121103qwq/dsh-vision-sidecar)
-的"免注册免费端点"发现（OVHcloud AI Endpoints 匿名层）。感谢
+对免注册免 Key 视觉端点的探索（LLM7.io 与 OVHcloud 匿名层）。感谢
 [dsh-vision-proxy](https://github.com/Flyvhidbwo/dsh-vision-proxy)、
 [dsh-vision-provider](https://github.com/libinyam/dsh-vision-provider)、
 [modlens](https://github.com/liustack/modlens)、


### PR DESCRIPTION
## 背景

恢复多插件对比表后，逐条对照六个社区项目当前的 README 重新核实措辞。

## 改动（中英同步）

- dsh-vision-sidecar：默认端点由 OVHcloud 匿名改为 LLM7.io 匿名（OVHcloud 为无 Key 备选）
- dsh-vision-provider：由「纯配置 bundle」改为 v0.3.0 实际的 `DeepSeek + Vision` 组合路由描述桥
- modlens：登录态复用列表补上 Claude Code
- dsh-vision-toolkit：本插件差异改为「整轮自动路由 + 免 Key 兜底」，替换过时的「一个通用对比工具」说法
- dsh-tool-vision：桥接瀑布由 `llm/stream` 更正为 `agent/pre-step`
- 致谢：OVHcloud「发现」改为「LLM7.io 与 OVHcloud 匿名层的免注册免 Key 端点探索」
- 表格加注「描述以各家 README 2026-08 状态为准」

纯文档改动，无代码变更。
