### PR TITLE
fix: diagnose unrelated profile plugin install blockers

### DIFF
--- a/lib/doctor-cli.js
+++ b/lib/doctor-cli.js
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'node:url'
 import { doctorProfiles, resolveDshHome } from './doctor.js'
 
 function usage() {
-  return `dsh-vision-router doctor [--profile <name>] [--fix]\ndsh-vision-router repair [--profile <name>]\n\nChecks DSH profile manifests even when DSH itself cannot boot.\n\nCommands:\n  doctor   Diagnose profile package.json files and the pnpm v11 release-age update gate.\n  repair   Diagnose and safely repair: remove a leading UTF-8 BOM, and rewrite version-pinned minimumReleaseAgeExclude entries to bare names.\n\nOptions:\n  --profile <name>  Check only one profile (for example: web).\n  --fix             With doctor, remove a leading UTF-8 BOM and rewrite version-pinned release-age exemptions when found.\n  --help            Show this help.\n`
+  return `dsh-vision-router doctor [--profile <name>] [--fix]\ndsh-vision-router repair [--profile <name>]\n\nChecks DSH profile manifests even when DSH itself cannot boot.\n\nCommands:\n  doctor   Diagnose profile package.json files, coexisting vision plugins, and the pnpm v11 release-age update gate.\n  repair   Diagnose and safely repair: remove a leading UTF-8 BOM, and rewrite version-pinned minimumReleaseAgeExclude entries to bare names.\n\nOptions:\n  --profile <name>  Check only one profile (for example: web).\n  --fix             With doctor, remove a leading UTF-8 BOM and rewrite version-pinned release-age exemptions when found.\n  --help            Show this help.\n`
 }
 
 function parseArgs(argv) {
@@ -45,6 +45,12 @@ function parseArgs(argv) {
   return { command, profile, fix }
 }
 
+function visionPluginLabel(plugin) {
+  if (plugin.installedVersion) return `${plugin.name}@${plugin.installedVersion}`
+  if (plugin.spec) return `${plugin.name}@${plugin.spec}`
+  return plugin.name
+}
+
 function statusLine(profile) {
   const prefix = profile.validJson ? '✓' : '✗'
   const parts = [`${prefix} ${profile.name}`]
@@ -61,6 +67,13 @@ function statusLine(profile) {
   if (profile.validJson) {
     parts.push(profile.pluginDependency ? `dependency ${profile.pluginDependency}` : 'Vision Router dependency not present')
     parts.push(profile.pluginBundle ? 'bundle registered' : 'bundle not registered')
+    if (profile.coexistingVisionPlugins?.length > 0) {
+      const listed = profile.coexistingVisionPlugins.slice(0, 4).map(visionPluginLabel).join(', ')
+      parts.push(
+        `other vision plugin(s) present: ${listed} — coexistence is not automatically a conflict, ` +
+        'but if pnpm install/update logs name one of them, that existing profile dependency may be the blocker',
+      )
+    }
   }
   const workspace = profile.workspace
   if (workspace?.exists && workspace.pinned.length > 0) {

--- a/lib/doctor.js
+++ b/lib/doctor.js
@@ -1,6 +1,7 @@
 import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import path from 'node:path'
+import { inspectCoexistingVisionPlugins } from './profile-pnpm-diagnostics.js'
 
 const UTF8_BOM = Buffer.from([0xef, 0xbb, 0xbf])
 const PLUGIN_NAME = 'dsh-vision-router'
@@ -185,8 +186,9 @@ export function doctorProfiles({
   const profiles = []
 
   for (const name of names) {
-    const manifestPath = path.join(dshHome, 'profiles', name, 'package.json')
-    const workspacePath = path.join(dshHome, 'profiles', name, WORKSPACE_FILENAME)
+    const profileDir = path.join(dshHome, 'profiles', name)
+    const manifestPath = path.join(profileDir, 'package.json')
+    const workspacePath = path.join(profileDir, WORKSPACE_FILENAME)
     if (!existsSync(manifestPath)) {
       profiles.push({
         name,
@@ -197,10 +199,14 @@ export function doctorProfiles({
       })
       continue
     }
+    const manifestReport = inspectProfileManifest(manifestPath, { fix })
     profiles.push({
       name,
       exists: true,
-      ...inspectProfileManifest(manifestPath, { fix }),
+      ...manifestReport,
+      coexistingVisionPlugins: manifestReport.validJson
+        ? inspectCoexistingVisionPlugins(profileDir)
+        : [],
       workspace: inspectProfileWorkspace(workspacePath, { fix }),
     })
   }

--- a/lib/profile-pnpm-diagnostics.js
+++ b/lib/profile-pnpm-diagnostics.js
@@ -1,0 +1,166 @@
+import { existsSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+
+export const VISION_ROUTER_PACKAGE = 'dsh-vision-router'
+
+const KNOWN_VISION_PACKAGES = new Set([
+  'dsh-vision-proxy',
+  'dsh-vision-sidecar',
+  'dsh-vision-provider',
+])
+
+function readJson(file) {
+  try {
+    const parsed = JSON.parse(readFileSync(file, 'utf8'))
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function dependencyMap(profileDir) {
+  const manifest = readJson(path.join(profileDir, 'package.json'))
+  const dependencies = manifest?.dependencies
+  return dependencies && typeof dependencies === 'object' && !Array.isArray(dependencies)
+    ? dependencies
+    : {}
+}
+
+function looksLikeOtherVisionPackage(name) {
+  if (name === VISION_ROUTER_PACKAGE) return false
+  return KNOWN_VISION_PACKAGES.has(name) || /^dsh-vision-(?!router(?:$|-))/.test(name)
+}
+
+function installedVersion(profileDir, packageName) {
+  const manifest = readJson(path.join(profileDir, 'node_modules', packageName, 'package.json'))
+  return typeof manifest?.version === 'string' && manifest.version.trim() !== ''
+    ? manifest.version.trim()
+    : undefined
+}
+
+/**
+ * Return advisory-only metadata for other vision plugins declared in the same
+ * DSH profile. Coexistence is not treated as a conflict by itself: these rows
+ * exist so doctor can explain a profile-level pnpm failure when the log names
+ * one of the already-installed plugins instead of Vision Router.
+ */
+export function inspectCoexistingVisionPlugins(profileDir) {
+  const dependencies = dependencyMap(profileDir)
+  return Object.entries(dependencies)
+    .filter(([name]) => looksLikeOtherVisionPackage(name))
+    .map(([name, spec]) => ({
+      name,
+      spec: typeof spec === 'string' ? spec : undefined,
+      installedVersion: installedVersion(profileDir, name),
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name))
+}
+
+function errorText(error) {
+  return [error?.stderr, error?.stdout, error?.message]
+    .filter((value) => typeof value === 'string' && value.trim() !== '')
+    .join('\n')
+}
+
+function packageNameFromVersionedSpec(spec) {
+  if (typeof spec !== 'string') return undefined
+  const value = spec.trim().replace(/[),;]+$/, '')
+  if (value.startsWith('@')) {
+    const slash = value.indexOf('/')
+    const marker = value.lastIndexOf('@')
+    return slash > 0 && marker > slash ? value.slice(0, marker) : value
+  }
+  const marker = value.lastIndexOf('@')
+  return marker > 0 ? value.slice(0, marker) : value
+}
+
+function ignoredBuildSpecs(text) {
+  const found = []
+  const linePattern = /Ignored build scripts:\s*([^\r\n]+)/gi
+  for (const match of text.matchAll(linePattern)) {
+    const line = match[1]
+    const specs = line.match(/(?:@[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+|[A-Za-z0-9._-]+)@[^\s,]+/g) ?? []
+    for (const spec of specs) {
+      if (!found.includes(spec)) found.push(spec)
+    }
+  }
+  return found
+}
+
+function blockerLabel(blocker) {
+  if (blocker.versionedSpec) return blocker.versionedSpec
+  if (blocker.installedVersion) return `${blocker.name}@${blocker.installedVersion}`
+  return blocker.name
+}
+
+/**
+ * Classify pnpm failures that were caused by another dependency already
+ * present in the DSH profile. `dsh plugin add/update` runs pnpm at the profile
+ * root, so an existing package's blocked build or optional dependency can
+ * abort a Vision Router update even though Vision Router itself is healthy.
+ */
+export function classifyProfilePnpmFailure(error, {
+  profileDir,
+  profile = 'web',
+  packageName = VISION_ROUTER_PACKAGE,
+} = {}) {
+  const text = errorText(error)
+  if (!text) return undefined
+
+  const ignored = ignoredBuildSpecs(text)
+  const dependencies = profileDir ? dependencyMap(profileDir) : {}
+  const blockers = new Map()
+
+  for (const versionedSpec of ignored) {
+    const name = packageNameFromVersionedSpec(versionedSpec)
+    if (!name || name === packageName) continue
+    blockers.set(name, {
+      name,
+      versionedSpec,
+      installedVersion: profileDir ? installedVersion(profileDir, name) : undefined,
+      source: 'ignored-build',
+    })
+  }
+
+  for (const name of Object.keys(dependencies)) {
+    if (name === packageName || blockers.has(name) || !text.includes(name)) continue
+    blockers.set(name, {
+      name,
+      installedVersion: profileDir ? installedVersion(profileDir, name) : undefined,
+      source: 'profile-log-mention',
+    })
+  }
+
+  if (blockers.size === 0) return undefined
+
+  const list = [...blockers.values()]
+  const labels = list.map(blockerLabel)
+  const primary = list[0]
+  const buildApproval = /ERR_PNPM_IGNORED_BUILDS|Ignored build scripts:/i.test(text)
+  const sharpArtifacts = /@img\/sharp-|sharp(?:@|-)/i.test(text)
+  const destroyedRequest = /UND_ERR_DESTROYED/i.test(text)
+
+  let message =
+    `DSH plugin update was blocked by another dependency already present in profile "${profile}": ` +
+    `${labels.join(', ')}. DSH runs pnpm for the whole profile, so this is a profile-level ` +
+    `dependency/build failure, not evidence that ${packageName} itself failed.`
+
+  if (buildApproval) {
+    message += ' pnpm also reported an ignored build script; the profile-level build-approval policy may need repair.'
+  }
+  if (primary?.name) {
+    message +=
+      ` If it is safe to remove the blocker, try \`npx @deepseek-ai/dsh plugin --profile ${profile} remove ${primary.name}\` ` +
+      `and then retry the Vision Router update. If remove fails with the same profile-level pnpm error, repair the ` +
+      `profile manifest/lockfile instead of repeatedly retrying add/update.`
+  }
+
+  return {
+    kind: 'existing-profile-dependency',
+    blockers: list,
+    buildApproval,
+    sharpArtifacts,
+    destroyedRequest,
+    message,
+  }
+}

--- a/lib/profile-pnpm-diagnostics.js
+++ b/lib/profile-pnpm-diagnostics.js
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'node:fs'
+import { readFileSync } from 'node:fs'
 import path from 'node:path'
 
 export const VISION_ROUTER_PACKAGE = 'dsh-vision-router'
@@ -87,6 +87,13 @@ function ignoredBuildSpecs(text) {
   return found
 }
 
+function dependencyAppearsInFailureContext(text, packageName) {
+  const failurePattern = /ERR_|error|failed|failure|postinstall|preinstall|prepare|build script|install script|ELIFECYCLE|command failed/i
+  return text
+    .split(/\r?\n/)
+    .some((line) => line.includes(packageName) && failurePattern.test(line))
+}
+
 function blockerLabel(blocker) {
   if (blocker.versionedSpec) return blocker.versionedSpec
   if (blocker.installedVersion) return `${blocker.name}@${blocker.installedVersion}`
@@ -122,12 +129,20 @@ export function classifyProfilePnpmFailure(error, {
     })
   }
 
+  // A package name appearing in ordinary pnpm progress output is not enough
+  // to blame it. Only use a declared dependency when the same log line carries
+  // clear failure/build context; ignored-build diagnostics above remain the
+  // strongest signal and do not need this heuristic.
   for (const name of Object.keys(dependencies)) {
-    if (name === packageName || blockers.has(name) || !text.includes(name)) continue
+    if (
+      name === packageName
+      || blockers.has(name)
+      || !dependencyAppearsInFailureContext(text, name)
+    ) continue
     blockers.set(name, {
       name,
       installedVersion: profileDir ? installedVersion(profileDir, name) : undefined,
-      source: 'profile-log-mention',
+      source: 'profile-failure-line',
     })
   }
 

--- a/lib/self-update.js
+++ b/lib/self-update.js
@@ -3,6 +3,7 @@ import { existsSync, readFileSync, realpathSync } from 'node:fs'
 import path from 'node:path'
 import { promisify } from 'node:util'
 import { resolveDshHome } from './doctor.js'
+import { classifyProfilePnpmFailure } from './profile-pnpm-diagnostics.js'
 import { CURRENT_VERSION, PACKAGE_NAME, compareSemver, parseSemver } from './update-check.js'
 
 const DSH_PACKAGE_NAME = '@deepseek-ai/dsh'
@@ -248,6 +249,14 @@ export async function runDshPluginUpdate(plan, {
       shell: false,
     })
   } catch (error) {
+    const diagnosis = classifyProfilePnpmFailure(error, {
+      profileDir: profileDirOf(dshHome, plan.profile),
+      profile: plan.profile,
+      packageName: PACKAGE_NAME,
+    })
+    if (diagnosis) {
+      throw new Error(`${diagnosis.message} Original pnpm output: ${outputDetail(error)}`)
+    }
     throw new Error(`DSH plugin update failed: ${outputDetail(error)}`)
   }
 

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "sharp": "^0.35.3"
   },
   "scripts": {
-    "test": "node --test tests/core.test.js tests/capability-advisory.test.js tests/vision-resilience.test.js tests/client.test.js tests/http-compat.test.js tests/catalog-corrections.test.js tests/update-check.test.js tests/self-update.test.js tests/doctor.test.js tests/doctor-cli.test.js tests/bundle-defaults.test.js tests/file-logger.test.js tests/replay-delegation.test.js tests/adversarial-hardening.test.js tests/wrapper-directory.test.js tests/logging-ui.test.js tests/manifest-dependencies.test.js tests/structured-bootstrap.test.js tests/structured-bootstrap-gate.test.js tests/local-ollama.test.js tests/zero-regression-gate.test.js tests/runtime-e2e.test.js tests/local-vision-stabilizer.test.js tests/local-connection-probe.test.js tests/repetition-guard.test.js tests/guide-scroll-gate.test.js"
+    "test": "node --test tests/core.test.js tests/capability-advisory.test.js tests/vision-resilience.test.js tests/client.test.js tests/http-compat.test.js tests/catalog-corrections.test.js tests/update-check.test.js tests/self-update.test.js tests/doctor.test.js tests/doctor-cli.test.js tests/profile-pnpm-diagnostics.test.js tests/bundle-defaults.test.js tests/file-logger.test.js tests/replay-delegation.test.js tests/adversarial-hardening.test.js tests/wrapper-directory.test.js tests/logging-ui.test.js tests/manifest-dependencies.test.js tests/structured-bootstrap.test.js tests/structured-bootstrap-gate.test.js tests/local-ollama.test.js tests/zero-regression-gate.test.js tests/runtime-e2e.test.js tests/local-vision-stabilizer.test.js tests/local-connection-probe.test.js tests/repetition-guard.test.js tests/guide-scroll-gate.test.js"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/tests/profile-pnpm-diagnostics.test.js
+++ b/tests/profile-pnpm-diagnostics.test.js
@@ -1,0 +1,121 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import {
+  classifyProfilePnpmFailure,
+  inspectCoexistingVisionPlugins,
+} from '../lib/profile-pnpm-diagnostics.js'
+
+function profileFixture({
+  dependencies = {},
+  installed = {},
+} = {}) {
+  const profileDir = mkdtempSync(path.join(tmpdir(), 'vision-profile-diag-'))
+  writeFileSync(
+    path.join(profileDir, 'package.json'),
+    JSON.stringify({ dependencies }, null, 2),
+  )
+  for (const [name, version] of Object.entries(installed)) {
+    const dir = path.join(profileDir, 'node_modules', name)
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(
+      path.join(dir, 'package.json'),
+      JSON.stringify({ name, version }),
+    )
+  }
+  return profileDir
+}
+
+test('doctor advisory detects coexisting vision plugins without calling them conflicts', () => {
+  const profileDir = profileFixture({
+    dependencies: {
+      'dsh-vision-router': '1.5.3',
+      'dsh-vision-proxy': '^0.2.5',
+      'dsh-vision-sidecar': '0.1.0',
+      unrelated: '1.0.0',
+    },
+    installed: {
+      'dsh-vision-proxy': '0.2.5',
+    },
+  })
+
+  assert.deepEqual(inspectCoexistingVisionPlugins(profileDir), [
+    {
+      name: 'dsh-vision-proxy',
+      spec: '^0.2.5',
+      installedVersion: '0.2.5',
+    },
+    {
+      name: 'dsh-vision-sidecar',
+      spec: '0.1.0',
+      installedVersion: undefined,
+    },
+  ])
+})
+
+test('classifies ignored build from an existing plugin as a profile-level blocker', () => {
+  const profileDir = profileFixture({
+    dependencies: {
+      'dsh-vision-router': '1.5.3',
+      'dsh-vision-proxy': '0.2.5',
+    },
+    installed: {
+      'dsh-vision-proxy': '0.2.5',
+    },
+  })
+  const error = new Error('dsh: pnpm failed in profile directory C:\\Users\\admin\\.dsh\\profiles\\web')
+  error.stderr = [
+    'ERR_PNPM_IGNORED_BUILDS Ignored build scripts: dsh-vision-proxy@0.2.5',
+    'Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.',
+    'GET https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz',
+    'UND_ERR_DESTROYED',
+  ].join('\n')
+
+  const result = classifyProfilePnpmFailure(error, {
+    profileDir,
+    profile: 'web',
+  })
+
+  assert.equal(result.kind, 'existing-profile-dependency')
+  assert.equal(result.blockers.length, 1)
+  assert.equal(result.blockers[0].name, 'dsh-vision-proxy')
+  assert.equal(result.blockers[0].versionedSpec, 'dsh-vision-proxy@0.2.5')
+  assert.equal(result.buildApproval, true)
+  assert.equal(result.sharpArtifacts, true)
+  assert.equal(result.destroyedRequest, true)
+  assert.match(result.message, /blocked by another dependency already present/)
+  assert.match(result.message, /dsh-vision-proxy@0\.2\.5/)
+  assert.match(result.message, /not evidence that dsh-vision-router itself failed/)
+  assert.match(result.message, /remove dsh-vision-proxy/)
+})
+
+test('does not blame another package when the ignored build is Vision Router itself', () => {
+  const profileDir = profileFixture({
+    dependencies: {
+      'dsh-vision-router': '1.5.3',
+    },
+  })
+  const error = new Error('exit 1')
+  error.stderr = 'ERR_PNPM_IGNORED_BUILDS Ignored build scripts: dsh-vision-router@1.5.3'
+
+  assert.equal(classifyProfilePnpmFailure(error, { profileDir }), undefined)
+})
+
+test('can attribute another declared profile dependency even without ignored-build syntax', () => {
+  const profileDir = profileFixture({
+    dependencies: {
+      'dsh-vision-router': '1.5.3',
+      'some-existing-plugin': '2.0.0',
+    },
+  })
+  const error = new Error('pnpm failed')
+  error.stderr = 'some-existing-plugin postinstall failed with exit code 1'
+
+  const result = classifyProfilePnpmFailure(error, { profileDir, profile: 'web' })
+  assert.equal(result.kind, 'existing-profile-dependency')
+  assert.equal(result.blockers[0].name, 'some-existing-plugin')
+  assert.equal(result.buildApproval, false)
+})

--- a/tests/profile-pnpm-diagnostics.test.js
+++ b/tests/profile-pnpm-diagnostics.test.js
@@ -8,6 +8,7 @@ import {
   classifyProfilePnpmFailure,
   inspectCoexistingVisionPlugins,
 } from '../lib/profile-pnpm-diagnostics.js'
+import { runDshPluginUpdate } from '../lib/self-update.js'
 
 function profileFixture({
   dependencies = {},
@@ -27,6 +28,25 @@ function profileFixture({
     )
   }
   return profileDir
+}
+
+function dshHomeFixture({ dependencies = {}, installed = {} } = {}) {
+  const dshHome = mkdtempSync(path.join(tmpdir(), 'vision-profile-home-'))
+  const profileDir = path.join(dshHome, 'profiles', 'web')
+  mkdirSync(profileDir, { recursive: true })
+  writeFileSync(
+    path.join(profileDir, 'package.json'),
+    JSON.stringify({ dependencies }, null, 2),
+  )
+  for (const [name, version] of Object.entries(installed)) {
+    const dir = path.join(profileDir, 'node_modules', name)
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(
+      path.join(dir, 'package.json'),
+      JSON.stringify({ name, version }),
+    )
+  }
+  return { dshHome, profileDir }
 }
 
 test('doctor advisory detects coexisting vision plugins without calling them conflicts', () => {
@@ -118,4 +138,47 @@ test('can attribute another declared profile dependency even without ignored-bui
   assert.equal(result.kind, 'existing-profile-dependency')
   assert.equal(result.blockers[0].name, 'some-existing-plugin')
   assert.equal(result.buildApproval, false)
+})
+
+test('self updater surfaces the existing profile blocker instead of a generic Vision Router failure', async () => {
+  const { dshHome } = dshHomeFixture({
+    dependencies: {
+      'dsh-vision-router': '1.5.3',
+      'dsh-vision-proxy': '0.2.5',
+    },
+    installed: {
+      'dsh-vision-proxy': '0.2.5',
+    },
+  })
+
+  await assert.rejects(
+    () => runDshPluginUpdate(
+      {
+        available: true,
+        method: 'current-dsh-cli',
+        execPath: 'node',
+        cliEntry: '/tmp/dsh.mjs',
+        profile: 'web',
+      },
+      {
+        dshHome,
+        execFileImpl: async () => {
+          const error = new Error('exit 1')
+          error.stderr = [
+            'ERR_PNPM_IGNORED_BUILDS Ignored build scripts: dsh-vision-proxy@0.2.5',
+            'GET https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz',
+            'UND_ERR_DESTROYED',
+          ].join('\n')
+          throw error
+        },
+      },
+    ),
+    (error) => {
+      assert.match(error.message, /blocked by another dependency already present in profile "web"/)
+      assert.match(error.message, /dsh-vision-proxy@0\.2\.5/)
+      assert.match(error.message, /not evidence that dsh-vision-router itself failed/)
+      assert.match(error.message, /Original pnpm output:/)
+      return true
+    },
+  )
 })

--- a/tests/profile-pnpm-diagnostics.test.js
+++ b/tests/profile-pnpm-diagnostics.test.js
@@ -4,6 +4,7 @@ import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 
+import { doctorProfiles } from '../lib/doctor.js'
 import {
   classifyProfilePnpmFailure,
   inspectCoexistingVisionPlugins,
@@ -76,6 +77,23 @@ test('doctor advisory detects coexisting vision plugins without calling them con
   ])
 })
 
+test('doctorProfiles exposes the advisory without marking an otherwise healthy profile unhealthy', () => {
+  const { dshHome } = dshHomeFixture({
+    dependencies: {
+      'dsh-vision-router': '1.5.3',
+      'dsh-vision-proxy': '0.2.5',
+    },
+    installed: {
+      'dsh-vision-proxy': '0.2.5',
+    },
+  })
+
+  const report = doctorProfiles({ dshHome, profile: 'web' })
+  assert.equal(report.ok, true)
+  assert.equal(report.profiles[0].coexistingVisionPlugins.length, 1)
+  assert.equal(report.profiles[0].coexistingVisionPlugins[0].name, 'dsh-vision-proxy')
+})
+
 test('classifies ignored build from an existing plugin as a profile-level blocker', () => {
   const profileDir = profileFixture({
     dependencies: {
@@ -124,7 +142,20 @@ test('does not blame another package when the ignored build is Vision Router its
   assert.equal(classifyProfilePnpmFailure(error, { profileDir }), undefined)
 })
 
-test('can attribute another declared profile dependency even without ignored-build syntax', () => {
+test('does not blame an existing dependency merely because pnpm progress output names it', () => {
+  const profileDir = profileFixture({
+    dependencies: {
+      'dsh-vision-router': '1.5.3',
+      'some-existing-plugin': '2.0.0',
+    },
+  })
+  const error = new Error('network request failed')
+  error.stderr = 'Progress: resolved some-existing-plugin@2.0.0\nERR_PNPM_FETCH_500 registry unavailable'
+
+  assert.equal(classifyProfilePnpmFailure(error, { profileDir, profile: 'web' }), undefined)
+})
+
+test('can attribute another declared profile dependency when its own failure line is explicit', () => {
   const profileDir = profileFixture({
     dependencies: {
       'dsh-vision-router': '1.5.3',


### PR DESCRIPTION
## What changed

- add profile-level pnpm diagnostics for failures caused by an existing dependency rather than `dsh-vision-router`
- detect coexisting `dsh-vision-*` plugins in `doctor` as advisory information only (not an automatic conflict/failure)
- parse `ERR_PNPM_IGNORED_BUILDS`, explicit dependency failure lines, Sharp artifact clues, and `UND_ERR_DESTROYED`
- when self-update is blocked by another profile dependency, identify that package and explain that DSH runs pnpm for the whole profile
- suggest removing the actual blocker first, while warning that a broken profile may require manual manifest/lockfile repair if `plugin remove` is blocked too
- keep attribution conservative so a package merely appearing in pnpm progress output is not blamed

## Root cause covered

Observed Windows case:

```text
npx @deepseek-ai/dsh plugin --profile web add dsh-vision-router@1.5.3
```

failed while pnpm reported:

```text
ERR_PNPM_IGNORED_BUILDS Ignored build scripts: dsh-vision-proxy@0.2.5
@img/sharp-...-0.34.5.tgz
UND_ERR_DESTROYED
```

The failing Sharp 0.34.x/build chain belongs to the already-installed `dsh-vision-proxy@0.2.5`, not to Vision Router's own Sharp peer range. DSH currently forwards pnpm at the whole profile root, so an unrelated existing dependency can abort the add/update transaction.

## Validation

New regression tests cover:

- advisory detection of `dsh-vision-proxy` / `dsh-vision-sidecar`
- doctor remains healthy when coexistence is only advisory
- exact `dsh-vision-proxy@0.2.5 + ERR_PNPM_IGNORED_BUILDS + sharp@0.34.5 + UND_ERR_DESTROYED` incident shape
- self-update surfaces the existing blocker instead of a generic Vision Router failure
- Vision Router's own ignored build is not misattributed
- ordinary pnpm progress mentions do not create false blame
- explicit postinstall failures from another declared dependency are attributed correctly

## Scope

This PR intentionally does **not** change Vision Router's `sharp >=0.35.3 <1` peer dependency. That is a separate technical evaluation and is not supported as the cause of this incident.