### PR TITLE
fix: stabilize local vision integration

### DIFF
--- a/entry.js
+++ b/entry.js
@@ -10,6 +10,7 @@ import z from '@deepseek-ai/schemastery'
 import * as core from './index.js'
 import { installVisionRouterFileLogging } from './lib/file-logger.js'
 import { contextWithDelegatedReplay } from './lib/replay-delegation.js'
+import { installLocalVisionStabilizer } from './lib/local-vision-stabilizer.js'
 
 // Schemastery object schemas expose set() as the supported way to replace a
 // field schema. This mutates the Config object that index.js itself later uses
@@ -28,6 +29,12 @@ export const Config = core.Config
 export function apply(ctx, config = {}) {
   const logging = installVisionRouterFileLogging(ctx)
   const runtimeCtx = contextWithDelegatedReplay(logging.ctx)
+  // #141 stabilization boundary: keep the recently merged local-vision
+  // behavior isolated from main's existing provider/router semantics. It
+  // normalizes only the local settings/runtime seams before core.apply sees
+  // the context (desktop screenshot exposure, instant-local budget/one-pass,
+  // local vision-http transport and connection-probe fallback).
+  const { ctx: stabilizedCtx, bootConfig } = installLocalVisionStabilizer(runtimeCtx, config, core)
   // 启动诊断摘要只描述 composition/apply 的基础配置。设置服务可能稍后
   // 覆盖这些值；每个图片轮还会记录 current() 的实时决策，避免把这个
   // 启动快照误当成最终设置状态。
@@ -46,8 +53,8 @@ export function apply(ctx, config = {}) {
     /* diagnostics must never break apply */
   }
   try {
-    const result = core.apply(runtimeCtx, {
-      ...config,
+    const result = core.apply(stabilizedCtx, {
+      ...bootConfig,
       progressiveTools: config.progressiveTools === true,
     })
     if (result && typeof result.then === 'function') {

--- a/lib/local-vision-stabilizer.js
+++ b/lib/local-vision-stabilizer.js
@@ -1,0 +1,474 @@
+/**
+ * Narrow runtime guard around the local-vision features merged in #141.
+ *
+ * The large router core stays untouched: this layer only fixes seams that are
+ * specific to opt-in local vision, while non-local providers continue through
+ * the original adapters byte-for-byte.
+ */
+export function installLocalVisionStabilizer(ctx, config = {}, core) {
+  if (!ctx || typeof ctx !== 'object') return { ctx, bootConfig: config }
+
+  let rawScope
+  let preStepDepth = 0
+  let wrapperStreamDepth = 0
+  let screenshotCandidate
+  let screenshotHandle
+  let screenshotMountedDef
+
+  const rawTools = ctx.tools
+  const rawLlm = ctx.llm
+  const rawInject = typeof ctx.inject === 'function' ? ctx.inject.bind(ctx) : undefined
+  const rawOn = typeof ctx.on === 'function' ? ctx.on.bind(ctx) : undefined
+
+  const positive = (value, fallback) =>
+    Number.isFinite(value) && value > 0 ? Number(value) : fallback
+
+  const actualConfig = () => {
+    try {
+      const value = rawScope && typeof rawScope.get === 'function' ? rawScope.get() : config
+      return value && typeof value === 'object' ? value : config
+    } catch {
+      return config
+    }
+  }
+
+  const localTaskBudget = (value = actualConfig()) =>
+    Math.max(
+      1000,
+      Math.min(
+        positive(value.timeoutMs, 120000),
+        positive(value.visionTaskTimeoutMs, 45000),
+      ),
+    )
+
+  const configForCore = () => {
+    const actual = actualConfig()
+    let view = actual
+    // instantDescribe is a pre-step convenience; do not let its local HTTP
+    // pass exceed the normal whole-vision task deadline (120s -> 45s by
+    // default). Other tools keep the user's ordinary timeoutMs unchanged.
+    if (preStepDepth > 0 && actual.instantDescribe === true) {
+      const bounded = localTaskBudget(actual)
+      if (positive(actual.timeoutMs, 120000) !== bounded) {
+        view = { ...view, timeoutMs: bounded }
+      }
+    }
+    // The pre-step owns the single automatic local caption pass. If that pass
+    // failed, the wrapper must not immediately repeat it with a fresh timeout.
+    if (wrapperStreamDepth > 0 && view.instantDescribe === true) {
+      view = { ...view, instantDescribe: false }
+    }
+    return view
+  }
+
+  const unmountScreenshot = () => {
+    if (typeof screenshotHandle === 'function') {
+      try { screenshotHandle() } catch { /* best effort */ }
+    }
+    screenshotHandle = undefined
+    screenshotMountedDef = undefined
+  }
+
+  const syncScreenshot = () => {
+    if (!screenshotCandidate || !rawTools || typeof rawTools.register !== 'function') return
+    if (actualConfig().desktopScreenshot !== true) {
+      unmountScreenshot()
+      return
+    }
+    if (screenshotHandle && screenshotMountedDef === screenshotCandidate) return
+    unmountScreenshot()
+    screenshotHandle = rawTools.register(screenshotCandidate)
+    screenshotMountedDef = screenshotCandidate
+  }
+
+  // Core must construct the screenshot definition even when the persisted
+  // setting is currently off, otherwise a later GUI opt-in has nothing to
+  // register. The settings base is replaced with the real config below, so
+  // this construction-only flag never changes the user's resolved default.
+  const bootConfig = { ...config, desktopScreenshot: true }
+
+  const tools = rawTools && typeof rawTools === 'object'
+    ? new Proxy(rawTools, {
+        get(target, property) {
+          if (property !== 'register') {
+            const value = Reflect.get(target, property, target)
+            return typeof value === 'function' ? value.bind(target) : value
+          }
+          return (def) => {
+            if (def && def.name === 'vision_screenshot') {
+              screenshotCandidate = def
+              syncScreenshot()
+              let active = true
+              return () => {
+                if (!active) return
+                active = false
+                if (screenshotCandidate === def) screenshotCandidate = undefined
+                if (screenshotMountedDef === def) unmountScreenshot()
+              }
+            }
+            return target.register(def)
+          }
+        },
+      })
+    : rawTools
+
+  const resolveCredential = async (ref) => {
+    if (typeof ref !== 'string' || ref === '') return undefined
+    try {
+      return (await ctx.get('credentials')?.resolve(ref))?.value
+    } catch {
+      return undefined
+    }
+  }
+
+  const localMessages = async (options) => {
+    const attachments = ctx.get('attachments')
+    const current = actualConfig()
+    const messages = []
+    for (const message of options.messages ?? []) {
+      if (!message || !Array.isArray(message.content)) continue
+      const content = []
+      for (const block of message.content) {
+        if (block && block.type === 'image' && block.attachment) {
+          if (!attachments || typeof attachments.readImage !== 'function') continue
+          try {
+            const stored = await attachments.readImage(block.attachment)
+            let bytes = stored.data
+            if (current.downscale !== false && bytes && bytes.length > 0) {
+              bytes = await core.downscaleImage(
+                bytes,
+                positive(current.downscaleMaxPixels, 4000000),
+              )
+            }
+            content.push(...core.toOpenAIContent([block], () => bytes))
+          } catch (error) {
+            ctx.logger?.warn(
+              'vision-http: failed to read image attachment: %s',
+              error && error.message ? error.message : String(error),
+            )
+          }
+        } else if (block && block.type === 'tool-result') {
+          const parts = []
+          for (const nested of Array.isArray(block.content) ? block.content : []) {
+            if (nested && nested.type === 'text' && typeof nested.text === 'string') {
+              parts.push(nested.text)
+            } else if (nested && nested.type === 'image') {
+              const attachment = nested.attachment || {}
+              const id = attachment.attachmentId || attachment.id || 'unknown'
+              parts.push(
+                `[attached image: ${id}] this tool result contained an image; ` +
+                  'inspect it with vision_describe (or re-read it with read_image)',
+              )
+            }
+          }
+          if (parts.length > 0) {
+            const call = typeof block.toolCallId === 'string' ? block.toolCallId : ''
+            content.push({
+              type: 'text',
+              text: `[tool result${call ? ` ${call}` : ''}]\n${parts.join('\n')}`,
+            })
+          }
+        } else if (block && block.type === 'text' && typeof block.text === 'string') {
+          content.push({ type: 'text', text: block.text })
+        }
+      }
+      if (content.length > 0) messages.push({ role: message.role, content })
+    }
+    return messages
+  }
+
+  const wrapVisionHttpAdapter = (adapter) =>
+    new Proxy(adapter, {
+      get(target, property) {
+        if (property !== 'stream') {
+          const value = Reflect.get(target, property, target)
+          return typeof value === 'function' ? value.bind(target) : value
+        }
+        return async function* stream(options) {
+          const local = core
+            .localProvidersOf(actualConfig())
+            .find((provider) => `${provider.name}/${provider.model}` === options.model)
+          if (!local) {
+            yield* target.stream(options)
+            return
+          }
+          try {
+            // Both local protocols go through the same local dispatcher. This
+            // is what preserves explicit temperature/top_p in the default
+            // OpenAI route as well as the Anthropic route.
+            const text = await core.callLocalBackend(local, await localMessages(options), {
+              maxTokens: local.maxTokens ?? 4096,
+              signal: options.signal,
+              resolveCredential,
+            })
+            if (text !== '') {
+              yield { type: 'block-start', index: 0, blockType: 'text' }
+              yield { type: 'text-delta', index: 0, text }
+              yield { type: 'block-end', index: 0, block: { type: 'text', text } }
+            }
+            yield { type: 'finish', reason: { kind: 'stop' } }
+          } catch (error) {
+            const classification = core.classifyVisionFailure(error)
+            const kinds = core.VISION_FAILURE_KINDS || {}
+            const code =
+              classification.kind === kinds.AUTH
+                ? 'AUTH'
+                : classification.kind === kinds.RATE_LIMIT
+                  ? 'RATE_LIMIT'
+                  : classification.kind === kinds.TIMEOUT
+                    ? 'TIMEOUT'
+                    : 'HTTP_PROVIDER_FAILED'
+            yield {
+              type: 'finish',
+              reason: {
+                kind: 'error',
+                failure: {
+                  message: error && error.message ? error.message : String(error),
+                  code,
+                },
+              },
+            }
+          }
+        }
+      },
+    })
+
+  const isWrapperRoute = (provider) => {
+    if (typeof provider !== 'string' || provider === '') return false
+    const current = actualConfig()
+    const wrapper =
+      typeof current.wrapperRoute === 'string' && current.wrapperRoute !== ''
+        ? current.wrapperRoute
+        : 'deepseek-vision'
+    return provider === wrapper || provider === 'deepseek-official' || provider.endsWith('-vision')
+  }
+
+  const wrapWrapperAdapter = (adapter) =>
+    new Proxy(adapter, {
+      get(target, property) {
+        if (property !== 'stream') {
+          const value = Reflect.get(target, property, target)
+          return typeof value === 'function' ? value.bind(target) : value
+        }
+        return async function* stream(options) {
+          wrapperStreamDepth += 1
+          try {
+            yield* target.stream(options)
+          } finally {
+            wrapperStreamDepth = Math.max(0, wrapperStreamDepth - 1)
+          }
+        }
+      },
+    })
+
+  const llm = rawLlm && typeof rawLlm === 'object'
+    ? new Proxy(rawLlm, {
+        get(target, property) {
+          if (property !== 'registerAdapter') {
+            const value = Reflect.get(target, property, target)
+            return typeof value === 'function' ? value.bind(target) : value
+          }
+          return (providers, adapter) => {
+            const list = Array.isArray(providers) ? providers : []
+            let wrapped = adapter
+            if (list.includes('vision-http')) wrapped = wrapVisionHttpAdapter(wrapped)
+            else if (list.some(isWrapperRoute)) wrapped = wrapWrapperAdapter(wrapped)
+            return target.registerAdapter(providers, wrapped)
+          }
+        },
+      })
+    : rawLlm
+
+  const wrapScope = (scope) =>
+    new Proxy(scope, {
+      get(target, property) {
+        if (property === 'get') return () => configForCore()
+        if (property === 'watch') {
+          const watch = Reflect.get(target, property, target)
+          if (typeof watch !== 'function') return watch
+          return (listener) =>
+            watch.call(target, (...args) => {
+              syncScreenshot()
+              return listener(...args)
+            })
+        }
+        const value = Reflect.get(target, property, target)
+        return typeof value === 'function' ? value.bind(target) : value
+      },
+    })
+
+  const wrapSettings = (settings) =>
+    new Proxy(settings, {
+      get(target, property) {
+        if (property !== 'register') {
+          const value = Reflect.get(target, property, target)
+          return typeof value === 'function' ? value.bind(target) : value
+        }
+        return (namespace, schema, options = {}) => {
+          // Core receives bootConfig only so it constructs the screenshot tool;
+          // resolved Settings must still inherit the user's real composition
+          // config (where desktopScreenshot remains false unless opted in).
+          const fixedOptions =
+            namespace === 'vision-router' ? { ...options, base: config } : options
+          const scope = target.register(namespace, schema, fixedOptions)
+          if (namespace === 'vision-router') {
+            rawScope = scope
+            syncScreenshot()
+            return wrapScope(scope)
+          }
+          return scope
+        }
+      },
+    })
+
+  const probeLocal = async (provider, signal) => {
+    try {
+      const response = await globalThis.fetch(`${provider.baseURL.replace(/\/$/, '')}/models`, {
+        method: 'GET',
+        signal,
+      })
+      if (!response.ok) return { ok: false, status: response.status, error: `HTTP ${response.status}` }
+      const data = await response.json().catch(() => undefined)
+      const models = data && Array.isArray(data.data) ? data.data : undefined
+      if (
+        models &&
+        typeof provider.model === 'string' &&
+        provider.model !== '' &&
+        !models.some((entry) => entry && String(entry.id) === provider.model)
+      ) {
+        return {
+          ok: false,
+          status: response.status,
+          models: models.length,
+          error: `configured model "${provider.model}" was not returned by /models`,
+        }
+      }
+      return {
+        ok: true,
+        status: response.status,
+        models: models ? models.length : undefined,
+        endpoint: provider.baseURL,
+      }
+    } catch (error) {
+      return { ok: false, error: error && error.message ? error.message : String(error) }
+    }
+  }
+
+  const wrapWebServer = (webServer) =>
+    new Proxy(webServer, {
+      get(target, property) {
+        if (property !== 'register') {
+          const value = Reflect.get(target, property, target)
+          return typeof value === 'function' ? value.bind(target) : value
+        }
+        return (spec) => {
+          if (!spec || spec.path !== '/_dsh/vision-router/test-connection') {
+            return target.register(spec)
+          }
+          const originalHandler = spec.handler
+          return target.register({
+            ...spec,
+            handler: async (req, res) => {
+              const locals = core.localProvidersOf(actualConfig())
+              if (req.method !== 'GET' || locals.length < 2) return originalHandler(req, res)
+              const started = Date.now()
+              const attempts = []
+              for (let index = 0; index < locals.length; index++) {
+                const controller = new AbortController()
+                const timer = setTimeout(() => controller.abort(), 5000)
+                try {
+                  const result = await probeLocal(locals[index], controller.signal)
+                  attempts.push({ backend: locals[index].name, ...result })
+                  if (result.ok) {
+                    res.writeHead(200, { 'content-type': 'application/json' })
+                    res.end(JSON.stringify({
+                      ...result,
+                      ok: true,
+                      backend: locals[index].name,
+                      fallbackUsed: index > 0,
+                      latencyMs: Date.now() - started,
+                      attempts,
+                    }))
+                    return
+                  }
+                } finally {
+                  clearTimeout(timer)
+                }
+              }
+              res.writeHead(502, { 'content-type': 'application/json' })
+              res.end(JSON.stringify({
+                ok: false,
+                latencyMs: Date.now() - started,
+                error: 'all enabled local vision backends failed the connection probe',
+                attempts,
+              }))
+            },
+          })
+        }
+      },
+    })
+
+  const inject = rawInject
+    ? (deps, callback) =>
+        rawInject(deps, (childCtx) => {
+          let wrapped = childCtx
+          if (Array.isArray(deps) && deps.includes('settings') && childCtx?.settings) {
+            const parent = wrapped
+            wrapped = new Proxy(parent, {
+              get(target, property) {
+                if (property === 'settings') return wrapSettings(target.settings)
+                const value = Reflect.get(target, property, target)
+                return typeof value === 'function' ? value.bind(target) : value
+              },
+            })
+          }
+          if (Array.isArray(deps) && deps.includes('webServer') && childCtx?.webServer) {
+            const parent = wrapped
+            wrapped = new Proxy(parent, {
+              get(target, property) {
+                if (property === 'webServer') return wrapWebServer(target.webServer)
+                const value = Reflect.get(target, property, target)
+                return typeof value === 'function' ? value.bind(target) : value
+              },
+            })
+          }
+          return callback(wrapped)
+        })
+    : undefined
+
+  const on = rawOn
+    ? (event, handler) => {
+        if (event !== 'agent/pre-step') return rawOn(event, handler)
+        return rawOn(event, async (...args) => {
+          preStepDepth += 1
+          try {
+            return await handler(...args)
+          } finally {
+            preStepDepth = Math.max(0, preStepDepth - 1)
+          }
+        })
+      }
+    : undefined
+
+  try {
+    ctx.effect?.(
+      () => () => unmountScreenshot(),
+      'vision-router: local vision stabilizer',
+    )
+  } catch {
+    /* cleanup registration is best effort */
+  }
+
+  const stabilizedCtx = new Proxy(ctx, {
+    get(target, property) {
+      if (property === 'tools') return tools
+      if (property === 'llm') return llm
+      if (property === 'inject' && inject) return inject
+      if (property === 'on' && on) return on
+      const value = Reflect.get(target, property, target)
+      return typeof value === 'function' ? value.bind(target) : value
+    },
+  })
+
+  return { ctx: stabilizedCtx, bootConfig }
+}

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "sharp": "^0.35.3"
   },
   "scripts": {
-    "test": "node --test tests/core.test.js tests/capability-advisory.test.js tests/vision-resilience.test.js tests/client.test.js tests/http-compat.test.js tests/catalog-corrections.test.js tests/update-check.test.js tests/self-update.test.js tests/doctor.test.js tests/doctor-cli.test.js tests/bundle-defaults.test.js tests/file-logger.test.js tests/replay-delegation.test.js tests/logging-ui.test.js tests/manifest-dependencies.test.js tests/structured-bootstrap.test.js tests/structured-bootstrap-gate.test.js tests/local-ollama.test.js tests/zero-regression-gate.test.js tests/runtime-e2e.test.js"
+    "test": "node --test tests/core.test.js tests/capability-advisory.test.js tests/vision-resilience.test.js tests/client.test.js tests/http-compat.test.js tests/catalog-corrections.test.js tests/update-check.test.js tests/self-update.test.js tests/doctor.test.js tests/doctor-cli.test.js tests/bundle-defaults.test.js tests/file-logger.test.js tests/replay-delegation.test.js tests/logging-ui.test.js tests/manifest-dependencies.test.js tests/structured-bootstrap.test.js tests/structured-bootstrap-gate.test.js tests/local-ollama.test.js tests/zero-regression-gate.test.js tests/runtime-e2e.test.js tests/local-vision-stabilizer.test.js"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/tests/local-vision-stabilizer.test.js
+++ b/tests/local-vision-stabilizer.test.js
@@ -1,0 +1,207 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { installLocalVisionStabilizer } from '../lib/local-vision-stabilizer.js'
+
+function makeCore() {
+  const calls = []
+  const localProvidersOf = (config = {}) => {
+    const out = []
+    if (config.localOllama?.enabled === true) out.push({
+      name: 'local-ollama', baseURL: config.localOllama.baseURL || 'http://ollama/v1',
+      model: config.localOllama.model || 'qwen2.5vl', maxTokens: 2048,
+      ...(typeof config.localOllama.temperature === 'number' ? { temperature: config.localOllama.temperature } : {}),
+      ...(typeof config.localOllama.top_p === 'number' ? { top_p: config.localOllama.top_p } : {}),
+      ...(config.localOllama.format === 'anthropic' ? { format: 'anthropic' } : {}),
+    })
+    if (config.localLmStudio?.enabled === true && config.localLmStudio.model) out.push({
+      name: 'local-lmstudio', baseURL: config.localLmStudio.baseURL || 'http://lm/v1',
+      model: config.localLmStudio.model, maxTokens: 2048,
+      ...(typeof config.localLmStudio.temperature === 'number' ? { temperature: config.localLmStudio.temperature } : {}),
+      ...(typeof config.localLmStudio.top_p === 'number' ? { top_p: config.localLmStudio.top_p } : {}),
+      ...(config.localLmStudio.format === 'anthropic' ? { format: 'anthropic' } : {}),
+    })
+    return out
+  }
+  return {
+    calls,
+    localProvidersOf,
+    toOpenAIContent(blocks, bytesOf) {
+      return blocks.map((block) => ({ type: 'image_url', image_url: { url: `data:image/png;base64,${Buffer.from(bytesOf(block.attachment)).toString('base64')}` } }))
+    },
+    downscaleImage: async (bytes) => bytes,
+    localDescribePrompt: () => 'describe',
+    async callLocalBackend(provider, messages, options) {
+      calls.push({ provider, messages, options })
+      return 'local answer'
+    },
+    classifyVisionFailure: () => ({ kind: 'other' }),
+    VISION_FAILURE_KINDS: { AUTH: 'auth', RATE_LIMIT: 'rate-limit', TIMEOUT: 'timeout' },
+  }
+}
+
+function makeHarness(initial = {}) {
+  let settings = { ...initial }
+  let watcher
+  const handlers = new Map()
+  const toolDefs = new Map()
+  const adapters = new Map()
+  const webRoutes = new Map()
+  const scope = {
+    get: () => settings,
+    watch(fn) { watcher = fn; return () => { if (watcher === fn) watcher = undefined } },
+  }
+  const ctx = {
+    logger: { warn() {}, info() {}, error() {} },
+    tools: {
+      register(def) {
+        toolDefs.set(def.name, def)
+        return () => { if (toolDefs.get(def.name) === def) toolDefs.delete(def.name) }
+      },
+    },
+    llm: {
+      registerAdapter(providers, adapter) {
+        for (const provider of providers) adapters.set(provider, adapter)
+        return () => { for (const provider of providers) if (adapters.get(provider) === adapter) adapters.delete(provider) }
+      },
+    },
+    get(name) {
+      if (name === 'attachments') return { readImage: async () => ({ data: Buffer.from('png') }) }
+      if (name === 'credentials') return { resolve: async () => ({ value: '' }) }
+      return undefined
+    },
+    on(event, handler) { handlers.set(event, handler); return () => handlers.delete(event) },
+    inject(deps, callback) {
+      if (deps.includes('settings')) callback({ settings: { register: () => scope }, effect() {} })
+      if (deps.includes('webServer')) callback({ webServer: { register(spec) { webRoutes.set(spec.path, spec); return () => webRoutes.delete(spec.path) } }, effect(fn) { return fn() } })
+    },
+    effect(fn) { return fn() },
+  }
+  return {
+    ctx, scope, handlers, toolDefs, adapters, webRoutes,
+    setSettings(next) { settings = { ...next }; if (watcher) watcher(settings) },
+  }
+}
+
+function installSettingsLikeCore(stabilized) {
+  let seenScope
+  stabilized.inject(['settings'], (sctx) => {
+    seenScope = sctx.settings.register('vision-router', {}, { base: {} })
+    seenScope.watch(() => {})
+  })
+  return () => seenScope
+}
+
+test('pre-step caps instantDescribe to the vision task budget without changing normal timeout', async () => {
+  const harness = makeHarness({ instantDescribe: true, timeoutMs: 120000, visionTaskTimeoutMs: 45000 })
+  const core = makeCore()
+  const { ctx: stabilized } = installLocalVisionStabilizer(harness.ctx, {}, core)
+  const scopeOf = installSettingsLikeCore(stabilized)
+  let seen
+  stabilized.on('agent/pre-step', async () => { seen = scopeOf().get().timeoutMs })
+  assert.equal(scopeOf().get().timeoutMs, 120000)
+  await harness.handlers.get('agent/pre-step')()
+  assert.equal(seen, 45000)
+  assert.equal(scopeOf().get().timeoutMs, 120000)
+})
+
+test('wrapper stream suppresses the second automatic instantDescribe pass only while streaming', async () => {
+  const harness = makeHarness({ instantDescribe: true })
+  const core = makeCore()
+  const { ctx: stabilized } = installLocalVisionStabilizer(harness.ctx, {}, core)
+  const scopeOf = installSettingsLikeCore(stabilized)
+  let inside
+  stabilized.llm.registerAdapter(['deepseek-vision'], {
+    async *stream() { inside = scopeOf().get().instantDescribe; yield { type: 'finish', reason: { kind: 'stop' } } },
+  })
+  assert.equal(scopeOf().get().instantDescribe, true)
+  for await (const _ of harness.adapters.get('deepseek-vision').stream({})) {}
+  assert.equal(inside, false)
+  assert.equal(scopeOf().get().instantDescribe, true)
+})
+
+test('vision-http dispatches OpenAI local providers through callLocalBackend so sampling is preserved', async () => {
+  const harness = makeHarness({
+    localOllama: { enabled: true, baseURL: 'http://ollama/v1', model: 'vl', temperature: 0.3, top_p: 0.7 },
+  })
+  const core = makeCore()
+  const { ctx: stabilized } = installLocalVisionStabilizer(harness.ctx, {}, core)
+  installSettingsLikeCore(stabilized)
+  let delegated = 0
+  stabilized.llm.registerAdapter(['vision-http'], {
+    async *stream() { delegated += 1; yield { type: 'finish', reason: { kind: 'stop' } } },
+  })
+  const chunks = []
+  for await (const chunk of harness.adapters.get('vision-http').stream({
+    model: 'local-ollama/vl',
+    messages: [{ role: 'user', content: [{ type: 'image', attachment: { attachmentId: 'x' } }, { type: 'text', text: 'what' }] }],
+  })) chunks.push(chunk)
+  assert.equal(delegated, 0)
+  assert.equal(core.calls.length, 1)
+  assert.equal(core.calls[0].provider.temperature, 0.3)
+  assert.equal(core.calls[0].provider.top_p, 0.7)
+  assert.ok(chunks.some((chunk) => chunk.type === 'text-delta' && chunk.text === 'local answer'))
+})
+
+test('vision-http leaves non-local models on the original adapter unchanged', async () => {
+  const harness = makeHarness({ localOllama: { enabled: true, model: 'vl' } })
+  const core = makeCore()
+  const { ctx: stabilized } = installLocalVisionStabilizer(harness.ctx, {}, core)
+  installSettingsLikeCore(stabilized)
+  let delegated = 0
+  stabilized.llm.registerAdapter(['vision-http'], {
+    async *stream() { delegated += 1; yield { type: 'finish', reason: { kind: 'stop' } } },
+  })
+  for await (const _ of harness.adapters.get('vision-http').stream({ model: 'ovh/Qwen3.5', messages: [] })) {}
+  assert.equal(delegated, 1)
+  assert.equal(core.calls.length, 0)
+})
+
+test('desktop screenshot tool follows the persisted setting and remains absent when disabled', () => {
+  const harness = makeHarness({ desktopScreenshot: false })
+  const core = makeCore()
+  const { ctx: stabilized } = installLocalVisionStabilizer(harness.ctx, {}, core)
+  installSettingsLikeCore(stabilized)
+  stabilized.tools.register({ name: 'vision_describe', execute() {} })
+  stabilized.tools.register({ name: 'vision_screenshot', execute() {} })
+  assert.equal(harness.toolDefs.has('vision_screenshot'), false)
+  harness.setSettings({ desktopScreenshot: true })
+  assert.equal(harness.toolDefs.has('vision_screenshot'), true)
+  harness.setSettings({ desktopScreenshot: false })
+  assert.equal(harness.toolDefs.has('vision_screenshot'), false)
+})
+
+test('connection probe falls through Ollama failure to LM Studio success', async () => {
+  const harness = makeHarness({
+    localOllama: { enabled: true, baseURL: 'http://ollama/v1', model: 'o' },
+    localLmStudio: { enabled: true, baseURL: 'http://lm/v1', model: 'l' },
+  })
+  const core = makeCore()
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = async (url) => {
+    if (String(url).startsWith('http://ollama')) throw new Error('offline')
+    return new Response(JSON.stringify({ data: [{ id: 'l' }] }), { status: 200, headers: { 'content-type': 'application/json' } })
+  }
+  try {
+    const { ctx: stabilized } = installLocalVisionStabilizer(harness.ctx, {}, core)
+    installSettingsLikeCore(stabilized)
+    stabilized.inject(['webServer'], (webCtx) => {
+      webCtx.webServer.register({ path: '/_dsh/vision-router/test-connection', handler: async (_req, res) => { res.writeHead(599); res.end('{}') } })
+    })
+    const route = harness.webRoutes.get('/_dsh/vision-router/test-connection')
+    let status
+    let body = ''
+    await route.handler({ method: 'GET' }, {
+      writeHead(code) { status = code },
+      end(value) { body = String(value ?? '') },
+    })
+    const parsed = JSON.parse(body)
+    assert.equal(status, 200)
+    assert.equal(parsed.backend, 'local-lmstudio')
+    assert.equal(parsed.fallbackUsed, true)
+    assert.equal(parsed.attempts.length, 2)
+    assert.equal(parsed.attempts[0].ok, false)
+    assert.equal(parsed.attempts[1].ok, true)
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})


### PR DESCRIPTION
## Context

Stabilization follow-up for the local-vision integration merged in #141. This PR intentionally does **not** publish or bump a new version: `package.json` remains at **v1.4.5** while the merged feature set is exercised and hardened.

The guiding constraint is the same zero-regression rule used during #98 review: local vision is opt-in, and users who do not enable it must keep current `main` behavior.

## Fixes in this PR

- **Desktop screenshot follows persisted Settings correctly.** `vision_screenshot` is constructed at boot but intercepted at the tool-registration boundary; it is absent while `desktopScreenshot=false`, appears when the persisted setting is explicitly enabled, and is removed again when disabled. The real Settings base still uses the original composition config, so the construction-only boot flag cannot turn the feature on by default.
- **Bound instantDescribe to the normal vision-task budget.** The automatic local pre-step now receives `min(timeoutMs, visionTaskTimeoutMs)` (45s with current defaults) instead of being able to consume the full 120s per-call timeout.
- **Prevent the hidden second instantDescribe pass.** The pre-step owns the single automatic local recognition attempt; wrapper/twin streaming temporarily sees `instantDescribe=false`, so a failed pre-step is not immediately retried with a fresh timeout.
- **Preserve local OpenAI sampling.** Local `vision-http` models now go through `callLocalBackend()` for both OpenAI and Anthropic formats, so explicit `temperature` / `top_p` behave the same in ordinary `vision_describe` / chain calls as they already do in instant describe and screenshot identify.
- **Connection probe follows local fallback order.** When both local backends are enabled, the Settings probe tries Ollama first and continues to LM Studio, reporting the attempts and whether fallback was used instead of declaring the whole setup broken when only Ollama is down.
- **Non-local `vision-http` models are delegated unchanged.** The stabilizer exits immediately for OVH/custom non-local entries, preserving the existing adapter path.

## Why this is an entry/runtime boundary

`index.js` just absorbed a large integration. Rather than rewriting that large file again while the feature set is still being stabilized, this PR puts the compatibility guard in a narrow public-entry wrapper (`lib/local-vision-stabilizer.js`). The existing router core and provider/fallback code remain untouched.

## Tests

Added `tests/local-vision-stabilizer.test.js` covering:

- pre-step timeout bounding without changing the normal timeout;
- no second wrapper instant pass;
- OpenAI local sampling via `callLocalBackend`;
- byte-for-byte delegation path for non-local models;
- persisted desktop screenshot on/off tool exposure;
- Ollama failure → LM Studio connection-probe fallback.

The focused suite was run locally against a fake Harness boundary: **6/6 passed**. GitHub CI run **#431 passed** on Node 22 + Node 24 and the Windows/macOS/Linux host-sharp/package matrix.

## Still to finish in this Draft before merge

These lower-risk presentation/documentation mismatches identified during the audit are intentionally kept visible here rather than pretending CI covers them:

- [ ] add/fix the missing `desktopScreenshot` zh/en Settings labels/hints;
- [ ] make the English `instantDescribe` hint match the Chinese 1+x suppression semantics;
- [ ] correct the local-backend priority copy (user-configured vision models remain before local Ollama/LM Studio; local is before HTTP/OVH fallback, not literally first overall);
- [ ] align README wording with `【输入图尺寸】`, the bounded instantDescribe behavior, and the now-live desktop screenshot toggle.

The current connector environment can safely patch the small runtime boundary without rewriting the 3k+ line prebuilt `lib/client.js`; those copy edits therefore remain explicit Draft blockers rather than being hidden in a risky full-file replacement.

## Before merge / before any next release

This PR is deliberately **Draft** while the #141 feature set is still under stabilization. Before publishing anything after v1.4.5, we should still smoke-test real local services:

- Ollama: OpenAI + image; Anthropic + image
- LM Studio: OpenAI + image; Anthropic + image (or document the actual limitation if the installed LM Studio build cannot do image content on Messages)
- hung Ollama → LM Studio fallback latency
- instantDescribe + 1+x remains 1+x, not 2+x
- desktop screenshot enable/disable from the real Settings page and actual capture permission paths

No version bump and no release are part of this PR.