### PR TITLE
fix: defer the deepseek-official takeover past the boot settle window

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,25 @@ npx @deepseek-ai/dsh --profile web --dump-config | grep vision-router
 
 When first adding the plugin to an already long-lived Web profile, let that Web process reload the plugin bundle; the host discovers the browser bundle through `dsh.client` at startup. **After the plugin is loaded, model-catalog and wrapper-scope changes hot-update and do not require a restart.**
 
+### Oh-DSH Desktop
+
+[Oh-DSH Desktop](https://github.com/hust-open-atom-club/oh-dsh) ships its own packaged DSH runtime and its own home layout: the desktop surface runs the `desktop` profile under `~/.ohdsh` and does **not** load ordinary `~/.dsh` profiles. The `--profile web` commands above therefore install into the wrong environment on that product.
+
+Install into the desktop profile by pointing `DSH_HOME` at the Oh-DSH home:
+
+```sh
+DSH_HOME=~/.ohdsh npx @deepseek-ai/dsh plugin --profile desktop add dsh-vision-router
+```
+
+(Windows PowerShell: run `$env:DSH_HOME = "$env:USERPROFILE\.ohdsh"` first, then the same command.)
+
+> [!WARNING]
+> Oh-DSH Desktop ≤ 0.1.5 bundles DSH `0.1.0-rc.5`. `dsh-vision-router` v1.4.1 and earlier crash that runtime at startup (`configurable provider "deepseek-official" is already declared`, surfacing as `DSH runtime exited before readiness`). Install v1.4.2+; until v1.4.2 is released, install the fix branch directly: `DSH_HOME=~/.ohdsh npx @deepseek-ai/dsh plugin --profile desktop add github:ysr666/dsh-vision-router#fix/keep-alive-takeover-race`.
+
+If a broken install already keeps the Desktop from starting, open `~/.ohdsh/profiles/desktop/package.json`, remove the `dsh-vision-router` entry from both `dependencies` and `dsh.profile.bundles`, save, and restart the Desktop.
+
+Oh-DSH Desktop's built-in plugin marketplace (search → prepare → isolated preview → apply, with a `previous` snapshot for recovery) also works once the community catalog lists this plugin; do not mix marketplace installs with the direct command above. The bundled `@oh-dsh/vision` (`view_image`) coexists with this plugin — the tool names do not collide.
+
 ### Disable / re-enable
 
 ```yaml

--- a/README.zh.md
+++ b/README.zh.md
@@ -317,6 +317,25 @@ npx @deepseek-ai/dsh --profile web --dump-config | grep vision-router
 
 首次把插件装进已经长期运行的 Web profile 时，需要让 Web 进程重新加载插件本体；宿主在启动时通过 `dsh.client` 声明发现浏览器端包。**插件加载完成后，模型目录与包装范围的变化会热更新，不需要为这些变化重启。**
 
+### Oh-DSH Desktop
+
+[Oh-DSH Desktop](https://github.com/hust-open-atom-club/oh-dsh) 自带一套独立打包的 DSH 运行时和独立的数据目录：桌面端实际运行的是 `~/.ohdsh` 下的 `desktop` profile，**不会**加载普通 `~/.dsh` 的 profile。因此上面 `--profile web` 的命令在 Oh-DSH Desktop 上会装错环境。
+
+把 `DSH_HOME` 指向 Oh-DSH 的数据目录再安装即可：
+
+```sh
+DSH_HOME=~/.ohdsh npx @deepseek-ai/dsh plugin --profile desktop add dsh-vision-router
+```
+
+（Windows PowerShell 先执行 `$env:DSH_HOME = "$env:USERPROFILE\.ohdsh"`，再运行同一命令。）
+
+> [!WARNING]
+> Oh-DSH Desktop ≤ 0.1.5 内置的是 DSH `0.1.0-rc.5`。`dsh-vision-router` v1.4.1 及更早版本会让该运行时在启动时崩溃（报 `configurable provider "deepseek-official" is already declared`，在 Oh-DSH Desktop 里表现为 `DSH runtime exited before readiness`）。请安装 v1.4.2+；在 v1.4.2 发布之前，可直接安装修复分支：`DSH_HOME=~/.ohdsh npx @deepseek-ai/dsh plugin --profile desktop add github:ysr666/dsh-vision-router#fix/keep-alive-takeover-race`。
+
+如果错误安装已经导致 Desktop 无法启动：打开 `~/.ohdsh/profiles/desktop/package.json`，从 `dependencies` 和 `dsh.profile.bundles` 中删掉 `dsh-vision-router` 条目，保存后重启 Desktop。
+
+Oh-DSH Desktop 内置的插件市场（搜索 → 准备 → 隔离预览 → 应用，并保留 `previous` 快照用于恢复）在社区目录收录本插件后同样可用；不要与上面的直接安装命令混用。其内置的 `@oh-dsh/vision`（`view_image`）与本插件可共存，工具名不冲突。
+
 ### 禁用 / 恢复
 
 ```yaml

--- a/index.js
+++ b/index.js
@@ -2439,12 +2439,26 @@ export function apply(ctx, config = {}) {
   // ourselves is the only way to keep the DeepSeek models in the picker.
   // The settings card surfaces this condition as a hint, and re-enabling
   // the stock row restores the fully official route.
-  const officialRouteAlive = adapterAvailable(ctx.llm, 'deepseek-official')
-  const takeoverReason = stealthEnabled ? 'stealth' : officialRouteAlive ? undefined : 'official-unavailable'
+  //
+  // The takeover decision runs AFTER a short settle window, never inside
+  // apply(): entry activation is service-driven, so this row can apply
+  // BEFORE the stock llm-deepseek row (reproduced on DSH 0.1.0-rc.5 hosts,
+  // e.g. Oh-DSH Desktop). Deciding synchronously misreads the not-yet-applied
+  // stock route as dead, and our directory registration then makes the stock
+  // row's own registration throw DUPLICATE_DIRECTORY, killing the whole
+  // runtime before readiness. Once the window elapses, a registered stock
+  // route means hands off; a still-dead route means the row is genuinely
+  // absent/disabled and the takeover is safe.
+  const KEEPALIVE_SETTLE_MS = 2000
   const nativeRoute = 'deepseek-official-native'
   let stealthActive = false
+  let takeoverReason
   let nativeAdapter
-  if (takeoverReason !== undefined) {
+  let takeoverAttempted = false
+  const attemptTakeover = (reason) => {
+    if (takeoverAttempted) return
+    takeoverAttempted = true
+    takeoverReason = reason
     try {
       nativeAdapter = createNativeDeepSeekAdapter(ctx)
       const nativeHandle = ctx.llm.registerAdapter([nativeRoute], {
@@ -2492,14 +2506,33 @@ export function apply(ctx, config = {}) {
         /* the stock row may still own the directory entry */
       }
     } catch (error) {
+      nativeAdapter = undefined
       stealthActive = false
       ctx.logger?.warn(
         'vision-router: deepseek-official takeover skipped (%s: %s); keeping the visible wrapper',
-        takeoverReason,
+        reason,
         error && error.message ? error.message : String(error),
       )
     }
   }
+  const maybeTakeover = () => {
+    if (!takeoverSettled || stealthActive || takeoverAttempted) return
+    if (adapterAvailable(ctx.llm, 'deepseek-official')) {
+      if (stealthEnabled) {
+        ctx.logger?.warn(
+          'vision-router: stealth is enabled but the stock deepseek-official route is alive; disable the llm-deepseek row to take it over',
+        )
+      }
+      return
+    }
+    attemptTakeover(stealthEnabled ? 'stealth' : 'official-unavailable')
+  }
+  let takeoverSettled = false
+  const settleTimer = setTimeout(() => {
+    takeoverSettled = true
+    maybeTakeover()
+  }, KEEPALIVE_SETTLE_MS)
+  ctx.effect(() => () => clearTimeout(settleTimer), 'vision-router: takeover settle timer')
   // ── vision-http route: first-class llm route over the OpenAI-compatible
   // http providers. The built-in OVHcloud anonymous endpoint (no account, no
   // key, 2 req/min/IP) is the DEFAULT vision model, so a fresh install works

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -1060,6 +1060,7 @@ test('stealth stream keeps the log intact and hands the model a tool-hint marker
 function mockHarnessCtx({ stockRoute = false, config0 = {}, skills = false } = {}) {
   const adapters = new Map() // provider -> adapter
   const registrations = new Map() // provider -> { adapter, retryPolicy }
+  const directories = [] // configurable-provider registrations (directory seam)
   const captured = { skills: [], on: new Map() }
   // The mutable user document and the watch seam: tests flip config0 fields
   // and fire the watchers to simulate a settings-card save.
@@ -1157,7 +1158,10 @@ function mockHarnessCtx({ stockRoute = false, config0 = {}, skills = false } = {
         if (hit === undefined) throw new Error(`no adapter registered for provider "${provider}"`)
         return hit
       },
-      registerConfigurableProviders: () => ({ replace: () => {} }),
+      registerConfigurableProviders: (entries) => {
+        directories.push({ entries })
+        return { replace: () => {} }
+      },
       listProviders() {
         return [...registrations.entries()].map(([provider, registration]) => {
           let info
@@ -1186,10 +1190,11 @@ function mockHarnessCtx({ stockRoute = false, config0 = {}, skills = false } = {
       },
     },
   }
-  return { ctx, adapters, captured, userDoc, settingsWatchers }
+  return { ctx, adapters, captured, directories, userDoc, settingsWatchers }
 }
 
-test('apply registers the stealth deepseek-official route with the stock catalog', async () => {
+test('apply registers the stealth deepseek-official route with the stock catalog', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] })
   const { ctx, adapters } = mockHarnessCtx()
   // the harness loader normalizes the entry config through the Config schema;
   // routing: true keeps the legacy chain route mounted (the default is off —
@@ -1200,6 +1205,9 @@ test('apply registers the stealth deepseek-official route with the stock catalog
     routing: true,
     stealth: true,
   }))
+  // the takeover decision waits out the boot settle window (a not-yet-applied
+  // stock llm-deepseek row must never be mistaken for a disabled one)
+  t.mock.timers.tick(2000)
 
   // all four routes came up: hidden native, public deepseek-official, the
   // hidden wrapper alias, and the vision chain
@@ -1220,7 +1228,8 @@ test('apply registers the stealth deepseek-official route with the stock catalog
   assert.deepEqual(await adapters.get('deepseek-vision').listModels('deepseek-vision'), [])
 })
 
-test('apply skips the chain route by default: image turns go through the vision tools', () => {
+test('apply skips the chain route by default: image turns go through the vision tools', (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] })
   const { ctx, adapters } = mockHarnessCtx()
   apply(ctx, Config({}))
   // tools-first philosophy: no whole-turn chain routing by default, but the
@@ -1230,6 +1239,7 @@ test('apply skips the chain route by default: image turns go through the vision 
   // keep-alive: the stock route is dead in this mock (no stockRoute), so the
   // plugin still takes over deepseek-official via the hidden native route —
   // otherwise the DeepSeek models would vanish entirely
+  t.mock.timers.tick(2000)
   assert.ok(adapters.has('deepseek-official-native'))
   assert.ok(adapters.has('deepseek-vision'))
 })
@@ -1256,12 +1266,14 @@ test('the vision chain ships with the built-in free model as its first row', () 
   ])
 })
 
-test('keep-alive fallback: stealth off + dead stock route still serves deepseek-official', async () => {
+test('keep-alive fallback: stealth off + dead stock route still serves deepseek-official', async (t) => {
   // No stockRoute in the mock = the official llm-deepseek row is disabled at
   // the composition layer (adapterAvailable throws). With stealth off the
   // plugin must STILL take over, or the DeepSeek models vanish entirely.
+  t.mock.timers.enable({ apis: ['setTimeout'] })
   const { ctx, adapters } = mockHarnessCtx()
   apply(ctx, Config({ stealth: false }))
+  t.mock.timers.tick(2000)
   assert.ok(adapters.has('deepseek-official'), 'expected the keep-alive deepseek-official route')
   assert.ok(adapters.has('deepseek-official-native'), 'expected the hidden native route')
   const official = adapters.get('deepseek-official')
@@ -1269,7 +1281,8 @@ test('keep-alive fallback: stealth off + dead stock route still serves deepseek-
   assert.deepEqual(listed.map((m) => m.id), ['deepseek-v4-flash', 'deepseek-v4-pro'])
 })
 
-test('stealth off + alive stock route performs no takeover at all', async () => {
+test('stealth off + alive stock route performs no takeover at all', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] })
   const { ctx, adapters } = mockHarnessCtx({ stockRoute: true })
   apply(ctx, Config({ stealth: false }))
   // the stock adapter keeps owning deepseek-official; the plugin registers no
@@ -1279,6 +1292,43 @@ test('stealth off + alive stock route performs no takeover at all', async () => 
   const listed = await stock.listModels('deepseek-official')
   assert.deepEqual(listed[0].inputModalities, ['text'])
   assert.ok(adapters.has('deepseek-vision'), 'expected the visible wrapper route')
+  // even after the settle window the stock row's live route is left alone
+  t.mock.timers.tick(2000)
+  assert.equal(adapters.has('deepseek-official-native'), false)
+})
+
+test('rc.5 activation order: a late stock row is never mistaken for a disabled one', (t) => {
+  // Reproduces the Oh-DSH Desktop (DSH 0.1.0-rc.5) boot crash: entry
+  // activation is service-driven there, so vision-router's apply can run
+  // BEFORE the stock llm-deepseek row. The old synchronous keep-alive check
+  // read the not-yet-registered route as dead, registered the
+  // deepseek-official directory entry first, and the stock row then threw
+  // DUPLICATE_DIRECTORY, killing the runtime before readiness.
+  t.mock.timers.enable({ apis: ['setTimeout'] })
+  const { ctx, adapters, directories } = mockHarnessCtx()
+  apply(ctx, Config({ stealth: false }))
+  // the stock row applies after us (late registration + its directory entry)
+  const stock = {
+    providerInfo: (p) => ({ id: p, name: 'DeepSeek' }),
+    providerRetryPolicy: () => 'retry',
+    listModels: async (p) => [
+      { provider: p, id: 'deepseek-v4-pro', name: 'DeepSeek-V4-Pro', inputModalities: ['text'] },
+    ],
+    resolveModel: async (p, m) => ({ provider: p, id: m, name: m, inputModalities: ['text'] }),
+    stream: async function* () {
+      yield { type: 'finish', reason: { kind: 'stop' } }
+    },
+  }
+  ctx.llm.registerAdapter(['deepseek-official'], stock)
+  // settle window elapses: the official route is alive, so hands off entirely
+  t.mock.timers.tick(2000)
+  assert.equal(adapters.has('deepseek-official-native'), false)
+  assert.equal(adapters.get('deepseek-official'), stock, 'stock adapter must stay in charge')
+  assert.deepEqual(
+    directories.filter((entry) => entry.entries.some((row) => row && row.provider === 'deepseek-official')),
+    [],
+    'the plugin must never claim the deepseek-official directory entry while the stock row is alive',
+  )
 })
 
 // ── legacy routing fallback (routing: true, chainRoute: '') ────────────────


### PR DESCRIPTION
## Problem

On DSH 0.1.0-rc.5 hosts (Oh-DSH Desktop 0.1.5 pins this runtime), the
plugin could crash the whole runtime at boot with:

    LlmError: configurable provider "deepseek-official" is already declared

surfacing in Oh-DSH Desktop as "DSH runtime exited before readiness".

Entry activation is service-driven on rc.5, so vision-router's apply can
run before the stock llm-deepseek row. The synchronous keep-alive check
then read the not-yet-applied stock route as dead, registered the
deepseek-official directory entry first, and the stock row's own
registration threw DUPLICATE_DIRECTORY, failing the profile boot.

## Fix

The takeover decision now runs after a short settle window (2s) instead
of inside apply():

- stock route registered when the window elapses -> hands off (unchanged
  behavior);
- stock route still dead -> the row is genuinely absent/disabled and the
  takeover proceeds (stealth and keep-alive paths unchanged).

## Docs

Adds an Oh-DSH Desktop install section to both READMEs: the `DSH_HOME`
install command for the desktop profile, the rc.5 startup caveat, the
recovery steps for a broken profile, the marketplace flow, and
coexistence with the bundled `@oh-dsh/vision` plugin.

## Verification

- 240 tests pass, including a new regression test reproducing the rc.5
  activation order (a late stock row must never be mistaken for a
  disabled one).
- Verified end-to-end against a real DSH 0.1.0-rc.5 host build: before
  the fix the web profile failed to boot with DUPLICATE_DIRECTORY; after
  the fix it boots and serves normally.
