### PR TITLE
fix: attribute profile pnpm failures only to declared plugins

### DIFF
--- a/lib/profile-pnpm-diagnostics.js
+++ b/lib/profile-pnpm-diagnostics.js
@@ -28,7 +28,7 @@ function dependencyMap(profileDir) {
 
 function looksLikeOtherVisionPackage(name) {
   if (name === VISION_ROUTER_PACKAGE) return false
-  return KNOWN_VISION_PACKAGES.has(name) || /^dsh-vision-(?!router(?:$|-))/.test(name)
+  return KNOWN_VISION_PACKAGES.has(name) || /^dsh-vision-(?!router(?:[A-Za-z0-9._-]*))/.test(name)
 }
 
 function installedVersion(profileDir, packageName) {
@@ -79,19 +79,32 @@ function ignoredBuildSpecs(text) {
   const linePattern = /Ignored build scripts:\s*([^\r\n]+)/gi
   for (const match of text.matchAll(linePattern)) {
     const line = match[1]
-    const specs = line.match(/(?:@[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+|[A-Za-z0-9._-]+)@[^\s,]+/g) ?? []
-    for (const spec of specs) {
-      if (!found.includes(spec)) found.push(spec)
+    // pnpm lists entries comma-separated, bare (esbuild) or versioned
+    // (sharp@0.33.5), and may append guidance after the last entry
+    // ("...core-js. Run \"pnpm approve-builds\"..."). Take the leading token of
+    // each comma chunk so both bare and versioned names are captured.
+    for (const chunk of line.split(',')) {
+      const token = (chunk.trim().split(/\s+/)[0] ?? '').replace(/[.),;]+$/, '')
+      if (token === '' || !/^@?[A-Za-z0-9._@/-]+$/.test(token)) continue
+      const name = packageNameFromVersionedSpec(token)
+      if (name && !found.includes(token)) found.push(token)
     }
   }
   return found
 }
 
 function dependencyAppearsInFailureContext(text, packageName) {
-  const failurePattern = /ERR_|error|failed|failure|postinstall|preinstall|prepare|build script|install script|ELIFECYCLE|command failed/i
+  // Word-boundary match on the package name: `dsh-vision-proxy` must not
+  // match `dsh-vision-proxy-core`, `sharp` must not match `@img/sharp-*`, and
+  // a package name inside a registry URL must not count. Scoped names treat
+  // @, /, - and . as name characters.
+  const escaped = packageName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const namePattern = new RegExp(`(?:^|[^\\w@./-])${escaped}(?:$|[^\\w./-])`, 'i')
+  const failurePattern =
+    /ERR_PNPM_|postinstall.*(?:failed|error)|preinstall.*(?:failed|error)|prepare.*(?:failed|error)|(?:build|install) script.*(?:failed|error)|ELIFECYCLE|command failed|failed to build|failed to run/i
   return text
     .split(/\r?\n/)
-    .some((line) => line.includes(packageName) && failurePattern.test(line))
+    .some((line) => namePattern.test(line) && failurePattern.test(line))
 }
 
 function blockerLabel(blocker) {
@@ -117,10 +130,21 @@ export function classifyProfilePnpmFailure(error, {
   const ignored = ignoredBuildSpecs(text)
   const dependencies = profileDir ? dependencyMap(profileDir) : {}
   const blockers = new Map()
+  const unattributable = []
 
   for (const versionedSpec of ignored) {
     const name = packageNameFromVersionedSpec(versionedSpec)
     if (!name || name === packageName) continue
+    // Only blame an ignored build when the package is a plugin already
+    // declared in this profile (or a known coexisting vision package).
+    // Vision Router's own transitive dependencies (sharp and its platform
+    // binaries) are not removable blockers: their ignored build is a profile
+    // build-approval policy issue, and suggesting `remove` for them is wrong.
+    const declared = Object.prototype.hasOwnProperty.call(dependencies, name)
+    if (!declared && !looksLikeOtherVisionPackage(name)) {
+      if (!unattributable.includes(versionedSpec)) unattributable.push(versionedSpec)
+      continue
+    }
     blockers.set(name, {
       name,
       versionedSpec,
@@ -146,14 +170,38 @@ export function classifyProfilePnpmFailure(error, {
     })
   }
 
-  if (blockers.size === 0) return undefined
+  const buildApproval = /ERR_PNPM_IGNORED_BUILDS|Ignored build scripts:/i.test(text)
+  const sharpArtifacts = /@img\/sharp-|sharp(?:@|-)/i.test(text)
+  const destroyedRequest = /UND_ERR_DESTROYED/i.test(text)
+
+  if (blockers.size === 0 && unattributable.length === 0) return undefined
+
+  if (blockers.size === 0) {
+    // pnpm ignored build scripts for packages that are not declared profile
+    // plugins — almost always this plugin's own transitive dependencies. Do
+    // not frame them as removable blockers; point at the approval policy.
+    let message =
+      `pnpm ignored build scripts for ${unattributable.join(', ')} while updating ${packageName} in profile "${profile}". ` +
+      `These are not other plugins, so removing them is not the fix: the profile-level build-approval policy is. ` +
+      `Run \`pnpm approve-builds\` in the profile (or list them under the profile's onlyBuiltDependencies) and retry the update.`
+    if (sharpArtifacts) {
+      message +=
+        ` The ignored list includes sharp, which ${packageName} itself needs at runtime; ` +
+        `approve its build instead of removing it.`
+    }
+    return {
+      kind: 'ignored-build-policy',
+      blockers: [],
+      buildApproval,
+      sharpArtifacts,
+      destroyedRequest,
+      message,
+    }
+  }
 
   const list = [...blockers.values()]
   const labels = list.map(blockerLabel)
   const primary = list[0]
-  const buildApproval = /ERR_PNPM_IGNORED_BUILDS|Ignored build scripts:/i.test(text)
-  const sharpArtifacts = /@img\/sharp-|sharp(?:@|-)/i.test(text)
-  const destroyedRequest = /UND_ERR_DESTROYED/i.test(text)
 
   let message =
     `DSH plugin update was blocked by another dependency already present in profile "${profile}": ` +
@@ -162,6 +210,11 @@ export function classifyProfilePnpmFailure(error, {
 
   if (buildApproval) {
     message += ' pnpm also reported an ignored build script; the profile-level build-approval policy may need repair.'
+  }
+  if (sharpArtifacts) {
+    message +=
+      ` The ignored list includes sharp, which ${packageName} itself needs at runtime; ` +
+      `approve its build instead of removing it.`
   }
   if (primary?.name) {
     message +=

--- a/tests/profile-pnpm-diagnostics.test.js
+++ b/tests/profile-pnpm-diagnostics.test.js
@@ -142,6 +142,98 @@ test('does not blame another package when the ignored build is Vision Router its
   assert.equal(classifyProfilePnpmFailure(error, { profileDir }), undefined)
 })
 
+test('does not frame Vision Router own transitive dependency sharp as a removable blocker', () => {
+  const profileDir = profileFixture({
+    dependencies: {
+      'dsh-vision-router': '1.5.3',
+    },
+  })
+  const error = new Error('exit 1')
+  error.stderr = [
+    'ERR_PNPM_IGNORED_BUILDS Ignored build scripts: sharp@0.33.5',
+    'Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.',
+  ].join('\n')
+
+  const result = classifyProfilePnpmFailure(error, { profileDir, profile: 'web' })
+  assert.equal(result.kind, 'ignored-build-policy')
+  assert.equal(result.blockers.length, 0)
+  assert.match(result.message, /sharp@0\.33\.5/)
+  assert.match(result.message, /approve-builds/)
+  assert.match(result.message, /approve its build instead of removing it/)
+  assert.doesNotMatch(result.message, /remove sharp/)
+})
+
+test('attributes bare-name ignored build entries for declared plugins', () => {
+  const profileDir = profileFixture({
+    dependencies: {
+      'dsh-vision-router': '1.5.3',
+      esbuild: '0.25.0',
+    },
+  })
+  const error = new Error('exit 1')
+  error.stderr =
+    'Ignored build scripts: esbuild, core-js. Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.'
+
+  const result = classifyProfilePnpmFailure(error, { profileDir, profile: 'web' })
+  assert.equal(result.kind, 'existing-profile-dependency')
+  assert.equal(result.blockers.length, 1)
+  assert.equal(result.blockers[0].name, 'esbuild')
+  assert.match(result.message, /remove esbuild/)
+})
+
+test('attributes a scoped dependency named in an ignored build list', () => {
+  const profileDir = profileFixture({
+    dependencies: {
+      'dsh-vision-router': '1.5.3',
+      '@scope/tool': '2.1.0',
+    },
+  })
+  const error = new Error('exit 1')
+  error.stderr = 'Ignored build scripts: @scope/tool@2.1.0'
+
+  const result = classifyProfilePnpmFailure(error, { profileDir, profile: 'web' })
+  assert.equal(result.kind, 'existing-profile-dependency')
+  assert.equal(result.blockers[0].name, '@scope/tool')
+})
+
+test('does not blame a dependency for a same-line substring match', () => {
+  const profileDir = profileFixture({
+    dependencies: {
+      'dsh-vision-router': '1.5.3',
+      'dsh-vision-proxy': '0.2.5',
+    },
+  })
+  const error = new Error('exit 1')
+  error.stderr = 'dsh-vision-proxy-core postinstall failed with exit code 1'
+
+  assert.equal(classifyProfilePnpmFailure(error, { profileDir, profile: 'web' }), undefined)
+})
+
+test('does not blame a dependency named inside a registry URL on the same line', () => {
+  const profileDir = profileFixture({
+    dependencies: {
+      'dsh-vision-router': '1.5.3',
+      foo: '1.0.0',
+    },
+  })
+  const error = new Error('exit 1')
+  error.stderr = 'GET https://registry.npmjs.org/foo/-/foo-1.0.0.tgz ERR_PNPM_FETCH_500 registry unavailable'
+
+  assert.equal(classifyProfilePnpmFailure(error, { profileDir, profile: 'web' }), undefined)
+})
+
+test('does not treat dsh-vision-routers or dsh-vision-router2 as coexisting vision plugins', () => {
+  const profileDir = profileFixture({
+    dependencies: {
+      'dsh-vision-router': '1.5.3',
+      'dsh-vision-routers': '9.9.9',
+      'dsh-vision-router2': '9.9.9',
+    },
+  })
+
+  assert.deepEqual(inspectCoexistingVisionPlugins(profileDir), [])
+})
+
 test('does not blame an existing dependency merely because pnpm progress output names it', () => {
   const profileDir = profileFixture({
     dependencies: {


### PR DESCRIPTION
#186 added profile-level pnpm failure attribution, but its "ignored build" branch blamed
any package named in the `Ignored build scripts:` list — including Vision Router's own
transitive dependency `sharp` — producing a harmful `remove sharp` suggestion. The exact
opposite of the intended attribution.

Changes: only treat an ignored build as a removable blocker when the package is a declared
profile dependency (or a known coexisting vision plugin); own transitive dependencies now
produce an `ignored-build-policy` diagnosis pointing at `pnpm approve-builds` /
`onlyBuiltDependencies`, with a specific hint when sharp is involved. Bare-name lists
(`Ignored build scripts: esbuild, core-js`) and scoped packages are now parsed. Failure
context uses word boundaries (no `dsh-vision-proxy-core` or registry-URL false positives)
and specific failure verbs instead of a bare `/error/`. `dsh-vision-routers`/`router2`
are no longer listed as coexisting vision plugins. Regression tests cover each case.
