### PR TITLE
fix: treat repetition-loop vision output as a backend failure

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,6 +60,7 @@ import {
   structuredBootstrapMemory,
   structuredBootstrapQuestion,
 } from './lib/structured-bootstrap.js'
+import { assertNoRepetitionLoop } from './lib/repetition-guard.js'
 
 // sharp is a native module with platform-specific prebuilt binaries. It used
 // to be imported statically, so a missing, broken, or conflicting install
@@ -5197,6 +5198,7 @@ export function apply(ctx, config = {}) {
               bridgeBlocks: blocks,
               bridgeInstruction: promptText,
             })
+            assertNoRepetitionLoop(text, backendKey)
             if (wantJson) {
               for (let attempt = 0; attempt < 2; attempt++) {
                 const parsed = extractJson(text)
@@ -5227,6 +5229,7 @@ export function apply(ctx, config = {}) {
                     bridgeInstruction:
                       promptText + '\n\nThat output was not valid JSON. Respond with ONLY a valid JSON object now.',
                   })
+                  assertNoRepetitionLoop(text, backendKey)
                 }
               }
               const fallback = `vision_describe: the model did not produce valid JSON. Raw output:\n${text.slice(0, 2000)}`
@@ -5317,6 +5320,7 @@ export function apply(ctx, config = {}) {
               return answer
             }
             let text = await askHttp(undefined)
+            assertNoRepetitionLoop(text, backendKey)
             if (wantJson) {
               for (let attempt = 0; attempt < 2; attempt++) {
                 const parsed = extractJson(text)
@@ -5329,6 +5333,7 @@ export function apply(ctx, config = {}) {
                   text = await askHttp(
                     'That output was not valid JSON. Respond with ONLY a valid JSON object now.',
                   )
+                  assertNoRepetitionLoop(text, backendKey)
                 }
               }
               const fallback = `vision_describe: the model did not produce valid JSON. Raw output:\n${text.slice(0, 2000)}`

--- a/lib/repetition-guard.js
+++ b/lib/repetition-guard.js
@@ -1,0 +1,163 @@
+/**
+ * Repetition-loop guard for vision backend output.
+ *
+ * Some vision backends occasionally degenerate into repetition loops when
+ * asked for long constrained output (e.g. the structured-bootstrap JSON
+ * schema) over a tall screenshot — the "answer" is one short phrase repeated
+ * hundreds of times (observed in the wild as 「網絡路由器 互聯網 路由器…」
+ * or 「華爲數據中心…」). Such output is useless to the agent and, worse,
+ * it looks like a successful backend result, so the fallback chain never
+ * runs. This module detects the signature of such loops so the vision chain
+ * can treat them as backend failures and move to the next candidate.
+ *
+ * Detection is intentionally cheap and heuristic:
+ *  - whitespace is stripped first, because loops are often separated by
+ *    spaces/punctuation that vary;
+ *  - a consecutive-run scan looks for one window repeated back-to-back
+ *    (the classic loop shape);
+ *  - a token-density check catches non-consecutive-but-overwhelming
+ *    repetition (the "路由器 / 互聯網 路由器" alternation shape).
+ */
+
+export const REPETITION_LOOP_MARKER = 'vision backend returned a repetition loop'
+
+/** Strip whitespace (and NBSP) so loops split by varying whitespace collapse. */
+export function compactForRepetition(text) {
+  return String(text ?? '').replace(/[\s\u00a0]+/gu, '')
+}
+
+const CANDIDATE_WINDOWS = [2, 3, 4, 5, 6, 8, 10, 12, 16, 20, 24, 32, 40]
+
+/**
+ * @param {string} text raw backend output
+ * @param {object} [options]
+ * @param {number} [options.minRun=6] minimum consecutive repeats for a run
+ * @param {number} [options.minCoveredChars=32] minimum chars a loop must cover
+ * @param {number} [options.minCoveredRatio=0.35] minimum share of the text a
+ *   consecutive run must cover (0..1)
+ * @param {number} [options.maxWindow=40] largest window size to try
+ * @returns {object|undefined} loop description, or undefined when healthy
+ */
+export function detectRepetitionLoop(text, options = {}) {
+  const source = compactForRepetition(text)
+  const total = source.length
+  const minRun = options.minRun ?? 6
+  const minCoveredChars = options.minCoveredChars ?? 32
+  const minCoveredRatio = options.minCoveredRatio ?? 0.35
+  const maxWindow = options.maxWindow ?? 40
+  if (total < minCoveredChars) return undefined
+  const coveredFloor = Math.max(minCoveredChars, total * minCoveredRatio)
+
+  // Pass 0: exact period — the whole text is one phrase repeated, possibly
+  // with a partial trailing repeat. Handles clean loops whose period is not
+  // one of the candidate windows below.
+  const maxPeriod = Math.min(64, Math.floor(total / 2))
+  for (let period = 2; period <= maxPeriod; period++) {
+    const full = Math.floor(total / period)
+    const remainder = total % period
+    if (full < minRun) continue
+    const prefix = source.slice(0, period)
+    let matches = true
+    for (let block = 1; block < full; block++) {
+      if (!source.startsWith(prefix, block * period)) {
+        matches = false
+        break
+      }
+    }
+    if (matches && source.startsWith(prefix.slice(0, remainder), full * period)) {
+      return {
+        looped: true,
+        mode: 'exact-period',
+        window: prefix,
+        windowSize: period,
+        repetitions: full,
+        coveredChars: full * period,
+        totalChars: total,
+        sample: source.slice(0, 120),
+      }
+    }
+  }
+
+  // Pass 1: one window repeated consecutively, back-to-back.
+  for (const windowSize of CANDIDATE_WINDOWS) {
+    if (windowSize > maxWindow || windowSize > Math.floor(total / 2)) continue
+    let bestCount = 0
+    let bestWindow = ''
+    for (let i = 0; i + windowSize <= total; ) {
+      const candidate = source.slice(i, i + windowSize)
+      let count = 1
+      let cursor = i + windowSize
+      while (source.startsWith(candidate, cursor)) {
+        count += 1
+        cursor += windowSize
+      }
+      if (count > bestCount) {
+        bestCount = count
+        bestWindow = candidate
+      }
+      i = cursor
+    }
+    const covered = bestCount * windowSize
+    if (bestCount >= minRun && covered >= coveredFloor) {
+      return {
+        looped: true,
+        mode: 'consecutive-run',
+        window: bestWindow,
+        windowSize,
+        repetitions: bestCount,
+        coveredChars: covered,
+        totalChars: total,
+        sample: source.slice(0, 120),
+      }
+    }
+  }
+
+  // Pass 2: one short token dominating the text without being consecutive
+  // (the alternating loop shape).
+  for (const windowSize of [2, 3, 4]) {
+    if (windowSize > maxWindow) continue
+    const counts = new Map()
+    for (let i = 0; i + windowSize <= total; i++) {
+      const token = source.slice(i, i + windowSize)
+      counts.set(token, (counts.get(token) ?? 0) + 1)
+    }
+    let topToken = ''
+    let topCount = 0
+    for (const [token, count] of counts) {
+      if (count > topCount) {
+        topCount = count
+        topToken = token
+      }
+    }
+    const covered = topCount * windowSize
+    if (topCount >= minRun && covered >= Math.max(minCoveredChars, total * 0.5)) {
+      return {
+        looped: true,
+        mode: 'token-density',
+        window: topToken,
+        windowSize,
+        repetitions: topCount,
+        coveredChars: covered,
+        totalChars: total,
+        sample: source.slice(0, 120),
+      }
+    }
+  }
+
+  return undefined
+}
+
+/**
+ * Throw when the output is a repetition loop. The thrown Error carries no
+ * status/code, so the vision chain's classifier maps it by message pattern;
+ * the message intentionally includes a stable marker for that classifier.
+ */
+export function assertNoRepetitionLoop(text, backendKey) {
+  const loop = detectRepetitionLoop(text)
+  if (loop === undefined) return
+  const label = backendKey ? ` (${backendKey})` : ''
+  throw new Error(
+    `${REPETITION_LOOP_MARKER}${label}: ${loop.repetitions} repeats of ${JSON.stringify(loop.window)} ` +
+      `(${loop.mode}) covering ${loop.coveredChars}/${loop.totalChars} chars; first ${loop.windowSize}-char window sampled from ${JSON.stringify(loop.sample)}`,
+  )
+}

--- a/lib/vision-resilience.js
+++ b/lib/vision-resilience.js
@@ -31,6 +31,7 @@ export const VISION_FAILURE_KINDS = {
   REGION: 'REGION',
   TOS: 'TOS',
   NO_ADAPTER: 'NO_ADAPTER',
+  REPETITION: 'REPETITION',
   OTHER: 'OTHER',
 }
 
@@ -67,6 +68,7 @@ const QUOTA_PATTERNS = [/\b402\b/, /insufficient/i, /balance/i, /credits/i]
 const REGION_PATTERNS = [/not available in your region/i, /prohibited region/i, /\bregion\b/i]
 const TOS_PATTERNS = [/terms of service/i, /\btos\b/i]
 const NO_ADAPTER_PATTERNS = [/no adapter registered/i, /is not registered/i, /no adapter for provider/i]
+const REPETITION_PATTERNS = [/repetition loop/i]
 
 /** Map an already-branded error code (LlmError-style) to a failure kind. */
 const CODE_KIND_MAP = {
@@ -91,6 +93,7 @@ const KIND_BY_PATTERN = [
   [VISION_FAILURE_KINDS.REGION, REGION_PATTERNS],
   [VISION_FAILURE_KINDS.TOS, TOS_PATTERNS],
   [VISION_FAILURE_KINDS.NO_ADAPTER, NO_ADAPTER_PATTERNS],
+  [VISION_FAILURE_KINDS.REPETITION, REPETITION_PATTERNS],
 ]
 
 /** Status → kind for HTTP-level failures. */

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "sharp": "^0.35.3"
   },
   "scripts": {
-    "test": "node --test tests/core.test.js tests/capability-advisory.test.js tests/vision-resilience.test.js tests/client.test.js tests/http-compat.test.js tests/catalog-corrections.test.js tests/update-check.test.js tests/self-update.test.js tests/doctor.test.js tests/doctor-cli.test.js tests/bundle-defaults.test.js tests/file-logger.test.js tests/replay-delegation.test.js tests/logging-ui.test.js tests/manifest-dependencies.test.js tests/structured-bootstrap.test.js tests/structured-bootstrap-gate.test.js tests/local-ollama.test.js tests/zero-regression-gate.test.js tests/runtime-e2e.test.js tests/local-vision-stabilizer.test.js tests/local-connection-probe.test.js"
+    "test": "node --test tests/core.test.js tests/capability-advisory.test.js tests/vision-resilience.test.js tests/client.test.js tests/http-compat.test.js tests/catalog-corrections.test.js tests/update-check.test.js tests/self-update.test.js tests/doctor.test.js tests/doctor-cli.test.js tests/bundle-defaults.test.js tests/file-logger.test.js tests/replay-delegation.test.js tests/logging-ui.test.js tests/manifest-dependencies.test.js tests/structured-bootstrap.test.js tests/structured-bootstrap-gate.test.js tests/local-ollama.test.js tests/zero-regression-gate.test.js tests/runtime-e2e.test.js tests/local-vision-stabilizer.test.js tests/local-connection-probe.test.js tests/repetition-guard.test.js"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/tests/repetition-guard.test.js
+++ b/tests/repetition-guard.test.js
@@ -1,0 +1,74 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  detectRepetitionLoop,
+  assertNoRepetitionLoop,
+  REPETITION_LOOP_MARKER,
+} from '../lib/repetition-guard.js'
+import { classifyVisionFailure, VISION_FAILURE_KINDS } from '../lib/vision-resilience.js'
+
+test('detects the real-world alternating router loop', () => {
+  const garbage = '網絡路由器 互聯網 互聯網 路由器 互聯網 路由器 路由器 互聯網 '.repeat(12)
+  const loop = detectRepetitionLoop(garbage)
+  assert.ok(loop)
+  assert.equal(loop.looped, true)
+  assert.ok(['exact-period', 'consecutive-run', 'token-density'].includes(loop.mode))
+  assert.ok(loop.coveredChars >= 0.5 * loop.totalChars)
+})
+
+test('detects a clean consecutive run loop', () => {
+  const loop = detectRepetitionLoop('华为数据中心设备型号：华为数据中心'.repeat(30))
+  assert.ok(loop)
+  assert.equal(loop.mode, 'exact-period')
+  assert.equal(loop.repetitions, 30)
+})
+
+test('detects the Huawei datacenter OCR loop shape', () => {
+  const garbage = Array.from({ length: 200 }, () => '數據中心設備型號：華爲數據中心').join(' ')
+  const loop = detectRepetitionLoop(garbage)
+  assert.ok(loop)
+})
+
+test('leaves normal prose alone', () => {
+  const prose = '图片里是 DeepSeek Harness 的插件设置页，包含识图模型列表、内置 OVH 免费模型兜底说明，以及添加备用识图模型的按钮。整体布局为上下结构。'
+  assert.equal(detectRepetitionLoop(prose), undefined)
+})
+
+test('leaves structured JSON alone', () => {
+  const json = JSON.stringify({
+    visual_kind: 'ui',
+    overview: 'A settings page listing vision models with fallback notes.',
+    regions: [{ id: 'r1', location: 'top', role: 'content', content: 'model list' }],
+    visible_text: [{ region_id: 'r1', text: '识图模型', uncertain: false }],
+  })
+  assert.equal(detectRepetitionLoop(json), undefined)
+})
+
+test('does not flag short legit repetition like laughter', () => {
+  assert.equal(detectRepetitionLoop('哈哈哈哈哈哈'), undefined)
+  assert.equal(detectRepetitionLoop('好的好的好的'), undefined)
+})
+
+test('does not flag a document that merely mentions one word often', () => {
+  const text = Array.from({ length: 30 }, (_, i) => `第 ${i + 1} 行：路由器配置项 ${i + 1} 的说明文字。`).join('')
+  assert.equal(detectRepetitionLoop(text), undefined)
+})
+
+test('assertNoRepetitionLoop throws a classifiable error on loops', () => {
+  const garbage = '互聯網 路由器 '.repeat(25)
+  let thrown
+  try {
+    assertNoRepetitionLoop(garbage, 'openrouter/openai/gpt-5.6-sol')
+  } catch (error) {
+    thrown = error
+  }
+  assert.ok(thrown)
+  assert.match(thrown.message, new RegExp(REPETITION_LOOP_MARKER))
+  assert.match(thrown.message, /openrouter\/openai\/gpt-5\.6-sol/)
+  const classification = classifyVisionFailure(thrown)
+  assert.equal(classification.kind, VISION_FAILURE_KINDS.REPETITION)
+})
+
+test('assertNoRepetitionLoop passes healthy output through silently', () => {
+  assert.doesNotThrow(() => assertNoRepetitionLoop('这是正常的识图结果。', 'any/backend'))
+})


### PR DESCRIPTION
## Problem

Some vision backends degenerate into repetition loops on long constrained output (e.g. the structured-bootstrap JSON schema over a tall screenshot), producing "answers" like a short router/datacenter phrase repeated hundreds of times. Such output is useless to the agent, but it looks like a successful backend result — so the fallback chain never runs and the garbage reaches the conversation.

## Change

Detect the loop signature right after each backend returns content — exact period, consecutive run, and token density over whitespace-stripped text — and throw a classifiable `REPETITION` failure so the existing per-backend fallback machinery moves to the next candidate. Detection thresholds are conservative (≥6 repeats covering ≥35% of the output) to avoid false positives on normal prose/JSON.

## Tests

New `tests/repetition-guard.test.js` (9 cases: real-world alternating loop, clean period loop, prose, JSON, laughter, classification). Full suite: 368/368.