### PR TITLE
refactor: simplify settings UX

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -15,32 +15,32 @@ window.__ModuleLoader__.load({
     // ── locale dictionaries (follow the app's language setting) ─────────────
     const NS = 'vision-router'
     const zh = {
-      nav: '视觉路由（自动识图）',
-      desc: '会话模型负责聊天，视觉后端负责看图；两者分开设置 · 面板 v8',
-      quickStartTitle: '聊天与看图分别设置',
-      quickStartBody: '① 会话/文字模型：在聊天页右下角选择；发图时选带「+ 自动识图」的模型组。② 视觉模型：在本卡片的「视觉后端链」里选择，只负责看图。',
-      quickStartLive: '只想换识图模型，就改下面的「视觉后端链」；不会改变聊天页右下角的会话模型。',
-      quickStartGuide: '重新查看模型引导',
+      nav: 'Vision Router · 图片识别',
+      desc: '聊天模型负责思考与回答，识图模型负责看图片；两者可以独立设置',
+      quickStartTitle: '聊天和看图分别设置',
+      quickStartBody: '聊天模型负责思考和回答，识图模型负责看图片。发图片时，在聊天页选择带「+ 自动识图」的模型即可。',
+      quickStartLive: '只想更换识图模型？直接修改下面的「识图模型」，不会影响当前聊天模型。',
+      quickStartGuide: '重新查看新手引导',
       onboardingTitle: 'Vision Router 已准备好 🎉',
-      onboardingBody: 'Vision Router 把“谁负责聊天”和“谁负责看图”拆成了两处设置。按下面 3 步就不会选错。',
-      onboardingStep1Title: '1 · 会话 / 文字模型',
-      onboardingStep1Body: '在聊天页右下角选择。发图片时，请选带「+ 自动识图」的模型组；组里的 DeepSeek / opencode 模型仍负责聊天、思考和调用工具。',
-      onboardingStep2Title: '2 · 视觉模型',
-      onboardingStep2Body: '打开「设置 → 插件 → Vision Router」，在「视觉后端链」里选择。它只负责看图，不会替换你的聊天模型。',
-      onboardingStep3Title: '3 · 主视觉模型与备用模型',
-      onboardingStep3Body: '视觉后端链每一行都是你自己的视觉模型，从上到下依次尝试；可以全部留空。内置 OVH 匿名免费链固定在最后自动兜底。',
-      onboardingGuide: '带我设置视觉模型',
+      onboardingBody: '第一次使用只需要记住：聊天模型负责回答，识图模型负责看图。跟着下面 3 步设置即可。',
+      onboardingStep1Title: '1 · 选择聊天模型',
+      onboardingStep1Body: '在聊天页右下角选择你平时使用的模型。需要发图片时，请选择带「+ 自动识图」的版本。',
+      onboardingStep2Title: '2 · 选择识图模型',
+      onboardingStep2Body: '打开「设置 → 插件 → Vision Router」，在「识图模型」里选择。它只负责读取图片，不会替换你的聊天模型。',
+      onboardingStep3Title: '3 · 设置备用模型',
+      onboardingStep3Body: '可以添加多个识图模型；前一个不可用时会自动尝试下一个。全部失败后，还可以使用内置免费兜底。',
+      onboardingGuide: '带我设置识图模型',
       onboardingLater: '稍后',
       onboardingClose: '关闭',
-      guideStep1Title: '第 1 步 · 会话 / 文字模型',
-      guideStep1Body: '聊天页右下角、输入框旁的模型选择器已经被高亮圈出。发图片时请选带「+ 自动识图」的模型组；组里的模型仍负责聊天、思考和调用工具。选好后点击「下一步」。',
+      guideStep1Title: '第 1 步 · 选择聊天模型',
+      guideStep1Body: '聊天页右下角、输入框旁的模型选择器已经被高亮。选择你平时使用的聊天模型；发图片时请选择带「+ 自动识图」的版本。选好后点击「下一步」。',
       guideStepNext: '下一步',
-      guidePromptTitle: '第 2 步 · 视觉模型',
+      guidePromptTitle: '第 2 步 · 选择识图模型',
       guidePromptGearBody: '点击侧边栏左下角被高亮圈出的「设置」齿轮打开设置面板；也可以直接点「下一步」帮你打开。',
-      guidePromptNavBody: '在设置面板左侧的导航里，点击被高亮的「插件」入口（或点「下一步」自动进入）。进入插件页后，我会自动展开 Vision Router 并定位到「视觉后端链」。',
+      guidePromptNavBody: '在设置面板左侧点击被高亮的「插件」入口（或点「下一步」自动进入）。进入插件页后，我会自动展开 Vision Router 并定位到「识图模型」。',
       guidePromptCancel: '结束引导',
-      guideChainTitle: '第 3 步 · 这里就是视觉模型',
-      guideChainBody: '上面的每一行都是你选择的视觉后端候选，从上到下依次实际尝试；可以全部留空。DSH 的图片能力声明现在只作提示，不再决定能不能选。内置 OVH 免费链固定在最后自动兜底。选好后点击页面底部「保存」。',
+      guideChainTitle: '第 3 步 · 设置备用模型',
+      guideChainBody: '这里的识图模型会从上到下依次尝试。可以添加多个备用模型，也可以全部留空；内置 OVH 免费模型会在最后自动兜底。选好后点击页面底部「保存」。',
       guideDone: '完成引导',
       pending: '未保存',
       readOnly: '当前设置提供方只读。',
@@ -59,15 +59,15 @@ window.__ModuleLoader__.load({
       builtinFallbackEnabled: '已启用',
       builtinFallbackDisabled: '已关闭',
       builtinFallbackBody: 'OVHcloud 匿名视觉链共 {count} 个模型，首选 {primary}。匿名限额为每 IP、每模型 2 次/分钟；5 个模型独立限额，理论合计约 10 次/分钟，实际以 OVH 限流为准。它固定在上面用户模型之后尝试，免注册、免 Key。',
-      chainLabel: '视觉后端链（给识图工具用）',
-      chainHint: '每行可选择「设置 → 模型」中的任意可调用生成式模型；DSH 的图片能力声明只用于提示。调用时优先走该供应商已注册的 DSH adapter（包括 WebSocket / RPC / 私有协议），失败自动尝试下一行；只有明确识别为 http(s) OpenAI Chat Completions 时才会尝试 HTTP 直连兼容兜底。',
-      addFallback: '+ 添加备用视觉模型',
+      chainLabel: '识图模型',
+      chainHint: '选择 Vision Router 用来读取图片的模型。将按从上到下的顺序尝试，失败时自动切换到下一个。',
+      addFallback: '+ 添加备用识图模型',
       remove: '移除',
       removeTitle: '移除这一行',
-      textModelLabel: '文本模型（文字轮走它）',
-      textModelHint: '通常无需设置；见上方说明，留空即恢复默认。',
+      textModelLabel: '文字回退模型',
+      textModelHint: '通常无需设置；留空即使用默认聊天模型。',
       defaultChainNote:
-        '这里配置识图工具真正调用的“眼睛”，不是聊天页右下角的“脑子/会话模型”。上面的行只选你自己的视觉模型；内置 OVH 匿名免费链固定显示在最下方，不需要选择 Vision HTTP。',
+        '这里设置负责看图的模型，不会改变聊天页选择的聊天模型。你的模型按顺序尝试；内置 OVH 免费模型固定作为最后兜底。',
       catalogLoading: '正在加载模型目录（与「设置 > 模型」同源）…',
       catalogUnavailable: '连接服务不可用（拿不到模型目录），退回手动输入。',
       catalogTimeout: '目录请求超时（15 秒）',
@@ -92,20 +92,25 @@ window.__ModuleLoader__.load({
       chainInvalidCurrent: '当前保存的后端已不在可调用模型目录中，或属于非生成式/递归路由，运行时会跳过：',
       retryCatalog: '重试加载目录',
       advanced: '高级设置',
-      groupTextModel: '文本模型（仅特殊场景）',
+      groupPerformance: '性能',
+      groupCompatibility: '兼容性',
+      groupNetwork: '网络',
+      groupDeveloper: '开发者设置',
+      groupDiagnostics: '版本与诊断',
+      developerHint: '这些选项用于路由覆盖、能力标记和兼容调试；一般无需修改。',
+      groupTextModel: '文字回退模型',
       textModelGroupHint:
-        '平时文字轮直接使用右下角选择的会话模型，无需设置；此字段仅在开启' +
-        '「图片轮整轮自动路由」且会话入口为视觉路由时，作为文字轮的回退模型。',
-      groupBehavior: '行为开关',
-      groupParams: '参数',
-      groupVisionOverrides: '视觉能力标记（可选）',
-      extraVisionModelsLabel: '额外视觉模型（仅覆盖能力标记，可选）',
+        '通常无需设置。仅在开启「整轮交给视觉模型」且需要把纯文字消息切回聊天模型时使用。',
+      groupBehavior: '识图行为',
+      groupParams: '性能与超时',
+      groupVisionOverrides: '视觉能力覆盖',
+      extraVisionModelsLabel: '额外视觉模型标记',
       extraVisionModelsHint:
         '这个设置不再用于“解锁”下拉或允许调用；所有可调用生成式模型本来就能被选择。' +
         '只有当你希望把某个未声明图片能力的模型明确标记为视觉模型时才需要填写。' +
         '实际调用仍优先走 DSH adapter；只有明确的 http(s) OpenAI Chat Completions 渠道才可能使用直连兼容兜底。',
-      groupRoutes: '路由名',
-      groupProxy: '代理',
+      groupRoutes: '路由名称',
+      groupProxy: '网络',
       proxyLabel: '代理地址',
       proxyHint: '如 http://127.0.0.1:10808 或 socks5h://127.0.0.1:10808；留空关闭。修改即时生效。',
       proxyHostsLabel: '走代理的域名（每行一个）',
@@ -144,34 +149,27 @@ window.__ModuleLoader__.load({
       save: '保存',
       saving: '保存中…',
       renderFailed: '设置卡渲染失败：',
-      toggleRouting: '图片轮整轮自动路由',
-      toggleReverseRouting: '文字轮反向路由',
+      toggleRouting: '整轮交给视觉模型',
+      toggleReverseRouting: '纯文字消息仍使用聊天模型',
       toggleTool: '识图工具',
-      toggleStructuredVisionBootstrap: '结构化预识别（实验）',
+      toggleStructuredVisionBootstrap: '结构化预识别（1+x，实验）',
       toggleAutoWrapProviders: '自动创建「+ 自动识图」模型组',
-      toggleRewriteImages: '图片块改写',
+      toggleRewriteImages: '保护纯文字模型',
       toggleDownscale: '图片自动压缩',
       toggleCache: '识图答案缓存',
-      toggleFreeFallback: '免费兜底',
+      toggleFreeFallback: '内置免费兜底',
       toggleStealth: '隐身模式',
       hintRouting:
-        '默认关闭：图片轮不整轮切到视觉模型，而是像普通文本轮一样由会话模型调用 ' +
-        'vision_describe 等工具看图，可连续多步操作（定位→裁剪→对比…）。' +
-        '开启后恢复旧的整轮一次性自动识图行为；注意：开启时降级链只包含 ' +
-        '「视觉后端链」里的 provider+fallbacks，httpProviders（含免费兜底端点）不参与。',
-      hintReverseRouting: '开启图片轮整轮路由时，把纯文字轮反向路由回文本模型；默认开启。',
-      hintTool: 'vision_describe / vision_ground 等像素级视觉工具；关闭后这些工具不可用。',
-      hintStructuredVisionBootstrap:
-        '默认关闭。开启后，每个含图片的新一轮先调用 vision_bootstrap 做 1 次任务无关、通用且详细的结构化视觉预识别；不需要预先选择模式，也不会给预识别传 goal。' +
-        '第 1 次结果会返回专用结构（visual_kind / regions / visible_text / entities / uncertainties / recommended_followups），随后必须再调用至少 1 次后续证据工具。' +
-        'OCR 不作为默认第二步；若结构化流程确实需要 OCR，auto 会优先使用视觉模型以提高中文/UI 文字准确率。这是 1+x（x≥1），需保持「识图工具」开启。',
-      hintAutoWrapProviders: '推荐保持开启。插件会自动发现「设置 → 模型」里已启用的路由，并额外创建同名的「+ 自动识图」模型组；发图时请在聊天页右下角选择这个新组。原模型组完全不变。模型增删与包装范围会热更新，无需重启。',
-      hintRewriteImages:
-        '把消息里的图片块替换为文字：已有视觉记录就给出记录，否则给出附件标记，' +
-        '文本模型始终不会收到它看不懂的图片内容。',
+        '默认关闭。开启后，发送图片的整轮对话会直接由视觉模型处理，而不是由当前聊天模型调用识图工具。' +
+        '用于兼容旧版行为，一般无需开启；开启后只使用上方识图模型链中的后端。',
+      hintReverseRouting: '仅在「整轮交给视觉模型」开启时生效；纯文字消息继续交给聊天模型处理。',
+      hintTool: '允许聊天模型按需查看、定位、裁剪和比较图片。推荐保持开启。',
+      hintStructuredVisionBootstrap: '默认关闭。开启后，每个图片任务会先做一次不读取具体任务目标的结构化预识别，再由聊天模型根据原问题至少追加一次验证或深挖识图调用（1+x，x≥1）。准确性更高，但会增加至少一次视觉调用；若后续需要 OCR，自动模式会优先使用视觉模型。需保持「识图工具」开启。',
+      hintAutoWrapProviders: '自动为已启用的聊天模型创建带「+ 自动识图」的版本。原模型不受影响，推荐保持开启。',
+      hintRewriteImages: '避免把无法读取的原始图片直接发送给纯文字模型。推荐保持开启。',
       hintDownscale: '超过像素预算的图片先缩放再送视觉模型，降低延迟与成本；默认开启。',
       hintCache: '缓存识图答案（按图片内容 + 问题）；默认开启。',
-      hintFreeFallback: '启用内置 OVH 匿名视觉链作为最终兜底：免注册、免 Key，并在你选择的用户视觉模型之后尝试；默认开启。',
+      hintFreeFallback: '当你选择的识图模型都不可用时，自动尝试内置 OVH 免费模型。免注册、免 API Key。',
       hintStealth:
         '只作用于官方 DeepSeek 路由：接管后模型选择器保持原样。需在 profile 补丁层 ' +
         '（cordis.patch.yml）禁用官方 llm-deepseek 行后才真正接管；官方行还在时 ' +
@@ -181,12 +179,12 @@ window.__ModuleLoader__.load({
         '提示：检测到官方 DeepSeek 行当前被禁用（profile 补丁层），所以即使关闭隐身模式，' +
         '本插件仍会接管 deepseek-official 路由，否则 DeepSeek 模型会从选择器消失。' +
         '如需完全恢复官方原生行，请先把 cordis.patch.yml 里 llm-deepseek 的 disabled 改回 false 再重启。',
-      numTimeoutMs: '视觉请求超时（毫秒）',
-      numVisionTaskTimeoutMs: '单次视觉任务总预算（毫秒）',
-      numOcrTimeoutMs: '单次 OCR 任务总预算（毫秒）',
-      numDownscaleMaxPixels: '图片像素预算',
+      numTimeoutMs: '单次识图请求超时（毫秒）',
+      numVisionTaskTimeoutMs: '识图任务最长时间（毫秒）',
+      numOcrTimeoutMs: 'OCR 最长时间（毫秒）',
+      numDownscaleMaxPixels: '图片像素上限',
       numCacheTtlSeconds: '缓存有效期（秒）',
-      numCacheMaxEntries: '缓存条目上限',
+      numCacheMaxEntries: '最大缓存数量',
       numHintTimeoutMs: '单个视觉请求超时；默认 120000。',
       numHintVisionTaskTimeoutMs: '一次识图任务（含全部 provider、回退与重试）共享的总时限；默认 45000。认证失败/限流会立即熔断对应后端。',
       numHintOcrTimeoutMs: '一次 OCR 任务的总时限；本地 tesseract 最多用 12 秒，视觉模型回退只用剩余部分；默认 30000。',
@@ -203,9 +201,9 @@ window.__ModuleLoader__.load({
       wrapHint: '通常无需配置：默认会自动发现并包装「设置 → 模型」里已启用的模型。只有想限制某个 provider 的自动识图范围，或关闭上方自动创建后手动指定时才在这里添加；模型留空 = 该路由全部模型。原模型组始终保留不变。改动即时生效，无需重启。',
       wrapAllModels: '全部模型（不选 = 包装全部）',
       addWrapper: '+ 添加手动包装',
-      textProviders: '视觉后端链',
-      textProvidersHint: '每行一个可调用生成式「provider/model」，从上到下失败回退。图片能力声明只作提示；运行时先走 DSH adapter，失败自动回退。留空清除用户覆盖。',
-      textTextProvider: '文本模型',
+      textProviders: '识图模型',
+      textProvidersHint: '每行一个识图模型，从上到下依次尝试；留空则只使用内置免费兜底。',
+      textTextProvider: '文字回退模型',
       textTextProviderHint: '格式「provider/model」。',
       presentingImage: '正在准备图片…',
       presentedImage: '图片',
@@ -217,32 +215,32 @@ window.__ModuleLoader__.load({
       closeImagePreview: '关闭预览',
     }
     const en = {
-      nav: 'Vision Router (auto image understanding)',
-      desc: 'The session model chats; the vision backend sees images. They are configured separately · panel v8',
-      quickStartTitle: 'Chat and vision are configured separately',
-      quickStartBody: '① Session/text model: choose it from the lower-right chat selector; for image turns use a group marked “+ Auto Vision”. ② Vision model: choose it in this card under “Vision backend chain”; it only handles image understanding.',
-      quickStartLive: 'To change only image understanding, edit “Vision backend chain” below; your lower-right session model is not changed.',
-      quickStartGuide: 'Show model guide again',
+      nav: 'Vision Router · Image understanding',
+      desc: 'Your chat model thinks and answers; the vision model reads images. Configure them independently.',
+      quickStartTitle: 'Chat and image understanding are separate',
+      quickStartBody: 'Your chat model handles reasoning and answers; the vision model reads images. When sending images, choose a model marked “+ Auto Vision” in chat.',
+      quickStartLive: 'To change only image understanding, edit “Vision model” below. Your current chat model will not change.',
+      quickStartGuide: 'Show beginner guide again',
       onboardingTitle: 'Vision Router is ready 🎉',
-      onboardingBody: 'Vision Router separates “who chats and reasons” from “who sees the image”. These 3 steps make the distinction explicit.',
-      onboardingStep1Title: '1 · Session / text model',
-      onboardingStep1Body: 'Choose it from the lower-right chat selector. For images, use a group marked “+ Auto Vision”; the DeepSeek/opencode model inside still handles chat, reasoning, and tool calls.',
-      onboardingStep2Title: '2 · Vision model',
-      onboardingStep2Body: 'Open Settings → Plugins → Vision Router and choose it under “Vision backend chain”. It only sees images and does not replace your chat model.',
-      onboardingStep3Title: '3 · Primary and fallback vision models',
-      onboardingStep3Body: 'Each row in the vision backend chain is one of your own vision models and is tried top to bottom. You may leave every row empty; the built-in anonymous OVH chain remains the automatic final fallback.',
-      onboardingGuide: 'Guide me to vision settings',
+      onboardingBody: 'For first use, remember one thing: the chat model answers, and the vision model reads images. Follow these 3 steps.',
+      onboardingStep1Title: '1 · Choose your chat model',
+      onboardingStep1Body: 'Choose the model you normally use from the lower-right chat selector. For images, choose its “+ Auto Vision” version.',
+      onboardingStep2Title: '2 · Choose the vision model',
+      onboardingStep2Body: 'Open Settings → Plugins → Vision Router and choose it under “Vision model”. It only reads images and does not replace your chat model.',
+      onboardingStep3Title: '3 · Add fallback models',
+      onboardingStep3Body: 'Add more than one vision model if you want. If one fails, Vision Router tries the next; the built-in free fallback remains available at the end.',
+      onboardingGuide: 'Guide me through vision setup',
       onboardingLater: 'Later',
       onboardingClose: 'Close',
-      guideStep1Title: 'Step 1 · Session / text model',
+      guideStep1Title: 'Step 1 · Choose your chat model',
       guideStep1Body: 'The model selector next to the chat input in the lower-right corner is now highlighted. For image turns, pick a group marked “+ Auto Vision”; the model inside still handles chat, reasoning, and tool calls. Click “Next” when done.',
       guideStepNext: 'Next',
-      guidePromptTitle: 'Step 2 · Vision model',
+      guidePromptTitle: 'Step 2 · Choose the vision model',
       guidePromptGearBody: 'Click the highlighted Settings gear at the bottom-left of the sidebar, or press “Next” and I will open it for you.',
-      guidePromptNavBody: 'In the settings panel’s left navigation, click the highlighted “Plugins” entry (or press “Next”). Once that page is open, I will expand Vision Router and take you to “Vision backend chain”.',
+      guidePromptNavBody: 'In Settings, click the highlighted “Plugins” entry (or press “Next”). I will expand Vision Router and take you directly to “Vision model”.',
       guidePromptCancel: 'End guide',
-      guideChainTitle: 'Step 3 · This is the vision model',
-      guideChainBody: 'Each row is a vision-backend candidate you chose and will be tried in order. Rows may all stay empty. DSH image-capability metadata is advisory only and no longer decides what you may select. The built-in OVH free chain remains the final fallback. Save when done.',
+      guideChainTitle: 'Step 3 · Add fallback models',
+      guideChainBody: 'Vision models are tried from top to bottom. You may add several fallbacks or leave them empty; the built-in OVH free model remains the final fallback. Save when done.',
       guideDone: 'Finish guide',
       pending: 'Unsaved',
       readOnly: 'The active settings provider is read-only.',
@@ -261,15 +259,15 @@ window.__ModuleLoader__.load({
       builtinFallbackEnabled: 'Enabled',
       builtinFallbackDisabled: 'Disabled',
       builtinFallbackBody: 'The anonymous OVHcloud vision chain contains {count} models, starting with {primary}. Anonymous limits are 2 requests/minute per IP per model; five independent model buckets are about 10 RPM in theory, subject to OVH rate limiting. It always runs after your user models and needs no signup or API key.',
-      chainLabel: 'Vision backend chain (used by the vision tools)',
-      chainHint: 'Each row may select any callable generative model from Settings → Models; DSH image-capability metadata is advisory only. Calls always go through the registered DSH adapter first (including WebSocket, RPC, or private transports), then fail over to the next row. The direct HTTP compatibility bridge is considered only for a positively identified http(s) OpenAI Chat Completions endpoint.',
-      addFallback: '+ Add vision fallback',
+      chainLabel: 'Vision model',
+      chainHint: 'Choose the models Vision Router uses to read images. They are tried from top to bottom, with automatic failover.',
+      addFallback: '+ Add fallback vision model',
       remove: 'Remove',
       removeTitle: 'Remove this row',
-      textModelLabel: 'Text model (text turns use it)',
-      textModelHint: 'Usually unneeded; leave empty to restore the default.',
+      textModelLabel: 'Text fallback model',
+      textModelHint: 'Usually unnecessary; leave empty to use the default chat model.',
       defaultChainNote:
-        'This section configures the “eyes” used by the vision tools, not the brain/conversation model in the lower-right picker. The rows above are only your own vision models; the built-in anonymous OVH chain is fixed at the bottom and never requires selecting Vision HTTP.',
+        'These models read images and do not change the chat model selected in the composer. Your models are tried in order; the built-in OVH free model remains the final fallback.',
       catalogLoading: 'Loading the model catalog (same source as Settings → Models)…',
       catalogUnavailable: 'Connection service unavailable (no model catalog); falling back to free-text input.',
       catalogTimeout: 'Catalog request timed out (15s)',
@@ -294,20 +292,25 @@ window.__ModuleLoader__.load({
       chainInvalidCurrent: 'This saved backend is no longer callable, or is a non-generative/recursive route, so runtime will skip it: ',
       retryCatalog: 'Retry catalog',
       advanced: 'Advanced settings',
-      groupTextModel: 'Text model (special cases only)',
+      groupPerformance: 'Performance',
+      groupCompatibility: 'Compatibility',
+      groupNetwork: 'Network',
+      groupDeveloper: 'Developer settings',
+      groupDiagnostics: 'Version & diagnostics',
+      developerHint: 'These controls are for route overrides, capability labels, and compatibility debugging. Most users can leave them alone.',
+      groupTextModel: 'Text fallback model',
       textModelGroupHint:
-        'Text turns normally use the session model picked in the composer; this field only acts as the ' +
-        'text-turn fallback when whole-turn routing is on and the session entry is a vision route.',
-      groupBehavior: 'Behavior',
-      groupParams: 'Parameters',
-      groupVisionOverrides: 'Vision capability labels (optional)',
-      extraVisionModelsLabel: 'Extra vision models (capability-label override, optional)',
+        'Usually unnecessary. Used only when whole-turn vision routing is enabled and plain text should return to the chat model.',
+      groupBehavior: 'Image behavior',
+      groupParams: 'Performance & timeouts',
+      groupVisionOverrides: 'Vision capability overrides',
+      extraVisionModelsLabel: 'Extra vision capability labels',
       extraVisionModelsHint:
         'This setting no longer unlocks the picker or admission: every callable generative model is selectable already. ' +
         'Use it only when you want to explicitly label an undeclared model as visual. ' +
         'Runtime still tries the DSH adapter first; only a confirmed http(s) OpenAI Chat Completions channel may use the direct compatibility bridge.',
       groupRoutes: 'Route names',
-      groupProxy: 'Proxy',
+      groupProxy: 'Network',
       proxyLabel: 'Proxy URL',
       proxyHint: 'e.g. http://127.0.0.1:10808 or socks5h://127.0.0.1:10808; empty disables. Applies immediately.',
       proxyHostsLabel: 'Proxied hosts (one per line)',
@@ -346,35 +349,28 @@ window.__ModuleLoader__.load({
       save: 'Save',
       saving: 'Saving…',
       renderFailed: 'Settings card failed to render: ',
-      toggleRouting: 'Whole-turn vision routing',
-      toggleReverseRouting: 'Reverse routing for text turns',
+      toggleRouting: 'Send the whole image turn to the vision model',
+      toggleReverseRouting: 'Keep text-only messages on the chat model',
       toggleTool: 'Vision tools',
-      toggleStructuredVisionBootstrap: 'Structured bootstrap (experimental)',
+      toggleStructuredVisionBootstrap: 'Structured pre-scan (1+x, experimental)',
       toggleAutoWrapProviders: 'Auto-create “+ Auto Vision” model groups',
-      toggleRewriteImages: 'Image-block rewriting',
+      toggleRewriteImages: 'Protect text-only models',
       toggleDownscale: 'Auto downscale',
       toggleCache: 'Vision answer cache',
-      toggleFreeFallback: 'Free fallback',
+      toggleFreeFallback: 'Built-in free fallback',
       toggleStealth: 'Stealth mode',
       hintRouting:
-        'Off by default: image turns are not switched to the vision model as a whole; instead the ' +
-        'session model looks at images through vision_describe and friends like any tool call, enabling ' +
-        'continuous multi-step work (ground → crop → diff → …). Turning it on restores the legacy one-shot ' +
-        'whole-turn behavior. Note: with routing on, the fallback chain only contains provider+fallbacks ' +
-        'from the vision backend chain; httpProviders (including the free fallback) do not participate.',
-      hintReverseRouting: 'With whole-turn routing on, route plain text turns back to the text model; on by default.',
-      hintTool: 'Pixel-level vision tools such as vision_describe / vision_ground; turning this off disables them.',
-      hintStructuredVisionBootstrap:
-        'Off by default. Each new image turn first calls vision_bootstrap for one universal, detailed structured visual baseline; no OCR/document/UI/code mode is chosen beforehand. ' +
-        'Pass 1 returns the dedicated bootstrap schema (visual_kind / regions / visible_text / entities / uncertainties / recommended_followups). ' +
-        'The agent must then make at least one follow-up evidence call before it may answer, and can continue freely after that. This is 1+x with x>=1; keep Vision tools enabled. It causes at least two visual/evidence tool calls per image task.',
-      hintAutoWrapProviders: 'Recommended on. The plugin discovers routes enabled in Settings → Models and creates an additional same-name “+ Auto Vision” model group. Choose that new group from the lower-right chat model selector when sending images; the original group is never changed. Model and wrapper changes hot-update without a restart.',
-      hintRewriteImages:
-        'Replaces image blocks in the model input with text: a recorded vision description when one exists, ' +
-        'otherwise an attachment marker — a text-only model never receives image content it cannot handle.',
+        'Off by default. When enabled, the entire image turn is handled directly by the vision model instead of ' +
+        'the current chat model calling vision tools. This preserves legacy behavior and is usually unnecessary; ' +
+        'only the vision models configured above participate.',
+      hintReverseRouting: 'Only applies when whole-turn vision routing is enabled; plain text messages continue to use the chat model.',
+      hintTool: 'Lets the chat model inspect, locate, crop, and compare images as needed. Recommended on.',
+      hintStructuredVisionBootstrap: 'Off by default. Each image task first gets one task-independent structured visual baseline with no task goal passed into the pre-scan, then the chat model must make at least one evidence or deepening vision call for the original request (1+x, x>=1). This improves evidence quality but adds at least one visual call. If OCR is needed, auto mode prefers vision-model OCR. Keep Vision tools enabled.',
+      hintAutoWrapProviders: 'Automatically creates a “+ Auto Vision” version of enabled chat models. Original model groups stay unchanged. Recommended on.',
+      hintRewriteImages: 'Prevents raw image content from being sent to a text-only model that cannot read it. Recommended on.',
       hintDownscale: 'Images beyond the pixel budget are resized before the vision call, cutting latency and cost; on by default.',
       hintCache: 'Caches vision answers (keyed by image content + question); on by default.',
-      hintFreeFallback: 'Keeps the built-in anonymous OVH vision chain as the final fallback after your user-selected vision models; no signup or API key required. On by default.',
+      hintFreeFallback: 'If your selected vision models fail, automatically try the built-in OVH free models. No signup or API key required.',
       hintStealth:
         'Only affects the official DeepSeek route: takes it over while the model picker looks exactly like stock. Requires the ' +
         'official llm-deepseek row to be disabled in your profile patch layer (cordis.patch.yml); while the ' +
@@ -386,12 +382,12 @@ window.__ModuleLoader__.load({
         'serving the deepseek-official route even with stealth mode off — otherwise the DeepSeek models would ' +
         'vanish from the picker. To restore the fully official route, re-enable the llm-deepseek row in ' +
         'cordis.patch.yml first, then restart.',
-      numTimeoutMs: 'Vision request timeout (ms)',
-      numVisionTaskTimeoutMs: 'Vision task budget (ms)',
-      numOcrTimeoutMs: 'OCR task budget (ms)',
-      numDownscaleMaxPixels: 'Image pixel budget',
+      numTimeoutMs: 'Single vision request timeout (ms)',
+      numVisionTaskTimeoutMs: 'Vision task maximum time (ms)',
+      numOcrTimeoutMs: 'OCR maximum time (ms)',
+      numDownscaleMaxPixels: 'Image pixel limit',
       numCacheTtlSeconds: 'Cache TTL (seconds)',
-      numCacheMaxEntries: 'Cache entry limit',
+      numCacheMaxEntries: 'Maximum cached answers',
       numHintTimeoutMs: 'Per vision-call deadline; default 120000.',
       numHintVisionTaskTimeoutMs: 'One vision task (all providers, fallbacks and retries) shares this wall-clock budget; default 45000. Auth failures and rate limits trip their backend immediately.',
       numHintOcrTimeoutMs: 'Total budget for one OCR task: tesseract gets at most 12s, the vision fallback only the remainder; default 30000.',
@@ -408,9 +404,9 @@ window.__ModuleLoader__.load({
       wrapHint: 'Usually no configuration is needed: enabled models from Settings → Models are discovered and wrapped automatically. Add rows here only to restrict one provider’s auto-vision scope, or after turning off automatic creation above. Empty model = every model on that route. The original model group always remains untouched. Applies immediately; no restart.',
       wrapAllModels: 'All models (empty = wrap all)',
       addWrapper: '+ Add manual wrapper',
-      textProviders: 'Vision backend chain',
-      textProvidersHint: 'One callable generative "provider/model" per line, top-down failover. Image-capability metadata is advisory; the registered DSH adapter is tried first and failures fall through. Empty clears the override.',
-      textTextProvider: 'Text model',
+      textProviders: 'Vision model',
+      textProvidersHint: 'One vision model per line, tried from top to bottom. Leave empty to rely on the built-in free fallback.',
+      textTextProvider: 'Text fallback model',
       textTextProviderHint: 'Format "provider/model".',
       presentingImage: 'Preparing image…',
       presentedImage: 'Image',
@@ -499,8 +495,11 @@ window.__ModuleLoader__.load({
     }
 
     // ── field specs ──────────────────────────────────────────────────────────
-    const TOGGLE_KEYS = ['routing', 'tool', 'structuredVisionBootstrap', 'autoWrapProviders', 'stealth']
-    const ADVANCED_TOGGLE_KEYS = ['reverseRouting', 'rewriteImages', 'downscale', 'cache', 'freeFallback']
+    const TOGGLE_KEYS = ['autoWrapProviders', 'tool', 'structuredVisionBootstrap', 'routing']
+    const PERFORMANCE_TOGGLE_KEYS = ['downscale', 'cache']
+    const COMPATIBILITY_TOGGLE_KEYS = ['reverseRouting', 'rewriteImages', 'freeFallback']
+    const DEVELOPER_TOGGLE_KEYS = ['stealth']
+    const ADVANCED_TOGGLE_KEYS = [...PERFORMANCE_TOGGLE_KEYS, ...COMPATIBILITY_TOGGLE_KEYS, ...DEVELOPER_TOGGLE_KEYS]
     const ALL_TOGGLE_KEYS = [...TOGGLE_KEYS, ...ADVANCED_TOGGLE_KEYS]
     const NUMBER_KEYS = ['timeoutMs', 'visionTaskTimeoutMs', 'ocrTimeoutMs', 'downscaleMaxPixels', 'cacheTtlSeconds', 'cacheMaxEntries']
     const NUMBER_META = {
@@ -770,8 +769,9 @@ window.__ModuleLoader__.load({
       '.vr-invalid{color:var(--dsw-alias-label-error);margin:0;font-size:12px;line-height:1.5}' +
       '.vr-hint{color:var(--dsw-alias-label-tertiary);margin:0;font-size:12px;line-height:1.5}' +
       '.vr-toggle{display:flex;align-items:center;gap:10px;justify-content:space-between;width:100%}' +
-      '.vr-savebar{position:sticky;top:0;z-index:20;margin:0 -8px;padding:8px;display:flex;justify-content:flex-end;align-items:center;gap:8px;flex-wrap:wrap;background:color-mix(in srgb,var(--dsw-alias-bg-layer-2) 94%,transparent);border-bottom:1px solid var(--dsw-alias-border-l2);box-shadow:0 8px 18px #0002;backdrop-filter:blur(10px)}' +
-      '.vr-savebar .vr-pending{margin-right:auto}' +
+      '.vr-savebar{position:sticky;top:10px;z-index:20;width:max-content;max-width:100%;margin:0 0 10px auto;padding:5px 6px;display:flex;justify-content:flex-end;align-items:center;gap:6px;flex-wrap:wrap;background:var(--dsw-alias-bg-layer-2);border:1px solid var(--dsw-alias-border-l2);border-radius:12px;box-shadow:0 3px 10px #00000012}' +
+      '.vr-savebar .vr-pending{margin:0 4px 0 2px;font-size:12px}' +
+      '.vr-savebar .vr-btn{padding:4px 10px}' +
       '.vr-footer{border-top:1px solid var(--dsw-alias-border-l2);justify-content:flex-end;align-items:center;gap:8px;padding:12px 0 4px;display:flex}' +
       '.vr-failed{min-width:0;color:var(--dsw-alias-label-error);flex:1;margin:0;font-size:12px;line-height:1.5}' +
       '.vr-btn{appearance:none;font:inherit;cursor:pointer;border:1px solid var(--dsw-alias-border-l2);border-radius:8px;padding:5px 14px;font-size:13px;line-height:1.5;color:var(--dsw-alias-label-secondary);background:0 0}' +
@@ -2803,17 +2803,13 @@ window.__ModuleLoader__.load({
                   }, t('quickStartGuide')),
                 ),
               ),
-              updatePanel(),
               TOGGLE_KEYS.map((key) => toggleField(key)),
-              stealthNotice(),
               h('p', { className: 'vr-hint' }, t('defaultChainNote')),
               visionCaps.status === 'loading'
                 ? h('p', { className: 'vr-hint' }, t('visionCapsLoading'))
                 : visionCaps.status === 'error'
                   ? h('p', { className: 'vr-hint vr-stealth-notice' }, t('visionCapsError'))
-                  : visionCaps.status === 'ready'
-                    ? h('p', { className: 'vr-hint' }, t('visionCapsFiltered'))
-                    : null,
+                  : null,
               catalogReady
                 ? chainEditor()
                 : h('div', {
@@ -2826,6 +2822,23 @@ window.__ModuleLoader__.load({
                     textField('providers', t('textProviders'), t('textProvidersHint'), true),
                   ),
               builtinFallbackPanel(),
+              h('div', { className: 'vr-quickstart-actions' },
+                h('button', {
+                  type: 'button', className: 'vr-btn', disabled: testState.status === 'running',
+                  onClick: runTestConnection,
+                }, t('testConnection')),
+                testState.status !== 'idle'
+                  ? h('p', {
+                      className: testState.result && testState.result.ok ? 'vr-hint' : 'vr-failed',
+                      style: { margin: 0 },
+                    },
+                      testState.status === 'running'
+                        ? t('testConnecting')
+                        : testState.result && testState.result.ok
+                          ? `${t('testOk')}（${typeof testState.result.latencyMs === 'number' ? testState.result.latencyMs + 'ms' : 'ok'}）`
+                          : `${t('testFailed')}：${testState.result && testState.result.error ? testState.result.error : 'unknown'}`)
+                  : null,
+              ),
               catalog.status === 'loading'
                 ? h('p', { className: 'vr-hint' }, t('catalogLoading'))
                 : catalog.status === 'error'
@@ -2848,57 +2861,47 @@ window.__ModuleLoader__.load({
                 h('span', { className: 'vr-chevron' + (showAdvanced ? ' vr-chevron-open' : '') }, '▾'),
               ),
               showAdvanced
-                ? h('div', { className: 'vr-advanced' },
-                    h('div', { className: 'vr-group' },
-                      h('p', { className: 'vr-group-title' }, t('groupTextModel')),
-                      catalogReady
-                        ? textProviderEditor()
-                        : textField('textProvider', t('textTextProvider'), t('textTextProviderHint'), false),
-                      h('p', { className: 'vr-hint' }, t('textModelGroupHint')),
-                    ),
-                    h('div', { className: 'vr-group' },
-                      h('p', { className: 'vr-group-title' }, t('groupBehavior')),
-                      ADVANCED_TOGGLE_KEYS.map((key) => toggleField(key)),
-                    ),
-                    h('div', { className: 'vr-group' },
-                      h('p', { className: 'vr-group-title' }, t('groupWrappers')),
-                      catalogReady
-                        ? wrappersEditor()
-                        : textField('wrappedProviders', t('textWrappedProviders'), t('textHintWrappedProviders'), true),
-                    ),
-                    h('div', { className: 'vr-group' },
-                      h('p', { className: 'vr-group-title' }, t('groupParams')),
-                      NUMBER_KEYS.map((key) => textField(key, t(LABEL_KEY[key]), t(HINT_KEY[key]), false)),
-                    ),
-                    h('div', { className: 'vr-group' },
-                      h('p', { className: 'vr-group-title' }, t('groupVisionOverrides')),
-                      catalogReady && hiddenVisionBackends.length > 0
-                        ? extraVisionModelsEditor()
-                        : textField('extraVisionModels', t('extraVisionModelsLabel'), t('extraVisionModelsHint'), true),
-                    ),
-                    h('div', { className: 'vr-group' },
-                      h('p', { className: 'vr-group-title' }, t('groupRoutes')),
-                      TEXT_KEYS.map((key) => textField(key, t(LABEL_KEY[key]), t(HINT_KEY[key]), false)),
-                    ),
-                    h('div', { className: 'vr-group' },
-                      h('p', { className: 'vr-group-title' }, t('groupProxy')),
-                      textField('proxy', t('proxyLabel'), t('proxyHint'), false),
-                      textField('proxyHosts', t('proxyHostsLabel'), t('proxyHostsHint'), true),
-                    ),
-                  )
-                : null,
-              h('div', { className: 'vr-footer' },
-                testState.status !== 'idle'
-                  ? h('p', {
-                      className: testState.result && testState.result.ok ? 'vr-hint' : 'vr-failed',
-                      style: { margin: 0 },
-                    },
-                      testState.status === 'running'
-                        ? t('testConnecting')
-                        : testState.result && testState.result.ok
-                          ? `${t('testOk')}（${typeof testState.result.latencyMs === 'number' ? testState.result.latencyMs + 'ms' : 'ok'}）`
-                          : `${t('testFailed')}：${testState.result && testState.result.error ? testState.result.error : 'unknown'}`)
-                  : null,
+      ? h('div', { className: 'vr-advanced' },
+          h('div', { className: 'vr-group' },
+            h('p', { className: 'vr-group-title' }, t('groupPerformance')),
+            PERFORMANCE_TOGGLE_KEYS.map((key) => toggleField(key)),
+            NUMBER_KEYS.map((key) => textField(key, t(LABEL_KEY[key]), t(HINT_KEY[key]), false)),
+          ),
+          h('div', { className: 'vr-group' },
+            h('p', { className: 'vr-group-title' }, t('groupCompatibility')),
+            COMPATIBILITY_TOGGLE_KEYS.map((key) => toggleField(key)),
+            catalogReady
+              ? textProviderEditor()
+              : textField('textProvider', t('textTextProvider'), t('textTextProviderHint'), false),
+            h('p', { className: 'vr-hint' }, t('textModelGroupHint')),
+          ),
+          h('div', { className: 'vr-group' },
+            h('p', { className: 'vr-group-title' }, t('groupNetwork')),
+            textField('proxy', t('proxyLabel'), t('proxyHint'), false),
+            textField('proxyHosts', t('proxyHostsLabel'), t('proxyHostsHint'), true),
+          ),
+          h('div', { className: 'vr-group' },
+            h('p', { className: 'vr-group-title' }, t('groupDeveloper')),
+            h('p', { className: 'vr-hint' }, t('developerHint')),
+            DEVELOPER_TOGGLE_KEYS.map((key) => toggleField(key)),
+            stealthNotice(),
+            h('p', { className: 'vr-group-title' }, t('groupWrappers')),
+            catalogReady
+              ? wrappersEditor()
+              : textField('wrappedProviders', t('textWrappedProviders'), t('textHintWrappedProviders'), true),
+            h('p', { className: 'vr-group-title' }, t('groupVisionOverrides')),
+            catalogReady && hiddenVisionBackends.length > 0
+              ? extraVisionModelsEditor()
+              : textField('extraVisionModels', t('extraVisionModelsLabel'), t('extraVisionModelsHint'), true),
+            h('p', { className: 'vr-group-title' }, t('groupRoutes')),
+            TEXT_KEYS.map((key) => textField(key, t(LABEL_KEY[key]), t(HINT_KEY[key]), false)),
+          ),
+        )
+      : null,
+    h('div', { className: 'vr-group' },
+      h('p', { className: 'vr-group-title' }, t('groupDiagnostics')),
+      updatePanel(),
+    ),              h('div', { className: 'vr-footer' },
                 h('button', {
                   type: 'button', className: 'vr-btn',
                   onClick: async () => {
@@ -2921,10 +2924,6 @@ window.__ModuleLoader__.load({
                     }
                   },
                 }, t('openLogFolder')),
-                h('button', {
-                  type: 'button', className: 'vr-btn', disabled: testState.status === 'running',
-                  onClick: runTestConnection,
-                }, t('testConnection')),
                 failed ? h('p', { className: 'vr-failed', role: 'alert' },
                   t('saveFailed') + (failedFields.length > 0 ? `（${failedFields.join('、')}）` : '')) : null,
                 h('button', {

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -264,15 +264,15 @@ test('settings save failure copy says unwritten drafts were kept', () => {
 
 test('model-selection guide separates session and vision models and targets the vision chain', () => {
   const source = readFileSync(new URL('../lib/client.js', import.meta.url), 'utf8')
-  assert.equal(source.includes("onboardingStep1Title: '1 · 会话 / 文字模型'"), true)
-  assert.equal(source.includes("quickStartTitle: '聊天与看图分别设置'"), true)
-  assert.equal(source.includes("quickStartTitle: 'Chat and vision are configured separately'"), true)
+  assert.equal(source.includes("onboardingStep1Title: '1 · 选择聊天模型'"), true)
+  assert.equal(source.includes("quickStartTitle: '聊天和看图分别设置'"), true)
+  assert.equal(source.includes("quickStartTitle: 'Chat and image understanding are separate'"), true)
   assert.equal(source.includes("updateProject: '项目主页'"), true)
   assert.equal(source.includes("updateManualSource: '源码仓库 / pnpm DSH：'"), true)
   assert.equal(source.includes('pnpm dsh plugin --profile '), true)
   assert.equal(source.includes('npx @deepseek-ai/dsh plugin --profile '), true)
   assert.equal(source.includes("onboardingStep2Body: '打开「设置 → 插件 → Vision Router」"), true)
-  assert.equal(source.includes("onboardingStep1Title: '1 · Session / text model'"), true)
+  assert.equal(source.includes("onboardingStep1Title: '1 · Choose your chat model'"), true)
   assert.equal(source.includes('Settings → Plugins → Vision Router'), true)
   assert.equal(source.includes("VISION_GUIDE_STORAGE_KEY = 'dsh-vision-router:guide:vision-backend-v2'"), true)
   assert.equal(source.includes('startVisionSettingsGuide(t)'), true)
@@ -360,14 +360,14 @@ test('the walkthrough walks step 1 (session model), step 2 (open settings), step
   assert.equal(source.includes("writeVisionGuideStep('step1')"), true)
   assert.equal(source.includes("writeVisionGuideStep('step2')"), true)
   // The step strings exist in both dictionaries, with the renumbered titles.
-  assert.equal(source.includes("guideStep1Title: '第 1 步 · 会话 / 文字模型'"), true)
+  assert.equal(source.includes("guideStep1Title: '第 1 步 · 选择聊天模型'"), true)
   assert.equal(source.includes("guideStepNext: '下一步'"), true)
-  assert.equal(source.includes("guidePromptTitle: '第 2 步 · 视觉模型'"), true)
-  assert.equal(source.includes("guideChainTitle: '第 3 步 · 这里就是视觉模型'"), true)
-  assert.equal(source.includes("guideStep1Title: 'Step 1 · Session / text model'"), true)
+  assert.equal(source.includes("guidePromptTitle: '第 2 步 · 选择识图模型'"), true)
+  assert.equal(source.includes("guideChainTitle: '第 3 步 · 设置备用模型'"), true)
+  assert.equal(source.includes("guideStep1Title: 'Step 1 · Choose your chat model'"), true)
   assert.equal(source.includes("guideStepNext: 'Next'"), true)
-  assert.equal(source.includes("guidePromptTitle: 'Step 2 · Vision model'"), true)
-  assert.equal(source.includes("guideChainTitle: 'Step 3 · This is the vision model'"), true)
+  assert.equal(source.includes("guidePromptTitle: 'Step 2 · Choose the vision model'"), true)
+  assert.equal(source.includes("guideChainTitle: 'Step 3 · Add fallback models'"), true)
   // Every step now carries a visual target, not just step 3: the prompt is
   // anchored to a highlighted element (spotlight hole + pulsing ring + arrow),
   // and step 2's copy differs between the sidebar gear phase and the settings
@@ -376,9 +376,9 @@ test('the walkthrough walks step 1 (session model), step 2 (open settings), step
   assert.equal(source.includes('vr-guide-spot-ring'), true)
   assert.equal(source.includes('vr-guide-arrow'), true)
   assert.equal(source.includes("guidePromptGearBody: '点击侧边栏左下角被高亮圈出的「设置」齿轮"), true)
-  assert.equal(source.includes("guidePromptNavBody: '在设置面板左侧的导航里，点击被高亮的「插件」入口"), true)
+  assert.equal(source.includes("guidePromptNavBody: '在设置面板左侧点击被高亮的「插件」入口"), true)
   assert.equal(source.includes("guidePromptGearBody: 'Click the highlighted Settings gear"), true)
-  assert.equal(source.includes("guidePromptNavBody: 'In the settings panel’s left navigation"), true)
+  assert.equal(source.includes("guidePromptNavBody: 'In Settings, click the highlighted “Plugins” entry"), true)
   // Stable DOM anchors: DSH web hashes its CSS-module class names, so targets
   // are addressed via data-slot / aria attributes instead of class names.
   assert.equal(source.includes('[data-slot="conversation.input.model"] button[aria-haspopup="menu"]'), true)

--- a/tests/logging-ui.test.js
+++ b/tests/logging-ui.test.js
@@ -10,6 +10,59 @@ test('settings card exposes a one-click logs-folder action', () => {
   assert.equal(source.includes("method: 'POST'"), true)
 })
 
+test('settings UX keeps beginner guidance while using user-facing labels', () => {
+  const source = readFileSync(new URL('../lib/client.js', import.meta.url), 'utf8')
+  assert.equal(source.includes("quickStartTitle: '聊天和看图分别设置'"), true)
+  assert.equal(source.includes("quickStartGuide: '重新查看新手引导'"), true)
+  assert.equal(source.includes("onboardingStep1Title: '1 · 选择聊天模型'"), true)
+  assert.equal(source.includes("onboardingStep2Title: '2 · 选择识图模型'"), true)
+  assert.equal(source.includes("onboardingStep3Title: '3 · 设置备用模型'"), true)
+  assert.equal(source.includes("chainLabel: '识图模型'"), true)
+  assert.equal(source.includes("toggleRouting: '整轮交给视觉模型'"), true)
+  assert.equal(source.includes("toggleStructuredVisionBootstrap: '结构化预识别（1+x，实验）'"), true)
+  assert.equal(source.includes("toggleRewriteImages: '保护纯文字模型'"), true)
+})
+
+test('settings UX keeps engineering controls behind advanced groups', () => {
+  const source = readFileSync(new URL('../lib/client.js', import.meta.url), 'utf8')
+  assert.equal(source.includes("groupPerformance: '性能'"), true)
+  assert.equal(source.includes("groupCompatibility: '兼容性'"), true)
+  assert.equal(source.includes("groupNetwork: '网络'"), true)
+  assert.equal(source.includes("groupDeveloper: '开发者设置'"), true)
+  assert.equal(source.includes("className: 'vr-savebar'"), true)
+  assert.equal(source.includes('width:max-content;max-width:100%'), true)
+  assert.equal(source.includes('margin:0 -8px'), false)
+  assert.equal(source.includes('backdrop-filter:blur(10px)'), false)
+  assert.equal(source.includes("const TOGGLE_KEYS = ['autoWrapProviders', 'tool', 'structuredVisionBootstrap', 'routing']"), true)
+  assert.equal(source.includes("const PERFORMANCE_TOGGLE_KEYS = ['downscale', 'cache']"), true)
+  assert.equal(source.includes("const COMPATIBILITY_TOGGLE_KEYS = ['reverseRouting', 'rewriteImages', 'freeFallback']"), true)
+  assert.equal(source.includes("const DEVELOPER_TOGGLE_KEYS = ['stealth']"), true)
+})
+
+test('settings UX puts model setup before advanced and diagnostics', () => {
+  const source = readFileSync(new URL('../lib/client.js', import.meta.url), 'utf8')
+  const renderStart = source.indexOf("return h('li', { className: 'vr-card'")
+  assert.notEqual(renderStart, -1)
+  const render = source.slice(renderStart)
+  const quickStart = render.indexOf("t('quickStartTitle')")
+  const primaryToggles = render.indexOf('TOGGLE_KEYS.map((key) => toggleField(key))')
+  const visionChain = render.indexOf('chainEditor()')
+  const testConnection = render.indexOf("t('testConnection')")
+  const advanced = render.indexOf("t('advanced')")
+  const developerControls = render.indexOf('DEVELOPER_TOGGLE_KEYS.map((key) => toggleField(key))')
+  const diagnostics = render.indexOf("t('groupDiagnostics')")
+  assert.equal(
+    [quickStart, primaryToggles, visionChain, testConnection, advanced, developerControls, diagnostics].every((index) => index >= 0),
+    true,
+  )
+  assert.equal(quickStart < primaryToggles, true)
+  assert.equal(primaryToggles < visionChain, true)
+  assert.equal(visionChain < testConnection, true)
+  assert.equal(testConnection < advanced, true)
+  assert.equal(advanced < developerControls, true)
+  assert.equal(developerControls < diagnostics, true)
+})
+
 test('log-folder failures include a machine-readable error code', () => {
   const serverSource = readFileSync(new URL('../lib/file-logger.js', import.meta.url), 'utf8')
   assert.equal(serverSource.includes("code: error && error.code !== undefined ? String(error.code) : undefined"), true)

--- a/tests/structured-bootstrap.test.js
+++ b/tests/structured-bootstrap.test.js
@@ -31,6 +31,6 @@ test('runtime removes goal and makes structured OCR vision-first', () => {
   assert.equal(index.includes('structuredBootstrapMemory(evidence)'), true)
   assert.equal(index.includes("def.name === 'vision_ocr'"), true)
   assert.equal(index.includes("effectiveArgs = { ...(args ?? {}), engine: 'vision' }"), true)
-  assert.equal(client.includes('不会给预识别传 goal'), true)
-  assert.equal(client.includes('auto 会优先使用视觉模型'), true)
+  assert.equal(client.includes('不读取具体任务目标'), true)
+  assert.equal(client.includes('自动模式会优先使用视觉模型'), true)
 })


### PR DESCRIPTION
Settings UX v2, rebased onto the latest `main` including merged PR #136.

Scope remains presentation-first:
- keep Quick Start and the three-step first-run guide;
- keep whole-turn routing as a toggle;
- rename user-facing controls around outcomes instead of internal routing terms;
- keep the main screen focused on Auto Vision, vision tools, structured pre-scan (1+x, experimental), whole-turn routing, and the vision model chain;
- regroup advanced controls into Performance, Compatibility, Network, and Developer settings;
- move update/diagnostic UI lower in the card;
- preserve #136's sticky unsaved/discard/save bar;
- preserve #136's `structuredVisionBootstrap` config and runtime behavior, including task-independent bootstrap and vision-first OCR in auto mode;
- do not change existing config defaults, routing semantics, provider behavior, or the 1+x runtime contract.

Regression coverage now checks the intended settings hierarchy and the #136 settings affordances. Integration was validated against the full suite including the structured-bootstrap tests.