### PR TITLE
fix: restore auto-vision model row on DSH rc.7

### DIFF
--- a/entry.js
+++ b/entry.js
@@ -12,6 +12,7 @@ import { installVisionRouterFileLogging } from './lib/file-logger.js'
 import { contextWithDelegatedReplay } from './lib/replay-delegation.js'
 import { installAdversarialHardening } from './lib/adversarial-hardening.js'
 import { installLocalVisionStabilizer } from './lib/local-vision-stabilizer.js'
+import { installWrapperDirectoryAlias } from './lib/wrapper-directory.js'
 
 // Schemastery object schemas expose set() as the supported way to replace a
 // field schema. This mutates the Config object that index.js itself later uses
@@ -72,10 +73,17 @@ export function apply(ctx, config = {}) {
     /* diagnostics must never break apply */
   }
   try {
-    const result = core.apply(stabilizedCtx, {
+    const runtimeConfig = {
       ...bootConfig,
       progressiveTools: hardenedConfig.progressiveTools === true,
-    })
+    }
+    const result = core.apply(stabilizedCtx, runtimeConfig)
+    // DSH rc.7's Settings -> Models surface is backed by the configurable
+    // provider directory, not by the live adapter registry alone. Publish the
+    // main DeepSeek + 自动识图 route as a derived alias of its text provider so
+    // a reinstall restores the expected model-group row without duplicating
+    // provider credentials/configuration.
+    installWrapperDirectoryAlias(stabilizedCtx, runtimeConfig, logging.logger)
     if (result && typeof result.then === 'function') {
       return result.catch((error) => {
         logging.logger.error(

--- a/lib/wrapper-directory.js
+++ b/lib/wrapper-directory.js
@@ -1,0 +1,165 @@
+// DSH rc.7 split the live adapter registry from the Models settings directory.
+// A wrapper registered only through llm.registerAdapter() is callable and shows
+// up in llm.models, but Settings -> Models intentionally hides live routes that
+// have no settings address. Vision Router's main `deepseek-vision` route is a
+// derived view of the configured text provider, not an independently configured
+// backend, so publish it in the directory as an alias of that source provider.
+
+const DEFAULT_WRAPPER_ROUTE = 'deepseek-vision'
+const DEFAULT_TEXT_PROVIDER = 'deepseek-official'
+
+function nonEmptyString(value, fallback) {
+  return typeof value === 'string' && value !== '' ? value : fallback
+}
+
+function resolvedVisionRouterConfig(ctx, baseConfig) {
+  try {
+    const settings = ctx && typeof ctx.get === 'function' ? ctx.get('settings') : undefined
+    const live = settings && typeof settings.get === 'function' ? settings.get('vision-router') : undefined
+    if (live && typeof live === 'object') return live
+  } catch {
+    // The settings service is optional during early composition startup.
+  }
+  return baseConfig && typeof baseConfig === 'object' ? baseConfig : {}
+}
+
+/**
+ * Resolve the rc.7 Models-directory entry for the main auto-vision wrapper.
+ * The wrapper deliberately reuses the source provider's settings namespace and
+ * path: editing the derived row edits the provider it delegates text calls to.
+ * Returns undefined until both the wrapper adapter and a configurable source
+ * provider are visible, preserving older DSH behavior as a no-op fallback.
+ */
+export function resolveWrapperDirectoryEntry(ctx, baseConfig = {}) {
+  const llm = ctx && ctx.llm
+  if (
+    !llm ||
+    typeof llm.listProviders !== 'function' ||
+    typeof llm.listConfigurableProviders !== 'function'
+  ) {
+    return undefined
+  }
+
+  const config = resolvedVisionRouterConfig(ctx, baseConfig)
+  const wrapperRoute = nonEmptyString(config.wrapperRoute, DEFAULT_WRAPPER_ROUTE)
+  const sourceProvider = nonEmptyString(config.textProvider && config.textProvider.provider, DEFAULT_TEXT_PROVIDER)
+
+  let liveProviders
+  let configurableProviders
+  try {
+    liveProviders = llm.listProviders()
+    configurableProviders = llm.listConfigurableProviders()
+  } catch {
+    return undefined
+  }
+  if (!Array.isArray(liveProviders) || !Array.isArray(configurableProviders)) return undefined
+
+  const wrapper = liveProviders.find((entry) => entry && entry.id === wrapperRoute)
+  if (!wrapper) return undefined
+
+  const source = configurableProviders.find((entry) => entry && entry.provider === sourceProvider)
+  if (!source || typeof source.settingsNs !== 'string' || source.settingsNs === '') return undefined
+
+  return {
+    provider: wrapperRoute,
+    displayName:
+      typeof wrapper.name === 'string' && wrapper.name !== ''
+        ? wrapper.name
+        : 'DeepSeek + 自动识图',
+    settingsNs: source.settingsNs,
+    settingsPath: Array.isArray(source.settingsPath) ? [...source.settingsPath] : [],
+  }
+}
+
+/**
+ * Keep the wrapper's configurable-provider alias synchronized with live
+ * settings/topology. registerConfigurableProviders() itself emits
+ * llm/adapters-updated, so the small re-entrancy guard is required.
+ */
+export function installWrapperDirectoryAlias(ctx, baseConfig = {}, logger = ctx && ctx.logger) {
+  const llm = ctx && ctx.llm
+  if (
+    !llm ||
+    typeof llm.registerConfigurableProviders !== 'function' ||
+    typeof llm.listConfigurableProviders !== 'function'
+  ) {
+    return () => undefined
+  }
+
+  let handle
+  let ownedProvider
+  let heldKey
+  let syncing = false
+
+  const sync = () => {
+    if (syncing) return
+    const next = resolveWrapperDirectoryEntry(ctx, baseConfig)
+    const nextEntries = next ? [next] : []
+    const nextKey = JSON.stringify(nextEntries)
+
+    // A future Harness/plugin version may already own this exact directory
+    // route. Never fight it; if we currently own an older alias, withdraw ours.
+    if (next && next.provider !== ownedProvider) {
+      let directory = []
+      try {
+        directory = llm.listConfigurableProviders()
+      } catch {
+        directory = []
+      }
+      if (Array.isArray(directory) && directory.some((entry) => entry && entry.provider === next.provider)) {
+        if (handle && ownedProvider !== undefined) {
+          syncing = true
+          try {
+            handle.replace([])
+            ownedProvider = undefined
+            heldKey = undefined
+          } catch (error) {
+            logger?.warn?.(
+              'vision-router: failed to withdraw stale Models-directory alias: %s',
+              error && error.message ? error.message : String(error),
+            )
+          } finally {
+            syncing = false
+          }
+        }
+        return
+      }
+    }
+
+    if (handle && heldKey === nextKey) return
+    if (!handle && !next) return
+
+    syncing = true
+    try {
+      if (handle) {
+        handle.replace(nextEntries)
+      } else {
+        handle = llm.registerConfigurableProviders(nextEntries)
+      }
+      ownedProvider = next ? next.provider : undefined
+      heldKey = nextKey
+    } catch (error) {
+      // Directory publication affects Settings -> Models discoverability only;
+      // never turn a healthy wrapper adapter into a plugin startup failure.
+      logger?.warn?.(
+        'vision-router: Models-directory alias sync failed: %s',
+        error && error.message ? error.message : String(error),
+      )
+    } finally {
+      syncing = false
+    }
+  }
+
+  sync()
+  if (typeof ctx.on === 'function') {
+    ctx.on('llm/adapters-updated', sync)
+    ctx.on('settings/updated', (ns) => {
+      if (String(ns) === 'vision-router') sync()
+    })
+    ctx.on('settings/document-updated', (ns) => {
+      if (String(ns) === 'vision-router') sync()
+    })
+  }
+
+  return sync
+}

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "sharp": "^0.35.3"
   },
   "scripts": {
-    "test": "node --test tests/core.test.js tests/capability-advisory.test.js tests/vision-resilience.test.js tests/client.test.js tests/http-compat.test.js tests/catalog-corrections.test.js tests/update-check.test.js tests/self-update.test.js tests/doctor.test.js tests/doctor-cli.test.js tests/bundle-defaults.test.js tests/file-logger.test.js tests/replay-delegation.test.js tests/adversarial-hardening.test.js tests/logging-ui.test.js tests/manifest-dependencies.test.js tests/structured-bootstrap.test.js tests/structured-bootstrap-gate.test.js tests/local-ollama.test.js tests/zero-regression-gate.test.js tests/runtime-e2e.test.js tests/local-vision-stabilizer.test.js tests/local-connection-probe.test.js tests/repetition-guard.test.js tests/guide-scroll-gate.test.js"
+    "test": "node --test tests/core.test.js tests/capability-advisory.test.js tests/vision-resilience.test.js tests/client.test.js tests/http-compat.test.js tests/catalog-corrections.test.js tests/update-check.test.js tests/self-update.test.js tests/doctor.test.js tests/doctor-cli.test.js tests/bundle-defaults.test.js tests/file-logger.test.js tests/replay-delegation.test.js tests/adversarial-hardening.test.js tests/wrapper-directory.test.js tests/logging-ui.test.js tests/manifest-dependencies.test.js tests/structured-bootstrap.test.js tests/structured-bootstrap-gate.test.js tests/local-ollama.test.js tests/zero-regression-gate.test.js tests/runtime-e2e.test.js tests/local-vision-stabilizer.test.js tests/local-connection-probe.test.js tests/repetition-guard.test.js tests/guide-scroll-gate.test.js"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/tests/wrapper-directory.test.js
+++ b/tests/wrapper-directory.test.js
@@ -1,0 +1,164 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  installWrapperDirectoryAlias,
+  resolveWrapperDirectoryEntry,
+} from '../lib/wrapper-directory.js'
+
+function fakeContext({
+  visionConfig = {},
+  liveProviders = [
+    { id: 'deepseek-official', name: 'DeepSeek' },
+    { id: 'deepseek-vision', name: 'DeepSeek + 自动识图' },
+  ],
+  configurableProviders = [
+    {
+      provider: 'deepseek-official',
+      displayName: 'DeepSeek',
+      settingsNs: 'llm-deepseek',
+      settingsPath: [],
+    },
+  ],
+} = {}) {
+  const listeners = new Map()
+  const state = {
+    visionConfig,
+    liveProviders: [...liveProviders],
+    sourceDirectory: configurableProviders.map((entry) => ({ ...entry })),
+    ownedDirectory: [],
+    registerCalls: 0,
+    replaceCalls: 0,
+  }
+
+  const emit = (name, ...args) => {
+    for (const listener of listeners.get(name) ?? []) listener(...args)
+  }
+
+  const llm = {
+    listProviders() {
+      return state.liveProviders.map((entry) => ({ ...entry }))
+    },
+    listConfigurableProviders() {
+      return [
+        ...state.sourceDirectory.map((entry) => ({ ...entry })),
+        ...state.ownedDirectory.map((entry) => ({ ...entry })),
+      ]
+    },
+    registerConfigurableProviders(entries) {
+      state.registerCalls += 1
+      state.ownedDirectory = entries.map((entry) => ({ ...entry, settingsPath: [...entry.settingsPath] }))
+      // rc.7 emits this notification from the directory commit itself. The
+      // helper must not recurse into a second registration.
+      emit('llm/adapters-updated')
+      const handle = () => {
+        state.ownedDirectory = []
+        emit('llm/adapters-updated')
+      }
+      handle.replace = (next) => {
+        state.replaceCalls += 1
+        state.ownedDirectory = next.map((entry) => ({ ...entry, settingsPath: [...entry.settingsPath] }))
+        emit('llm/adapters-updated')
+      }
+      return handle
+    },
+  }
+
+  const ctx = {
+    llm,
+    get(name) {
+      if (name !== 'settings') return undefined
+      return {
+        get(ns) {
+          return ns === 'vision-router' ? state.visionConfig : undefined
+        },
+      }
+    },
+    on(name, listener) {
+      const list = listeners.get(name) ?? []
+      list.push(listener)
+      listeners.set(name, list)
+    },
+    logger: { warn() {} },
+  }
+
+  return { ctx, state, emit }
+}
+
+test('resolves DeepSeek + auto-vision as an alias of the official provider settings', () => {
+  const { ctx } = fakeContext()
+  assert.deepEqual(resolveWrapperDirectoryEntry(ctx), {
+    provider: 'deepseek-vision',
+    displayName: 'DeepSeek + 自动识图',
+    settingsNs: 'llm-deepseek',
+    settingsPath: [],
+  })
+})
+
+test('publishes the wrapper into the rc.7 configurable-provider directory exactly once', () => {
+  const { ctx, state } = fakeContext()
+  installWrapperDirectoryAlias(ctx)
+
+  assert.equal(state.registerCalls, 1)
+  assert.equal(state.replaceCalls, 0)
+  assert.deepEqual(state.ownedDirectory, [
+    {
+      provider: 'deepseek-vision',
+      displayName: 'DeepSeek + 自动识图',
+      settingsNs: 'llm-deepseek',
+      settingsPath: [],
+    },
+  ])
+})
+
+test('tracks live wrapper/text-provider settings and mirrors the new source settings path', () => {
+  const { ctx, state, emit } = fakeContext()
+  installWrapperDirectoryAlias(ctx)
+
+  state.visionConfig = {
+    wrapperRoute: 'relay-auto-vision',
+    textProvider: { provider: 'openrouter' },
+  }
+  state.liveProviders = [
+    { id: 'openrouter', name: 'OpenRouter' },
+    { id: 'relay-auto-vision', name: 'DeepSeek + 自动识图' },
+  ]
+  state.sourceDirectory.push({
+    provider: 'openrouter',
+    displayName: 'OpenRouter',
+    settingsNs: 'llm-pi-ai',
+    settingsPath: ['providers', 'openrouter'],
+  })
+
+  emit('settings/updated', 'vision-router', state.visionConfig, {}, 'update')
+
+  assert.equal(state.registerCalls, 1)
+  assert.equal(state.replaceCalls, 1)
+  assert.deepEqual(state.ownedDirectory, [
+    {
+      provider: 'relay-auto-vision',
+      displayName: 'DeepSeek + 自动识图',
+      settingsNs: 'llm-pi-ai',
+      settingsPath: ['providers', 'openrouter'],
+    },
+  ])
+})
+
+test('does not publish a phantom Models row when the wrapper adapter is not live', () => {
+  const { ctx, state } = fakeContext({
+    liveProviders: [{ id: 'deepseek-official', name: 'DeepSeek' }],
+  })
+  installWrapperDirectoryAlias(ctx)
+  assert.equal(state.registerCalls, 0)
+  assert.deepEqual(state.ownedDirectory, [])
+})
+
+test('is a no-op on older LLM runtimes without the configurable-provider directory API', () => {
+  const ctx = {
+    llm: {
+      listProviders: () => [],
+    },
+  }
+  assert.doesNotThrow(() => installWrapperDirectoryAlias(ctx))
+  assert.equal(resolveWrapperDirectoryEntry(ctx), undefined)
+})


### PR DESCRIPTION
## What changed

- publish the live `deepseek-vision` wrapper into DSH rc.7's configurable-provider directory
- mirror the wrapper row to the configured text provider's settings namespace/path instead of creating a second credential/config source
- resync the alias on LLM topology changes and Vision Router settings changes
- keep older DSH runtimes as a feature-detected no-op
- add regression coverage for rc.7's `llm/adapters-updated` re-entrancy and live provider switching

## Root cause

DSH rc.7 separates the live adapter registry from the Models settings directory. Vision Router still registered `deepseek-vision` only through `llm.registerAdapter()`. The wrapper therefore remained callable, but `Settings -> Models` filtered it out because the route had no configurable-provider settings address.

This is independent of `autoWrapProviders`: `deepseek-official` is intentionally an own route and is excluded from generic `syncTwins()`; its `+ 自动识图` entry is the main `deepseek-vision` wrapper.

## Expected result

After reinstall/restart on DSH rc.7, `Settings -> Models` again shows the native `DeepSeek` row plus the derived `DeepSeek + 自动识图` row, with the latter reusing the underlying text provider's configuration.
