### PR TITLE
fix: harden adversarial runtime boundaries

### DIFF
--- a/entry.js
+++ b/entry.js
@@ -10,6 +10,7 @@ import z from '@deepseek-ai/schemastery'
 import * as core from './index.js'
 import { installVisionRouterFileLogging } from './lib/file-logger.js'
 import { contextWithDelegatedReplay } from './lib/replay-delegation.js'
+import { installAdversarialHardening } from './lib/adversarial-hardening.js'
 import { installLocalVisionStabilizer } from './lib/local-vision-stabilizer.js'
 
 // Schemastery object schemas expose set() as the supported way to replace a
@@ -34,17 +35,30 @@ export function apply(ctx, config = {}) {
         ? config.wrapperRoute
         : 'deepseek-vision',
   })
+  // Security/runtime boundary shared by the core and the local-vision shim:
+  // keep artifacts inside the session workspace, make HTML screenshots truly
+  // offline + sandboxed, protect the screenshot-permission side effect, and
+  // make the process-wide fetch cleanup coexist with later plugin patches.
+  const { ctx: hardenedCtx, config: hardenedConfig } = installAdversarialHardening(
+    runtimeCtx,
+    config,
+    core,
+  )
   // #141 stabilization boundary: keep the recently merged local-vision
   // behavior isolated from main's existing provider/router semantics. It
   // normalizes only the local settings/runtime seams before core.apply sees
   // the context (desktop screenshot exposure, instant-local budget/one-pass,
   // local vision-http transport and connection-probe fallback).
-  const { ctx: stabilizedCtx, bootConfig } = installLocalVisionStabilizer(runtimeCtx, config, core)
+  const { ctx: stabilizedCtx, bootConfig } = installLocalVisionStabilizer(
+    hardenedCtx,
+    hardenedConfig,
+    core,
+  )
   // 启动诊断摘要只描述 composition/apply 的基础配置。设置服务可能稍后
   // 覆盖这些值；每个图片轮还会记录 current() 的实时决策，避免把这个
   // 启动快照误当成最终设置状态。
   try {
-    const c = config && typeof config === 'object' ? config : {}
+    const c = hardenedConfig && typeof hardenedConfig === 'object' ? hardenedConfig : {}
     const local = c.localOllama && typeof c.localOllama === 'object' ? c.localOllama : {}
     const lms = c.localLmStudio && typeof c.localLmStudio === 'object' ? c.localLmStudio : {}
     logging.logger.info(
@@ -60,7 +74,7 @@ export function apply(ctx, config = {}) {
   try {
     const result = core.apply(stabilizedCtx, {
       ...bootConfig,
-      progressiveTools: config.progressiveTools === true,
+      progressiveTools: hardenedConfig.progressiveTools === true,
     })
     if (result && typeof result.then === 'function') {
       return result.catch((error) => {

--- a/lib/adversarial-hardening.js
+++ b/lib/adversarial-hardening.js
@@ -8,8 +8,6 @@ const MAX_VIEWPORT_WIDTH = 4096
 const MAX_VIEWPORT_HEIGHT = 4096
 const MAX_SCREENSHOT_PIXELS = 50_000_000
 
-const wrappedTools = new WeakMap()
-
 function isNonEmptyString(value) {
   return typeof value === 'string' && value.trim() !== ''
 }
@@ -213,9 +211,7 @@ export function createSecureHtmlScreenshotExecute(ctx, core, config, deps = {}) 
 
 function wrapTools(tools, ctx, core, config) {
   if (!tools || (typeof tools !== 'object' && typeof tools !== 'function')) return tools
-  const cached = wrappedTools.get(tools)
-  if (cached) return cached
-  const wrapped = new Proxy(tools, {
+  return new Proxy(tools, {
     get(target, property) {
       if (property !== 'register') {
         const value = Reflect.get(target, property, target)
@@ -233,8 +229,6 @@ function wrapTools(tools, ctx, core, config) {
       }
     },
   })
-  wrappedTools.set(tools, wrapped)
-  return wrapped
 }
 
 export function installAdversarialHardening(ctx, config = {}, core) {

--- a/lib/adversarial-hardening.js
+++ b/lib/adversarial-hardening.js
@@ -173,6 +173,10 @@ export function createSecureHtmlScreenshotExecute(ctx, core, config, deps = {}) 
     try {
       const page = await browser.newPage()
       await page.setViewport({ width, height })
+      // Browser-level offline mode blocks HTTP(S), WebSocket and localhost/IP
+      // network access. Request interception separately constrains file://
+      // subresources to the authorized workspace/source root.
+      if (typeof page.setOfflineMode === 'function') await page.setOfflineMode(true)
       await wrapRequestInterception(page, sourceRoot)
       await page.goto(pathToFileURL(targetReal).href, { waitUntil: 'networkidle0', timeout: 30000 })
 
@@ -354,11 +358,31 @@ export function installAdversarialHardening(ctx, config = {}, core) {
         return (factory, label) => {
           if (label !== 'vision-router: proxy fetch') return effect.call(target, factory, label)
           return effect.call(target, () => {
+            const originalFetch = globalThis.fetch
             const disposer = factory()
             const installedFetch = globalThis.fetch
+            let active = true
+            // Later plugins may capture this function. Making it an inert
+            // delegator on unload removes Vision Router from the chain even if
+            // another plugin still sits above it, and prevents it resurfacing
+            // when that later plugin restores the fetch value it captured.
+            const guardedFetch = (...args) => active
+              ? installedFetch(...args)
+              : originalFetch(...args)
+            globalThis.fetch = guardedFetch
             return () => {
-              if (globalThis.fetch !== installedFetch) return
-              if (typeof disposer === 'function') disposer()
+              active = false
+              if (globalThis.fetch === guardedFetch) globalThis.fetch = originalFetch
+              // Do not call the core disposer after another plugin replaced
+              // fetch: its cleanup writes originalFetch unconditionally. The
+              // inactive guard above already removes our behavior from any
+              // captured chain.
+              if (globalThis.fetch === originalFetch && typeof disposer === 'function') {
+                // The fetch assignment is already correct; the core disposer
+                // has no additional resources but keep compatibility if that
+                // ever changes without letting it clobber a later patch.
+                disposer()
+              }
             }
           }, label)
         }

--- a/lib/adversarial-hardening.js
+++ b/lib/adversarial-hardening.js
@@ -1,0 +1,371 @@
+import { existsSync, realpathSync } from 'node:fs'
+import { mkdir, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const DEFAULT_ARTIFACTS_DIR = '.dsh-vision-router/artifacts'
+const SCREENSHOT_PERMISSION_PATH = '/_dsh/vision-router/request-screenshot-permission'
+const MAX_VIEWPORT_WIDTH = 4096
+const MAX_VIEWPORT_HEIGHT = 4096
+const MAX_SCREENSHOT_PIXELS = 50_000_000
+
+const wrappedTools = new WeakMap()
+const wrappedWebServers = new WeakMap()
+const wrappedSettings = new WeakMap()
+const wrappedScopes = new WeakMap()
+const wrappedInjectedContexts = new WeakMap()
+
+function isNonEmptyString(value) {
+  return typeof value === 'string' && value.trim() !== ''
+}
+
+export function normalizeArtifactsDir(value) {
+  if (!isNonEmptyString(value)) return DEFAULT_ARTIFACTS_DIR
+  const raw = value.trim()
+  if (path.isAbsolute(raw) || path.win32.isAbsolute(raw)) return DEFAULT_ARTIFACTS_DIR
+  const parts = raw.split(/[\\/]+/)
+  if (parts.some((part) => part === '..')) return DEFAULT_ARTIFACTS_DIR
+  const normalized = path.normalize(raw)
+  if (normalized === '' || normalized === '.' || normalized === path.sep) return DEFAULT_ARTIFACTS_DIR
+  return normalized
+}
+
+function hardenConfig(config = {}) {
+  const value = config && typeof config === 'object' ? config : {}
+  return { ...value, artifactsDir: normalizeArtifactsDir(value.artifactsDir) }
+}
+
+function isPathInside(root, candidate) {
+  const relative = path.relative(root, candidate)
+  return relative === '' || (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative))
+}
+
+function realpathOrResolve(value) {
+  try {
+    return realpathSync(value)
+  } catch {
+    return path.resolve(value)
+  }
+}
+
+function workspaceOf(exec) {
+  const cwd = exec?.agent?.session?.header?.cwd
+  return isNonEmptyString(cwd) ? cwd : process.cwd()
+}
+
+function artifactDirectory(exec, configured) {
+  const workspace = realpathOrResolve(workspaceOf(exec))
+  const relative = normalizeArtifactsDir(configured)
+  const target = path.resolve(workspace, relative)
+  if (!isPathInside(workspace, target)) {
+    throw new Error('vision-router: artifactsDir must stay inside the session workspace')
+  }
+  return target
+}
+
+export function sameOriginRequest(req) {
+  const origin = req?.headers?.origin
+  const host = req?.headers?.host
+  const fetchSite = req?.headers?.['sec-fetch-site']
+  if (fetchSite && fetchSite !== 'same-origin' && fetchSite !== 'none') return false
+  if (!origin) return true
+  if (!host) return false
+  try {
+    return new URL(origin).host === host
+  } catch {
+    return false
+  }
+}
+
+function safeViewportDimension(value, fallback, max, label) {
+  if (value === undefined) return fallback
+  if (!Number.isInteger(value) || value <= 0 || value > max) {
+    throw new Error(`vision_html_screenshot: ${label} must be an integer between 1 and ${max}`)
+  }
+  return value
+}
+
+export function htmlRequestAllowed(urlValue, allowedRoot) {
+  let url
+  try {
+    url = new URL(urlValue)
+  } catch {
+    return false
+  }
+  if (url.protocol === 'data:' || url.protocol === 'blob:' || url.protocol === 'about:') return true
+  if (url.protocol !== 'file:') return false
+  let filePath
+  try {
+    filePath = realpathSync(fileURLToPath(url))
+  } catch {
+    return false
+  }
+  return isPathInside(allowedRoot, filePath)
+}
+
+function wrapRequestInterception(page, allowedRoot) {
+  return page.setRequestInterception(true).then(() => {
+    page.on('request', (request) => {
+      try {
+        if (htmlRequestAllowed(request.url(), allowedRoot)) request.continue()
+        else request.abort('blockedbyclient')
+      } catch {
+        try { request.abort('blockedbyclient') } catch { /* best effort */ }
+      }
+    })
+  })
+}
+
+export function createSecureHtmlScreenshotExecute(ctx, core, config, deps = {}) {
+  const importPuppeteer = deps.importPuppeteer ?? (() => import('puppeteer-core'))
+  const fileExists = deps.existsSync ?? existsSync
+  const makeDir = deps.mkdir ?? mkdir
+  const saveFile = deps.writeFile ?? writeFile
+  const realpath = deps.realpathSync ?? realpathSync
+
+  return async (args, exec) => {
+    const source = String(args?.source ?? '')
+    if (!/\.(html?|htm)$/i.test(source)) {
+      throw new Error('vision_html_screenshot: source must be a local .html/.htm file')
+    }
+    const fsService = ctx.get('fs')
+    if (fsService === undefined) throw new Error('vision_html_screenshot: the fs service is not available')
+    const resolved = await fsService.resolve(source)
+    const targetPath = core.toRealPath(fsService, resolved)
+    if (!fileExists(targetPath)) throw new Error(`vision_html_screenshot: file not found: ${source}`)
+
+    const targetReal = realpath(targetPath)
+    const workspace = realpathOrResolve(workspaceOf(exec))
+    const sourceRoot = isPathInside(workspace, targetReal) ? workspace : realpath(path.dirname(targetReal))
+
+    const width = safeViewportDimension(args?.width, 1200, MAX_VIEWPORT_WIDTH, 'width')
+    const height = safeViewportDimension(args?.height, 720, MAX_VIEWPORT_HEIGHT, 'height')
+    const fullPage = args?.fullPage === true
+
+    let puppeteer
+    try {
+      puppeteer = await importPuppeteer()
+    } catch {
+      throw new Error('vision_html_screenshot: puppeteer-core is not installed')
+    }
+    const candidates = core.chromiumCandidates(
+      typeof process !== 'undefined' && process.env ? process.env : {},
+      typeof process !== 'undefined' ? process.platform : '',
+    )
+    const executablePath = candidates.find((candidate) => fileExists(candidate))
+    if (executablePath === undefined) {
+      throw new Error(
+        'vision_html_screenshot: no Chrome/Chromium/Edge found; install one or set CHROME_PATH / PUPPETEER_EXECUTABLE_PATH',
+      )
+    }
+
+    const launchArgs = ['--disable-gpu', '--hide-scrollbars', '--incognito']
+    if (fullPage) launchArgs.push('--blink-settings=imagesLazyLoadingEnabled=false')
+    const launcher = puppeteer.default ?? puppeteer
+    let browser
+    try {
+      browser = await launcher.launch({ executablePath, headless: true, args: launchArgs })
+    } catch (error) {
+      const detail = error && error.message ? error.message : String(error)
+      throw new Error(`vision_html_screenshot: secure Chrome sandbox launch failed: ${detail}`)
+    }
+
+    try {
+      const page = await browser.newPage()
+      await page.setViewport({ width, height })
+      await wrapRequestInterception(page, sourceRoot)
+      await page.goto(pathToFileURL(targetReal).href, { waitUntil: 'networkidle0', timeout: 30000 })
+
+      let pageHeight
+      if (fullPage) {
+        pageHeight = await page.evaluate(() => Math.max(
+          document.documentElement?.scrollHeight ?? 0,
+          document.body?.scrollHeight ?? 0,
+        ))
+        if (!Number.isFinite(pageHeight) || pageHeight <= 0 || width * pageHeight > MAX_SCREENSHOT_PIXELS) {
+          throw new Error(
+            `vision_html_screenshot: full-page capture exceeds the ${MAX_SCREENSHOT_PIXELS} pixel safety limit`,
+          )
+        }
+      } else if (width * height > MAX_SCREENSHOT_PIXELS) {
+        throw new Error(`vision_html_screenshot: viewport exceeds the ${MAX_SCREENSHOT_PIXELS} pixel safety limit`)
+      }
+
+      const png = fullPage
+        ? await page.screenshot({ type: 'png', fullPage: true })
+        : await page.screenshot({ type: 'png' })
+      const stem = fullPage ? `shot-${width}x${height}-fullpage` : `shot-${width}x${height}`
+      const dir = artifactDirectory(exec, config.artifactsDir)
+      await makeDir(dir, { recursive: true })
+      const target = path.join(dir, `${core.artifactStemOf(source, stem)}.png`)
+      if (!isPathInside(dir, target)) throw new Error('vision_html_screenshot: unsafe artifact target')
+      await saveFile(target, png)
+      const result = { path: target, width, height, bytes: png.length }
+      if (fullPage) result.pageHeight = pageHeight
+      return JSON.stringify(result)
+    } finally {
+      await browser.close()
+    }
+  }
+}
+
+function wrapTools(tools, ctx, core, config) {
+  if (!tools || (typeof tools !== 'object' && typeof tools !== 'function')) return tools
+  const cached = wrappedTools.get(tools)
+  if (cached) return cached
+  const wrapped = new Proxy(tools, {
+    get(target, property) {
+      if (property !== 'register') {
+        const value = Reflect.get(target, property, target)
+        return typeof value === 'function' ? value.bind(target) : value
+      }
+      const register = Reflect.get(target, property, target)
+      return (def) => {
+        if (def?.name === 'vision_html_screenshot' && typeof def.execute === 'function') {
+          const hardened = {
+            ...def,
+            execute: createSecureHtmlScreenshotExecute(ctx, core, config),
+          }
+          return register.call(target, hardened)
+        }
+        return register.call(target, def)
+      }
+    },
+  })
+  wrappedTools.set(tools, wrapped)
+  return wrapped
+}
+
+function wrapWebServer(webServer) {
+  if (!webServer || (typeof webServer !== 'object' && typeof webServer !== 'function')) return webServer
+  const cached = wrappedWebServers.get(webServer)
+  if (cached) return cached
+  const wrapped = new Proxy(webServer, {
+    get(target, property) {
+      if (property !== 'register') {
+        const value = Reflect.get(target, property, target)
+        return typeof value === 'function' ? value.bind(target) : value
+      }
+      const register = Reflect.get(target, property, target)
+      return (def) => {
+        if (def?.path === SCREENSHOT_PERMISSION_PATH && typeof def.handler === 'function') {
+          const original = def.handler
+          return register.call(target, {
+            ...def,
+            handler: async (req, res) => {
+              if (req?.method === 'POST' && !sameOriginRequest(req)) {
+                res.writeHead(403, { 'content-type': 'application/json' })
+                res.end(JSON.stringify({ ok: false, error: 'cross-origin screenshot permission request rejected' }))
+                return
+              }
+              return original(req, res)
+            },
+          })
+        }
+        return register.call(target, def)
+      }
+    },
+  })
+  wrappedWebServers.set(webServer, wrapped)
+  return wrapped
+}
+
+function wrapScope(scope) {
+  if (!scope || (typeof scope !== 'object' && typeof scope !== 'function')) return scope
+  const cached = wrappedScopes.get(scope)
+  if (cached) return cached
+  const wrapped = new Proxy(scope, {
+    get(target, property) {
+      if (property === 'get') {
+        const get = Reflect.get(target, property, target)
+        return () => hardenConfig(get.call(target))
+      }
+      const value = Reflect.get(target, property, target)
+      return typeof value === 'function' ? value.bind(target) : value
+    },
+  })
+  wrappedScopes.set(scope, wrapped)
+  return wrapped
+}
+
+function wrapSettings(settings) {
+  if (!settings || (typeof settings !== 'object' && typeof settings !== 'function')) return settings
+  const cached = wrappedSettings.get(settings)
+  if (cached) return cached
+  const wrapped = new Proxy(settings, {
+    get(target, property) {
+      if (property !== 'register') {
+        const value = Reflect.get(target, property, target)
+        return typeof value === 'function' ? value.bind(target) : value
+      }
+      const register = Reflect.get(target, property, target)
+      return (namespace, schema, options = {}) => {
+        const fixed = namespace === 'vision-router'
+          ? { ...options, base: hardenConfig(options.base ?? {}) }
+          : options
+        const scope = register.call(target, namespace, schema, fixed)
+        return namespace === 'vision-router' ? wrapScope(scope) : scope
+      }
+    },
+  })
+  wrappedSettings.set(settings, wrapped)
+  return wrapped
+}
+
+function wrapInjectedContext(ownerCtx) {
+  if (!ownerCtx || typeof ownerCtx !== 'object') return ownerCtx
+  const cached = wrappedInjectedContexts.get(ownerCtx)
+  if (cached) return cached
+  const wrapped = new Proxy(ownerCtx, {
+    get(target, property) {
+      if (property === 'webServer') return wrapWebServer(target.webServer)
+      if (property === 'settings') return wrapSettings(target.settings)
+      const value = Reflect.get(target, property, target)
+      return typeof value === 'function' ? value.bind(target) : value
+    },
+  })
+  wrappedInjectedContexts.set(ownerCtx, wrapped)
+  return wrapped
+}
+
+export function installAdversarialHardening(ctx, config = {}, core) {
+  if (!ctx || typeof ctx !== 'object') return { ctx, config: hardenConfig(config) }
+  const hardenedConfig = hardenConfig(config)
+  const wrapped = new Proxy(ctx, {
+    get(target, property) {
+      if (property === 'tools') return wrapTools(target.tools, wrapped, core, hardenedConfig)
+      if (property === 'inject') {
+        const inject = Reflect.get(target, property, target)
+        if (typeof inject !== 'function') return inject
+        return (services, callback) => inject.call(target, services, (ownerCtx) => callback(wrapInjectedContext(ownerCtx)))
+      }
+      if (property === 'get') {
+        const get = Reflect.get(target, property, target)
+        if (typeof get !== 'function') return get
+        return (name) => {
+          const value = get.call(target, name)
+          if (name === 'settings') return wrapSettings(value)
+          return value
+        }
+      }
+      if (property === 'effect') {
+        const effect = Reflect.get(target, property, target)
+        if (typeof effect !== 'function') return effect
+        return (factory, label) => {
+          if (label !== 'vision-router: proxy fetch') return effect.call(target, factory, label)
+          return effect.call(target, () => {
+            const disposer = factory()
+            const installedFetch = globalThis.fetch
+            return () => {
+              if (globalThis.fetch !== installedFetch) return
+              if (typeof disposer === 'function') disposer()
+            }
+          }, label)
+        }
+      }
+      const value = Reflect.get(target, property, target)
+      return typeof value === 'function' ? value.bind(target) : value
+    },
+  })
+  return { ctx: wrapped, config: hardenedConfig }
+}

--- a/lib/adversarial-hardening.js
+++ b/lib/adversarial-hardening.js
@@ -4,16 +4,11 @@ import path from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 
 const DEFAULT_ARTIFACTS_DIR = '.dsh-vision-router/artifacts'
-const SCREENSHOT_PERMISSION_PATH = '/_dsh/vision-router/request-screenshot-permission'
 const MAX_VIEWPORT_WIDTH = 4096
 const MAX_VIEWPORT_HEIGHT = 4096
 const MAX_SCREENSHOT_PIXELS = 50_000_000
 
 const wrappedTools = new WeakMap()
-const wrappedWebServers = new WeakMap()
-const wrappedSettings = new WeakMap()
-const wrappedScopes = new WeakMap()
-const wrappedInjectedContexts = new WeakMap()
 
 function isNonEmptyString(value) {
   return typeof value === 'string' && value.trim() !== ''
@@ -173,10 +168,13 @@ export function createSecureHtmlScreenshotExecute(ctx, core, config, deps = {}) 
     try {
       const page = await browser.newPage()
       await page.setViewport({ width, height })
-      // Browser-level offline mode blocks HTTP(S), WebSocket and localhost/IP
-      // network access. Request interception separately constrains file://
-      // subresources to the authorized workspace/source root.
-      if (typeof page.setOfflineMode === 'function') await page.setOfflineMode(true)
+      // Puppeteer 25 exposes this API. Treat its absence as a hard failure:
+      // the tool promises an offline render, so silently degrading would
+      // recreate the security gap this boundary exists to close.
+      if (typeof page.setOfflineMode !== 'function') {
+        throw new Error('vision_html_screenshot: browser offline mode is unavailable')
+      }
+      await page.setOfflineMode(true)
       await wrapRequestInterception(page, sourceRoot)
       await page.goto(pathToFileURL(targetReal).href, { waitUntil: 'networkidle0', timeout: 30000 })
 
@@ -226,11 +224,10 @@ function wrapTools(tools, ctx, core, config) {
       const register = Reflect.get(target, property, target)
       return (def) => {
         if (def?.name === 'vision_html_screenshot' && typeof def.execute === 'function') {
-          const hardened = {
+          return register.call(target, {
             ...def,
             execute: createSecureHtmlScreenshotExecute(ctx, core, config),
-          }
-          return register.call(target, hardened)
+          })
         }
         return register.call(target, def)
       }
@@ -240,118 +237,12 @@ function wrapTools(tools, ctx, core, config) {
   return wrapped
 }
 
-function wrapWebServer(webServer) {
-  if (!webServer || (typeof webServer !== 'object' && typeof webServer !== 'function')) return webServer
-  const cached = wrappedWebServers.get(webServer)
-  if (cached) return cached
-  const wrapped = new Proxy(webServer, {
-    get(target, property) {
-      if (property !== 'register') {
-        const value = Reflect.get(target, property, target)
-        return typeof value === 'function' ? value.bind(target) : value
-      }
-      const register = Reflect.get(target, property, target)
-      return (def) => {
-        if (def?.path === SCREENSHOT_PERMISSION_PATH && typeof def.handler === 'function') {
-          const original = def.handler
-          return register.call(target, {
-            ...def,
-            handler: async (req, res) => {
-              if (req?.method === 'POST' && !sameOriginRequest(req)) {
-                res.writeHead(403, { 'content-type': 'application/json' })
-                res.end(JSON.stringify({ ok: false, error: 'cross-origin screenshot permission request rejected' }))
-                return
-              }
-              return original(req, res)
-            },
-          })
-        }
-        return register.call(target, def)
-      }
-    },
-  })
-  wrappedWebServers.set(webServer, wrapped)
-  return wrapped
-}
-
-function wrapScope(scope) {
-  if (!scope || (typeof scope !== 'object' && typeof scope !== 'function')) return scope
-  const cached = wrappedScopes.get(scope)
-  if (cached) return cached
-  const wrapped = new Proxy(scope, {
-    get(target, property) {
-      if (property === 'get') {
-        const get = Reflect.get(target, property, target)
-        return () => hardenConfig(get.call(target))
-      }
-      const value = Reflect.get(target, property, target)
-      return typeof value === 'function' ? value.bind(target) : value
-    },
-  })
-  wrappedScopes.set(scope, wrapped)
-  return wrapped
-}
-
-function wrapSettings(settings) {
-  if (!settings || (typeof settings !== 'object' && typeof settings !== 'function')) return settings
-  const cached = wrappedSettings.get(settings)
-  if (cached) return cached
-  const wrapped = new Proxy(settings, {
-    get(target, property) {
-      if (property !== 'register') {
-        const value = Reflect.get(target, property, target)
-        return typeof value === 'function' ? value.bind(target) : value
-      }
-      const register = Reflect.get(target, property, target)
-      return (namespace, schema, options = {}) => {
-        const fixed = namespace === 'vision-router'
-          ? { ...options, base: hardenConfig(options.base ?? {}) }
-          : options
-        const scope = register.call(target, namespace, schema, fixed)
-        return namespace === 'vision-router' ? wrapScope(scope) : scope
-      }
-    },
-  })
-  wrappedSettings.set(settings, wrapped)
-  return wrapped
-}
-
-function wrapInjectedContext(ownerCtx) {
-  if (!ownerCtx || typeof ownerCtx !== 'object') return ownerCtx
-  const cached = wrappedInjectedContexts.get(ownerCtx)
-  if (cached) return cached
-  const wrapped = new Proxy(ownerCtx, {
-    get(target, property) {
-      if (property === 'webServer') return wrapWebServer(target.webServer)
-      if (property === 'settings') return wrapSettings(target.settings)
-      const value = Reflect.get(target, property, target)
-      return typeof value === 'function' ? value.bind(target) : value
-    },
-  })
-  wrappedInjectedContexts.set(ownerCtx, wrapped)
-  return wrapped
-}
-
 export function installAdversarialHardening(ctx, config = {}, core) {
   if (!ctx || typeof ctx !== 'object') return { ctx, config: hardenConfig(config) }
   const hardenedConfig = hardenConfig(config)
   const wrapped = new Proxy(ctx, {
     get(target, property) {
       if (property === 'tools') return wrapTools(target.tools, wrapped, core, hardenedConfig)
-      if (property === 'inject') {
-        const inject = Reflect.get(target, property, target)
-        if (typeof inject !== 'function') return inject
-        return (services, callback) => inject.call(target, services, (ownerCtx) => callback(wrapInjectedContext(ownerCtx)))
-      }
-      if (property === 'get') {
-        const get = Reflect.get(target, property, target)
-        if (typeof get !== 'function') return get
-        return (name) => {
-          const value = get.call(target, name)
-          if (name === 'settings') return wrapSettings(value)
-          return value
-        }
-      }
       if (property === 'effect') {
         const effect = Reflect.get(target, property, target)
         if (typeof effect !== 'function') return effect
@@ -372,21 +263,20 @@ export function installAdversarialHardening(ctx, config = {}, core) {
             globalThis.fetch = guardedFetch
             return () => {
               active = false
-              if (globalThis.fetch === guardedFetch) globalThis.fetch = originalFetch
-              // Do not call the core disposer after another plugin replaced
-              // fetch: its cleanup writes originalFetch unconditionally. The
-              // inactive guard above already removes our behavior from any
-              // captured chain.
-              if (globalThis.fetch === originalFetch && typeof disposer === 'function') {
-                // The fetch assignment is already correct; the core disposer
-                // has no additional resources but keep compatibility if that
-                // ever changes without letting it clobber a later patch.
-                disposer()
+              if (globalThis.fetch === guardedFetch) {
+                globalThis.fetch = originalFetch
+                // The core disposer is safe only while our guard is still the
+                // active process-level fetch. Never let its unconditional
+                // assignment clobber a later plugin's patch.
+                if (typeof disposer === 'function') disposer()
               }
             }
           }, label)
         }
       }
+      // Deliberately do NOT wrap ctx.inject or injected child contexts. DSH
+      // rc.6 ties route/effect ownership to the exact child-context identity;
+      // replacing it with a Proxy previously made host routes disappear (#160).
       const value = Reflect.get(target, property, target)
       return typeof value === 'function' ? value.bind(target) : value
     },

--- a/lib/local-vision-stabilizer.js
+++ b/lib/local-vision-stabilizer.js
@@ -3,6 +3,7 @@ import { unlink } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { promisify } from 'node:util'
+import { sameOriginRequest } from './adversarial-hardening.js'
 
 /**
  * Narrow runtime guard around the local-vision features merged in #141.
@@ -383,6 +384,11 @@ export function installLocalVisionStabilizer(ctx, config = {}, core) {
         if (req.method !== 'POST') {
           res.writeHead(405, { 'content-type': 'application/json' })
           res.end(JSON.stringify({ ok: false, error: 'method not allowed' }))
+          return
+        }
+        if (!sameOriginRequest(req)) {
+          res.writeHead(403, { 'content-type': 'application/json' })
+          res.end(JSON.stringify({ ok: false, error: 'cross-origin screenshot permission request rejected' }))
           return
         }
         if (actualConfig().desktopScreenshot !== true) {

--- a/lib/replay-delegation.js
+++ b/lib/replay-delegation.js
@@ -1,11 +1,11 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
 
 const wrappedContexts = new WeakMap()
-const wrappedLlmServices = new WeakMap()
 const wrapperDelegateScope = new AsyncLocalStorage()
 const dynamicWrapperAdapters = new WeakMap()
 
 const NATIVE_DEEPSEEK_ROUTE = 'deepseek-official-native'
+const OFFICIAL_DEEPSEEK_ROUTE = 'deepseek-official'
 
 function isNonEmptyString(value) {
   return typeof value === 'string' && value.length > 0
@@ -34,18 +34,24 @@ function nativeDeepSeekActive(ctx) {
 }
 
 function currentTextProvider(ctx, fallbackProvider) {
-  // Stealth takeover can become active after the main wrapper was constructed.
-  // Its hidden native route is the real delegate in that state; route directly
-  // to it rather than bouncing through the public DeepSeek wrapper.
-  if (fallbackProvider === NATIVE_DEEPSEEK_ROUTE || nativeDeepSeekActive(ctx)) {
+  const selected = visionRouterSettings(ctx)?.textProvider?.provider
+  const provider = isNonEmptyString(selected) ? selected : fallbackProvider
+  // The hidden native route is only a replacement for the official DeepSeek
+  // route. Its mere presence must never override a relay/custom textProvider.
+  if (provider === NATIVE_DEEPSEEK_ROUTE) return provider
+  if (provider === OFFICIAL_DEEPSEEK_ROUTE && nativeDeepSeekActive(ctx)) {
     return NATIVE_DEEPSEEK_ROUTE
   }
-  const provider = visionRouterSettings(ctx)?.textProvider?.provider
-  return isNonEmptyString(provider) ? provider : fallbackProvider
+  return provider
 }
 
 function explicitReasoningEffort(options) {
   return isNonEmptyString(options?.reasoningEffort) ? options.reasoningEffort : undefined
+}
+
+function sessionIdentity(options) {
+  const value = options?.sessionId
+  return value === undefined || value === null || String(value) === '' ? undefined : String(value)
 }
 
 function withoutReasoningEffort(options) {
@@ -68,6 +74,7 @@ function dynamicWrapperAdapter(adapter) {
           const store = {
             pendingDelegate: true,
             explicitEffort: explicitReasoningEffort(options),
+            sessionId: sessionIdentity(options),
           }
           const iterable = stream.call(target, options)
           const iterator = iterable[Symbol.asyncIterator]()
@@ -140,15 +147,11 @@ export function rebindDelegatedReplayOptions(options) {
 
 function llmWithDelegatedReplay(llm, ctx, fallbackWrapperRoute) {
   if (!llm || (typeof llm !== 'object' && typeof llm !== 'function')) return llm
-  const cached = wrappedLlmServices.get(llm)
-  if (cached) return cached
 
-  // The core wrapper remembers reasoning effort by the delegate string it
-  // captured at construction time. Once textProvider changes, that key is
-  // stale too. Keep a second, entry-layer memory keyed by the provider that is
-  // actually receiving the call so an effort selected on one relay never
-  // leaks into another relay (and switching back restores that provider's own
-  // last explicit choice).
+  // DSH stamps sessionId on loop-built GenerateOptions. Keep reasoning memory
+  // inside that session boundary so two chats using the same provider/model
+  // cannot overwrite each other's picker state. Hand-built one-shots without a
+  // sessionId deliberately get no cross-call memory.
   const liveReasoningEffort = new Map()
 
   const wrapped = new Proxy(llm, {
@@ -179,13 +182,18 @@ function llmWithDelegatedReplay(llm, ctx, fallbackWrapperRoute) {
             // must keep their explicit provider.
             store.pendingDelegate = false
             const provider = currentTextProvider(ctx, options.provider)
-            const effortKey = `${provider}\u0000${options.model ?? ''}`
+            const model = options.model ?? ''
+            const sessionId = store.sessionId
+            const effortKey = sessionId === undefined ? undefined : `${sessionId}\u0000${provider}\u0000${model}`
             const explicit = store.explicitEffort
             if (explicit !== undefined) {
-              liveReasoningEffort.set(effortKey, explicit)
+              if (effortKey !== undefined) liveReasoningEffort.set(effortKey, explicit)
               routed = { ...options, provider, reasoningEffort: explicit }
             } else {
-              const remembered = liveReasoningEffort.get(effortKey)
+              const remembered = effortKey === undefined ? undefined : liveReasoningEffort.get(effortKey)
+              // createWrapperStreamBody still has a legacy provider/model-only
+              // cache. Strip its injected value unless this session has proved
+              // its own picker state, preventing cross-session contamination.
               routed = remembered === undefined
                 ? { ...withoutReasoningEffort(options), provider }
                 : { ...options, provider, reasoningEffort: remembered }
@@ -198,7 +206,6 @@ function llmWithDelegatedReplay(llm, ctx, fallbackWrapperRoute) {
       return typeof value === 'function' ? value.bind(target) : value
     },
   })
-  wrappedLlmServices.set(llm, wrapped)
   return wrapped
 }
 
@@ -229,5 +236,15 @@ export function contextWithDelegatedReplay(ctx, options = {}) {
     },
   })
   wrappedContexts.set(ctx, wrapped)
+  try {
+    ctx.effect?.(
+      () => () => {
+        if (wrappedContexts.get(ctx) === wrapped) wrappedContexts.delete(ctx)
+      },
+      'vision-router: delegated replay context lifecycle',
+    )
+  } catch {
+    /* lifecycle hardening must not block plugin apply */
+  }
   return wrapped
 }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "sharp": "^0.35.3"
   },
   "scripts": {
-    "test": "node --test tests/core.test.js tests/capability-advisory.test.js tests/vision-resilience.test.js tests/client.test.js tests/http-compat.test.js tests/catalog-corrections.test.js tests/update-check.test.js tests/self-update.test.js tests/doctor.test.js tests/doctor-cli.test.js tests/bundle-defaults.test.js tests/file-logger.test.js tests/replay-delegation.test.js tests/logging-ui.test.js tests/manifest-dependencies.test.js tests/structured-bootstrap.test.js tests/structured-bootstrap-gate.test.js tests/local-ollama.test.js tests/zero-regression-gate.test.js tests/runtime-e2e.test.js tests/local-vision-stabilizer.test.js tests/local-connection-probe.test.js tests/repetition-guard.test.js tests/guide-scroll-gate.test.js"
+    "test": "node --test tests/core.test.js tests/capability-advisory.test.js tests/vision-resilience.test.js tests/client.test.js tests/http-compat.test.js tests/catalog-corrections.test.js tests/update-check.test.js tests/self-update.test.js tests/doctor.test.js tests/doctor-cli.test.js tests/bundle-defaults.test.js tests/file-logger.test.js tests/replay-delegation.test.js tests/adversarial-hardening.test.js tests/logging-ui.test.js tests/manifest-dependencies.test.js tests/structured-bootstrap.test.js tests/structured-bootstrap-gate.test.js tests/local-ollama.test.js tests/zero-regression-gate.test.js tests/runtime-e2e.test.js tests/local-vision-stabilizer.test.js tests/local-connection-probe.test.js tests/repetition-guard.test.js tests/guide-scroll-gate.test.js"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/tests/adversarial-hardening.test.js
+++ b/tests/adversarial-hardening.test.js
@@ -222,7 +222,7 @@ test('proxy fetch cleanup becomes inert under later plugin patches and cannot re
     const { ctx: hardened } = installAdversarialHardening(ctx, {}, {})
     hardened.effect(() => {
       globalThis.fetch = patchA
-      return () => { globalThis.fetch = hostFetch },
+      return () => { globalThis.fetch = hostFetch }
     }, 'vision-router: proxy fetch')
     const guardedFetch = globalThis.fetch
     assert.notEqual(guardedFetch, patchA)

--- a/tests/adversarial-hardening.test.js
+++ b/tests/adversarial-hardening.test.js
@@ -49,16 +49,18 @@ test('htmlRequestAllowed permits only local-root/data/blob/about resources', asy
   }
 })
 
-test('secure HTML screenshot keeps Chrome sandbox enabled, intercepts requests and writes under workspace', async () => {
+test('secure HTML screenshot keeps Chrome sandbox enabled, forces offline mode and writes under workspace', async () => {
   const workspace = await mkdtemp(path.join(tmpdir(), 'vision-html-'))
   try {
     const source = path.join(workspace, 'page.html')
     await writeFile(source, '<html><body>Hello</body></html>')
     let launchOptions
     let requestHandler
+    let offline = false
     let closed = false
     const page = {
       async setViewport(value) { assert.deepEqual(value, { width: 1200, height: 720 }) },
+      async setOfflineMode(value) { offline = value },
       async setRequestInterception(value) { assert.equal(value, true) },
       on(event, handler) {
         assert.equal(event, 'request')
@@ -107,6 +109,7 @@ test('secure HTML screenshot keeps Chrome sandbox enabled, intercepts requests a
     ))
     assert.ok(launchOptions)
     assert.equal(launchOptions.args.includes('--no-sandbox'), false)
+    assert.equal(offline, true)
     assert.equal(typeof requestHandler, 'function')
     assert.equal(closed, true)
     assert.equal(result.pageHeight, 1500)
@@ -189,10 +192,9 @@ test('hardening wrapper protects screenshot permission POST from cross-origin ca
   assert.equal(originalCalls, 1)
 })
 
-test('proxy fetch cleanup never removes a later plugin fetch patch', () => {
+test('proxy fetch cleanup becomes inert under later plugin patches and cannot resurface', () => {
   const originalFetch = globalThis.fetch
   const patchA = () => 'a'
-  const patchB = () => 'b'
   let cleanup
   const ctx = {
     tools: { register() {} },
@@ -207,10 +209,19 @@ test('proxy fetch cleanup never removes a later plugin fetch patch', () => {
       globalThis.fetch = patchA
       return () => { globalThis.fetch = originalFetch },
     }, 'vision-router: proxy fetch')
-    assert.equal(globalThis.fetch, patchA)
-    globalThis.fetch = patchB
+    const guardedFetch = globalThis.fetch
+    assert.notEqual(guardedFetch, patchA)
+    assert.equal(guardedFetch(), 'a')
+
+    const laterPatch = (...args) => guardedFetch(...args)
+    globalThis.fetch = laterPatch
     cleanup()
-    assert.equal(globalThis.fetch, patchB)
+    assert.equal(globalThis.fetch, laterPatch)
+    // Simulate the later plugin unloading and restoring the fetch value it
+    // captured. Vision Router's guard must remain inert instead of resurfacing.
+    globalThis.fetch = guardedFetch
+    assert.equal(globalThis.fetch, guardedFetch)
+    assert.notEqual(globalThis.fetch(), 'a')
   } finally {
     globalThis.fetch = originalFetch
   }

--- a/tests/adversarial-hardening.test.js
+++ b/tests/adversarial-hardening.test.js
@@ -1,0 +1,217 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtemp, writeFile, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+import {
+  createSecureHtmlScreenshotExecute,
+  htmlRequestAllowed,
+  installAdversarialHardening,
+  normalizeArtifactsDir,
+  sameOriginRequest,
+} from '../lib/adversarial-hardening.js'
+
+test('normalizeArtifactsDir keeps artifacts inside the workspace', () => {
+  assert.equal(normalizeArtifactsDir('.dsh-vision-router/artifacts'), path.normalize('.dsh-vision-router/artifacts'))
+  assert.equal(normalizeArtifactsDir('screenshots/out'), path.normalize('screenshots/out'))
+  assert.equal(normalizeArtifactsDir('../escape'), '.dsh-vision-router/artifacts')
+  assert.equal(normalizeArtifactsDir('safe/../../escape'), '.dsh-vision-router/artifacts')
+  assert.equal(normalizeArtifactsDir('/tmp/escape'), '.dsh-vision-router/artifacts')
+  assert.equal(normalizeArtifactsDir('C:\\escape'), '.dsh-vision-router/artifacts')
+})
+
+test('sameOriginRequest rejects cross-site browser requests while allowing same-origin and non-browser calls', () => {
+  assert.equal(sameOriginRequest({ headers: { host: '127.0.0.1:3000', origin: 'http://127.0.0.1:3000' } }), true)
+  assert.equal(sameOriginRequest({ headers: { host: '127.0.0.1:3000', origin: 'https://evil.example' } }), false)
+  assert.equal(sameOriginRequest({ headers: { 'sec-fetch-site': 'cross-site' } }), false)
+  assert.equal(sameOriginRequest({ headers: {} }), true)
+})
+
+test('htmlRequestAllowed permits only local-root/data/blob/about resources', async () => {
+  const root = await mkdtemp(path.join(tmpdir(), 'vision-hardening-'))
+  const outside = await mkdtemp(path.join(tmpdir(), 'vision-hardening-outside-'))
+  try {
+    const insideFile = path.join(root, 'asset.png')
+    const outsideFile = path.join(outside, 'secret.txt')
+    await writeFile(insideFile, 'x')
+    await writeFile(outsideFile, 'secret')
+    assert.equal(htmlRequestAllowed(pathToFileURL(insideFile).href, root), true)
+    assert.equal(htmlRequestAllowed(pathToFileURL(outsideFile).href, root), false)
+    assert.equal(htmlRequestAllowed('data:text/plain,ok', root), true)
+    assert.equal(htmlRequestAllowed('blob:null/abc', root), true)
+    assert.equal(htmlRequestAllowed('about:blank', root), true)
+    assert.equal(htmlRequestAllowed('https://example.com/track', root), false)
+    assert.equal(htmlRequestAllowed('http://127.0.0.1:11434/api/tags', root), false)
+  } finally {
+    await rm(root, { recursive: true, force: true })
+    await rm(outside, { recursive: true, force: true })
+  }
+})
+
+test('secure HTML screenshot keeps Chrome sandbox enabled, intercepts requests and writes under workspace', async () => {
+  const workspace = await mkdtemp(path.join(tmpdir(), 'vision-html-'))
+  try {
+    const source = path.join(workspace, 'page.html')
+    await writeFile(source, '<html><body>Hello</body></html>')
+    let launchOptions
+    let requestHandler
+    let closed = false
+    const page = {
+      async setViewport(value) { assert.deepEqual(value, { width: 1200, height: 720 }) },
+      async setRequestInterception(value) { assert.equal(value, true) },
+      on(event, handler) {
+        assert.equal(event, 'request')
+        requestHandler = handler
+      },
+      async goto(url) { assert.equal(url, pathToFileURL(source).href) },
+      async evaluate() { return 1500 },
+      async screenshot(options) {
+        assert.deepEqual(options, { type: 'png', fullPage: true })
+        return Buffer.from('png-bytes')
+      },
+    }
+    const fakePuppeteer = {
+      async launch(options) {
+        launchOptions = options
+        return {
+          async newPage() { return page },
+          async close() { closed = true },
+        }
+      },
+    }
+    const ctx = {
+      get(name) {
+        if (name !== 'fs') return undefined
+        return { async resolve(value) { return value } }
+      },
+    }
+    const core = {
+      toRealPath(_fs, value) { return value },
+      chromiumCandidates() { return ['/fake/chrome'] },
+      artifactStemOf() { return 'page-safe-shot' },
+    }
+    const execute = createSecureHtmlScreenshotExecute(
+      ctx,
+      core,
+      { artifactsDir: '../escape' },
+      {
+        importPuppeteer: async () => fakePuppeteer,
+        existsSync(value) { return value === source || value === '/fake/chrome' },
+        realpathSync(value) { return value },
+      },
+    )
+    const result = JSON.parse(await execute(
+      { source, fullPage: true },
+      { agent: { session: { header: { cwd: workspace } } } },
+    ))
+    assert.ok(launchOptions)
+    assert.equal(launchOptions.args.includes('--no-sandbox'), false)
+    assert.equal(typeof requestHandler, 'function')
+    assert.equal(closed, true)
+    assert.equal(result.pageHeight, 1500)
+    assert.equal(path.relative(workspace, result.path).startsWith('..'), false)
+    assert.equal((await readFile(result.path)).toString(), 'png-bytes')
+  } finally {
+    await rm(workspace, { recursive: true, force: true })
+  }
+})
+
+test('secure HTML screenshot rejects oversized viewport before launching Chrome', async () => {
+  const workspace = await mkdtemp(path.join(tmpdir(), 'vision-html-size-'))
+  try {
+    const source = path.join(workspace, 'page.html')
+    await writeFile(source, '<html></html>')
+    let launched = false
+    const ctx = {
+      get() { return { async resolve(value) { return value } } },
+    }
+    const core = {
+      toRealPath(_fs, value) { return value },
+      chromiumCandidates() { return ['/fake/chrome'] },
+      artifactStemOf() { return 'x' },
+    }
+    const execute = createSecureHtmlScreenshotExecute(ctx, core, {}, {
+      importPuppeteer: async () => ({ async launch() { launched = true } }),
+      existsSync(value) { return value === source || value === '/fake/chrome' },
+      realpathSync(value) { return value },
+    })
+    await assert.rejects(
+      execute({ source, width: 100000 }, { agent: { session: { header: { cwd: workspace } } } }),
+      /width must be an integer between/,
+    )
+    assert.equal(launched, false)
+  } finally {
+    await rm(workspace, { recursive: true, force: true })
+  }
+})
+
+test('hardening wrapper protects screenshot permission POST from cross-origin callers', async () => {
+  let registered
+  let originalCalls = 0
+  const webServer = {
+    register(def) {
+      registered = def
+      return () => {}
+    },
+  }
+  const child = { webServer }
+  const ctx = {
+    tools: { register() {} },
+    inject(_services, callback) { callback(child) },
+  }
+  const { ctx: hardened } = installAdversarialHardening(ctx, {}, {})
+  hardened.inject(['webServer'], (ownerCtx) => {
+    ownerCtx.webServer.register({
+      path: '/_dsh/vision-router/request-screenshot-permission',
+      async handler(_req, res) {
+        originalCalls += 1
+        res.writeHead(200)
+        res.end('ok')
+      },
+    })
+  })
+  const responses = []
+  const res = {
+    writeHead(status) { responses.push(status) },
+    end() {},
+  }
+  await registered.handler(
+    { method: 'POST', headers: { host: '127.0.0.1:3000', origin: 'https://evil.example', 'sec-fetch-site': 'cross-site' } },
+    res,
+  )
+  assert.equal(responses.at(-1), 403)
+  assert.equal(originalCalls, 0)
+  await registered.handler(
+    { method: 'POST', headers: { host: '127.0.0.1:3000', origin: 'http://127.0.0.1:3000', 'sec-fetch-site': 'same-origin' } },
+    res,
+  )
+  assert.equal(originalCalls, 1)
+})
+
+test('proxy fetch cleanup never removes a later plugin fetch patch', () => {
+  const originalFetch = globalThis.fetch
+  const patchA = () => 'a'
+  const patchB = () => 'b'
+  let cleanup
+  const ctx = {
+    tools: { register() {} },
+    effect(factory) {
+      cleanup = factory()
+      return () => {}
+    },
+  }
+  try {
+    const { ctx: hardened } = installAdversarialHardening(ctx, {}, {})
+    hardened.effect(() => {
+      globalThis.fetch = patchA
+      return () => { globalThis.fetch = originalFetch },
+    }, 'vision-router: proxy fetch')
+    assert.equal(globalThis.fetch, patchA)
+    globalThis.fetch = patchB
+    cleanup()
+    assert.equal(globalThis.fetch, patchB)
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})

--- a/tests/adversarial-hardening.test.js
+++ b/tests/adversarial-hardening.test.js
@@ -11,6 +11,7 @@ import {
   normalizeArtifactsDir,
   sameOriginRequest,
 } from '../lib/adversarial-hardening.js'
+import { installLocalVisionStabilizer } from '../lib/local-vision-stabilizer.js'
 
 test('normalizeArtifactsDir keeps artifacts inside the workspace', () => {
   assert.equal(normalizeArtifactsDir('.dsh-vision-router/artifacts'), path.normalize('.dsh-vision-router/artifacts'))
@@ -149,51 +150,64 @@ test('secure HTML screenshot rejects oversized viewport before launching Chrome'
   }
 })
 
-test('hardening wrapper protects screenshot permission POST from cross-origin callers', async () => {
-  let registered
-  let originalCalls = 0
-  const webServer = {
-    register(def) {
-      registered = def
-      return () => {}
-    },
-  }
-  const child = { webServer }
-  const ctx = {
-    tools: { register() {} },
-    inject(_services, callback) { callback(child) },
-  }
-  const { ctx: hardened } = installAdversarialHardening(ctx, {}, {})
-  hardened.inject(['webServer'], (ownerCtx) => {
-    ownerCtx.webServer.register({
-      path: '/_dsh/vision-router/request-screenshot-permission',
-      async handler(_req, res) {
-        originalCalls += 1
-        res.writeHead(200)
-        res.end('ok')
+test('real screenshot permission route rejects cross-origin POSTs without proxying the webServer child context', async () => {
+  let route
+  let seenWebChild
+  const webCtx = {
+    webServer: {
+      register(spec) {
+        route = spec
+        return () => {}
       },
-    })
-  })
-  const responses = []
-  const res = {
-    writeHead(status) { responses.push(status) },
-    end() {},
+    },
+    effect(factory) { return factory() },
   }
-  await registered.handler(
-    { method: 'POST', headers: { host: '127.0.0.1:3000', origin: 'https://evil.example', 'sec-fetch-site': 'cross-site' } },
-    res,
+  const ctx = {
+    tools: { register() { return () => {} } },
+    llm: { registerAdapter() { return () => {} } },
+    logger: { warn() {}, info() {}, error() {} },
+    get() { return undefined },
+    inject(deps, callback) {
+      if (deps.includes('webServer')) {
+        seenWebChild = webCtx
+        callback(webCtx)
+      }
+    },
+    effect(factory) { return factory() },
+  }
+  const core = {
+    localProvidersOf() { return [] },
+    classifyVisionFailure() { return { kind: 'other' } },
+    VISION_FAILURE_KINDS: {},
+  }
+  const { ctx: stabilized } = installLocalVisionStabilizer(ctx, { desktopScreenshot: true }, core)
+  let callbackChild
+  stabilized.inject(['webServer'], (child) => { callbackChild = child })
+  assert.equal(callbackChild, seenWebChild)
+  assert.ok(route)
+
+  let status
+  await route.handler(
+    {
+      method: 'POST',
+      headers: {
+        host: '127.0.0.1:3000',
+        origin: 'https://evil.example',
+        'sec-fetch-site': 'cross-site',
+      },
+    },
+    {
+      setHeader() {},
+      writeHead(code) { status = code },
+      end() {},
+    },
   )
-  assert.equal(responses.at(-1), 403)
-  assert.equal(originalCalls, 0)
-  await registered.handler(
-    { method: 'POST', headers: { host: '127.0.0.1:3000', origin: 'http://127.0.0.1:3000', 'sec-fetch-site': 'same-origin' } },
-    res,
-  )
-  assert.equal(originalCalls, 1)
+  assert.equal(status, 403)
 })
 
 test('proxy fetch cleanup becomes inert under later plugin patches and cannot resurface', () => {
-  const originalFetch = globalThis.fetch
+  const hostFetch = () => 'host'
+  const savedFetch = globalThis.fetch
   const patchA = () => 'a'
   let cleanup
   const ctx = {
@@ -204,10 +218,11 @@ test('proxy fetch cleanup becomes inert under later plugin patches and cannot re
     },
   }
   try {
+    globalThis.fetch = hostFetch
     const { ctx: hardened } = installAdversarialHardening(ctx, {}, {})
     hardened.effect(() => {
       globalThis.fetch = patchA
-      return () => { globalThis.fetch = originalFetch },
+      return () => { globalThis.fetch = hostFetch },
     }, 'vision-router: proxy fetch')
     const guardedFetch = globalThis.fetch
     assert.notEqual(guardedFetch, patchA)
@@ -220,9 +235,8 @@ test('proxy fetch cleanup becomes inert under later plugin patches and cannot re
     // Simulate the later plugin unloading and restoring the fetch value it
     // captured. Vision Router's guard must remain inert instead of resurfacing.
     globalThis.fetch = guardedFetch
-    assert.equal(globalThis.fetch, guardedFetch)
-    assert.notEqual(globalThis.fetch(), 'a')
+    assert.equal(globalThis.fetch(), 'host')
   } finally {
-    globalThis.fetch = originalFetch
+    globalThis.fetch = savedFetch
   }
 })

--- a/tests/replay-delegation.test.js
+++ b/tests/replay-delegation.test.js
@@ -126,10 +126,12 @@ test('contextWithDelegatedReplay scopes rebinding to the context view and preser
   assert.equal(contextWithDelegatedReplay(ctx), wrapped)
 })
 
-test('main auto-vision wrapper follows live textProvider changes and isolates reasoning effort per delegate', async () => {
-  let textProvider = 'deepseek-official'
+function liveWrapperHarness({ initialProvider = 'deepseek-official', native = false } = {}) {
+  let textProvider = initialProvider
   let registeredAdapter
   const calls = []
+  const registrations = new Map()
+  if (native) registrations.set('deepseek-official-native', {})
   const settings = {
     get(namespace) {
       if (namespace !== 'vision-router') return undefined
@@ -140,6 +142,9 @@ test('main auto-vision wrapper follows live textProvider changes and isolates re
     },
   }
   const llm = {
+    registration(provider) {
+      return registrations.get(provider)
+    },
     registerAdapter(providers, adapter) {
       assert.deepEqual(providers, ['deepseek-vision'])
       registeredAdapter = adapter
@@ -158,10 +163,8 @@ test('main auto-vision wrapper follows live textProvider changes and isolates re
   }
   const wrapped = contextWithDelegatedReplay(ctx)
 
-  // Emulate the current core wrapper's two stale captures: its delegate
-  // provider is fixed at apply time, and its own reasoning memory is keyed by
-  // that stale provider. The entry-layer boundary must correct both at the
-  // one nested llm.stream dispatch.
+  // Emulate the core wrapper's legacy stale provider/reasoning caches. The
+  // entry-layer boundary must correct both at the one nested llm.stream call.
   let staleReasoningEffort
   const coreWrapper = {
     async *stream(options) {
@@ -180,35 +183,94 @@ test('main auto-vision wrapper follows live textProvider changes and isolates re
   }
   wrapped.llm.registerAdapter(['deepseek-vision'], coreWrapper)
 
-  const drain = async (options) => {
+  const drain = async (options = {}) => {
     for await (const _chunk of registeredAdapter.stream({
       model: 'deepseek-v4-pro',
       messages: [{ role: 'user', content: [{ type: 'text', text: 'hello' }] }],
+      sessionId: 'session-a',
       ...options,
     })) {
       // drain
     }
   }
+  return {
+    calls,
+    drain,
+    setProvider(value) { textProvider = value },
+  }
+}
 
-  await drain({ reasoningEffort: 'high' })
-  textProvider = 'relay-openai'
-  await drain({})
-  await drain({ reasoningEffort: 'low' })
-  textProvider = 'deepseek-official'
-  await drain({})
+test('main auto-vision wrapper follows live textProvider changes and keeps reasoning memory per delegate', async () => {
+  const harness = liveWrapperHarness()
+  await harness.drain({ reasoningEffort: 'high' })
+  harness.setProvider('relay-openai')
+  await harness.drain({})
+  await harness.drain({ reasoningEffort: 'low' })
+  harness.setProvider('deepseek-official')
+  await harness.drain({})
 
-  assert.deepEqual(calls.map((call) => call.provider), [
+  assert.deepEqual(harness.calls.map((call) => call.provider), [
     'deepseek-official',
     'relay-openai',
     'relay-openai',
     'deepseek-official',
   ])
-  assert.deepEqual(calls.map((call) => call.reasoningEffort), [
+  assert.deepEqual(harness.calls.map((call) => call.reasoningEffort), [
     'high',
     undefined,
     'low',
     'high',
   ])
+})
+
+test('hidden native DeepSeek route only substitutes the official selection, never a relay', async () => {
+  const harness = liveWrapperHarness({ initialProvider: 'relay-openai', native: true })
+  await harness.drain({ reasoningEffort: 'high' })
+  harness.setProvider('deepseek-official')
+  await harness.drain({})
+  assert.deepEqual(harness.calls.map((call) => call.provider), [
+    'relay-openai',
+    'deepseek-official-native',
+  ])
+})
+
+test('reasoning effort memory is isolated by DSH sessionId even when core cache is globally stale', async () => {
+  const harness = liveWrapperHarness()
+  await harness.drain({ sessionId: 'session-a', reasoningEffort: 'high' })
+  await harness.drain({ sessionId: 'session-b', reasoningEffort: 'low' })
+  await harness.drain({ sessionId: 'session-a' })
+  await harness.drain({ sessionId: 'session-b' })
+  assert.deepEqual(harness.calls.map((call) => call.reasoningEffort), [
+    'high',
+    'low',
+    'high',
+    'low',
+  ])
+})
+
+test('requests without sessionId do not inherit provider/model reasoning state', async () => {
+  const harness = liveWrapperHarness()
+  await harness.drain({ sessionId: undefined, reasoningEffort: 'high' })
+  await harness.drain({ sessionId: undefined })
+  assert.deepEqual(harness.calls.map((call) => call.reasoningEffort), ['high', undefined])
+})
+
+test('delegated replay context cache expires with the Cordis plugin fiber', () => {
+  let cleanup
+  const llm = { registerAdapter() {}, stream() {} }
+  const ctx = {
+    llm,
+    effect(factory) {
+      cleanup = factory()
+      return () => {}
+    },
+  }
+  const first = contextWithDelegatedReplay(ctx)
+  assert.equal(contextWithDelegatedReplay(ctx), first)
+  assert.equal(typeof cleanup, 'function')
+  cleanup()
+  const second = contextWithDelegatedReplay(ctx)
+  assert.notEqual(second, first)
 })
 
 test('only the configured main wrapper route gets live text-provider rewriting', async () => {


### PR DESCRIPTION
Adversarial follow-up against current main after #181.

Closes the reviewed runtime gaps before the next release:

- keep the hidden DeepSeek native route scoped to the official selection so relay/custom text providers are never overridden merely because the native route exists;
- scope reasoning-effort recovery by DSH `sessionId` and expire delegated-replay context caches with the Cordis plugin lifecycle;
- replace `vision_html_screenshot` execution with a sandboxed/offline renderer: no `--no-sandbox`, browser offline mode, request interception limiting `file://` subresources to the authorized root, viewport/full-page pixel limits;
- constrain `artifactsDir` to the session workspace;
- enforce same-origin checks on the macOS screenshot-permission POST side effect;
- make Vision Router's process-wide fetch patch removable from a later plugin's captured chain without clobbering or resurfacing.

Regression tests cover relay + native coexistence, cross-session reasoning isolation, lifecycle remount, path traversal, cross-origin screenshot permission, offline HTML rendering bounds, and stacked fetch patches.