### PR TITLE
fix: dispose the Models-directory alias with the plugin fiber

### DIFF
--- a/lib/wrapper-directory.js
+++ b/lib/wrapper-directory.js
@@ -90,9 +90,20 @@ export function installWrapperDirectoryAlias(ctx, baseConfig = {}, logger = ctx 
   let ownedProvider
   let heldKey
   let syncing = false
+  let disposed = false
+  let lastWarnMessage = ''
+
+  // Repeated llm/adapters-updated emissions with a persistent error must not
+  // spam the log with the identical warning on every emission.
+  const warn = (label, detail) => {
+    const message = detail === undefined ? label : `${label} ${detail}`
+    if (message === lastWarnMessage) return
+    lastWarnMessage = message
+    logger?.warn?.(message)
+  }
 
   const sync = () => {
-    if (syncing) return
+    if (disposed || syncing) return
     const next = resolveWrapperDirectoryEntry(ctx, baseConfig)
     const nextEntries = next ? [next] : []
     const nextKey = JSON.stringify(nextEntries)
@@ -112,10 +123,12 @@ export function installWrapperDirectoryAlias(ctx, baseConfig = {}, logger = ctx 
           try {
             handle.replace([])
             ownedProvider = undefined
-            heldKey = undefined
+            // The withdrawal already published the empty set; record that key
+            // so the next no-op sync does not issue a redundant replace.
+            heldKey = JSON.stringify([])
           } catch (error) {
-            logger?.warn?.(
-              'vision-router: failed to withdraw stale Models-directory alias: %s',
+            warn(
+              'vision-router: failed to withdraw stale Models-directory alias:',
               error && error.message ? error.message : String(error),
             )
           } finally {
@@ -141,8 +154,8 @@ export function installWrapperDirectoryAlias(ctx, baseConfig = {}, logger = ctx 
     } catch (error) {
       // Directory publication affects Settings -> Models discoverability only;
       // never turn a healthy wrapper adapter into a plugin startup failure.
-      logger?.warn?.(
-        'vision-router: Models-directory alias sync failed: %s',
+      warn(
+        'vision-router: Models-directory alias sync failed:',
         error && error.message ? error.message : String(error),
       )
     } finally {
@@ -151,6 +164,38 @@ export function installWrapperDirectoryAlias(ctx, baseConfig = {}, logger = ctx 
   }
 
   sync()
+  // DSH's registerConfigurableProviders ties its internal cleanup to the
+  // shared LLM service context, not to this plugin's fiber: without an
+  // explicit plugin-scoped disposer the directory entry survives a plugin
+  // reload, and the reloaded instance then mistakes the stale row for an
+  // external owner and never takes the route back. Dispose through this
+  // plugin's own lifecycle so reloads re-publish cleanly.
+  if (typeof ctx.effect === 'function') {
+    try {
+      ctx.effect(
+        () => () => {
+          disposed = true
+          if (handle) {
+            const current = handle
+            handle = undefined
+            ownedProvider = undefined
+            heldKey = undefined
+            try {
+              current()
+            } catch (error) {
+              warn(
+                'vision-router: failed to dispose Models-directory alias:',
+                error && error.message ? error.message : String(error),
+              )
+            }
+          }
+        },
+        'vision-router: models-directory alias lifecycle',
+      )
+    } catch {
+      /* lifecycle wiring must not break alias sync */
+    }
+  }
   if (typeof ctx.on === 'function') {
     ctx.on('llm/adapters-updated', sync)
     ctx.on('settings/updated', (ns) => {

--- a/tests/wrapper-directory.test.js
+++ b/tests/wrapper-directory.test.js
@@ -20,8 +20,11 @@ function fakeContext({
       settingsPath: [],
     },
   ],
+  registerError,
 } = {}) {
   const listeners = new Map()
+  const disposals = []
+  const warns = []
   const state = {
     visionConfig,
     liveProviders: [...liveProviders],
@@ -47,6 +50,7 @@ function fakeContext({
     },
     registerConfigurableProviders(entries) {
       state.registerCalls += 1
+      if (registerError) throw registerError
       state.ownedDirectory = entries.map((entry) => ({ ...entry, settingsPath: [...entry.settingsPath] }))
       // rc.7 emits this notification from the directory commit itself. The
       // helper must not recurse into a second registration.
@@ -79,10 +83,23 @@ function fakeContext({
       list.push(listener)
       listeners.set(name, list)
     },
-    logger: { warn() {} },
+    effect(factory) {
+      const cleanup = factory()
+      disposals.push(cleanup)
+      return () => {}
+    },
+    logger: { warn(message) { warns.push(message) } },
   }
 
-  return { ctx, state, emit }
+  return {
+    ctx,
+    state,
+    emit,
+    warns,
+    dispose() {
+      for (const cleanup of disposals.splice(0)) cleanup()
+    },
+  }
 }
 
 test('resolves DeepSeek + auto-vision as an alias of the official provider settings', () => {
@@ -161,4 +178,72 @@ test('is a no-op on older LLM runtimes without the configurable-provider directo
   }
   assert.doesNotThrow(() => installWrapperDirectoryAlias(ctx))
   assert.equal(resolveWrapperDirectoryEntry(ctx), undefined)
+})
+
+test('disposes the directory alias with the plugin fiber and stays inert afterwards', () => {
+  const { ctx, state, emit, dispose } = fakeContext()
+  installWrapperDirectoryAlias(ctx)
+  assert.equal(state.registerCalls, 1)
+  assert.equal(state.ownedDirectory.length, 1)
+
+  dispose()
+  assert.deepEqual(state.ownedDirectory, [])
+
+  state.visionConfig = { wrapperRoute: 'relay-auto-vision' }
+  state.liveProviders.push({ id: 'relay-auto-vision', name: 'DeepSeek + 自动识图' })
+  emit('settings/updated', 'vision-router', state.visionConfig, {}, 'update')
+
+  assert.equal(state.registerCalls, 1)
+  assert.equal(state.replaceCalls, 0)
+  assert.deepEqual(state.ownedDirectory, [])
+})
+
+test('re-registers cleanly after a fiber reload instead of freezing on the stale row', () => {
+  const { ctx, state, dispose } = fakeContext()
+  installWrapperDirectoryAlias(ctx)
+  dispose()
+
+  // Same context object, fresh install: the reloaded instance must see an
+  // empty directory (the old row was disposed with the fiber) and publish.
+  installWrapperDirectoryAlias(ctx)
+  assert.equal(state.registerCalls, 2)
+  assert.equal(state.ownedDirectory.length, 1)
+  assert.equal(state.ownedDirectory[0].provider, 'deepseek-vision')
+})
+
+test('withdrawal records the empty-state key and skips redundant replaces', () => {
+  const { ctx, state, emit } = fakeContext()
+  installWrapperDirectoryAlias(ctx)
+  assert.equal(state.ownedDirectory[0].provider, 'deepseek-vision')
+
+  // An external owner takes over a NEW route the settings now point at.
+  state.visionConfig = { wrapperRoute: 'relay-auto-vision' }
+  state.liveProviders.push({ id: 'relay-auto-vision', name: 'DeepSeek + 自动识图' })
+  state.sourceDirectory.push({
+    provider: 'relay-auto-vision',
+    displayName: 'External',
+    settingsNs: 'external-ns',
+    settingsPath: [],
+  })
+  emit('settings/updated', 'vision-router', state.visionConfig, {}, 'update')
+  assert.equal(state.replaceCalls, 1)
+  assert.deepEqual(state.ownedDirectory, [])
+
+  // The wrapper disappears entirely: the cached empty-state key must make
+  // this a no-op rather than a second redundant replace.
+  state.liveProviders = []
+  emit('llm/adapters-updated')
+  assert.equal(state.replaceCalls, 1)
+})
+
+test('deduplicates identical sync warnings across repeated adapter events', () => {
+  const error = new Error('already declared')
+  error.code = 'DUPLICATE_DIRECTORY'
+  const { ctx, emit, warns } = fakeContext({ registerError: error })
+  installWrapperDirectoryAlias(ctx)
+  emit('llm/adapters-updated')
+  emit('llm/adapters-updated')
+
+  assert.equal(warns.length, 1)
+  assert.match(warns[0], /Models-directory alias sync failed/)
 })


### PR DESCRIPTION
#185 publishes the deepseek-vision wrapper into the rc.7 configurable-provider directory,
but the registration handle was never tied to the plugin's own lifecycle: DSH's
`registerConfigurableProviders` registers its internal cleanup on the shared LLM service
context, so a plugin reload left the old directory row behind. The reloaded instance then
misread the stale row as an external owner (its own "never fight" guard) and never took
the route back — the Models row froze until a host restart.

Changes: register a plugin-scoped `ctx.effect` that disposes the handle on fiber teardown
and ignores further syncs after disposal; record the empty-set state key on withdrawal to
avoid a redundant replace; deduplicate identical sync warnings. Regression tests: fiber
disposal removes the row and makes the instance inert; a reload re-publishes cleanly
instead of freezing; withdrawal skips redundant replaces; repeated identical errors warn once.
