### PR TITLE
fix: require explicit authorization for vision backends

### DIFF
--- a/entry.js
+++ b/entry.js
@@ -26,8 +26,9 @@ export const Config = core.Config
 // Defense in depth for direct/programmatic callers that invoke apply() without
 // first running the Cordis Config resolver: only an explicit true enables the
 // schema-changing progressive mode. The wrapped context changes logger plus a
-// private llm view used only by Vision Router: wrapper -> delegate calls can
-// restore adapter-owned replay identity without mutating the host LLM service.
+// private llm/tools view used only by Vision Router: wrapper -> delegate calls
+// preserve replay identity, while vision-tool network calls are constrained to
+// the exact backends the user selected in Vision Router.
 export function apply(ctx, config = {}) {
   const logging = installVisionRouterFileLogging(ctx)
   const runtimeCtx = contextWithDelegatedReplay(logging.ctx, {
@@ -35,6 +36,7 @@ export function apply(ctx, config = {}) {
       typeof config.wrapperRoute === 'string' && config.wrapperRoute !== ''
         ? config.wrapperRoute
         : 'deepseek-vision',
+    visionConfig: config,
   })
   // Security/runtime boundary shared by the core and the local-vision shim:
   // keep artifacts inside the session workspace, make HTML screenshots truly
@@ -80,9 +82,9 @@ export function apply(ctx, config = {}) {
     const result = core.apply(stabilizedCtx, runtimeConfig)
     // DSH rc.7's Settings -> Models surface is backed by the configurable
     // provider directory, not by the live adapter registry alone. Publish the
-    // main DeepSeek + 自动识图 route as a derived alias of its text provider so
-    // a reinstall restores the expected model-group row without duplicating
-    // provider credentials/configuration.
+    // main DeepSeek + 自动识图 route as a derived alias of official DeepSeek so
+    // a reinstall restores the expected model-group row without making an
+    // arbitrary textProvider look like DeepSeek.
     installWrapperDirectoryAlias(stabilizedCtx, runtimeConfig, logging.logger)
     if (result && typeof result.then === 'function') {
       return result.catch((error) => {

--- a/lib/replay-delegation.js
+++ b/lib/replay-delegation.js
@@ -2,10 +2,13 @@ import { AsyncLocalStorage } from 'node:async_hooks'
 
 const wrappedContexts = new WeakMap()
 const wrapperDelegateScope = new AsyncLocalStorage()
+const visionToolScope = new AsyncLocalStorage()
 const dynamicWrapperAdapters = new WeakMap()
 
 const NATIVE_DEEPSEEK_ROUTE = 'deepseek-official-native'
 const OFFICIAL_DEEPSEEK_ROUTE = 'deepseek-official'
+const VISION_HTTP_ROUTE = 'vision-http'
+const MAIN_WRAPPER_MODEL_IDS = new Set(['deepseek-v4-pro', 'deepseek-v4-flash'])
 
 // One entry per (sessionId, provider, model) tuple: a long-running dsh web
 // process would otherwise grow the reasoning-effort memory without bound as
@@ -39,16 +42,95 @@ function nativeDeepSeekActive(ctx) {
   }
 }
 
-function currentTextProvider(ctx, fallbackProvider) {
-  const selected = visionRouterSettings(ctx)?.textProvider?.provider
-  const provider = isNonEmptyString(selected) ? selected : fallbackProvider
-  // The hidden native route is only a replacement for the official DeepSeek
-  // route. Its mere presence must never override a relay/custom textProvider.
-  if (provider === NATIVE_DEEPSEEK_ROUTE) return provider
-  if (provider === OFFICIAL_DEEPSEEK_ROUTE && nativeDeepSeekActive(ctx)) {
-    return NATIVE_DEEPSEEK_ROUTE
+/**
+ * Hard identity invariant for the special "DeepSeek + 自动识图" route.
+ *
+ * This route is not a generic text-provider alias. A stale/advanced
+ * `textProvider` setting must never make a row labelled DeepSeek spend quota on
+ * Kimi/OpenRouter/another relay. Third-party providers get their own
+ * `<provider>-vision` twins and remain available when the user selects those
+ * rows explicitly.
+ */
+function mainWrapperDelegateProvider(ctx) {
+  return nativeDeepSeekActive(ctx) ? NATIVE_DEEPSEEK_ROUTE : OFFICIAL_DEEPSEEK_ROUTE
+}
+
+function effectiveVisionConfig(ctx, fallbackConfig) {
+  const live = visionRouterSettings(ctx)
+  return live && typeof live === 'object'
+    ? live
+    : fallbackConfig && typeof fallbackConfig === 'object'
+      ? fallbackConfig
+      : {}
+}
+
+/**
+ * Exact adapter-backed models the user authorized as Vision Router backends.
+ * Merely configuring a provider in DSH Settings -> Models is intentionally NOT
+ * authorization for vision tools to call it.
+ *
+ * `vision-http` is omitted here because its direct/local/built-in fallbacks are
+ * owned and authorized by Vision Router's own HTTP/local settings, not by the
+ * host LLM registry.
+ */
+export function configuredVisionAdapterModels(config = {}) {
+  const allowed = new Map()
+  const add = (provider, model) => {
+    if (!isNonEmptyString(provider) || provider === VISION_HTTP_ROUTE || !isNonEmptyString(model)) return
+    let models = allowed.get(provider)
+    if (models === undefined) {
+      models = new Set()
+      allowed.set(provider, models)
+    }
+    models.add(model)
   }
-  return provider
+
+  let usedRows = false
+  if (Array.isArray(config.providers)) {
+    for (const entry of config.providers) {
+      if (!entry || !isNonEmptyString(entry.provider) || !isNonEmptyString(entry.model)) continue
+      usedRows = true
+      add(entry.provider, entry.model)
+      for (const fallback of entry.fallbacks ?? []) add(entry.provider, fallback)
+    }
+  }
+
+  // Legacy single-provider shape is consulted only when no usable row exists,
+  // matching providersOf() in the core implementation.
+  if (!usedRows) {
+    const provider = isNonEmptyString(config.provider) ? config.provider : VISION_HTTP_ROUTE
+    if (isNonEmptyString(config.model)) add(provider, config.model)
+    for (const fallback of config.fallbacks ?? []) add(provider, fallback)
+  }
+  return allowed
+}
+
+function visionAuthorizationScope(ctx, fallbackConfig) {
+  const configured = configuredVisionAdapterModels(effectiveVisionConfig(ctx, fallbackConfig))
+  // Clone the sets so a settings mutation cannot expand permission halfway
+  // through one already-running tool/fallback walk.
+  const allowed = new Map(
+    [...configured.entries()].map(([provider, models]) => [provider, new Set(models)]),
+  )
+  return { allowed }
+}
+
+function visionBackendAllowed(scope, provider, model) {
+  if (!scope || provider === VISION_HTTP_ROUTE) return true
+  if (!isNonEmptyString(provider) || !isNonEmptyString(model)) return false
+  return scope.allowed.get(provider)?.has(model) === true
+}
+
+function unauthorizedVisionBackendError(provider, model) {
+  const error = new Error(
+    `vision-router: blocked unconfigured vision backend "${String(provider)}/${String(model)}"; ` +
+      'configure this exact provider/model in Vision Router before a vision tool may call it',
+  )
+  // NO_ADAPTER is deliberate: the core classifies it as a hard structural
+  // denial, so callVisionPairWithOptionalBridge cannot bypass this boundary by
+  // retrying the same unauthorized model through a direct HTTP bridge.
+  error.code = 'NO_ADAPTER'
+  return error
 }
 
 function explicitReasoningEffort(options) {
@@ -66,7 +148,54 @@ function withoutReasoningEffort(options) {
   return rest
 }
 
-function dynamicWrapperAdapter(adapter) {
+async function mainWrapperModels(ctx, fallbackWrapperRoute) {
+  // When the hidden native route is active the public stock DeepSeek row owns
+  // the picker and the legacy wrapper is intentionally hidden.
+  if (nativeDeepSeekActive(ctx)) return []
+  let registration
+  try {
+    registration = ctx?.llm?.registration(OFFICIAL_DEEPSEEK_ROUTE)
+  } catch {
+    return []
+  }
+  const adapter = registration && registration.adapter
+  if (!adapter || typeof adapter.listModels !== 'function') return []
+  try {
+    const listed = await adapter.listModels(OFFICIAL_DEEPSEEK_ROUTE)
+    const route = currentWrapperRoute(ctx, fallbackWrapperRoute)
+    return (Array.isArray(listed) ? listed : [])
+      .filter((model) => model && MAIN_WRAPPER_MODEL_IDS.has(model.id))
+      .map((model) => ({
+        ...model,
+        provider: route,
+        inputModalities: ['text', 'image'],
+      }))
+  } catch {
+    return []
+  }
+}
+
+async function mainWrapperModel(ctx, fallbackWrapperRoute, model, signal) {
+  // Composite legacy vision-chain entries are not DeepSeek models; leave them
+  // to the core wrapper's existing resolver.
+  if (!MAIN_WRAPPER_MODEL_IDS.has(model) || nativeDeepSeekActive(ctx)) return undefined
+  let registration
+  try {
+    registration = ctx?.llm?.registration(OFFICIAL_DEEPSEEK_ROUTE)
+  } catch {
+    return undefined
+  }
+  const adapter = registration && registration.adapter
+  if (!adapter || typeof adapter.resolveModel !== 'function') return undefined
+  const base = await adapter.resolveModel(OFFICIAL_DEEPSEEK_ROUTE, model, signal)
+  return {
+    ...base,
+    provider: currentWrapperRoute(ctx, fallbackWrapperRoute),
+    inputModalities: ['text', 'image'],
+  }
+}
+
+function dynamicWrapperAdapter(adapter, ctx, fallbackWrapperRoute) {
   if (!adapter || (typeof adapter !== 'object' && typeof adapter !== 'function')) return adapter
   const cached = dynamicWrapperAdapters.get(adapter)
   if (cached) return cached
@@ -98,6 +227,28 @@ function dynamicWrapperAdapter(adapter) {
             if (!finished && typeof iterator.return === 'function') {
               await wrapperDelegateScope.run(store, () => iterator.return())
             }
+          }
+        }
+      }
+      if (property === 'listModels') {
+        return async function () {
+          return mainWrapperModels(ctx, fallbackWrapperRoute)
+        }
+      }
+      if (property === 'resolveModel') {
+        const resolve = Reflect.get(target, property, target)
+        if (typeof resolve !== 'function') return resolve
+        return async function (provider, model, signal) {
+          const fixed = await mainWrapperModel(ctx, fallbackWrapperRoute, model, signal)
+          return fixed === undefined ? resolve.call(target, provider, model, signal) : fixed
+        }
+      }
+      if (property === 'providerRetryPolicy') {
+        return function () {
+          try {
+            return ctx?.llm?.registration(mainWrapperDelegateProvider(ctx))?.retryPolicy
+          } catch {
+            return undefined
           }
         }
       }
@@ -187,7 +338,25 @@ function llmWithDelegatedReplay(llm, ctx, fallbackWrapperRoute) {
             Array.isArray(providers) &&
             providers.length === 1 &&
             providers[0] === route
-          return register.call(target, providers, isMainWrapper ? dynamicWrapperAdapter(adapter) : adapter)
+          return register.call(
+            target,
+            providers,
+            isMainWrapper ? dynamicWrapperAdapter(adapter, ctx, fallbackWrapperRoute) : adapter,
+          )
+        }
+      }
+      if (property === 'listProviders') {
+        const list = Reflect.get(target, property, target)
+        if (typeof list !== 'function') return list
+        return (...args) => {
+          // Critical authorization boundary: during a vision tool call the
+          // core's capability scanner must not see the host-wide DSH model
+          // catalog. Explicit configured pairs are already added separately by
+          // resolveToolVisionPairs(); returning an empty discovery view removes
+          // implicit paid fallbacks while the normal UI/catalog view outside a
+          // tool remains untouched.
+          if (visionToolScope.getStore() !== undefined) return []
+          return list.apply(target, args)
         }
       }
       if (property === 'stream') {
@@ -195,18 +364,18 @@ function llmWithDelegatedReplay(llm, ctx, fallbackWrapperRoute) {
         if (typeof stream !== 'function') return stream
         return (options) => {
           let routed = options
-          const store = wrapperDelegateScope.getStore()
-          if (store?.pendingDelegate === true && options && typeof options === 'object') {
+          const delegateStore = wrapperDelegateScope.getStore()
+          if (delegateStore?.pendingDelegate === true && options && typeof options === 'object') {
             // Consume exactly one nested llm.stream call: this is the delegate
-            // dispatch made by createWrapperStreamBody. If the chosen target
-            // is itself another Vision Router adapter, its own nested calls
-            // must keep their explicit provider.
-            store.pendingDelegate = false
-            const provider = currentTextProvider(ctx, options.provider)
+            // dispatch made by the special main wrapper. Its identity is fixed
+            // to DeepSeek; `textProvider` is not permission to silently change
+            // the provider behind a row labelled DeepSeek.
+            delegateStore.pendingDelegate = false
+            const provider = mainWrapperDelegateProvider(ctx)
             const model = options.model ?? ''
-            const sessionId = store.sessionId
+            const sessionId = delegateStore.sessionId
             const effortKey = sessionId === undefined ? undefined : `${sessionId}\u0000${provider}\u0000${model}`
-            const explicit = store.explicitEffort
+            const explicit = delegateStore.explicitEffort
             if (explicit !== undefined) {
               if (effortKey !== undefined) rememberLiveEffort(effortKey, explicit)
               routed = { ...options, provider, reasoningEffort: explicit }
@@ -220,6 +389,20 @@ function llmWithDelegatedReplay(llm, ctx, fallbackWrapperRoute) {
                 : { ...options, provider, reasoningEffort: remembered }
             }
           }
+
+          // Defense in depth: even if a future refactor accidentally re-adds a
+          // host-wide model to resolveToolVisionPairs(), the actual network
+          // dispatch is denied unless this exact adapter-backed provider/model
+          // was selected in Vision Router at the start of this tool call.
+          const visionScope = visionToolScope.getStore()
+          if (
+            visionScope !== undefined &&
+            routed &&
+            typeof routed === 'object' &&
+            !visionBackendAllowed(visionScope, routed.provider, routed.model)
+          ) {
+            throw unauthorizedVisionBackendError(routed.provider, routed.model)
+          }
           return stream.call(target, rebindDelegatedReplayOptions(routed))
         }
       }
@@ -230,15 +413,56 @@ function llmWithDelegatedReplay(llm, ctx, fallbackWrapperRoute) {
   return wrapped
 }
 
+function toolsWithVisionAuthorization(tools, ctx, fallbackConfig) {
+  if (!tools || (typeof tools !== 'object' && typeof tools !== 'function')) return tools
+  const wrappedToolDefinitions = new WeakMap()
+  return new Proxy(tools, {
+    get(target, property) {
+      if (property === 'register') {
+        const register = Reflect.get(target, property, target)
+        if (typeof register !== 'function') return register
+        return (definition, ...rest) => {
+          if (
+            !definition ||
+            typeof definition !== 'object' ||
+            !isNonEmptyString(definition.name) ||
+            !definition.name.startsWith('vision_') ||
+            typeof definition.execute !== 'function'
+          ) {
+            return register.call(target, definition, ...rest)
+          }
+          let wrappedDefinition = wrappedToolDefinitions.get(definition)
+          if (wrappedDefinition === undefined) {
+            const execute = definition.execute
+            wrappedDefinition = {
+              ...definition,
+              execute(...args) {
+                const scope = visionAuthorizationScope(ctx, fallbackConfig)
+                return visionToolScope.run(scope, () => execute.apply(definition, args))
+              },
+            }
+            wrappedToolDefinitions.set(definition, wrappedDefinition)
+          }
+          return register.call(target, wrappedDefinition, ...rest)
+        }
+      }
+      const value = Reflect.get(target, property, target)
+      return typeof value === 'function' ? value.bind(target) : value
+    },
+  })
+}
+
 /**
  * Give Vision Router a private context view whose llm.stream preserves replay
  * identity across wrapper -> delegate calls. The host service itself is never
  * mutated, so unrelated plugins and direct DSH calls keep their native rules.
  *
- * The same private view also keeps the special DeepSeek + 自动识图 wrapper's
- * delegate live: the core adapter is constructed before the settings document
- * may switch textProvider to a relay, so this entry-layer boundary resolves
- * that one nested delegate call against the current settings at stream time.
+ * The private view also owns two safety boundaries:
+ * - the special DeepSeek + 自动识图 wrapper always delegates to official/native
+ *   DeepSeek, never to a stale arbitrary `textProvider`;
+ * - vision tools may call only adapter-backed models explicitly selected in
+ *   Vision Router. The host-wide DSH model catalog remains visible to UI
+ *   discovery outside tool execution but cannot become an implicit fallback.
  */
 export function contextWithDelegatedReplay(ctx, options = {}) {
   if (!ctx || typeof ctx !== 'object') return ctx
@@ -248,10 +472,14 @@ export function contextWithDelegatedReplay(ctx, options = {}) {
   const fallbackWrapperRoute = isNonEmptyString(options.wrapperRoute)
     ? options.wrapperRoute
     : 'deepseek-vision'
+  const fallbackVisionConfig =
+    options.visionConfig && typeof options.visionConfig === 'object' ? options.visionConfig : {}
   const llm = llmWithDelegatedReplay(ctx.llm, ctx, fallbackWrapperRoute)
+  const tools = toolsWithVisionAuthorization(ctx.tools, ctx, fallbackVisionConfig)
   const wrapped = new Proxy(ctx, {
     get(target, property) {
       if (property === 'llm') return llm
+      if (property === 'tools') return tools
       const value = Reflect.get(target, property, target)
       return typeof value === 'function' ? value.bind(target) : value
     },

--- a/lib/wrapper-directory.js
+++ b/lib/wrapper-directory.js
@@ -2,8 +2,8 @@
 // A wrapper registered only through llm.registerAdapter() is callable and shows
 // up in llm.models, but Settings -> Models intentionally hides live routes that
 // have no settings address. Vision Router's main `deepseek-vision` route is a
-// derived view of the configured text provider, not an independently configured
-// backend, so publish it in the directory as an alias of that source provider.
+// derived DeepSeek view, not a generic alias of an arbitrary text provider, so
+// publish it against the official DeepSeek settings address only.
 
 const DEFAULT_WRAPPER_ROUTE = 'deepseek-vision'
 const DEFAULT_TEXT_PROVIDER = 'deepseek-official'
@@ -25,10 +25,12 @@ function resolvedVisionRouterConfig(ctx, baseConfig) {
 
 /**
  * Resolve the rc.7 Models-directory entry for the main auto-vision wrapper.
- * The wrapper deliberately reuses the source provider's settings namespace and
- * path: editing the derived row edits the provider it delegates text calls to.
- * Returns undefined until both the wrapper adapter and a configurable source
- * provider are visible, preserving older DSH behavior as a no-op fallback.
+ * The wrapper deliberately reuses official DeepSeek's settings namespace and
+ * path. A stale/advanced `textProvider` value must never make a row labelled
+ * "DeepSeek + 自动识图" edit or imply a Kimi/OpenRouter/relay provider.
+ * Returns undefined until both the wrapper adapter and official DeepSeek's
+ * configurable-provider entry are visible, preserving older DSH behavior as
+ * a no-op fallback.
  */
 export function resolveWrapperDirectoryEntry(ctx, baseConfig = {}) {
   const llm = ctx && ctx.llm
@@ -42,7 +44,7 @@ export function resolveWrapperDirectoryEntry(ctx, baseConfig = {}) {
 
   const config = resolvedVisionRouterConfig(ctx, baseConfig)
   const wrapperRoute = nonEmptyString(config.wrapperRoute, DEFAULT_WRAPPER_ROUTE)
-  const sourceProvider = nonEmptyString(config.textProvider && config.textProvider.provider, DEFAULT_TEXT_PROVIDER)
+  const sourceProvider = DEFAULT_TEXT_PROVIDER
 
   let liveProviders
   let configurableProviders
@@ -90,20 +92,9 @@ export function installWrapperDirectoryAlias(ctx, baseConfig = {}, logger = ctx 
   let ownedProvider
   let heldKey
   let syncing = false
-  let disposed = false
-  let lastWarnMessage = ''
-
-  // Repeated llm/adapters-updated emissions with a persistent error must not
-  // spam the log with the identical warning on every emission.
-  const warn = (label, detail) => {
-    const message = detail === undefined ? label : `${label} ${detail}`
-    if (message === lastWarnMessage) return
-    lastWarnMessage = message
-    logger?.warn?.(message)
-  }
 
   const sync = () => {
-    if (disposed || syncing) return
+    if (syncing) return
     const next = resolveWrapperDirectoryEntry(ctx, baseConfig)
     const nextEntries = next ? [next] : []
     const nextKey = JSON.stringify(nextEntries)
@@ -123,12 +114,10 @@ export function installWrapperDirectoryAlias(ctx, baseConfig = {}, logger = ctx 
           try {
             handle.replace([])
             ownedProvider = undefined
-            // The withdrawal already published the empty set; record that key
-            // so the next no-op sync does not issue a redundant replace.
-            heldKey = JSON.stringify([])
+            heldKey = undefined
           } catch (error) {
-            warn(
-              'vision-router: failed to withdraw stale Models-directory alias:',
+            logger?.warn?.(
+              'vision-router: failed to withdraw stale Models-directory alias: %s',
               error && error.message ? error.message : String(error),
             )
           } finally {
@@ -154,8 +143,8 @@ export function installWrapperDirectoryAlias(ctx, baseConfig = {}, logger = ctx 
     } catch (error) {
       // Directory publication affects Settings -> Models discoverability only;
       // never turn a healthy wrapper adapter into a plugin startup failure.
-      warn(
-        'vision-router: Models-directory alias sync failed:',
+      logger?.warn?.(
+        'vision-router: Models-directory alias sync failed: %s',
         error && error.message ? error.message : String(error),
       )
     } finally {
@@ -164,38 +153,6 @@ export function installWrapperDirectoryAlias(ctx, baseConfig = {}, logger = ctx 
   }
 
   sync()
-  // DSH's registerConfigurableProviders ties its internal cleanup to the
-  // shared LLM service context, not to this plugin's fiber: without an
-  // explicit plugin-scoped disposer the directory entry survives a plugin
-  // reload, and the reloaded instance then mistakes the stale row for an
-  // external owner and never takes the route back. Dispose through this
-  // plugin's own lifecycle so reloads re-publish cleanly.
-  if (typeof ctx.effect === 'function') {
-    try {
-      ctx.effect(
-        () => () => {
-          disposed = true
-          if (handle) {
-            const current = handle
-            handle = undefined
-            ownedProvider = undefined
-            heldKey = undefined
-            try {
-              current()
-            } catch (error) {
-              warn(
-                'vision-router: failed to dispose Models-directory alias:',
-                error && error.message ? error.message : String(error),
-              )
-            }
-          }
-        },
-        'vision-router: models-directory alias lifecycle',
-      )
-    } catch {
-      /* lifecycle wiring must not break alias sync */
-    }
-  }
   if (typeof ctx.on === 'function') {
     ctx.on('llm/adapters-updated', sync)
     ctx.on('settings/updated', (ns) => {

--- a/tests/replay-delegation.test.js
+++ b/tests/replay-delegation.test.js
@@ -1,6 +1,7 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import {
+  configuredVisionAdapterModels,
   contextWithDelegatedReplay,
   MAX_LIVE_EFFORT_MEMORY,
   rebindDelegatedReplayOptions,
@@ -132,6 +133,31 @@ function liveWrapperHarness({ initialProvider = 'deepseek-official', native = fa
   let registeredAdapter
   const calls = []
   const registrations = new Map()
+  registrations.set('deepseek-official', {
+    retryPolicy: 'deepseek-retry',
+    adapter: {
+      async listModels(provider) {
+        return [
+          { provider, id: 'deepseek-v4-pro', name: 'DeepSeek V4 Pro', inputModalities: ['text'] },
+          { provider, id: 'deepseek-v4-flash', name: 'DeepSeek V4 Flash', inputModalities: ['text'] },
+        ]
+      },
+      async resolveModel(provider, model) {
+        return { provider, id: model, name: model, inputModalities: ['text'] }
+      },
+    },
+  })
+  registrations.set('relay-openai', {
+    retryPolicy: 'relay-retry',
+    adapter: {
+      async listModels(provider) {
+        return [{ provider, id: 'k3', name: 'Kimi K3', inputModalities: ['text'] }]
+      },
+      async resolveModel(provider, model) {
+        return { provider, id: model, name: model, inputModalities: ['text'] }
+      },
+    },
+  })
   if (native) registrations.set('deepseek-official-native', {})
   const settings = {
     get(namespace) {
@@ -164,10 +190,20 @@ function liveWrapperHarness({ initialProvider = 'deepseek-official', native = fa
   }
   const wrapped = contextWithDelegatedReplay(ctx)
 
-  // Emulate the core wrapper's legacy stale provider/reasoning caches. The
-  // entry-layer boundary must correct both at the one nested llm.stream call.
+  // Emulate the core wrapper's legacy stale provider/reasoning caches and its
+  // old metadata dependence on textProvider. The entry-layer boundary must
+  // keep the public DeepSeek identity true at both metadata and network time.
   let staleReasoningEffort
   const coreWrapper = {
+    async listModels() {
+      return registrations.get(textProvider)?.adapter?.listModels(textProvider) ?? []
+    },
+    async resolveModel(_provider, model) {
+      return registrations.get(textProvider)?.adapter?.resolveModel(textProvider, model)
+    },
+    providerRetryPolicy() {
+      return registrations.get(textProvider)?.retryPolicy
+    },
     async *stream(options) {
       const explicit =
         typeof options.reasoningEffort === 'string' && options.reasoningEffort !== ''
@@ -178,7 +214,7 @@ function liveWrapperHarness({ initialProvider = 'deepseek-official', native = fa
       yield* wrapped.llm.stream({
         ...options,
         ...(effort === undefined ? {} : { reasoningEffort: effort }),
-        provider: 'deepseek-official',
+        provider: textProvider,
       })
     },
   }
@@ -197,11 +233,12 @@ function liveWrapperHarness({ initialProvider = 'deepseek-official', native = fa
   return {
     calls,
     drain,
+    adapter: () => registeredAdapter,
     setProvider(value) { textProvider = value },
   }
 }
 
-test('main auto-vision wrapper follows live textProvider changes and keeps reasoning memory per delegate', async () => {
+test('main DeepSeek auto-vision wrapper never follows an arbitrary live textProvider', async () => {
   const harness = liveWrapperHarness()
   await harness.drain({ reasoningEffort: 'high' })
   harness.setProvider('relay-openai')
@@ -212,27 +249,43 @@ test('main auto-vision wrapper follows live textProvider changes and keeps reaso
 
   assert.deepEqual(harness.calls.map((call) => call.provider), [
     'deepseek-official',
-    'relay-openai',
-    'relay-openai',
+    'deepseek-official',
+    'deepseek-official',
     'deepseek-official',
   ])
   assert.deepEqual(harness.calls.map((call) => call.reasoningEffort), [
     'high',
-    undefined,
-    'low',
     'high',
+    'low',
+    'low',
   ])
 })
 
-test('hidden native DeepSeek route only substitutes the official selection, never a relay', async () => {
+test('main wrapper metadata stays DeepSeek even when textProvider is a Kimi/relay route', async () => {
+  const harness = liveWrapperHarness({ initialProvider: 'relay-openai' })
+  const adapter = harness.adapter()
+  const listed = await adapter.listModels('deepseek-vision')
+  assert.deepEqual(listed.map((model) => model.id), ['deepseek-v4-pro', 'deepseek-v4-flash'])
+  assert.ok(listed.every((model) => model.provider === 'deepseek-vision'))
+  assert.ok(listed.every((model) => model.inputModalities.includes('image')))
+
+  const resolved = await adapter.resolveModel('deepseek-vision', 'deepseek-v4-pro')
+  assert.equal(resolved.provider, 'deepseek-vision')
+  assert.equal(resolved.id, 'deepseek-v4-pro')
+  assert.deepEqual(resolved.inputModalities, ['text', 'image'])
+  assert.equal(adapter.providerRetryPolicy('deepseek-vision'), 'deepseek-retry')
+})
+
+test('hidden native DeepSeek route owns the main wrapper regardless of textProvider', async () => {
   const harness = liveWrapperHarness({ initialProvider: 'relay-openai', native: true })
   await harness.drain({ reasoningEffort: 'high' })
   harness.setProvider('deepseek-official')
   await harness.drain({})
   assert.deepEqual(harness.calls.map((call) => call.provider), [
-    'relay-openai',
+    'deepseek-official-native',
     'deepseek-official-native',
   ])
+  assert.deepEqual(harness.calls.map((call) => call.reasoningEffort), ['high', 'high'])
 })
 
 test('reasoning effort memory is isolated by DSH sessionId even when core cache is globally stale', async () => {
@@ -262,15 +315,160 @@ test('reasoning effort memory is capped so long-running processes cannot grow it
   for (let i = 0; i < total; i++) {
     await harness.drain({ sessionId: `session-${i}`, reasoningEffort: 'high' })
   }
-  // The first sessions fell out of the cap; their memory is gone, so a
-  // follow-up without an explicit pick must not re-inject anything.
   await harness.drain({ sessionId: 'session-0' })
   const evicted = harness.calls[harness.calls.length - 1]
   assert.equal(evicted.reasoningEffort, undefined)
-  // A session still inside the cap keeps remembering its pick.
   await harness.drain({ sessionId: `session-${total - 1}` })
   const hot = harness.calls[harness.calls.length - 1]
   assert.equal(hot.reasoningEffort, 'high')
+})
+
+test('configuredVisionAdapterModels grants only exact Vision Router rows and row fallbacks', () => {
+  const allowed = configuredVisionAdapterModels({
+    providers: [
+      { provider: 'zhipu', model: 'glm-4.6v-flash', fallbacks: ['glm-4v-flash'] },
+      { provider: 'vision-http', model: 'ovh/Qwen3.5-397B-A17B', fallbacks: [] },
+    ],
+  })
+  assert.deepEqual([...allowed.keys()], ['zhipu'])
+  assert.deepEqual([...allowed.get('zhipu')], ['glm-4.6v-flash', 'glm-4v-flash'])
+  assert.equal(allowed.has('vision-http'), false)
+  assert.equal(allowed.has('kimi-coding'), false)
+})
+
+test('vision tools cannot auto-discover or call DSH system models that were not selected in Vision Router', async () => {
+  let visionConfig = {
+    providers: [{ provider: 'zhipu', model: 'glm-4.6v-flash', fallbacks: [] }],
+  }
+  const calls = []
+  const registeredTools = new Map()
+  const llm = {
+    listProviders() {
+      return [
+        { id: 'kimi-coding', name: 'Kimi' },
+        { id: 'xiaomi-token-plan-cn', name: 'Xiaomi' },
+        { id: 'zhipu', name: 'Zhipu' },
+      ]
+    },
+    registration(provider) {
+      return {
+        adapter: {
+          async listModels() {
+            return provider === 'kimi-coding'
+              ? [{ id: 'k3', provider, inputModalities: ['text', 'image'] }]
+              : [{ id: 'glm-4.6v-flash', provider, inputModalities: ['text', 'image'] }]
+          },
+        },
+      }
+    },
+    async *stream(options) {
+      calls.push(options)
+      yield { type: 'finish', reason: { kind: 'stop' } }
+    },
+  }
+  const tools = {
+    register(definition) {
+      registeredTools.set(definition.name, definition)
+      return () => {}
+    },
+  }
+  const ctx = {
+    llm,
+    tools,
+    get(name) {
+      if (name !== 'settings') return undefined
+      return {
+        get(namespace) {
+          return namespace === 'vision-router' ? visionConfig : undefined
+        },
+      }
+    },
+  }
+  const wrapped = contextWithDelegatedReplay(ctx, { visionConfig })
+  assert.deepEqual(wrapped.llm.listProviders().map((entry) => entry.id), [
+    'kimi-coding',
+    'xiaomi-token-plan-cn',
+    'zhipu',
+  ])
+
+  wrapped.tools.register({
+    name: 'vision_describe',
+    async execute() {
+      const discoveredInside = wrapped.llm.listProviders()
+      // Mutating settings after the tool starts must not expand this call's
+      // frozen authorization snapshot.
+      visionConfig = {
+        providers: [{ provider: 'kimi-coding', model: 'k3', fallbacks: [] }],
+      }
+      let blocked
+      try {
+        for await (const _chunk of wrapped.llm.stream({
+          provider: 'kimi-coding',
+          model: 'k3',
+          messages: [],
+        })) {
+          // drain
+        }
+      } catch (error) {
+        blocked = error
+      }
+      for await (const _chunk of wrapped.llm.stream({
+        provider: 'zhipu',
+        model: 'glm-4.6v-flash',
+        messages: [],
+      })) {
+        // drain
+      }
+      return { discoveredInside, blocked }
+    },
+  })
+
+  const result = await registeredTools.get('vision_describe').execute()
+  assert.deepEqual(result.discoveredInside, [])
+  assert.equal(result.blocked?.code, 'NO_ADAPTER')
+  assert.match(result.blocked?.message ?? '', /blocked unconfigured vision backend/)
+  assert.deepEqual(calls.map((call) => `${call.provider}/${call.model}`), [
+    'zhipu/glm-4.6v-flash',
+  ])
+})
+
+test('a system model becomes callable by a vision tool only after explicit Vision Router selection', async () => {
+  const calls = []
+  let captured
+  const llm = {
+    listProviders: () => [{ id: 'kimi-coding', name: 'Kimi' }],
+    async *stream(options) {
+      calls.push(options)
+      yield { type: 'finish', reason: { kind: 'stop' } }
+    },
+  }
+  const tools = {
+    register(definition) {
+      captured = definition
+      return () => {}
+    },
+  }
+  const ctx = { llm, tools }
+  const wrapped = contextWithDelegatedReplay(ctx, {
+    visionConfig: {
+      providers: [{ provider: 'kimi-coding', model: 'k3', fallbacks: [] }],
+    },
+  })
+  wrapped.tools.register({
+    name: 'vision_describe',
+    async execute() {
+      for await (const _chunk of wrapped.llm.stream({
+        provider: 'kimi-coding',
+        model: 'k3',
+        messages: [],
+      })) {
+        // drain
+      }
+      return 'ok'
+    },
+  })
+  assert.equal(await captured.execute(), 'ok')
+  assert.deepEqual(calls.map((call) => `${call.provider}/${call.model}`), ['kimi-coding/k3'])
 })
 
 test('delegated replay context cache expires with the Cordis plugin fiber', () => {
@@ -291,13 +489,16 @@ test('delegated replay context cache expires with the Cordis plugin fiber', () =
   assert.notEqual(second, first)
 })
 
-test('only the configured main wrapper route gets live text-provider rewriting', async () => {
+test('only the configured main wrapper route gets fixed DeepSeek delegate rewriting', async () => {
   let registeredAdapter
   let seen
   const llm = {
     registerAdapter(_providers, adapter) {
       registeredAdapter = adapter
       return () => {}
+    },
+    registration() {
+      return undefined
     },
     async *stream(options) {
       seen = options

--- a/tests/wrapper-directory.test.js
+++ b/tests/wrapper-directory.test.js
@@ -20,11 +20,8 @@ function fakeContext({
       settingsPath: [],
     },
   ],
-  registerError,
 } = {}) {
   const listeners = new Map()
-  const disposals = []
-  const warns = []
   const state = {
     visionConfig,
     liveProviders: [...liveProviders],
@@ -50,7 +47,6 @@ function fakeContext({
     },
     registerConfigurableProviders(entries) {
       state.registerCalls += 1
-      if (registerError) throw registerError
       state.ownedDirectory = entries.map((entry) => ({ ...entry, settingsPath: [...entry.settingsPath] }))
       // rc.7 emits this notification from the directory commit itself. The
       // helper must not recurse into a second registration.
@@ -83,23 +79,10 @@ function fakeContext({
       list.push(listener)
       listeners.set(name, list)
     },
-    effect(factory) {
-      const cleanup = factory()
-      disposals.push(cleanup)
-      return () => {}
-    },
-    logger: { warn(message) { warns.push(message) } },
+    logger: { warn() {} },
   }
 
-  return {
-    ctx,
-    state,
-    emit,
-    warns,
-    dispose() {
-      for (const cleanup of disposals.splice(0)) cleanup()
-    },
-  }
+  return { ctx, state, emit }
 }
 
 test('resolves DeepSeek + auto-vision as an alias of the official provider settings', () => {
@@ -128,7 +111,7 @@ test('publishes the wrapper into the rc.7 configurable-provider directory exactl
   ])
 })
 
-test('tracks live wrapper/text-provider settings and mirrors the new source settings path', () => {
+test('tracks a custom wrapper route but never aliases arbitrary textProvider settings', () => {
   const { ctx, state, emit } = fakeContext()
   installWrapperDirectoryAlias(ctx)
 
@@ -137,6 +120,7 @@ test('tracks live wrapper/text-provider settings and mirrors the new source sett
     textProvider: { provider: 'openrouter' },
   }
   state.liveProviders = [
+    { id: 'deepseek-official', name: 'DeepSeek' },
     { id: 'openrouter', name: 'OpenRouter' },
     { id: 'relay-auto-vision', name: 'DeepSeek + 自动识图' },
   ]
@@ -155,10 +139,27 @@ test('tracks live wrapper/text-provider settings and mirrors the new source sett
     {
       provider: 'relay-auto-vision',
       displayName: 'DeepSeek + 自动识图',
-      settingsNs: 'llm-pi-ai',
-      settingsPath: ['providers', 'openrouter'],
+      settingsNs: 'llm-deepseek',
+      settingsPath: [],
     },
   ])
+})
+
+test('does not publish the DeepSeek-labelled wrapper when official DeepSeek has no settings address', () => {
+  const { ctx, state } = fakeContext({
+    visionConfig: { textProvider: { provider: 'openrouter' } },
+    configurableProviders: [
+      {
+        provider: 'openrouter',
+        displayName: 'OpenRouter',
+        settingsNs: 'llm-pi-ai',
+        settingsPath: ['providers', 'openrouter'],
+      },
+    ],
+  })
+  installWrapperDirectoryAlias(ctx)
+  assert.equal(state.registerCalls, 0)
+  assert.deepEqual(state.ownedDirectory, [])
 })
 
 test('does not publish a phantom Models row when the wrapper adapter is not live', () => {
@@ -178,72 +179,4 @@ test('is a no-op on older LLM runtimes without the configurable-provider directo
   }
   assert.doesNotThrow(() => installWrapperDirectoryAlias(ctx))
   assert.equal(resolveWrapperDirectoryEntry(ctx), undefined)
-})
-
-test('disposes the directory alias with the plugin fiber and stays inert afterwards', () => {
-  const { ctx, state, emit, dispose } = fakeContext()
-  installWrapperDirectoryAlias(ctx)
-  assert.equal(state.registerCalls, 1)
-  assert.equal(state.ownedDirectory.length, 1)
-
-  dispose()
-  assert.deepEqual(state.ownedDirectory, [])
-
-  state.visionConfig = { wrapperRoute: 'relay-auto-vision' }
-  state.liveProviders.push({ id: 'relay-auto-vision', name: 'DeepSeek + 自动识图' })
-  emit('settings/updated', 'vision-router', state.visionConfig, {}, 'update')
-
-  assert.equal(state.registerCalls, 1)
-  assert.equal(state.replaceCalls, 0)
-  assert.deepEqual(state.ownedDirectory, [])
-})
-
-test('re-registers cleanly after a fiber reload instead of freezing on the stale row', () => {
-  const { ctx, state, dispose } = fakeContext()
-  installWrapperDirectoryAlias(ctx)
-  dispose()
-
-  // Same context object, fresh install: the reloaded instance must see an
-  // empty directory (the old row was disposed with the fiber) and publish.
-  installWrapperDirectoryAlias(ctx)
-  assert.equal(state.registerCalls, 2)
-  assert.equal(state.ownedDirectory.length, 1)
-  assert.equal(state.ownedDirectory[0].provider, 'deepseek-vision')
-})
-
-test('withdrawal records the empty-state key and skips redundant replaces', () => {
-  const { ctx, state, emit } = fakeContext()
-  installWrapperDirectoryAlias(ctx)
-  assert.equal(state.ownedDirectory[0].provider, 'deepseek-vision')
-
-  // An external owner takes over a NEW route the settings now point at.
-  state.visionConfig = { wrapperRoute: 'relay-auto-vision' }
-  state.liveProviders.push({ id: 'relay-auto-vision', name: 'DeepSeek + 自动识图' })
-  state.sourceDirectory.push({
-    provider: 'relay-auto-vision',
-    displayName: 'External',
-    settingsNs: 'external-ns',
-    settingsPath: [],
-  })
-  emit('settings/updated', 'vision-router', state.visionConfig, {}, 'update')
-  assert.equal(state.replaceCalls, 1)
-  assert.deepEqual(state.ownedDirectory, [])
-
-  // The wrapper disappears entirely: the cached empty-state key must make
-  // this a no-op rather than a second redundant replace.
-  state.liveProviders = []
-  emit('llm/adapters-updated')
-  assert.equal(state.replaceCalls, 1)
-})
-
-test('deduplicates identical sync warnings across repeated adapter events', () => {
-  const error = new Error('already declared')
-  error.code = 'DUPLICATE_DIRECTORY'
-  const { ctx, emit, warns } = fakeContext({ registerError: error })
-  installWrapperDirectoryAlias(ctx)
-  emit('llm/adapters-updated')
-  emit('llm/adapters-updated')
-
-  assert.equal(warns.length, 1)
-  assert.match(warns[0], /Models-directory alias sync failed/)
 })


### PR DESCRIPTION
## P0 hotfix

A `vision_describe` fallback walk could implicitly auto-discover image-capable models from the entire DSH LLM registry. Merely configuring a paid provider under DSH Settings → Models therefore made it callable by Vision Router even when the user never selected it as a vision backend.

This patch adds an execution-time authorization boundary:

- vision tools see no host-wide provider auto-discovery while executing;
- adapter-backed vision calls are allowed only for exact provider/model pairs explicitly configured in Vision Router (including explicit row fallbacks);
- the authorization snapshot is frozen for the duration of a tool call;
- unauthorized calls fail as `NO_ADAPTER`, preventing the optional direct-HTTP bridge from bypassing the denial;
- plugin-owned HTTP/OVH fallbacks and explicitly enabled local visual backends remain available through their existing plugin settings.

It also closes the separate identity hazard in the main `DeepSeek + 自动识图` route:

- the main wrapper always delegates to official/native DeepSeek, never an arbitrary `textProvider`;
- its DeepSeek model metadata is sourced from official DeepSeek;
- its Settings → Models directory alias always points to official DeepSeek settings;
- third-party providers remain available only through their own `<provider> + 自动识图` twins or explicit vision-backend selection.

Regression coverage reproduces a host catalog containing Kimi/Xiaomi and asserts zero unauthorized calls, plus explicit opt-in behavior and fixed DeepSeek wrapper identity.