### PR TITLE
fix: cap the per-session reasoning-effort memory

### DIFF
--- a/lib/replay-delegation.js
+++ b/lib/replay-delegation.js
@@ -7,6 +7,12 @@ const dynamicWrapperAdapters = new WeakMap()
 const NATIVE_DEEPSEEK_ROUTE = 'deepseek-official-native'
 const OFFICIAL_DEEPSEEK_ROUTE = 'deepseek-official'
 
+// One entry per (sessionId, provider, model) tuple: a long-running dsh web
+// process would otherwise grow the reasoning-effort memory without bound as
+// sessions come and go. Evict the oldest entry first; reads refresh recency
+// so live sessions survive the cap.
+export const MAX_LIVE_EFFORT_MEMORY = 512
+
 function isNonEmptyString(value) {
   return typeof value === 'string' && value.length > 0
 }
@@ -153,6 +159,21 @@ function llmWithDelegatedReplay(llm, ctx, fallbackWrapperRoute) {
   // cannot overwrite each other's picker state. Hand-built one-shots without a
   // sessionId deliberately get no cross-call memory.
   const liveReasoningEffort = new Map()
+  const rememberLiveEffort = (key, value) => {
+    if (liveReasoningEffort.size >= MAX_LIVE_EFFORT_MEMORY && !liveReasoningEffort.has(key)) {
+      const oldest = liveReasoningEffort.keys().next().value
+      liveReasoningEffort.delete(oldest)
+    }
+    liveReasoningEffort.set(key, value)
+  }
+  const recallLiveEffort = (key) => {
+    if (!liveReasoningEffort.has(key)) return undefined
+    const value = liveReasoningEffort.get(key)
+    // Refresh recency: hot sessions must survive the cap.
+    liveReasoningEffort.delete(key)
+    liveReasoningEffort.set(key, value)
+    return value
+  }
 
   const wrapped = new Proxy(llm, {
     get(target, property) {
@@ -187,10 +208,10 @@ function llmWithDelegatedReplay(llm, ctx, fallbackWrapperRoute) {
             const effortKey = sessionId === undefined ? undefined : `${sessionId}\u0000${provider}\u0000${model}`
             const explicit = store.explicitEffort
             if (explicit !== undefined) {
-              if (effortKey !== undefined) liveReasoningEffort.set(effortKey, explicit)
+              if (effortKey !== undefined) rememberLiveEffort(effortKey, explicit)
               routed = { ...options, provider, reasoningEffort: explicit }
             } else {
-              const remembered = effortKey === undefined ? undefined : liveReasoningEffort.get(effortKey)
+              const remembered = effortKey === undefined ? undefined : recallLiveEffort(effortKey)
               // createWrapperStreamBody still has a legacy provider/model-only
               // cache. Strip its injected value unless this session has proved
               // its own picker state, preventing cross-session contamination.

--- a/tests/replay-delegation.test.js
+++ b/tests/replay-delegation.test.js
@@ -2,6 +2,7 @@ import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import {
   contextWithDelegatedReplay,
+  MAX_LIVE_EFFORT_MEMORY,
   rebindDelegatedReplayOptions,
   rebindDelegatedReplaySources,
 } from '../lib/replay-delegation.js'
@@ -253,6 +254,23 @@ test('requests without sessionId do not inherit provider/model reasoning state',
   await harness.drain({ sessionId: undefined, reasoningEffort: 'high' })
   await harness.drain({ sessionId: undefined })
   assert.deepEqual(harness.calls.map((call) => call.reasoningEffort), ['high', undefined])
+})
+
+test('reasoning effort memory is capped so long-running processes cannot grow it without bound', async () => {
+  const harness = liveWrapperHarness()
+  const total = MAX_LIVE_EFFORT_MEMORY + 10
+  for (let i = 0; i < total; i++) {
+    await harness.drain({ sessionId: `session-${i}`, reasoningEffort: 'high' })
+  }
+  // The first sessions fell out of the cap; their memory is gone, so a
+  // follow-up without an explicit pick must not re-inject anything.
+  await harness.drain({ sessionId: 'session-0' })
+  const evicted = harness.calls[harness.calls.length - 1]
+  assert.equal(evicted.reasoningEffort, undefined)
+  // A session still inside the cap keeps remembering its pick.
+  await harness.drain({ sessionId: `session-${total - 1}` })
+  const hot = harness.calls[harness.calls.length - 1]
+  assert.equal(hot.reasoningEffort, 'high')
 })
 
 test('delegated replay context cache expires with the Cordis plugin fiber', () => {


### PR DESCRIPTION
#184 scoped the entry-layer reasoning-effort memory by DSH sessionId, but the map is only
ever written: a long-running process accumulates one entry per (session, provider, model)
tuple forever.

Changes: cap the map (512 entries) with FIFO eviction of the oldest entry; reads refresh
recency so live sessions survive the cap. A regression test drives more sessions than the
cap and asserts the evicted session forgets its pick while a hot session still remembers it.
