### PR TITLE
fix: stop per-frame DOM re-resolution in the settings guide while scrolling

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1056,6 +1056,24 @@ window.__ModuleLoader__.load({
     // into at most one sync per frame so scrolling never forces layout
     // mid-gesture. undefined means no frame is pending.
     let guideSyncFrame
+    // Cached walkthrough resolution. Phase / settings-panel / target
+    // re-resolution is the only expensive part of a sync (several
+    // querySelectorAll passes plus a dialog getBoundingClientRect). Even after
+    // the idle-branch gate (#170), every scroll frame re-resolved them while
+    // the walkthrough was active — that per-frame forced layout is the
+    // remaining settings-panel scroll stutter. Resolution now refreshes at
+    // most every GUIDE_RESOLVE_THROTTLE_MS, immediately on step changes and
+    // when the cached target detaches, and lazily through the 600ms keep-alive
+    // interval. The per-frame path only reads one small element's rect and
+    // writes spotlight/prompt styles.
+    const GUIDE_RESOLVE_THROTTLE_MS = 250
+    let visionGuideResolved = {
+      step: undefined,
+      phase: undefined,
+      panelOpen: false,
+      target: undefined,
+      at: 0,
+    }
     let onboardingSeenMemory = false
     let visionGuideStepMemory
     let visionGuideMemoryAuthoritative = false
@@ -1578,10 +1596,33 @@ window.__ModuleLoader__.load({
         arrow.style.setProperty('--vr-arrow-pos', pos + 'px')
       }
     }
+    function refreshGuideResolution(step) {
+      const now = Date.now()
+      const cached = visionGuideResolved
+      if (
+        cached.step === step &&
+        now - cached.at < GUIDE_RESOLVE_THROTTLE_MS &&
+        (cached.target === undefined || cached.target.isConnected !== false)
+      ) {
+        return cached
+      }
+      const phase = guidePhase(step)
+      const panelOpen =
+        phase !== 'none' && phase !== 'suspend'
+          ? guideSettingsPanelOpen()
+          : false
+      const target =
+        phase === 'none' || phase === 'done' || phase === 'suspend'
+          ? undefined
+          : guideTarget(step, phase)
+      visionGuideResolved = { step, phase, panelOpen, target, at: now }
+      return visionGuideResolved
+    }
+
     function syncVisionGuidePrompt(t) {
       if (typeof document === 'undefined' || typeof window === 'undefined' || !document.body) return
       const step = readVisionGuideStep()
-      const phase = guidePhase(step)
+      const { phase, panelOpen, target } = refreshGuideResolution(step)
       if (phase === 'none' || phase === 'done' || phase === 'suspend') {
         // No floating layer: the walkthrough is over, the in-card callout
         // (step 3) has taken over, or the onboarding overview dialog covers
@@ -1593,7 +1634,6 @@ window.__ModuleLoader__.load({
         if (phase === 'none') stopGuideSync()
         return
       }
-      const panelOpen = guideSettingsPanelOpen()
       if (step !== undefined && visionGuidePanelSeen && !panelOpen) {
         // The settings panel was open during this walkthrough round and the
         // user has just closed it: honor the close by ending the round
@@ -1632,7 +1672,6 @@ window.__ModuleLoader__.load({
       } else if (visionGuidePrompt.dataset.vrPhase !== phase) {
         updateGuidePrompt(visionGuidePrompt, t, step, phase)
       }
-      const target = guideTarget(step, phase)
       const rect =
         target && typeof target.getBoundingClientRect === 'function' ? target.getBoundingClientRect() : undefined
       applyGuideSpotlight(rect)

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "sharp": "^0.35.3"
   },
   "scripts": {
-    "test": "node --test tests/core.test.js tests/capability-advisory.test.js tests/vision-resilience.test.js tests/client.test.js tests/http-compat.test.js tests/catalog-corrections.test.js tests/update-check.test.js tests/self-update.test.js tests/doctor.test.js tests/doctor-cli.test.js tests/bundle-defaults.test.js tests/file-logger.test.js tests/replay-delegation.test.js tests/logging-ui.test.js tests/manifest-dependencies.test.js tests/structured-bootstrap.test.js tests/structured-bootstrap-gate.test.js tests/local-ollama.test.js tests/zero-regression-gate.test.js tests/runtime-e2e.test.js tests/local-vision-stabilizer.test.js tests/local-connection-probe.test.js tests/repetition-guard.test.js"
+    "test": "node --test tests/core.test.js tests/capability-advisory.test.js tests/vision-resilience.test.js tests/client.test.js tests/http-compat.test.js tests/catalog-corrections.test.js tests/update-check.test.js tests/self-update.test.js tests/doctor.test.js tests/doctor-cli.test.js tests/bundle-defaults.test.js tests/file-logger.test.js tests/replay-delegation.test.js tests/logging-ui.test.js tests/manifest-dependencies.test.js tests/structured-bootstrap.test.js tests/structured-bootstrap-gate.test.js tests/local-ollama.test.js tests/zero-regression-gate.test.js tests/runtime-e2e.test.js tests/local-vision-stabilizer.test.js tests/local-connection-probe.test.js tests/repetition-guard.test.js tests/guide-scroll-gate.test.js"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/tests/guide-scroll-gate.test.js
+++ b/tests/guide-scroll-gate.test.js
@@ -1,0 +1,273 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const GUIDE_STORAGE_KEY = 'dsh-vision-router:guide:vision-backend-v2'
+
+function loadClientBundle() {
+  let spec = null
+  globalThis.window = { __ModuleLoader__: { load(s) { spec = s } } }
+  const url = new URL('../lib/client.js', import.meta.url)
+  // eslint-disable-next-line no-eval
+  ;(0, eval)(readFileSync(url, 'utf8'))
+  const ReactStub = {
+    useState: (initial) => [initial, () => {}],
+    useMemo: (fn) => fn(),
+    useSyncExternalStore: () => ({ status: 'ready', writable: true, value: {}, user: {} }),
+  }
+  return spec.factory((name) => {
+    if (name === 'react') return ReactStub
+    if (name === '@deepseek-ai/dsh-client-ui-attachment') {
+      return { ImageGallery: () => null }
+    }
+    throw new Error('require(' + name + ')')
+  })
+}
+
+function makeFakeElement(tag = 'div') {
+  return {
+    tag,
+    type: '',
+    className: '',
+    dataset: {},
+    textContent: '',
+    offsetWidth: 360,
+    offsetHeight: 160,
+    children: [],
+    style: {
+      removeProperty() {},
+      setProperty() {},
+      remove() {},
+    },
+    classList: {
+      add() {},
+      remove() {},
+      toggle() {},
+    },
+    setAttribute() {},
+    addEventListener() {},
+    removeAttribute() {},
+    append(...children) { this.children.push(...children) },
+    remove() {},
+    querySelector(selector) {
+      const match = selector.match(/^\.([\w-]+)$/)
+      if (match) return this.children.find((child) => child.className.split(/\s+/).includes(match[1])) ?? null
+      if (selector === 'nav') return null
+      return null
+    },
+    getBoundingClientRect() {
+      return { x: 100, y: 100, width: 120, height: 40, left: 100, right: 220, top: 100, bottom: 140 }
+    },
+    getAttribute() { return null },
+    isConnected: true,
+  }
+}
+
+function makeGuideHarness({ guideStep } = {}) {
+  const counters = { domQueries: 0, rectReads: 0, scrollEvents: 0, frames: 0 }
+  const listeners = {}
+  const frames = []
+  const timers = []
+  let intervalCounter = 0
+  let timeoutCounter = 0
+
+  const panel = {
+    ...makeFakeElement('div'),
+    closest: () => null,
+    getBoundingClientRect() {
+      counters.rectReads += 1
+      return { x: 0, y: 0, width: 800, height: 600, left: 0, right: 800, top: 0, bottom: 600 }
+    },
+  }
+  const gear = {
+    ...makeFakeElement('button'),
+    closest: () => null,
+    getBoundingClientRect() {
+      counters.rectReads += 1
+      return { x: 10, y: 10, width: 40, height: 40, left: 10, right: 50, top: 10, bottom: 50 }
+    },
+  }
+  const composerTarget = {
+    ...makeFakeElement('button'),
+    closest: () => null,
+    getBoundingClientRect() {
+      counters.rectReads += 1
+      return { x: 100, y: 100, width: 120, height: 40, left: 100, right: 220, top: 100, bottom: 140 }
+    },
+  }
+
+  const documentStub = {
+    body: { appendChild() {} },
+    addEventListener(type, callback) { listeners[type] = callback },
+    removeEventListener(type) { delete listeners[type] },
+    dispatchEvent() {},
+    querySelectorAll(selector) {
+      counters.domQueries += 1
+      if (selector === '[role="dialog"][aria-modal="true"]') return [panel]
+      if (selector === 'button[aria-haspopup="dialog"]') return [gear]
+      if (selector.includes('[data-slot="conversation.input.model"]')) return [composerTarget]
+      return []
+    },
+    querySelector(selector) {
+      counters.domQueries += 1
+      return null
+    },
+    createElement(tag) { return makeFakeElement(tag) },
+  }
+
+  const windowStub = {
+    innerWidth: 1280,
+    innerHeight: 800,
+    localStorage: {
+      getItem: (key) => (key === GUIDE_STORAGE_KEY ? guideStep ?? null : null),
+      setItem() {},
+      removeItem() {},
+    },
+    addEventListener(type, callback) { listeners['window:' + type] = callback },
+    removeEventListener() {},
+    dispatchEvent() {},
+    requestAnimationFrame(callback) {
+      frames.push(callback)
+      return frames.length
+    },
+    setTimeout(callback, delay) {
+      const id = ++timeoutCounter
+      timers.push({ id, kind: 'timeout', callback, delay })
+      return id
+    },
+    clearTimeout() {},
+    setInterval(callback, delay) {
+      const id = ++intervalCounter
+      timers.push({ id, kind: 'interval', callback, delay })
+      return id
+    },
+    clearInterval() {},
+  }
+
+  return {
+    counters,
+    get document() { return documentStub },
+    get window() { return windowStub },
+    runScrollEvent() {
+      counters.scrollEvents += 1
+      listeners['scroll'] && listeners['scroll']()
+    },
+    runFrame() {
+      counters.frames += 1
+      const pending = frames.splice(0)
+      for (const callback of pending) callback()
+    },
+    runIntervals() {
+      for (const timer of timers) {
+        if (timer.kind === 'interval') timer.callback()
+      }
+    },
+    disposeListeners() {
+      delete listeners['scroll']
+    },
+  }
+}
+
+function bootBundle(harness, guideStep) {
+  const realNow = Date.now
+  let fakeNow = 0
+  Date.now = () => fakeNow
+  // Load the bundle first: the eval only needs window.__ModuleLoader__.
+  // Afterwards the bundle code reads the real test window/document globals.
+  const bundle = loadClientBundle()
+  globalThis.document = harness.document
+  globalThis.window = harness.window
+  const dispose = bundle.installVisionSettingsGuide((key) => key)
+  return {
+    bundle,
+    dispose,
+    setNow(value) { fakeNow = value },
+    restore() {
+      Date.now = realNow
+    },
+  }
+}
+
+test('active walkthrough scroll frames never re-run DOM queries (only re-anchor)', () => {
+  const harness = makeGuideHarness({ guideStep: 'step2' })
+  const session = bootBundle(harness, 'step2')
+  try {
+    // Install-time sync resolves once (panel + target queries). From now on,
+    // scroll frames must NOT add a single DOM query: only one target rect
+    // read plus style writes per frame.
+    const queriesAfterInstall = harness.counters.domQueries
+    assert.ok(queriesAfterInstall > 0, 'install-time resolution must query the DOM')
+    for (let i = 0; i < 30; i++) {
+      harness.runScrollEvent()
+      harness.runFrame()
+    }
+    assert.equal(
+      harness.counters.domQueries,
+      queriesAfterInstall,
+      'scroll frames must not re-run querySelectorAll/querySelector',
+    )
+    assert.ok(harness.counters.rectReads > 0, 'frames must still re-anchor the target')
+
+    // After the throttle window the resolution refreshes once (fresh DOM
+    // query), then stays bounded again.
+    const beforeRefresh = harness.counters.domQueries
+    session.setNow(400)
+    harness.runScrollEvent()
+    harness.runFrame()
+    const refreshed = harness.counters.domQueries - beforeRefresh
+    assert.ok(refreshed >= 1, 'a stale resolution must refresh after the throttle window')
+    assert.ok(refreshed <= 6, `refresh must be bounded (got ${refreshed})`)
+
+    for (let i = 0; i < 10; i++) {
+      harness.runScrollEvent()
+      harness.runFrame()
+    }
+    assert.ok(
+      harness.counters.domQueries <= beforeRefresh + refreshed + 1,
+      'frames after the refresh must not keep re-resolving',
+    )
+  } finally {
+    session.restore()
+    harness.disposeListeners()
+    session.dispose()
+  }
+})
+
+test('idle (no walkthrough) scroll events perform zero DOM queries', () => {
+  const harness = makeGuideHarness({ guideStep: null })
+  const session = bootBundle(harness, null)
+  try {
+    const queriesAfterInstall = harness.counters.domQueries
+    assert.equal(queriesAfterInstall, 0, 'idle install must not query the DOM')
+    for (let i = 0; i < 30; i++) {
+      harness.runScrollEvent()
+      harness.runFrame()
+    }
+    assert.equal(harness.counters.domQueries, 0, 'idle scroll frames must stay DOM-free')
+  } finally {
+    session.restore()
+    harness.disposeListeners()
+    session.dispose()
+  }
+})
+
+test('step1 selector walkthrough keeps per-frame queries bounded', () => {
+  const harness = makeGuideHarness({ guideStep: 'step1' })
+  const session = bootBundle(harness, 'step1')
+  try {
+    const queriesAfterInstall = harness.counters.domQueries
+    for (let i = 0; i < 30; i++) {
+      harness.runScrollEvent()
+      harness.runFrame()
+    }
+    assert.equal(
+      harness.counters.domQueries,
+      queriesAfterInstall,
+      'step1 scroll frames must not re-resolve selector targets per frame',
+    )
+  } finally {
+    session.restore()
+    harness.disposeListeners()
+    session.dispose()
+  }
+})


### PR DESCRIPTION
## Problem

The settings panel still stuttered during the walkthrough after #170: that PR only gated the idle branch. While a guide step is active, every scroll frame re-ran the full expensive resolution — several `querySelectorAll` passes (panel lookup, selector targets, plugins nav, gear button) plus a dialog `getBoundingClientRect`, forcing layout on every animation frame.

## Change

Cache the resolved `(step, phase, panelOpen, target)` tuple. Resolution refreshes at most every 250ms, immediately on step changes or target detachment, and through the existing 600ms keep-alive interval. Scroll frames now only read one small element's rect and write spotlight/prompt styles — the irreducible cost of a glued spotlight.

## Tests

New cost-gate test (`tests/guide-scroll-gate.test.js`) runs 30 scroll events + animation frames with a counting fake DOM and asserts **zero added DOM queries per frame** in the active walkthrough, zero queries in the idle path, and a single bounded refresh after the throttle window. It fails on the old code (2 failures). Full suite: 374/374.