### PR TITLE
fix: restore composite vision picker rows and Models-directory alias lifecycle

### DIFF
--- a/lib/replay-delegation.js
+++ b/lib/replay-delegation.js
@@ -231,8 +231,34 @@ function dynamicWrapperAdapter(adapter, ctx, fallbackWrapperRoute) {
         }
       }
       if (property === 'listModels') {
-        return async function () {
-          return mainWrapperModels(ctx, fallbackWrapperRoute)
+        const original = Reflect.get(target, property, target)
+        return async function (...args) {
+          const pinned = await mainWrapperModels(ctx, fallbackWrapperRoute)
+          if (typeof original !== 'function') return pinned
+          const route = currentWrapperRoute(ctx, fallbackWrapperRoute)
+          let composites = []
+          try {
+            const listed = await original.apply(target, args)
+            if (Array.isArray(listed)) {
+              // Restore ONLY the core's config-driven composite vision rows
+              // ("provider/model（视觉）", published when whole-turn routing is
+              // enabled) so the legacy routing mode keeps its picker entries.
+              // These rows are structurally composite ids (`provider/model`);
+              // any DeepSeek mirror — and any other row the core might emit —
+              // is dropped here: normal DeepSeek models must keep coming from
+              // the pinned official/native identity above, never from the
+              // possibly-stale textProvider.
+              composites = listed.filter(
+                (row) => row
+                  && row.provider === route
+                  && !MAIN_WRAPPER_MODEL_IDS.has(row.id)
+                  && String(row.id ?? '').includes('/'),
+              )
+            }
+          } catch {
+            /* the pinned DeepSeek rows still return */
+          }
+          return [...pinned, ...composites]
         }
       }
       if (property === 'resolveModel') {

--- a/lib/wrapper-directory.js
+++ b/lib/wrapper-directory.js
@@ -92,9 +92,20 @@ export function installWrapperDirectoryAlias(ctx, baseConfig = {}, logger = ctx 
   let ownedProvider
   let heldKey
   let syncing = false
+  let disposed = false
+  let lastWarnMessage = ''
+
+  // Repeated llm/adapters-updated emissions with a persistent error must not
+  // spam the log with the identical warning on every emission.
+  const warn = (label, detail) => {
+    const message = detail === undefined ? label : `${label} ${detail}`
+    if (message === lastWarnMessage) return
+    lastWarnMessage = message
+    logger?.warn?.(message)
+  }
 
   const sync = () => {
-    if (syncing) return
+    if (disposed || syncing) return
     const next = resolveWrapperDirectoryEntry(ctx, baseConfig)
     const nextEntries = next ? [next] : []
     const nextKey = JSON.stringify(nextEntries)
@@ -114,10 +125,12 @@ export function installWrapperDirectoryAlias(ctx, baseConfig = {}, logger = ctx 
           try {
             handle.replace([])
             ownedProvider = undefined
-            heldKey = undefined
+            // The withdrawal already published the empty set; record that key
+            // so the next no-op sync does not issue a redundant replace.
+            heldKey = JSON.stringify([])
           } catch (error) {
-            logger?.warn?.(
-              'vision-router: failed to withdraw stale Models-directory alias: %s',
+            warn(
+              'vision-router: failed to withdraw stale Models-directory alias:',
               error && error.message ? error.message : String(error),
             )
           } finally {
@@ -143,8 +156,8 @@ export function installWrapperDirectoryAlias(ctx, baseConfig = {}, logger = ctx 
     } catch (error) {
       // Directory publication affects Settings -> Models discoverability only;
       // never turn a healthy wrapper adapter into a plugin startup failure.
-      logger?.warn?.(
-        'vision-router: Models-directory alias sync failed: %s',
+      warn(
+        'vision-router: Models-directory alias sync failed:',
         error && error.message ? error.message : String(error),
       )
     } finally {
@@ -153,6 +166,38 @@ export function installWrapperDirectoryAlias(ctx, baseConfig = {}, logger = ctx 
   }
 
   sync()
+  // DSH's registerConfigurableProviders ties its internal cleanup to the
+  // shared LLM service context, not to this plugin's fiber: without an
+  // explicit plugin-scoped disposer the directory entry survives a plugin
+  // reload, and the reloaded instance then mistakes the stale row for an
+  // external owner and never takes the route back. Dispose through this
+  // plugin's own lifecycle so reloads re-publish cleanly.
+  if (typeof ctx.effect === 'function') {
+    try {
+      ctx.effect(
+        () => () => {
+          disposed = true
+          if (handle) {
+            const current = handle
+            handle = undefined
+            ownedProvider = undefined
+            heldKey = undefined
+            try {
+              current()
+            } catch (error) {
+              warn(
+                'vision-router: failed to dispose Models-directory alias:',
+                error && error.message ? error.message : String(error),
+              )
+            }
+          }
+        },
+        'vision-router: models-directory alias lifecycle',
+      )
+    } catch {
+      /* lifecycle wiring must not break alias sync */
+    }
+  }
   if (typeof ctx.on === 'function') {
     ctx.on('llm/adapters-updated', sync)
     ctx.on('settings/updated', (ns) => {

--- a/tests/replay-delegation.test.js
+++ b/tests/replay-delegation.test.js
@@ -276,6 +276,157 @@ test('main wrapper metadata stays DeepSeek even when textProvider is a Kimi/rela
   assert.equal(adapter.providerRetryPolicy('deepseek-vision'), 'deepseek-retry')
 })
 
+test('main wrapper listModels restores only config-driven composite rows while pinning DeepSeek mirrors', async () => {
+  let routingEnabled = false
+  let registeredAdapter
+  const registeredTools = new Map()
+  const networkCalls = []
+  const registrations = new Map()
+  registrations.set('deepseek-official', {
+    retryPolicy: 'deepseek-retry',
+    adapter: {
+      async listModels(provider) {
+        return [
+          { provider, id: 'deepseek-v4-pro', name: 'DeepSeek V4 Pro', inputModalities: ['text'] },
+          { provider, id: 'deepseek-v4-flash', name: 'DeepSeek V4 Flash', inputModalities: ['text'] },
+        ]
+      },
+    },
+  })
+  registrations.set('kimi-coding', {
+    adapter: {
+      async listModels(provider) {
+        return [{ provider, id: 'k3', name: 'Kimi K3', inputModalities: ['text', 'image'] }]
+      },
+    },
+  })
+  registrations.set('xiaomi-token-plan-cn', {
+    adapter: {
+      async listModels(provider) {
+        return [{ provider, id: 'xiaomi-vision', name: 'Xiaomi Vision', inputModalities: ['text', 'image'] }]
+      },
+    },
+  })
+  const settings = {
+    get(namespace) {
+      if (namespace !== 'vision-router') return undefined
+      return {
+        wrapperRoute: 'deepseek-vision',
+        routing: routingEnabled,
+        textProvider: { provider: 'relay-openai' },
+        providers: [{ provider: 'zhipu', model: 'glm-4.6v-flash', fallbacks: [] }],
+      }
+    },
+  }
+  const llm = {
+    registration(provider) {
+      return registrations.get(provider)
+    },
+    listProviders() {
+      // Host-wide DSH catalog: Kimi/Xiaomi are configured in DSH but are NOT
+      // authorized in Vision Router.
+      return [
+        { id: 'kimi-coding', name: 'Kimi' },
+        { id: 'xiaomi-token-plan-cn', name: 'Xiaomi' },
+        { id: 'zhipu', name: 'Zhipu' },
+      ]
+    },
+    registerAdapter(_providers, adapter) {
+      registeredAdapter = adapter
+      return () => {}
+    },
+    async *stream(options) {
+      networkCalls.push(options)
+      yield { type: 'finish', reason: { kind: 'stop' } }
+    },
+  }
+  const tools = {
+    register(definition) {
+      registeredTools.set(definition.name, definition)
+      return () => {}
+    },
+  }
+  const ctx = {
+    llm,
+    tools,
+    get(name) {
+      return name === 'settings' ? settings : undefined
+    },
+  }
+  const wrapped = contextWithDelegatedReplay(ctx)
+
+  // Core-like wrapper. Like the real core it mirrors only the two DeepSeek
+  // ids from the (stale) relay catalog, and appends config-driven composite
+  // rows only when whole-turn routing is on. It deliberately leaks a stray
+  // non-composite Kimi row to prove the boundary drops it.
+  const coreWrapper = {
+    async listModels() {
+      const rows = [
+        { provider: 'deepseek-vision', id: 'deepseek-v4-pro', name: 'DeepSeek V4 Pro', inputModalities: ['text', 'image'] },
+        { provider: 'deepseek-vision', id: 'deepseek-v4-flash', name: 'DeepSeek V4 Flash', inputModalities: ['text', 'image'] },
+      ]
+      if (routingEnabled) {
+        rows.push(
+          {
+            provider: 'deepseek-vision',
+            id: 'zhipu/glm-4.6v-flash',
+            name: 'zhipu/glm-4.6v-flash（视觉）',
+            inputModalities: ['text', 'image'],
+          },
+          { provider: 'deepseek-vision', id: 'k3', name: 'Kimi K3', inputModalities: ['text', 'image'] },
+        )
+      }
+      return rows
+    },
+    async resolveModel(_provider, model) {
+      return { provider: 'deepseek-vision', id: model, name: model, inputModalities: ['text', 'image'] }
+    },
+    providerRetryPolicy() {
+      return 'deepseek-retry'
+    },
+    async *stream(options) {
+      yield* wrapped.llm.stream(options)
+    },
+  }
+  wrapped.llm.registerAdapter(['deepseek-vision'], coreWrapper)
+
+  // routing=false: pinned official DeepSeek only, no composite noise.
+  const listedOff = await registeredAdapter.listModels('deepseek-vision')
+  assert.deepEqual(listedOff.map((model) => model.id), ['deepseek-v4-pro', 'deepseek-v4-flash'])
+  assert.ok(listedOff.every((model) => model.provider === 'deepseek-vision'))
+  assert.ok(listedOff.every((model) => model.inputModalities.includes('image')))
+
+  // routing=true: the authorized composite row joins the pinned mirrors; the
+  // stray non-composite Kimi row and any DSH-only provider never appear.
+  routingEnabled = true
+  const listedOn = await registeredAdapter.listModels('deepseek-vision')
+  const idsOn = listedOn.map((model) => model.id)
+  assert.ok(idsOn.includes('deepseek-v4-pro') && idsOn.includes('deepseek-v4-flash'))
+  assert.ok(idsOn.includes('zhipu/glm-4.6v-flash'), 'authorized composite row kept')
+  assert.ok(!idsOn.includes('k3'), 'stray non-composite row dropped')
+  assert.ok(!idsOn.some((id) => id.includes('kimi') || id.includes('xiaomi')), 'DSH-only providers never listed')
+
+  // P0 surface stays intact during a vision tool call: host-wide discovery is
+  // hidden, and an unauthorized DSH system model cannot produce a network call.
+  wrapped.tools.register({
+    name: 'vision_describe',
+    async execute() {
+      assert.deepEqual(wrapped.llm.listProviders(), [], 'host catalog hidden inside a vision tool')
+      await assert.rejects(
+        (async () => {
+          for await (const _chunk of wrapped.llm.stream({ provider: 'kimi-coding', model: 'k3', messages: [] })) {
+            // drain
+          }
+        })(),
+        (error) => error && error.code === 'NO_ADAPTER',
+        'unauthorized system model must be denied at the stream gate',
+      )
+    },
+  })
+  await registeredTools.get('vision_describe').execute()
+  assert.equal(networkCalls.length, 0, 'no network call for DSH-only providers')
+})
+
 test('hidden native DeepSeek route owns the main wrapper regardless of textProvider', async () => {
   const harness = liveWrapperHarness({ initialProvider: 'relay-openai', native: true })
   await harness.drain({ reasoningEffort: 'high' })

--- a/tests/wrapper-directory.test.js
+++ b/tests/wrapper-directory.test.js
@@ -20,8 +20,11 @@ function fakeContext({
       settingsPath: [],
     },
   ],
+  registerError,
 } = {}) {
   const listeners = new Map()
+  const disposals = []
+  const warns = []
   const state = {
     visionConfig,
     liveProviders: [...liveProviders],
@@ -47,6 +50,7 @@ function fakeContext({
     },
     registerConfigurableProviders(entries) {
       state.registerCalls += 1
+      if (registerError) throw registerError
       state.ownedDirectory = entries.map((entry) => ({ ...entry, settingsPath: [...entry.settingsPath] }))
       // rc.7 emits this notification from the directory commit itself. The
       // helper must not recurse into a second registration.
@@ -79,10 +83,23 @@ function fakeContext({
       list.push(listener)
       listeners.set(name, list)
     },
-    logger: { warn() {} },
+    effect(factory) {
+      const cleanup = factory()
+      disposals.push(cleanup)
+      return () => {}
+    },
+    logger: { warn(message) { warns.push(message) } },
   }
 
-  return { ctx, state, emit }
+  return {
+    ctx,
+    state,
+    emit,
+    warns,
+    dispose() {
+      for (const cleanup of disposals.splice(0)) cleanup()
+    },
+  }
 }
 
 test('resolves DeepSeek + auto-vision as an alias of the official provider settings', () => {
@@ -179,4 +196,72 @@ test('is a no-op on older LLM runtimes without the configurable-provider directo
   }
   assert.doesNotThrow(() => installWrapperDirectoryAlias(ctx))
   assert.equal(resolveWrapperDirectoryEntry(ctx), undefined)
+})
+
+test('disposes the directory alias with the plugin fiber and stays inert afterwards', () => {
+  const { ctx, state, emit, dispose } = fakeContext()
+  installWrapperDirectoryAlias(ctx)
+  assert.equal(state.registerCalls, 1)
+  assert.equal(state.ownedDirectory.length, 1)
+
+  dispose()
+  assert.deepEqual(state.ownedDirectory, [])
+
+  state.visionConfig = { wrapperRoute: 'relay-auto-vision' }
+  state.liveProviders.push({ id: 'relay-auto-vision', name: 'DeepSeek + 自动识图' })
+  emit('settings/updated', 'vision-router', state.visionConfig, {}, 'update')
+
+  assert.equal(state.registerCalls, 1)
+  assert.equal(state.replaceCalls, 0)
+  assert.deepEqual(state.ownedDirectory, [])
+})
+
+test('re-registers cleanly after a fiber reload instead of freezing on the stale row', () => {
+  const { ctx, state, dispose } = fakeContext()
+  installWrapperDirectoryAlias(ctx)
+  dispose()
+
+  // Same context object, fresh install: the reloaded instance must see an
+  // empty directory (the old row was disposed with the fiber) and publish.
+  installWrapperDirectoryAlias(ctx)
+  assert.equal(state.registerCalls, 2)
+  assert.equal(state.ownedDirectory.length, 1)
+  assert.equal(state.ownedDirectory[0].provider, 'deepseek-vision')
+})
+
+test('withdrawal records the empty-state key and skips redundant replaces', () => {
+  const { ctx, state, emit } = fakeContext()
+  installWrapperDirectoryAlias(ctx)
+  assert.equal(state.ownedDirectory[0].provider, 'deepseek-vision')
+
+  // An external owner takes over a NEW route the settings now point at.
+  state.visionConfig = { wrapperRoute: 'relay-auto-vision' }
+  state.liveProviders.push({ id: 'relay-auto-vision', name: 'DeepSeek + 自动识图' })
+  state.sourceDirectory.push({
+    provider: 'relay-auto-vision',
+    displayName: 'External',
+    settingsNs: 'external-ns',
+    settingsPath: [],
+  })
+  emit('settings/updated', 'vision-router', state.visionConfig, {}, 'update')
+  assert.equal(state.replaceCalls, 1)
+  assert.deepEqual(state.ownedDirectory, [])
+
+  // The wrapper disappears entirely: the cached empty-state key must make
+  // this a no-op rather than a second redundant replace.
+  state.liveProviders = []
+  emit('llm/adapters-updated')
+  assert.equal(state.replaceCalls, 1)
+})
+
+test('deduplicates identical sync warnings across repeated adapter events', () => {
+  const error = new Error('already declared')
+  error.code = 'DUPLICATE_DIRECTORY'
+  const { ctx, emit, warns } = fakeContext({ registerError: error })
+  installWrapperDirectoryAlias(ctx)
+  emit('llm/adapters-updated')
+  emit('llm/adapters-updated')
+
+  assert.equal(warns.length, 1)
+  assert.match(warns[0], /Models-directory alias sync failed/)
 })


### PR DESCRIPTION
#191 pinned the DeepSeek + 自动识图 wrapper to official DeepSeek, but two things
got lost in the merge:

1. The wrapper's listModels intercept replaced the core listing wholesale, so
   whole-turn routing mode (routingEnabled) lost its config-driven composite
   picker rows ("provider/model（视觉）"). These rows come from routingPairs(),
   which is purely configuration-driven and was never part of the P0 leak
   surface.
2. The merge clobbered #189's Models-directory alias lifecycle fix (the hotfix
   branch predated it): the directory row leaked past plugin reloads again.

Changes:
- listModels now merges: pinned official/native DeepSeek mirrors PLUS only the
  core's composite vision rows (structurally `provider/model` ids, published by
  routingPairs when routing is enabled). Normal DeepSeek models continue to come
  exclusively from official/native DeepSeek, never from a stale textProvider;
  any non-composite row the core might emit is dropped.
- All #191 P0 boundaries stay intact: host-wide auto-discovery stays hidden
  during vision tool execution, the exact provider/model allowlist and the hard
  stream gate (NO_ADAPTER) are unchanged, and the direct-HTTP bridge cannot
  bypass them.
- The Models-directory alias lifecycle fix is restored: plugin-scoped ctx.effect
  disposal, post-dispose inertness, empty-state key consistency, and warning
  deduplication, with its four regression tests back.

Regression coverage: routing=false lists only official DeepSeek; routing=true
additionally lists the explicitly configured composite rows; DSH-only system
models (Kimi/Xiaomi) never appear in the listing and cannot produce network
calls inside a vision tool; the wrapper's normal model identity stays pinned to
official/native DeepSeek.
