### PR TITLE
feat: log per-backend vision call diagnostics

### DIFF
--- a/index.js
+++ b/index.js
@@ -5169,8 +5169,12 @@ export function apply(ctx, config = {}) {
           const gate = visionBreaker.inspect(backendKey, fingerprint, scope)
           if (gate.blocked) {
             errors.push(`${backendKey}: skipped (circuit open: ${gate.reason})`)
+            ctx.logger?.info('vision-router: vision call %s skipped (circuit open: %s)', backendKey, gate.reason)
             continue
           }
+          // Declared outside the try so the catch can report the elapsed time
+          // even when the failure happens before the first network call.
+          let attemptStarted = Date.now()
           try {
             let messages = baseMessages
             // Local backends get an independent anti-hang budget (a fair share
@@ -5197,6 +5201,12 @@ export function apply(ctx, config = {}) {
               bridgeBlocks: blocks,
               bridgeInstruction: promptText,
             })
+            ctx.logger?.info(
+              'vision-router: vision call %s ok (%d chars, %d ms)',
+              backendKey,
+              String(text ?? '').length,
+              Date.now() - attemptStarted,
+            )
             if (wantJson) {
               for (let attempt = 0; attempt < 2; attempt++) {
                 const parsed = extractJson(text)
@@ -5219,6 +5229,7 @@ export function apply(ctx, config = {}) {
                       source: { kind: 'plugin', plugin: 'dsh-vision-router' },
                     },
                   ]
+                  attemptStarted = Date.now()
                   text = await callVisionPairWithOptionalBridge(pair, messages, {
                     maxTokens: 4096,
                     signal,
@@ -5227,6 +5238,12 @@ export function apply(ctx, config = {}) {
                     bridgeInstruction:
                       promptText + '\n\nThat output was not valid JSON. Respond with ONLY a valid JSON object now.',
                   })
+                  ctx.logger?.info(
+                    'vision-router: vision call %s ok after JSON correction (%d chars, %d ms)',
+                    backendKey,
+                    String(text ?? '').length,
+                    Date.now() - attemptStarted,
+                  )
                 }
               }
               const fallback = `vision_describe: the model did not produce valid JSON. Raw output:\n${text.slice(0, 2000)}`
@@ -5252,8 +5269,10 @@ export function apply(ctx, config = {}) {
             const message = error && error.message ? error.message : String(error)
             errors.push(`${backendKey}: ${message}`)
             ctx.logger?.warn(
-              'vision-router: vision_describe fallback (%s): %s',
+              'vision-router: vision_describe fallback [%s] (%s, %d ms): %s',
+              backendKey,
               classification.kind,
+              Date.now() - attemptStarted,
               message,
             )
           }
@@ -5275,8 +5294,12 @@ export function apply(ctx, config = {}) {
           const gate = visionBreaker.inspect(backendKey, fingerprint, scope)
           if (gate.blocked) {
             errors.push(`${backendKey}: skipped (circuit open: ${gate.reason})`)
+            ctx.logger?.info('vision-router: vision call %s skipped (circuit open: %s)', backendKey, gate.reason)
             continue
           }
+          // Declared outside the try so the catch can report the elapsed time
+          // even when the failure happens before the first network call.
+          let attemptStarted = Date.now()
           try {
             // Precompute bytes once per block (attachments.readImage is async).
             const openAIBlocks = []
@@ -5317,6 +5340,12 @@ export function apply(ctx, config = {}) {
               return answer
             }
             let text = await askHttp(undefined)
+            ctx.logger?.info(
+              'vision-router: vision call %s ok (%d chars, %d ms)',
+              backendKey,
+              String(text ?? '').length,
+              Date.now() - attemptStarted,
+            )
             if (wantJson) {
               for (let attempt = 0; attempt < 2; attempt++) {
                 const parsed = extractJson(text)
@@ -5326,8 +5355,15 @@ export function apply(ctx, config = {}) {
                   return compact
                 }
                 if (attempt === 0) {
+                  attemptStarted = Date.now()
                   text = await askHttp(
                     'That output was not valid JSON. Respond with ONLY a valid JSON object now.',
+                  )
+                  ctx.logger?.info(
+                    'vision-router: vision call %s ok after JSON correction (%d chars, %d ms)',
+                    backendKey,
+                    String(text ?? '').length,
+                    Date.now() - attemptStarted,
                   )
                 }
               }
@@ -5351,8 +5387,10 @@ export function apply(ctx, config = {}) {
             const message = error && error.message ? error.message : String(error)
             errors.push(`${backendKey}: ${message}`)
             ctx.logger?.warn(
-              'vision-router: vision_describe http fallback (%s): %s',
+              'vision-router: vision_describe http fallback [%s] (%s, %d ms): %s',
+              backendKey,
               classification.kind,
+              Date.now() - attemptStarted,
               message,
             )
           }

--- a/tests/runtime-e2e.test.js
+++ b/tests/runtime-e2e.test.js
@@ -998,6 +998,16 @@ test('vision chain falls through from a hung local backend to the next local bac
     visionTaskTimeoutMs: 1200,
   }
   const { ctx, registrations, toolDefs } = bootHarness(config0)
+  // Capture the plugin's logger after boot but before apply, so per-backend
+  // call diagnostics can be asserted (regression: degenerate outputs used to
+  // look like successes with no way to tell which backend produced them).
+  const infos = []
+  const warns = []
+  ctx.logger = {
+    info: (...args) => { infos.push(args) },
+    warn: (...args) => { warns.push(args) },
+    error() {},
+  }
   apply(ctx, Config(config0))
   // Route the chain's delegation through the registered adapters like a real
   // harness would (the stock mock stream is a no-op stub).
@@ -1026,6 +1036,18 @@ test('vision chain falls through from a hung local backend to the next local bac
     assert.ok(hang.requests.length >= 1, 'the hanging local backend must have been tried')
     assert.ok(fast.requests.length >= 1, 'the next local backend must still get a real attempt')
     assert.ok(elapsed < 2500, `fallthrough should stay inside the shared task budget (took ${elapsed}ms)`)
+
+    // Per-backend diagnostics: the successful call must name its backend,
+    // content length and latency; the hung backend's fallthrough must be
+    // logged with the backend key so degenerate/failed hops are traceable.
+    const okLine = infos.find((args) => String(args[0]).includes('vision call') && String(args[0]).includes(' ok '))
+    assert.ok(okLine, 'a per-backend ok diagnostic must be logged')
+    assert.match(String(okLine[1]), /fast-vl/)
+    assert.equal(okLine[2], 'fast provider answered'.length)
+    const fallbackWarn = warns.find((args) => String(args[0]).includes('fallback'))
+    assert.ok(fallbackWarn, 'the hung backend fallthrough must be logged as a warn')
+    assert.match(String(fallbackWarn[1]), /hang-vl/)
+    assert.equal(fallbackWarn[2], 'TIMEOUT')
   } finally {
     await hang.close()
     await fast.close()


### PR DESCRIPTION
## Problem

Successful vision calls left no trace, so a degenerate backend that returned a repetition loop instead of an error looked identical to a healthy one in the logs and was impossible to attribute without manually replaying every candidate backend.

## Change

Log every backend attempt through the plugin logger (already captured by the diagnostics file): skips (circuit open), successes (backend key, content length, latency, JSON-correction retries), and failures (backend key, failure kind, latency in the existing fallback warn).

## Tests

Extended the hung-local-backend e2e test to assert the ok line and the fallback warn both carry the backend key. Full suite: 359/359.