### PR TITLE
fix: canonicalize vision providers before save/readback

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -678,6 +678,37 @@ window.__ModuleLoader__.load({
       )
     }
 
+    /**
+     * Canonicalize only the schema-defaulted shape of `providers`.
+     * SettingsScope may materialize a missing `fallbacks` as [] on readback;
+     * treating those two shapes as equivalent avoids a false save failure
+     * without weakening deep comparison for any other settings field.
+     */
+    function canonicalizeProviders(value) {
+      if (!Array.isArray(value)) return value
+      return value.map((row) => {
+        if (!row || typeof row !== 'object') return row
+        return {
+          ...row,
+          fallbacks: row.fallbacks === undefined ? [] : row.fallbacks,
+        }
+      })
+    }
+
+    function settingsValueEqual(key, left, right) {
+      if (key === 'providers') {
+        return jsonValueEqual(canonicalizeProviders(left), canonicalizeProviders(right))
+      }
+      return jsonValueEqual(left, right)
+    }
+
+    function canonicalizeSettingsRun(key, run) {
+      if (key === 'providers' && run && !run.clear) {
+        return { ...run, value: canonicalizeProviders(run.value) }
+      }
+      return run
+    }
+
     function settingsSaveErrorMessage(error) {
       return error && error.message ? error.message : String(error)
     }
@@ -707,7 +738,7 @@ window.__ModuleLoader__.load({
         const stored = !!user && typeof user === 'object' && Object.prototype.hasOwnProperty.call(user, item.key)
         const ok = item.run.clear
           ? !stored
-          : stored && jsonValueEqual(user[item.key], item.run.value)
+          : stored && settingsValueEqual(item.key, user[item.key], item.run.value)
         return { ok, stored }
       }
       const writeItem = async (item) => {
@@ -831,7 +862,7 @@ window.__ModuleLoader__.load({
         const provider = line.slice(0, idx).trim()
         const model = line.slice(idx + 1).trim()
         if (provider === '' || model === '') return undefined
-        list.push({ provider, model })
+        list.push({ provider, model, fallbacks: [] })
       }
       return list
     }
@@ -2271,7 +2302,7 @@ window.__ModuleLoader__.load({
         return trimmed === '' ? { clear: true } : { value: trimmed }
       }
       const plan = Object.keys(drafts)
-        .map((key) => ({ key, run: parse(key, drafts[key]) }))
+        .map((key) => ({ key, run: canonicalizeSettingsRun(key, parse(key, drafts[key])) }))
         .filter((item) => item.run !== undefined)
       const dirty = Object.keys(drafts).length > 0
       const invalid = plan.length !== Object.keys(drafts).length
@@ -2665,7 +2696,9 @@ window.__ModuleLoader__.load({
           : null
       const chainEditor = () => {
         const value = format('providers')
-        const rows = Array.isArray(value) && value.length > 0 ? value : [{ provider: '', model: '' }]
+        const rows = Array.isArray(value) && value.length > 0
+          ? value
+          : [{ provider: '', model: '', fallbacks: [] }]
         const invalidRows = catalogReady
           ? rows.filter((row) => row && row.provider && row.model && !visionModelVisible(row.provider, row.model))
           : []
@@ -2687,7 +2720,10 @@ window.__ModuleLoader__.load({
         }
         const removeChain = (index) => {
           const list = rows.filter((_row, i) => i !== index)
-          setDraft('providers', list.length > 0 ? list : [{ provider: '', model: '' }])
+          setDraft(
+            'providers',
+            list.length > 0 ? list : [{ provider: '', model: '', fallbacks: [] }],
+          )
         }
         return h('div', {
           className: 'vr-field' + (guideStep === 'step2' ? ' vr-guide-target' : ''),
@@ -2704,7 +2740,12 @@ window.__ModuleLoader__.load({
             h('div', { className: 'vr-chain-row', key: index },
               h('select', {
                 className: 'vr-input vr-select', value: visionProviderVisible(row.provider) ? row.provider : '', disabled: editBlocked,
-                onChange: (event) => updateChain(index, { provider: event.target.value, model: '' }),
+                onChange: (event) => updateChain(index, {
+                  ...row,
+                  provider: event.target.value,
+                  model: '',
+                  fallbacks: row.fallbacks === undefined ? [] : row.fallbacks,
+                }),
               },
                 h('option', { value: '' }, t('selectProvider')),
                 visionGroupOptions,
@@ -2713,7 +2754,12 @@ window.__ModuleLoader__.load({
                 className: 'vr-input vr-select', value: visionModelVisible(row.provider, row.model) ? row.model : '',
                 disabled: editBlocked || !visionProviderVisible(row.provider),
                 onChange: (event) => {
-                  updateChain(index, { provider: row.provider, model: event.target.value })
+                  updateChain(index, {
+                    ...row,
+                    provider: row.provider,
+                    model: event.target.value,
+                    fallbacks: row.fallbacks === undefined ? [] : row.fallbacks,
+                  })
                   // Picking a real vision model is an active backend choice:
                   // the walkthrough has done its job, so end it right away
                   // instead of waiting for the in-card button. Picking only a
@@ -2741,7 +2787,10 @@ window.__ModuleLoader__.load({
             : null,
           h('button', {
             type: 'button', className: 'vr-btn', disabled: editBlocked,
-            onClick: () => setDraft('providers', [...rows, { provider: '', model: '' }]),
+            onClick: () => setDraft('providers', [
+              ...rows,
+              { provider: '', model: '', fallbacks: [] },
+            ]),
           }, t('addFallback')),
           h('p', { className: 'vr-hint' }, t('chainHint')),
         )
@@ -3610,6 +3659,9 @@ window.__ModuleLoader__.load({
     exports.normalizeLocalProviderDraft = normalizeLocalProviderDraft
     exports.parseLocalProviderDraft = parseLocalProviderDraft
     exports.jsonValueEqual = jsonValueEqual
+    exports.canonicalizeProviders = canonicalizeProviders
+    exports.settingsValueEqual = settingsValueEqual
+    exports.canonicalizeSettingsRun = canonicalizeSettingsRun
     exports.commitSettingsPlan = commitSettingsPlan
     exports.installSettingsPersistence = installSettingsPersistence
     return module.exports

--- a/tests/providers-persistence.test.js
+++ b/tests/providers-persistence.test.js
@@ -1,0 +1,90 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+function loadClientBundle() {
+  let spec = null
+  globalThis.window = { __ModuleLoader__: { load(s) { spec = s } } }
+  const url = new URL('../lib/client.js', import.meta.url)
+  // eslint-disable-next-line no-eval
+  ;(0, eval)(readFileSync(url, 'utf8'))
+  const ReactStub = { memo: (value) => value }
+  return spec.factory((name) => {
+    if (name === 'react') return ReactStub
+    if (name === '@deepseek-ai/dsh-client-ui-attachment') return { ImageGallery: () => null }
+    throw new Error('require(' + name + ')')
+  })
+}
+
+test('providers save canonicalizes fallback defaults and survives reopen/restart', async () => {
+  const bundle = loadClientBundle()
+  const sparse = [{ provider: 'zhipu', model: 'glm-4.6v-flash' }]
+  const normalized = [{ provider: 'zhipu', model: 'glm-4.6v-flash', fallbacks: [] }]
+
+  assert.deepEqual(bundle.canonicalizeProviders(sparse), normalized)
+  assert.equal(bundle.settingsValueEqual('providers', sparse, normalized), true)
+  assert.equal(
+    bundle.settingsValueEqual(
+      'other',
+      { provider: 'x', model: 'y' },
+      { provider: 'x', model: 'y', fallbacks: [] },
+    ),
+    false,
+  )
+
+  const run = bundle.canonicalizeSettingsRun('providers', { value: sparse })
+  assert.deepEqual(run.value, normalized)
+
+  const snapshot = { status: 'ready', writable: true, user: {} }
+  const persisted = {}
+  const outcome = await bundle.commitSettingsPlan({
+    async set(field, value) {
+      persisted[field] = structuredClone(value)
+      snapshot.user[field] = structuredClone(value)
+    },
+    getSnapshot() { return snapshot },
+  }, [{ key: 'providers', run }], { providers: sparse })
+
+  assert.equal(outcome.landed, true)
+  assert.equal(outcome.failed, false)
+  assert.deepEqual(persisted.providers, normalized)
+
+  const reopened = bundle.normalizeVisionChainRows(structuredClone(persisted.providers))
+  const restarted = bundle.normalizeVisionChainRows(JSON.parse(JSON.stringify(persisted.providers)))
+  assert.deepEqual(reopened, normalized)
+  assert.deepEqual(restarted, normalized)
+  assert.equal(restarted[0].provider, 'zhipu')
+  assert.equal(restarted[0].model, 'glm-4.6v-flash')
+})
+
+test('providers readback accepts inserted empty fallbacks but rejects a real model mismatch', async () => {
+  const bundle = loadClientBundle()
+  const requested = [{ provider: 'zhipu', model: 'glm-4.6v-flash' }]
+  const snapshot = { status: 'ready', writable: true, user: {} }
+
+  const accepted = await bundle.commitSettingsPlan({
+    async set(field) {
+      snapshot.user[field] = [{ provider: 'zhipu', model: 'glm-4.6v-flash', fallbacks: [] }]
+    },
+    getSnapshot() { return snapshot },
+  }, [{ key: 'providers', run: { value: requested } }], { providers: requested })
+  assert.equal(accepted.landed, true)
+
+  const rejected = await bundle.commitSettingsPlan({
+    async set(field) {
+      snapshot.user[field] = [{ provider: 'zhipu', model: 'different-model', fallbacks: [] }]
+    },
+    getSnapshot() { return snapshot },
+  }, [{ key: 'providers', run: { value: requested } }], { providers: requested })
+  assert.equal(rejected.landed, false)
+  assert.equal(rejected.failures[0].reason, 'readback-mismatch')
+})
+
+test('vision chain editor preserves or initializes fallbacks on provider/model edits', () => {
+  const source = readFileSync(new URL('../lib/client.js', import.meta.url), 'utf8')
+  assert.equal(source.includes("{ provider: '', model: '', fallbacks: [] }"), true)
+  assert.equal(
+    source.includes('fallbacks: row.fallbacks === undefined ? [] : row.fallbacks'),
+    true,
+  )
+})


### PR DESCRIPTION
## Summary

Fix the Vision Router settings save path where `providers` rows could be written as `{ provider, model }` but read back from the config layer as `{ provider, model, fallbacks: [] }`. The previous strict structural comparison treated those schema-equivalent shapes as a failed write and kept `providers` in the failed field set.

## Changes

- preserve or initialize `fallbacks: []` when the vision-chain editor changes provider/model or creates an empty row
- canonicalize only `providers` before the settings write plan is committed
- canonicalize both requested/read-back `providers` values before verification, while retaining strict deep comparison for every other setting
- keep real provider/model mismatches as `readback-mismatch`
- add persistence regression coverage for save → reopen → serialized restart

## Verification

- `node --check lib/client.js`
- `node --test tests/client.test.js tests/providers-persistence.test.js`
- 34/34 targeted tests passed, including the new fallback-default and persistence cases

This intentionally does not touch the separate DSH rc.6 host web-route/update-check issue fixed by #166.