### PR TITLE
fix: bind self-update to the active DSH profile

### DIFF
--- a/lib/self-update.js
+++ b/lib/self-update.js
@@ -1,6 +1,7 @@
 import { execFile } from 'node:child_process'
-import { existsSync, readFileSync, realpathSync } from 'node:fs'
+import { existsSync, readFileSync, readdirSync, realpathSync } from 'node:fs'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { promisify } from 'node:util'
 import { resolveDshHome } from './doctor.js'
 import { classifyProfilePnpmFailure } from './profile-pnpm-diagnostics.js'
@@ -8,6 +9,7 @@ import { CURRENT_VERSION, PACKAGE_NAME, compareSemver, parseSemver } from './upd
 
 const DSH_PACKAGE_NAME = '@deepseek-ai/dsh'
 const PROFILE_RE = /^[A-Za-z0-9._-]+$/
+const UNKNOWN_PROFILE = '<profile>'
 
 // Specifiers pnpm resolves outside the npm registry: git/hosted repos, local
 // paths, workspace links and tarballs. Those must keep `update` semantics;
@@ -31,22 +33,53 @@ function readPackageJson(file) {
   }
 }
 
-export function profileFromArgv(argv = process.argv) {
+function normalizedPath(value) {
+  const normalized = path.normalize(value)
+  return process.platform === 'win32' ? normalized.toLowerCase() : normalized
+}
+
+function samePath(a, b) {
+  return typeof a === 'string' && typeof b === 'string' && normalizedPath(a) === normalizedPath(b)
+}
+
+function modulePathOf(moduleEntry) {
+  if (moduleEntry instanceof URL) {
+    try {
+      return fileURLToPath(moduleEntry)
+    } catch {
+      return undefined
+    }
+  }
+  if (typeof moduleEntry !== 'string' || moduleEntry.trim() === '') return undefined
+  if (moduleEntry.startsWith('file:')) {
+    try {
+      return fileURLToPath(moduleEntry)
+    } catch {
+      return undefined
+    }
+  }
+  return moduleEntry
+}
+
+function profileArgState(argv = process.argv) {
   const list = Array.isArray(argv) ? argv : []
   for (let index = 2; index < list.length; index += 1) {
     const value = String(list[index] ?? '')
     if (value === '--profile') {
       const next = String(list[index + 1] ?? '')
-      return PROFILE_RE.test(next) ? next : undefined
+      return { present: true, profile: PROFILE_RE.test(next) ? next : undefined }
     }
     if (value.startsWith('--profile=')) {
       const next = value.slice('--profile='.length)
-      return PROFILE_RE.test(next) ? next : undefined
+      return { present: true, profile: PROFILE_RE.test(next) ? next : undefined }
     }
   }
-  // This updater is exposed by the Web settings card. When DSH did not pass
-  // an explicit --profile, use the documented Web profile default.
-  return 'web'
+  return { present: false, profile: undefined }
+}
+
+/** Return only an explicitly supplied --profile. Never guess a default. */
+export function profileFromArgv(argv = process.argv) {
+  return profileArgState(argv).profile
 }
 
 export function findDshPackageRoot(cliEntry, { maxParents = 12 } = {}) {
@@ -72,38 +105,174 @@ export function findDshPackageRoot(cliEntry, { maxParents = 12 } = {}) {
   return undefined
 }
 
+/** Resolve the package root that owns the currently executing updater module. */
+export function findPluginPackageRoot(moduleEntry, { maxParents = 12 } = {}) {
+  const modulePath = modulePathOf(moduleEntry)
+  const resolved = modulePath && safeRealpath(modulePath)
+  if (!resolved) return undefined
+  let directory = path.dirname(resolved)
+  for (let depth = 0; depth <= maxParents; depth += 1) {
+    const manifestPath = path.join(directory, 'package.json')
+    if (existsSync(manifestPath)) {
+      const manifest = readPackageJson(manifestPath)
+      if (manifest && manifest.name === PACKAGE_NAME) {
+        return {
+          packageRoot: directory,
+          manifestPath,
+          version: typeof manifest.version === 'string' ? manifest.version : undefined,
+        }
+      }
+    }
+    const parent = path.dirname(directory)
+    if (parent === directory) break
+    directory = parent
+  }
+  return undefined
+}
+
+function installedPluginRoot({ dshHome, profile }) {
+  if (!PROFILE_RE.test(String(profile ?? ''))) return undefined
+  const packageDir = path.join(dshHome, 'profiles', profile, 'node_modules', PACKAGE_NAME)
+  const manifest = readPackageJson(path.join(packageDir, 'package.json'))
+  if (!manifest || manifest.name !== PACKAGE_NAME) return undefined
+  return safeRealpath(packageDir)
+}
+
+/** True only when this profile's installed package resolves to the executing plugin root. */
+export function profileOwnsPlugin({ dshHome, profile, pluginRoot }) {
+  const installedRoot = installedPluginRoot({ dshHome, profile })
+  const runningRoot = safeRealpath(pluginRoot)
+  return installedRoot !== undefined && runningRoot !== undefined && samePath(installedRoot, runningRoot)
+}
+
+/**
+ * Infer the active profile from package ownership, not from the UI mode or a
+ * hard-coded `web` default. This follows pnpm symlinks by realpath, so it works
+ * for Web, Desktop, custom profiles and linked/workspace installs alike.
+ */
+export function inferProfileFromPluginPath({
+  dshHome = resolveDshHome(process.env),
+  moduleEntry = import.meta.url,
+} = {}) {
+  const plugin = findPluginPackageRoot(moduleEntry)
+  if (!plugin) return { ok: false, reason: 'plugin-root-unresolved' }
+
+  const profilesDir = path.join(dshHome, 'profiles')
+  let entries
+  try {
+    entries = readdirSync(profilesDir, { withFileTypes: true })
+  } catch {
+    return { ok: false, reason: 'profiles-unavailable', pluginRoot: plugin.packageRoot }
+  }
+
+  const matches = []
+  for (const entry of entries) {
+    if (!entry || !entry.isDirectory() || !PROFILE_RE.test(entry.name)) continue
+    if (profileOwnsPlugin({ dshHome, profile: entry.name, pluginRoot: plugin.packageRoot })) {
+      matches.push(entry.name)
+    }
+  }
+
+  if (matches.length === 1) {
+    return {
+      ok: true,
+      profile: matches[0],
+      pluginRoot: plugin.packageRoot,
+      pluginVersion: plugin.version,
+      source: 'plugin-path',
+    }
+  }
+  if (matches.length > 1) {
+    return {
+      ok: false,
+      reason: 'profile-ambiguous',
+      profiles: matches,
+      pluginRoot: plugin.packageRoot,
+    }
+  }
+  return {
+    ok: false,
+    reason: 'profile-not-owned',
+    pluginRoot: plugin.packageRoot,
+  }
+}
+
 /**
  * Detect whether the running process exposes a DSH CLI entry we can safely
  * re-use. This deliberately does not infer npm/pnpm/npx/bun: the updater calls
  * the exact DSH CLI package that is already running and lets DSH own plugin
  * installation semantics.
+ *
+ * The target profile is fail-closed: an explicit --profile must own the
+ * currently executing plugin package; without --profile we infer ownership by
+ * matching this module's real package root against every DSH profile. We never
+ * silently default to `web`.
  */
 export function detectDshSelfUpdatePlan({
   argv = process.argv,
   execPath = process.execPath,
+  env = process.env,
+  dshHome = resolveDshHome(env),
+  moduleEntry = import.meta.url,
 } = {}) {
+  const profileArg = profileArgState(argv)
+  if (profileArg.present && !profileArg.profile) {
+    return { available: false, reason: 'profile-unresolved', profile: UNKNOWN_PROFILE }
+  }
+
+  const inferred = inferProfileFromPluginPath({ dshHome, moduleEntry })
+  let profile
+  let profileSource
+  let pluginRoot = inferred.pluginRoot
+
+  if (profileArg.profile) {
+    const plugin = findPluginPackageRoot(moduleEntry)
+    pluginRoot = plugin?.packageRoot
+    if (!pluginRoot) {
+      return { available: false, reason: 'plugin-root-unresolved', profile: profileArg.profile }
+    }
+    if (!profileOwnsPlugin({ dshHome, profile: profileArg.profile, pluginRoot })) {
+      return {
+        available: false,
+        reason: 'profile-plugin-mismatch',
+        profile: profileArg.profile,
+        detectedProfile: inferred.ok === true ? inferred.profile : undefined,
+      }
+    }
+    profile = profileArg.profile
+    profileSource = 'argv+plugin-path'
+  } else if (inferred.ok === true) {
+    profile = inferred.profile
+    profileSource = inferred.source
+  } else {
+    return {
+      available: false,
+      reason: inferred.reason || 'profile-unresolved',
+      profile: UNKNOWN_PROFILE,
+      ...(Array.isArray(inferred.profiles) ? { detectedProfiles: inferred.profiles } : {}),
+    }
+  }
+
   const cliArg = Array.isArray(argv) ? argv[1] : undefined
   if (typeof cliArg !== 'string' || cliArg.trim() === '') {
-    return { available: false, reason: 'cli-entry-missing' }
+    return { available: false, reason: 'cli-entry-missing', profile }
   }
   const cliEntry = safeRealpath(cliArg)
-  if (!cliEntry) return { available: false, reason: 'cli-entry-unresolved' }
-  const profile = profileFromArgv(argv)
-  if (!profile) return { available: false, reason: 'profile-unresolved' }
+  if (!cliEntry) return { available: false, reason: 'cli-entry-unresolved', profile }
 
   // Running a raw TS/TSX source entry with plain Node may require a loader
   // owned by the source workspace. Do not guess that loader; fall back to the
-  // manual update instructions instead. Preserve the profile so the UI can
-  // print the exact pnpm command the user should run.
+  // manual update instructions instead. Preserve the verified profile so the
+  // UI can print the exact command the user should run.
   const extension = path.extname(cliEntry).toLowerCase()
   if (extension === '.ts' || extension === '.tsx') {
     return { available: false, reason: 'source-cli-needs-loader', profile }
   }
 
   const owner = findDshPackageRoot(cliEntry)
-  if (!owner) return { available: false, reason: 'unverified-dsh-cli' }
+  if (!owner) return { available: false, reason: 'unverified-dsh-cli', profile }
   if (typeof execPath !== 'string' || execPath.trim() === '') {
-    return { available: false, reason: 'node-entry-missing' }
+    return { available: false, reason: 'node-entry-missing', profile }
   }
 
   return {
@@ -112,6 +281,8 @@ export function detectDshSelfUpdatePlan({
     execPath,
     cliEntry,
     profile,
+    profileSource,
+    pluginRoot,
     dshVersion: owner.version,
     packageRoot: owner.packageRoot,
   }
@@ -220,6 +391,21 @@ export async function runDshPluginUpdate(plan, {
   if (!plan || plan.available !== true) {
     throw new Error(`automatic update unavailable (${plan?.reason || 'unknown reason'})`)
   }
+  if (!PROFILE_RE.test(String(plan.profile ?? ''))) {
+    throw new Error('automatic update aborted: the active DSH profile is not valid')
+  }
+  // Re-check ownership immediately before mutation. A profile can be replaced,
+  // relinked or repaired after startup; never let a stale plan update a profile
+  // that no longer owns the running plugin package.
+  if (
+    typeof plan.pluginRoot === 'string' &&
+    !profileOwnsPlugin({ dshHome, profile: plan.profile, pluginRoot: plan.pluginRoot })
+  ) {
+    throw new Error(
+      `automatic update aborted: profile "${plan.profile}" no longer owns the running ${PACKAGE_NAME} package`,
+    )
+  }
+
   const runner = execFileImpl || promisify(execFile)
   const target = typeof targetVersion === 'string' && parseSemver(targetVersion) !== undefined
     ? targetVersion.trim()
@@ -264,7 +450,7 @@ export async function runDshPluginUpdate(plan, {
   const stderr = typeof result?.stderr === 'string' ? result.stderr.trim() : ''
 
   // Exit code 0 does not prove the version moved (see above): verify the
-  // manifest pnpm actually materialized under the profile.
+  // manifest pnpm actually materialized under the SAME verified profile.
   const installedVersion = readInstalledPluginVersion({ dshHome, profile: plan.profile })
   const verification = updateTookEffect({
     installedVersion,

--- a/tests/self-update.test.js
+++ b/tests/self-update.test.js
@@ -6,7 +6,10 @@ import path from 'node:path'
 import {
   detectDshSelfUpdatePlan,
   findDshPackageRoot,
+  findPluginPackageRoot,
+  inferProfileFromPluginPath,
   profileFromArgv,
+  profileOwnsPlugin,
   runDshPluginUpdate,
   updateTookEffect,
 } from '../lib/self-update.js'
@@ -38,14 +41,19 @@ function profileFixture({
     path.join(profileDir, 'package.json'),
     JSON.stringify({ dependencies: { 'dsh-vision-router': dependencySpec } }),
   )
+  let pluginRoot
+  let moduleEntry
   if (withInstalledManifest) {
-    mkdirSync(path.join(profileDir, 'node_modules', 'dsh-vision-router'), { recursive: true })
+    pluginRoot = path.join(profileDir, 'node_modules', 'dsh-vision-router')
+    mkdirSync(path.join(pluginRoot, 'lib'), { recursive: true })
     writeFileSync(
-      path.join(profileDir, 'node_modules', 'dsh-vision-router', 'package.json'),
+      path.join(pluginRoot, 'package.json'),
       JSON.stringify({ name: 'dsh-vision-router', version: installedVersion }),
     )
+    moduleEntry = path.join(pluginRoot, 'lib', 'self-update.js')
+    writeFileSync(moduleEntry, '// fixture\n')
   }
-  return { dshHome }
+  return { dshHome, profileDir, pluginRoot, moduleEntry }
 }
 
 function planFor(cliEntry, profile = 'web') {
@@ -60,8 +68,8 @@ function planFor(cliEntry, profile = 'web') {
 
 const exitZero = async (_file, _args, _options) => ({ stdout: 'downloaded 0 / added 0\n', stderr: '' })
 
-test('profileFromArgv honors explicit profiles and defaults Web hosts to web', () => {
-  assert.equal(profileFromArgv(['node', 'dsh', 'web']), 'web')
+test('profileFromArgv honors only explicit profiles and never guesses web', () => {
+  assert.equal(profileFromArgv(['node', 'dsh', 'web']), undefined)
   assert.equal(profileFromArgv(['node', 'dsh', '--profile', 'custom-web', 'web']), 'custom-web')
   assert.equal(profileFromArgv(['node', 'dsh', '--profile=lab.1', 'web']), 'lab.1')
   assert.equal(profileFromArgv(['node', 'dsh', '--profile', '../bad', 'web']), undefined)
@@ -76,31 +84,126 @@ test('findDshPackageRoot only trusts an owning @deepseek-ai/dsh manifest', () =>
   assert.equal(findDshPackageRoot(unrelated.cliEntry), undefined)
 })
 
-test('detectDshSelfUpdatePlan reuses a verified packaged DSH CLI', () => {
+test('plugin package ownership identifies Desktop and custom profiles without argv hints', () => {
+  const desktop = profileFixture({ profile: 'desktop' })
+  assert.equal(findPluginPackageRoot(desktop.moduleEntry)?.packageRoot, realpathSync(desktop.pluginRoot))
+  assert.equal(
+    profileOwnsPlugin({
+      dshHome: desktop.dshHome,
+      profile: 'desktop',
+      pluginRoot: desktop.pluginRoot,
+    }),
+    true,
+  )
+  assert.deepEqual(
+    inferProfileFromPluginPath({ dshHome: desktop.dshHome, moduleEntry: desktop.moduleEntry }),
+    {
+      ok: true,
+      profile: 'desktop',
+      pluginRoot: realpathSync(desktop.pluginRoot),
+      pluginVersion: '1.4.0',
+      source: 'plugin-path',
+    },
+  )
+})
+
+test('detectDshSelfUpdatePlan infers the active Desktop profile instead of defaulting to web', () => {
   const { root, cliEntry } = fixture()
+  const desktop = profileFixture({ profile: 'desktop' })
   const plan = detectDshSelfUpdatePlan({
     argv: ['/usr/bin/node', cliEntry, 'web'],
     execPath: '/usr/bin/node',
+    dshHome: desktop.dshHome,
+    moduleEntry: desktop.moduleEntry,
   })
   assert.equal(plan.available, true)
   assert.equal(plan.method, 'current-dsh-cli')
   assert.equal(plan.cliEntry, realpathSync(cliEntry))
   assert.equal(plan.packageRoot, realpathSync(root))
-  assert.equal(plan.profile, 'web')
+  assert.equal(plan.profile, 'desktop')
+  assert.equal(plan.profileSource, 'plugin-path')
+  assert.equal(plan.pluginRoot, realpathSync(desktop.pluginRoot))
   assert.equal(plan.dshVersion, '0.1.0-rc.6')
 })
 
-test('detectDshSelfUpdatePlan refuses unverified or loader-dependent CLI entries', () => {
+test('detectDshSelfUpdatePlan accepts an explicit profile only when it owns this plugin', () => {
+  const { cliEntry } = fixture()
+  const custom = profileFixture({ profile: 'lab.1' })
+  const plan = detectDshSelfUpdatePlan({
+    argv: ['/usr/bin/node', cliEntry, '--profile=lab.1', 'web'],
+    execPath: '/usr/bin/node',
+    dshHome: custom.dshHome,
+    moduleEntry: custom.moduleEntry,
+  })
+  assert.equal(plan.available, true)
+  assert.equal(plan.profile, 'lab.1')
+  assert.equal(plan.profileSource, 'argv+plugin-path')
+
+  const mismatch = detectDshSelfUpdatePlan({
+    argv: ['/usr/bin/node', cliEntry, '--profile', 'web', 'web'],
+    execPath: '/usr/bin/node',
+    dshHome: custom.dshHome,
+    moduleEntry: custom.moduleEntry,
+  })
+  assert.equal(mismatch.available, false)
+  assert.equal(mismatch.reason, 'profile-plugin-mismatch')
+  assert.equal(mismatch.profile, 'web')
+  assert.equal(mismatch.detectedProfile, 'lab.1')
+})
+
+test('detectDshSelfUpdatePlan fails closed when profile ownership cannot be proven', () => {
+  const { cliEntry } = fixture()
+  const active = profileFixture({ profile: 'desktop' })
+  const otherHome = profileFixture({ profile: 'web' })
+  const plan = detectDshSelfUpdatePlan({
+    argv: ['/usr/bin/node', cliEntry, 'web'],
+    execPath: '/usr/bin/node',
+    dshHome: otherHome.dshHome,
+    moduleEntry: active.moduleEntry,
+  })
+  assert.equal(plan.available, false)
+  assert.equal(plan.reason, 'profile-not-owned')
+  // The settings UI will render a non-executable placeholder instead of a
+  // dangerously guessed `--profile web` command.
+  assert.equal(plan.profile, '<profile>')
+})
+
+test('detectDshSelfUpdatePlan preserves verified profiles on other safety failures', () => {
   const unrelated = fixture({ packageName: 'not-dsh' })
+  const active = profileFixture({ profile: 'desktop' })
   assert.deepEqual(
-    detectDshSelfUpdatePlan({ argv: ['node', unrelated.cliEntry, 'web'], execPath: 'node' }),
-    { available: false, reason: 'unverified-dsh-cli' },
+    detectDshSelfUpdatePlan({
+      argv: ['node', unrelated.cliEntry, 'web'],
+      execPath: 'node',
+      dshHome: active.dshHome,
+      moduleEntry: active.moduleEntry,
+    }),
+    { available: false, reason: 'unverified-dsh-cli', profile: 'desktop' },
   )
 
   const source = fixture({ entry: 'src/cli.ts' })
   assert.deepEqual(
-    detectDshSelfUpdatePlan({ argv: ['node', source.cliEntry, 'web'], execPath: 'node' }),
-    { available: false, reason: 'source-cli-needs-loader', profile: 'web' },
+    detectDshSelfUpdatePlan({
+      argv: ['node', source.cliEntry, 'web'],
+      execPath: 'node',
+      dshHome: active.dshHome,
+      moduleEntry: active.moduleEntry,
+    }),
+    { available: false, reason: 'source-cli-needs-loader', profile: 'desktop' },
+  )
+})
+
+test('detectDshSelfUpdatePlan rejects an invalid explicit profile instead of falling back', () => {
+  const { cliEntry } = fixture()
+  const active = profileFixture({ profile: 'desktop' })
+  assert.deepEqual(
+    detectDshSelfUpdatePlan({
+      argv: ['node', cliEntry, '--profile', '../web', 'web'],
+      execPath: 'node',
+      dshHome: active.dshHome,
+      moduleEntry: active.moduleEntry,
+    }),
+    { available: false, reason: 'profile-unresolved', profile: '<profile>' },
   )
 })
 
@@ -143,9 +246,35 @@ test('runDshPluginUpdate installs the confirmed target explicitly and verifies i
   assert.equal(invocation.options.windowsHide, true)
   assert.equal(invocation.options.env.TEST_ENV, '1')
   assert.equal(result.ok, true)
+  assert.equal(result.profile, 'custom-web')
   assert.equal(result.installedVersion, '1.4.0')
   assert.equal(result.verified, true)
   assert.equal(result.restartRequired, true)
+})
+
+test('runDshPluginUpdate re-checks profile ownership immediately before mutation', async () => {
+  const { cliEntry } = fixture()
+  const active = profileFixture({ profile: 'desktop', installedVersion: '1.4.0' })
+  let invoked = false
+  await assert.rejects(
+    () =>
+      runDshPluginUpdate(
+        {
+          ...planFor(cliEntry, 'desktop'),
+          pluginRoot: path.join(active.dshHome, 'not-the-running-plugin'),
+        },
+        {
+          dshHome: active.dshHome,
+          targetVersion: '1.4.0',
+          execFileImpl: async () => {
+            invoked = true
+            return { stdout: 'should not run', stderr: '' }
+          },
+        },
+      ),
+    /no longer owns the running dsh-vision-router package/,
+  )
+  assert.equal(invoked, false)
 })
 
 test('runDshPluginUpdate keeps update semantics without a target and verifies the move', async () => {


### PR DESCRIPTION
## What changed

- Removed the unsafe implicit `web` fallback from self-update profile detection.
- Infer the active profile by matching the currently executing `dsh-vision-router` package realpath against each DSH profile's installed package.
- Require explicit `--profile` values to actually own the running plugin package; fail closed on mismatches, invalid profiles, ambiguous ownership, or unknown layouts.
- Re-check profile ownership immediately before invoking the DSH plugin updater, protecting against profile relinks/replacements after startup.
- Keep post-update verification scoped to that same verified profile.
- Return `<profile>` when ownership cannot be proven so the settings UI cannot silently generate a `--profile web` recovery command.

## Root cause

The updater previously returned `web` whenever the DSH process did not include an explicit `--profile`. Desktop and custom-profile launches can omit that flag, so a one-click update could mutate `~/.dsh/profiles/web` while the running plugin actually came from `desktop` (or another profile). The UI then reported the target version as installed, but restarting the real profile could still load an older incompatible plugin and fail boot.

## Coverage

Regression tests cover:
- Desktop inference without `--profile`
- custom profiles
- explicit profile ownership and mismatch rejection
- unknown ownership fail-closed behavior
- invalid explicit profiles
- preserving a verified profile when the CLI itself is not safe for auto-update
- a second ownership check immediately before mutation
- existing target-version verification and pnpm release-age behavior
