### PR TITLE
fix: tolerate Windows Explorer relay exit code for log folder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
           node-version: '22'
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      - name: Run cross-platform log folder regression tests
+        run: node --test tests/file-logger.test.js tests/logging-ui.test.js
       - name: Prepare pack directory
         shell: node {0}
         run: |

--- a/lib/file-logger.js
+++ b/lib/file-logger.js
@@ -169,8 +169,35 @@ export async function openLogDirectory(directory, {
     return
   }
   if (platform === 'win32') {
-    await exec('explorer.exe', [directory], { timeout: 10_000, windowsHide: true })
-    return
+    try {
+      await exec('explorer.exe', [directory], { timeout: 10_000, windowsHide: true })
+      return
+    } catch (error) {
+      // explorer.exe is a shell relay. On some Windows installs it hands the
+      // request to the existing Explorer process, opens the folder, then exits
+      // with code 1. A numeric exit code therefore means the relay did run and
+      // must not be treated as an open failure.
+      if (typeof error?.code === 'number') return
+
+      // Spawn-level failures (ENOENT/EPERM/EACCES/UNKNOWN, timeout, etc.) mean
+      // the relay did not complete reliably. Fall back to ShellExecute via the
+      // built-in `start` command without invoking a Node shell.
+      try {
+        await exec('cmd.exe', ['/d', '/s', '/c', `start "" "${directory}"`], {
+          timeout: 10_000,
+          windowsHide: true,
+        })
+        return
+      } catch (startError) {
+        const wrapped = new Error(
+          `explorer.exe spawn failed (${error?.code ?? 'unknown'}); cmd start failed (${startError?.code ?? 'unknown'})`,
+        )
+        wrapped.code = 'OPEN_LOG_DIRECTORY_FAILED'
+        wrapped.explorer = error
+        wrapped.start = startError
+        throw wrapped
+      }
+    }
   }
   await exec('xdg-open', [directory], { timeout: 10_000, windowsHide: true })
 }
@@ -265,6 +292,7 @@ function installLogRoute(ctx, paths, logger) {
             directory: paths.directory,
             file: paths.file,
             error: error && error.message ? error.message : String(error),
+            code: error && error.code !== undefined ? String(error.code) : undefined,
           })
         }
       },

--- a/tests/file-logger.test.js
+++ b/tests/file-logger.test.js
@@ -177,7 +177,7 @@ test('file log sink writes formatted diagnostics and rotates bounded logs', asyn
   }
 })
 
-test('openLogDirectory uses the platform file manager with an argument array', async () => {
+test('openLogDirectory uses the native file manager on macOS, Windows, and Linux', async () => {
   const calls = []
   const exec = async (...args) => calls.push(args)
   const root = await mkdtemp(path.join(tmpdir(), 'vision-router-open-'))
@@ -190,6 +190,85 @@ test('openLogDirectory uses the platform file manager with an argument array', a
       ['explorer.exe', [root]],
       ['xdg-open', [root]],
     ])
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('openLogDirectory accepts a numeric explorer relay exit code on Windows', async () => {
+  const calls = []
+  const root = await mkdtemp(path.join(tmpdir(), 'vision-router-open-win-exit-'))
+  const exec = async (...args) => {
+    calls.push(args)
+    const error = new Error('Command failed: explorer.exe')
+    error.code = 1
+    throw error
+  }
+  try {
+    await assert.doesNotReject(openLogDirectory(root, { platform: 'win32', exec }))
+    assert.deepEqual(calls.map(([command, args]) => [command, args]), [
+      ['explorer.exe', [root]],
+    ])
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('openLogDirectory falls back to cmd start for a Windows spawn-level failure', async () => {
+  const calls = []
+  const root = await mkdtemp(path.join(tmpdir(), 'vision-router-open-win-fallback-'))
+  const exec = async (...args) => {
+    calls.push(args)
+    if (args[0] === 'explorer.exe') {
+      const error = new Error('spawn explorer.exe ENOENT')
+      error.code = 'ENOENT'
+      throw error
+    }
+  }
+  try {
+    await openLogDirectory(root, { platform: 'win32', exec })
+    assert.deepEqual(calls.map(([command, args]) => [command, args]), [
+      ['explorer.exe', [root]],
+      ['cmd.exe', ['/d', '/s', '/c', `start "" "${root}"`]],
+    ])
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('openLogDirectory reports both Windows launch failures when fallback also fails', async () => {
+  const root = await mkdtemp(path.join(tmpdir(), 'vision-router-open-win-fail-'))
+  const exec = async (command) => {
+    const error = new Error(`failed ${command}`)
+    error.code = command === 'explorer.exe' ? 'ENOENT' : 2
+    throw error
+  }
+  try {
+    await assert.rejects(
+      openLogDirectory(root, { platform: 'win32', exec }),
+      (error) => {
+        assert.equal(error.code, 'OPEN_LOG_DIRECTORY_FAILED')
+        assert.equal(error.explorer?.code, 'ENOENT')
+        assert.equal(error.start?.code, 2)
+        assert.match(error.message, /explorer\.exe spawn failed \(ENOENT\); cmd start failed \(2\)/)
+        return true
+      },
+    )
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('openLogDirectory keeps native nonzero failures strict on macOS and Linux', async () => {
+  const root = await mkdtemp(path.join(tmpdir(), 'vision-router-open-unix-fail-'))
+  const exec = async (command) => {
+    const error = new Error(`failed ${command}`)
+    error.code = 1
+    throw error
+  }
+  try {
+    await assert.rejects(openLogDirectory(root, { platform: 'darwin', exec }), { code: 1 })
+    await assert.rejects(openLogDirectory(root, { platform: 'linux', exec }), { code: 1 })
   } finally {
     await rm(root, { recursive: true, force: true })
   }

--- a/tests/logging-ui.test.js
+++ b/tests/logging-ui.test.js
@@ -10,6 +10,11 @@ test('settings card exposes a one-click logs-folder action', () => {
   assert.equal(source.includes("method: 'POST'"), true)
 })
 
+test('log-folder failures include a machine-readable error code', () => {
+  const serverSource = readFileSync(new URL('../lib/file-logger.js', import.meta.url), 'utf8')
+  assert.equal(serverSource.includes("code: error && error.code !== undefined ? String(error.code) : undefined"), true)
+})
+
 test('settings save failures are forwarded to the bounded server diagnostic route', () => {
   const clientSource = readFileSync(new URL('../lib/client.js', import.meta.url), 'utf8')
   const serverSource = readFileSync(new URL('../lib/file-logger.js', import.meta.url), 'utf8')


### PR DESCRIPTION
Fixes #112.

- Treat numeric `explorer.exe` exit codes on Windows as a successful shell hand-off, because Explorer can open the folder and still return 1.
- Fall back to `cmd.exe ... start` only for spawn-level / non-numeric failures, avoiding duplicate windows on the reported case.
- Include a machine-readable `code` in the log-route 500 response.
- Add regression coverage for Windows numeric exit codes, Windows spawn fallback/fallback failure, and the native macOS/Windows/Linux command paths. macOS/Linux keep their existing strict nonzero-exit behavior.