### PR TITLE
fix: gate guide sync layout work behind the active phase and coalesce scroll syncs via rAF

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1051,6 +1051,11 @@ window.__ModuleLoader__.load({
     let visionGuidePrompt
     let visionGuideSpotlight
     let visionGuideSyncTimer
+    // requestAnimationFrame handle for event-driven guide syncs (scroll,
+    // resize, popstate, guide event): coalesces the 60-120 scroll events/s
+    // into at most one sync per frame so scrolling never forces layout
+    // mid-gesture. undefined means no frame is pending.
+    let guideSyncFrame
     let onboardingSeenMemory = false
     let visionGuideStepMemory
     let visionGuideMemoryAuthoritative = false
@@ -1576,6 +1581,18 @@ window.__ModuleLoader__.load({
     function syncVisionGuidePrompt(t) {
       if (typeof document === 'undefined' || typeof window === 'undefined' || !document.body) return
       const step = readVisionGuideStep()
+      const phase = guidePhase(step)
+      if (phase === 'none' || phase === 'done' || phase === 'suspend') {
+        // No floating layer: the walkthrough is over, the in-card callout
+        // (step 3) has taken over, or the onboarding overview dialog covers
+        // the page. This idle branch runs on every scroll event site-wide
+        // (document-level capture listener), so it must return BEFORE any
+        // DOM query or getBoundingClientRect: per-event forced layout was
+        // the direct cause of the settings panel scroll stutter.
+        clearGuidePromptUI()
+        if (phase === 'none') stopGuideSync()
+        return
+      }
       const panelOpen = guideSettingsPanelOpen()
       if (step !== undefined && visionGuidePanelSeen && !panelOpen) {
         // The settings panel was open during this walkthrough round and the
@@ -1601,15 +1618,6 @@ window.__ModuleLoader__.load({
           window.clearTimeout(visionGuidePanelCloseTimer)
           visionGuidePanelCloseTimer = undefined
         }
-      }
-      const phase = guidePhase(step)
-      if (phase === 'none' || phase === 'done' || phase === 'suspend') {
-        // No floating layer: the walkthrough is over, the in-card callout
-        // (step 3) has taken over, or the onboarding overview dialog covers
-        // the page.
-        clearGuidePromptUI()
-        if (phase === 'none') stopGuideSync()
-        return
       }
       // Keep the light re-sync tick alive while any step is active; it is the
       // only thing that follows targets through SPA renders and menus.
@@ -1660,7 +1668,21 @@ window.__ModuleLoader__.load({
     }
     function installVisionSettingsGuide(t) {
       if (typeof document === 'undefined' || typeof window === 'undefined') return
-      const sync = () => window.setTimeout(() => syncVisionGuidePrompt(t), 0)
+      // Event-driven syncs (scroll, resize, popstate, guide event) coalesce
+      // into at most one requestAnimationFrame per frame. Scroll fires 60-120
+      // events per second; running a full sync per event (timeout-deferred)
+      // forced layout mid-scroll and made the settings panel stutter.
+      const sync = () => {
+        if (guideSyncFrame !== undefined) return
+        if (typeof window.requestAnimationFrame !== 'function') {
+          window.setTimeout(() => syncVisionGuidePrompt(t), 0)
+          return
+        }
+        guideSyncFrame = window.requestAnimationFrame(() => {
+          guideSyncFrame = undefined
+          syncVisionGuidePrompt(t)
+        })
+      }
       syncVisionGuidePrompt(t)
       window.addEventListener(VISION_GUIDE_EVENT, sync)
       window.addEventListener('popstate', sync)
@@ -1677,6 +1699,10 @@ window.__ModuleLoader__.load({
         if (visionGuidePanelCloseTimer !== undefined) {
           window.clearTimeout(visionGuidePanelCloseTimer)
           visionGuidePanelCloseTimer = undefined
+        }
+        if (guideSyncFrame !== undefined && typeof window.cancelAnimationFrame === 'function') {
+          window.cancelAnimationFrame(guideSyncFrame)
+          guideSyncFrame = undefined
         }
         window.removeEventListener(VISION_GUIDE_EVENT, sync)
         window.removeEventListener('popstate', sync)
@@ -3664,6 +3690,13 @@ window.__ModuleLoader__.load({
     exports.canonicalizeSettingsRun = canonicalizeSettingsRun
     exports.commitSettingsPlan = commitSettingsPlan
     exports.installSettingsPersistence = installSettingsPersistence
+    // Guide lifecycle hooks for behavioral tests: the idle-path layout-cost
+    // gate and the per-frame sync coalescing are the exact regression guards
+    // against settings panel scroll stutter.
+    exports.syncVisionGuidePrompt = syncVisionGuidePrompt
+    exports.installVisionSettingsGuide = installVisionSettingsGuide
+    exports.stopGuideSync = stopGuideSync
+    exports.readVisionGuideStep = readVisionGuideStep
     return module.exports
   },
 })

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -455,6 +455,105 @@ test('the settings card skips offscreen paint and reuses bounded model-option ca
   assert.equal(source.includes('inject: () => cardInject'), true)
 })
 
+test('guide sync never queries the DOM or forces layout when no walkthrough is active', () => {
+  const bundle = loadClientBundle()
+  const savedDocument = globalThis.document
+  const savedWindow = globalThis.window
+  let queryCount = 0
+  let rectCount = 0
+  // A settings dialog is on screen (as it is while scrolling the settings
+  // panel). The idle guide sync must not even look for it: querySelectorAll
+  // and getBoundingClientRect per scroll event are what forced layout and
+  // stuttered the panel.
+  const fakeDialog = {
+    getBoundingClientRect: () => {
+      rectCount += 1
+      return { width: 800, height: 600, x: 0, y: 0, left: 0, top: 0, right: 800, bottom: 600 }
+    },
+  }
+  globalThis.document = {
+    body: {},
+    querySelectorAll: () => {
+      queryCount += 1
+      return [fakeDialog]
+    },
+  }
+  globalThis.window = { clearInterval: () => {}, clearTimeout: () => {}, setTimeout: () => 0 }
+  try {
+    bundle.syncVisionGuidePrompt((key) => key)
+    assert.equal(queryCount, 0)
+    assert.equal(rectCount, 0)
+  } finally {
+    globalThis.document = savedDocument
+    globalThis.window = savedWindow
+  }
+})
+
+test('guide scroll syncs coalesce into one requestAnimationFrame per frame', () => {
+  const bundle = loadClientBundle()
+  const savedDocument = globalThis.document
+  const savedWindow = globalThis.window
+  const rafQueue = []
+  const scrollHandlers = []
+  globalThis.window = {
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    requestAnimationFrame: (fn) => {
+      rafQueue.push(fn)
+      return rafQueue.length
+    },
+    cancelAnimationFrame: () => {},
+    setTimeout: () => 0,
+    clearTimeout: () => {},
+    clearInterval: () => {},
+    setInterval: () => 0,
+  }
+  globalThis.document = {
+    body: {},
+    addEventListener: (name, handler, capture) => {
+      if (name === 'scroll' && capture === true) scrollHandlers.push(handler)
+    },
+    removeEventListener: () => {},
+    querySelectorAll: () => [],
+  }
+  try {
+    bundle.installVisionSettingsGuide((key) => key)
+    assert.equal(scrollHandlers.length, 1)
+    const scroll = scrollHandlers[0]
+    // Five scroll events in the same frame queue exactly one rAF.
+    for (let i = 0; i < 5; i++) scroll()
+    assert.equal(rafQueue.length, 1)
+    // Running the frame lets the next burst queue exactly one more.
+    rafQueue[0]()
+    for (let i = 0; i < 3; i++) scroll()
+    assert.equal(rafQueue.length, 2)
+  } finally {
+    globalThis.document = savedDocument
+    globalThis.window = savedWindow
+  }
+})
+
+test('guide sync gates DOM layout work behind the active phase and coalesces via rAF', () => {
+  const source = readFileSync(new URL('../lib/client.js', import.meta.url), 'utf8')
+  // syncVisionGuidePrompt must compute the phase and return on the idle
+  // branches BEFORE guideSettingsPanelOpen() can run its dialog query and
+  // getBoundingClientRect — per-event forced layout was the direct cause of
+  // the settings panel scroll stutter.
+  const fn = source.match(/function syncVisionGuidePrompt\(t\) \{[\s\S]*?\n    \}/)
+  assert.ok(fn, 'syncVisionGuidePrompt body found')
+  const body = fn[0]
+  assert.ok(
+    body.indexOf('const phase = guidePhase(step)') < body.indexOf('guideSettingsPanelOpen()'),
+    'phase gate precedes the panel DOM query',
+  )
+  // Event-driven syncs coalesce through requestAnimationFrame (one per frame)
+  // instead of one setTimeout per scroll event.
+  assert.equal(source.includes('guideSyncFrame !== undefined'), true)
+  assert.equal(source.includes('window.requestAnimationFrame'), true)
+  assert.equal(source.includes('cancelAnimationFrame'), true)
+  assert.equal(source.includes("document.addEventListener('scroll', sync, true)"), true)
+})
+
 test('local provider drafts preserve protocol and optional sampling fields', () => {
   const bundle = loadClientBundle()
   const defaults = { baseURL: 'http://local.test/v1', model: 'model-default' }


### PR DESCRIPTION
## What

The model-selection guide installs a document-level capture scroll listener
at plugin load. Every scroll event deferred a full guide sync (setTimeout 0)
that queried the settings dialog and forced layout via
getBoundingClientRect() — even when no walkthrough was active. At 60-120
scroll events/s this forced layout mid-gesture, which users reported as the
settings panel stuttering while scrolling (it applied to every page, not
just Settings).

## Fix

- syncVisionGuidePrompt computes the guide phase first and returns on the
  idle branches BEFORE any DOM query or rect, so an inactive guide costs one
  settings snapshot read per frame and zero layout work.
- installVisionSettingsGuide coalesces event-driven syncs (scroll / resize /
  popstate / guide event) into at most one requestAnimationFrame per frame,
  aligned with paint (setTimeout fallback when rAF is unavailable); cleanup
  cancels the pending frame.
- Exports the guide lifecycle hooks for behavioral tests.

## Why this keeps coming back

Previous fixes addressed different jank sources (offscreen paint and option
memoization in #70, hidden-settings mutate loops in #156, the visionGroups
memo regression in #144), and the existing tests were source-string guards
that could not catch per-event layout cost. This PR adds behavioral
regression tests that assert the idle sync performs zero DOM/layout work and
that scroll bursts queue exactly one rAF per frame.

## Tests

Full suite passes locally (362 tests, Node 24), including the new
behavioral guards.