### PR TITLE
fix: restore full-page scroll wake and macOS-safe path containment in hardened HTML screenshots

### DIFF
--- a/lib/adversarial-hardening.js
+++ b/lib/adversarial-hardening.js
@@ -33,9 +33,9 @@ function isPathInside(root, candidate) {
   return relative === '' || (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative))
 }
 
-function realpathOrResolve(value) {
+function realpathOrResolve(value, realpath = realpathSync) {
   try {
-    return realpathSync(value)
+    return realpath(value)
   } catch {
     return path.resolve(value)
   }
@@ -46,8 +46,8 @@ function workspaceOf(exec) {
   return isNonEmptyString(cwd) ? cwd : process.cwd()
 }
 
-function artifactDirectory(exec, configured) {
-  const workspace = realpathOrResolve(workspaceOf(exec))
+function artifactDirectory(exec, configured, realpath = realpathSync) {
+  const workspace = realpathOrResolve(workspaceOf(exec), realpath)
   const relative = normalizeArtifactsDir(configured)
   const target = path.resolve(workspace, relative)
   if (!isPathInside(workspace, target)) {
@@ -88,12 +88,18 @@ export function htmlRequestAllowed(urlValue, allowedRoot) {
   if (url.protocol === 'data:' || url.protocol === 'blob:' || url.protocol === 'about:') return true
   if (url.protocol !== 'file:') return false
   let filePath
+  let root
   try {
     filePath = realpathSync(fileURLToPath(url))
+    // The allowed root can sit under a symlinked path (macOS /var ->
+    // /private/var, /tmp -> /private/tmp). Resolve it the same way the file
+    // path is resolved, otherwise genuinely local files fail the containment
+    // check. Fail closed when the root cannot be resolved at all.
+    root = realpathSync(allowedRoot)
   } catch {
     return false
   }
-  return isPathInside(allowedRoot, filePath)
+  return isPathInside(root, filePath)
 }
 
 function wrapRequestInterception(page, allowedRoot) {
@@ -109,12 +115,48 @@ function wrapRequestInterception(page, allowedRoot) {
   })
 }
 
+// Full-page wake used when the core module predates wakePageForFullCapture:
+// sweep the scrollbar so lazy images and scroll-triggered reveals below the
+// fold exist before the height is measured and the page is captured.
+async function fallbackWakePageForFullCapture(page, viewportHeight) {
+  const step = Number.isInteger(viewportHeight) && viewportHeight > 0 ? viewportHeight : 720
+  await page.evaluate(() => {
+    document.documentElement.style.scrollBehavior = 'auto'
+  })
+  const total = await page.evaluate(() =>
+    Math.max(document.documentElement.scrollHeight, document.body ? document.body.scrollHeight : 0),
+  )
+  for (let y = 0; y < total; y += step) {
+    await page.evaluate((yy) => window.scrollTo(0, yy), y)
+    await new Promise((resolve) => setTimeout(resolve, 60))
+  }
+  await page.evaluate(() => window.scrollTo(0, 0))
+  await new Promise((resolve) => setTimeout(resolve, 800))
+}
+
+/**
+ * Full scrollable page height (CSS px), measured after reveals have woken.
+ * The viewport height is part of the max: an empty page has zero scroll
+ * height, and must not be misreported as exceeding the pixel safety limit.
+ */
+export async function fullPageHeightOf(page) {
+  return await page.evaluate(() => Math.max(
+    document.documentElement?.scrollHeight ?? 0,
+    document.body?.scrollHeight ?? 0,
+    window.innerHeight,
+  ))
+}
+
 export function createSecureHtmlScreenshotExecute(ctx, core, config, deps = {}) {
   const importPuppeteer = deps.importPuppeteer ?? (() => import('puppeteer-core'))
   const fileExists = deps.existsSync ?? existsSync
   const makeDir = deps.mkdir ?? mkdir
   const saveFile = deps.writeFile ?? writeFile
   const realpath = deps.realpathSync ?? realpathSync
+  const wakeFullPage =
+    typeof core?.wakePageForFullCapture === 'function'
+      ? core.wakePageForFullCapture
+      : fallbackWakePageForFullCapture
 
   return async (args, exec) => {
     const source = String(args?.source ?? '')
@@ -128,7 +170,7 @@ export function createSecureHtmlScreenshotExecute(ctx, core, config, deps = {}) 
     if (!fileExists(targetPath)) throw new Error(`vision_html_screenshot: file not found: ${source}`)
 
     const targetReal = realpath(targetPath)
-    const workspace = realpathOrResolve(workspaceOf(exec))
+    const workspace = realpathOrResolve(workspaceOf(exec), realpath)
     const sourceRoot = isPathInside(workspace, targetReal) ? workspace : realpath(path.dirname(targetReal))
 
     const width = safeViewportDimension(args?.width, 1200, MAX_VIEWPORT_WIDTH, 'width')
@@ -178,10 +220,11 @@ export function createSecureHtmlScreenshotExecute(ctx, core, config, deps = {}) 
 
       let pageHeight
       if (fullPage) {
-        pageHeight = await page.evaluate(() => Math.max(
-          document.documentElement?.scrollHeight ?? 0,
-          document.body?.scrollHeight ?? 0,
-        ))
+        // Recreate the pre-hardening behavior: wake lazy/scroll-triggered
+        // content before measuring, so below-the-fold reveals are not silently
+        // missing from the capture.
+        await wakeFullPage(page, height)
+        pageHeight = await fullPageHeightOf(page)
         if (!Number.isFinite(pageHeight) || pageHeight <= 0 || width * pageHeight > MAX_SCREENSHOT_PIXELS) {
           throw new Error(
             `vision_html_screenshot: full-page capture exceeds the ${MAX_SCREENSHOT_PIXELS} pixel safety limit`,
@@ -195,7 +238,7 @@ export function createSecureHtmlScreenshotExecute(ctx, core, config, deps = {}) 
         ? await page.screenshot({ type: 'png', fullPage: true })
         : await page.screenshot({ type: 'png' })
       const stem = fullPage ? `shot-${width}x${height}-fullpage` : `shot-${width}x${height}`
-      const dir = artifactDirectory(exec, config.artifactsDir)
+      const dir = artifactDirectory(exec, config.artifactsDir, realpath)
       await makeDir(dir, { recursive: true })
       const target = path.join(dir, `${core.artifactStemOf(source, stem)}.png`)
       if (!isPathInside(dir, target)) throw new Error('vision_html_screenshot: unsafe artifact target')

--- a/tests/adversarial-hardening.test.js
+++ b/tests/adversarial-hardening.test.js
@@ -6,6 +6,7 @@ import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 import {
   createSecureHtmlScreenshotExecute,
+  fullPageHeightOf,
   htmlRequestAllowed,
   installAdversarialHardening,
   normalizeArtifactsDir,
@@ -59,6 +60,7 @@ test('secure HTML screenshot keeps Chrome sandbox enabled, forces offline mode a
     let requestHandler
     let offline = false
     let closed = false
+    const wakeCalls = []
     const page = {
       async setViewport(value) { assert.deepEqual(value, { width: 1200, height: 720 }) },
       async setOfflineMode(value) { offline = value },
@@ -93,6 +95,7 @@ test('secure HTML screenshot keeps Chrome sandbox enabled, forces offline mode a
       toRealPath(_fs, value) { return value },
       chromiumCandidates() { return ['/fake/chrome'] },
       artifactStemOf() { return 'page-safe-shot' },
+      wakePageForFullCapture: async (p, h) => { wakeCalls.push([p, h]) },
     }
     const execute = createSecureHtmlScreenshotExecute(
       ctx,
@@ -114,8 +117,84 @@ test('secure HTML screenshot keeps Chrome sandbox enabled, forces offline mode a
     assert.equal(typeof requestHandler, 'function')
     assert.equal(closed, true)
     assert.equal(result.pageHeight, 1500)
+    // The full-page wake must run before the height is measured, or
+    // scroll-triggered content below the fold is silently missing.
+    assert.equal(wakeCalls.length, 1)
+    assert.equal(wakeCalls[0][0], page)
+    assert.equal(wakeCalls[0][1], 720)
     assert.equal(path.relative(workspace, result.path).startsWith('..'), false)
     assert.equal((await readFile(result.path)).toString(), 'png-bytes')
+  } finally {
+    await rm(workspace, { recursive: true, force: true })
+  }
+})
+
+test('fullPageHeightOf falls back to the viewport height for empty pages', async () => {
+  const page = {
+    async evaluate(fn) {
+      const runner = new Function('document', 'window', `return (${fn.toString()})()`)
+      return runner(
+        { documentElement: { scrollHeight: 0 }, body: { scrollHeight: 0 } },
+        { innerHeight: 800 },
+      )
+    },
+  }
+  assert.equal(await fullPageHeightOf(page), 800)
+})
+
+test('non-fullPage capture skips the scroll wake', async () => {
+  const workspace = await mkdtemp(path.join(tmpdir(), 'vision-html-nofull-'))
+  try {
+    const source = path.join(workspace, 'page.html')
+    await writeFile(source, '<html><body>Hello</body></html>')
+    const wakeCalls = []
+    const page = {
+      async setViewport() {},
+      async setOfflineMode() {},
+      async setRequestInterception(value) { assert.equal(value, true) },
+      on() {},
+      async goto(url) { assert.equal(url, pathToFileURL(source).href) },
+      async screenshot(options) {
+        assert.deepEqual(options, { type: 'png' })
+        return Buffer.from('png-bytes')
+      },
+    }
+    const fakePuppeteer = {
+      async launch() {
+        return {
+          async newPage() { return page },
+          async close() {},
+        }
+      },
+    }
+    const ctx = {
+      get(name) {
+        if (name !== 'fs') return undefined
+        return { async resolve(value) { return value } }
+      },
+    }
+    const core = {
+      toRealPath(_fs, value) { return value },
+      chromiumCandidates() { return ['/fake/chrome'] },
+      artifactStemOf() { return 'page-safe-shot' },
+      wakePageForFullCapture: async (p, h) => { wakeCalls.push([p, h]) },
+    }
+    const execute = createSecureHtmlScreenshotExecute(
+      ctx,
+      core,
+      {},
+      {
+        importPuppeteer: async () => fakePuppeteer,
+        existsSync(value) { return value === source || value === '/fake/chrome' },
+        realpathSync(value) { return value },
+      },
+    )
+    const result = JSON.parse(await execute(
+      { source },
+      { agent: { session: { header: { cwd: workspace } } } },
+    ))
+    assert.equal(wakeCalls.length, 0)
+    assert.equal(result.pageHeight, undefined)
   } finally {
     await rm(workspace, { recursive: true, force: true })
   }


### PR DESCRIPTION
#184 hardened the HTML-screenshot flow, but three gaps slipped through review:

1. macOS containment rejects genuinely local files. `htmlRequestAllowed` resolved the
   requested file with `realpathSync` but compared it against an unresolved allowed root.
   On macOS the workspace often sits under the `/var` → `/private/var` symlink, so local
   assets were rejected and the test suite is red on macOS (the CI main job only runs Linux).
2. The injected `deps.realpathSync` never reached `realpathOrResolve`/`artifactDirectory`
   (they used the static import), breaking the factory's deterministic-DI contract.
3. Full-page captures dropped the pre-hardening scroll wake (`wakePageForFullCapture`),
   silently missing lazy/scroll-triggered content below the fold; the height measurement
   also lost `window.innerHeight`, so an empty page could be misreported as exceeding the
   pixel safety limit.

Changes: resolve the allowed root like the file path (fail-closed); thread the injected
realpath through the helpers; re-run the scroll wake before full-page capture (reusing
`core.wakePageForFullCapture`, local fallback for older cores); include `window.innerHeight`.
Regression tests cover each: symlink-root containment, wake invocation for fullPage, no
wake for viewport captures, empty-page height fallback.
