### PR TITLE
fix: support DSH rc.6 and rc.7 contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,92 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm test
 
+  dsh-contract-smoke:
+    name: dsh contract / ${{ matrix.dsh }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - dsh: 0.1.0-rc.6
+            expectedRc7: 'false'
+          - dsh: 0.1.0-rc.7
+            expectedRc7: 'true'
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 11.20.0
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Prepare and pack plugin
+        shell: node {0}
+        run: |
+          require('node:fs').mkdirSync('tmp-pack', { recursive: true })
+      - run: pnpm pack --pack-destination tmp-pack
+      - name: Verify against released DSH contract
+        shell: node {0}
+        env:
+          DSH_VERSION: ${{ matrix.dsh }}
+          EXPECT_RC7: ${{ matrix.expectedRc7 }}
+        run: |
+          const fs = require('node:fs')
+          const path = require('node:path')
+          const { spawnSync } = require('node:child_process')
+          const { createRequire } = require('node:module')
+          const { pathToFileURL } = require('node:url')
+          ;(async () => {
+            const tgz = fs.readdirSync('tmp-pack').find((name) => name.endsWith('.tgz'))
+            if (!tgz) throw new Error('packed plugin tarball not found')
+            const tarball = path.resolve('tmp-pack', tgz).replaceAll('\\', '/')
+            const hostDir = path.join(process.env.RUNNER_TEMP, `dsh-contract-${process.env.DSH_VERSION}`)
+            fs.rmSync(hostDir, { recursive: true, force: true })
+            fs.mkdirSync(hostDir, { recursive: true })
+            const v = process.env.DSH_VERSION
+            fs.writeFileSync(path.join(hostDir, 'package.json'), JSON.stringify({
+              private: true,
+              type: 'module',
+              packageManager: 'pnpm@11.20.0',
+              dependencies: {
+                'dsh-vision-router': `file:${tarball}`,
+                '@deepseek-ai/dsh-attachment': v,
+                '@deepseek-ai/dsh-llm-deepseek': v,
+                '@deepseek-ai/dsh-anonymous-user-id': v,
+                '@deepseek-ai/dsh-settings': v,
+                '@deepseek-ai/dsh-llm': v,
+                sharp: '0.35.3',
+              },
+            }, null, 2))
+            const installed = spawnSync('pnpm', ['install'], {
+              cwd: hostDir,
+              stdio: 'inherit',
+            })
+            if (installed.status !== 0) process.exit(installed.status ?? 1)
+
+            const hostRequire = createRequire(path.join(hostDir, 'host-check.cjs'))
+            const pluginEntry = hostRequire.resolve('dsh-vision-router')
+            const attachmentEntry = hostRequire.resolve('@deepseek-ai/dsh-attachment')
+            const plugin = await import(pathToFileURL(pluginEntry).href)
+            const attachment = await import(pathToFileURL(attachmentEntry).href)
+            const store = Object.create(attachment.default.prototype)
+            const detected = plugin.isRc7ContractRuntime({
+              get(name) {
+                return name === 'attachments' ? store : undefined
+              },
+            })
+            const expected = process.env.EXPECT_RC7 === 'true'
+            console.log({ version: v, hasSaveImages: typeof store.saveImages === 'function', detected, expected })
+            if (detected !== expected) {
+              throw new Error(`contract detector misclassified DSH ${v}: expected rc7=${expected}, got ${detected}`)
+            }
+          })().catch((error) => {
+            console.error(error)
+            process.exit(1)
+          })
+
   native-host-sharp:
     name: host sharp / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/cordis.patch.yml
+++ b/cordis.patch.yml
@@ -4,9 +4,9 @@
 # without any manual cordis.patch.yml edits. Later layers (the profile's own
 # cordis.patch.yml, --patch overlays) override these rows by id.
 
-# 纯增量补丁（issue #34）：不碰核心行。官方 llm-deepseek 行保持原样，插件
-# 挂载后是否接管官方 deepseek-official 路由由设置里的「隐身模式」开关决定
-# （默认关；开启后需自行在 profile 补丁层禁用 llm-deepseek 行）。
+# 纯增量补丁（issue #34）：不碰核心行。DSH rc.6仍保留旧版隐身接管兼容路径；
+# DSH rc.7则始终由宿主拥有deepseek-official，插件只提供「+ 自动识图」包装路由。
+# 因此这里永远不默认禁用官方llm-deepseek行。
 
 # 挂载插件行。默认保持完整视觉工具表常驻（issue #81）：虽然渐进挂载可以
 # 少发一小段工具 schema，但图片轮首次扩展工具列表会改变请求前缀，可能让
@@ -17,10 +17,3 @@
       name: dsh-vision-router
       config:
         progressiveTools: false
-
-# 放宽附件图片限制（部署默认 5MB / 4000 万像素 → 20MB / 1 亿像素），
-# 大尺寸设计稿/扫描图可过审。字段可选，不需要可在 profile 补丁层覆写。
-- id: attachment-local
-  config:
-    maxImageBytes: 20971520
-    maxImagePixels: 100000000

--- a/entry.js
+++ b/entry.js
@@ -7,6 +7,7 @@
 // explicit opt-in rather than the implicit fallback.
 
 import z from '@deepseek-ai/schemastery'
+import { installSettingsSection, settingsNamespace } from '@deepseek-ai/dsh-settings'
 import * as core from './index.js'
 import { installVisionRouterFileLogging } from './lib/file-logger.js'
 import { contextWithDelegatedReplay } from './lib/replay-delegation.js'
@@ -14,6 +15,12 @@ import { installAdversarialHardening } from './lib/adversarial-hardening.js'
 import { installLocalVisionStabilizer } from './lib/local-vision-stabilizer.js'
 import { installWrapperDirectoryAlias } from './lib/wrapper-directory.js'
 import { installAndroidAttachmentCompat } from './lib/android-attachment-compat.js'
+import {
+  attachmentContextForContract,
+  installRc7SettingsCompatibility,
+  isRc7ContractRuntime,
+  protectRc7ProviderOwnership,
+} from './lib/dsh-contract-compat.js'
 
 // Schemastery object schemas expose set() as the supported way to replace a
 // field schema. This mutates the Config object that index.js itself later uses
@@ -22,7 +29,15 @@ import { installAndroidAttachmentCompat } from './lib/android-attachment-compat.
 core.Config.set('progressiveTools', z.boolean().default(false))
 
 export * from './index.js'
+export {
+  attachmentContextForContract,
+  installRc7SettingsCompatibility,
+  isRc7ContractRuntime,
+  protectRc7ProviderOwnership,
+} from './lib/dsh-contract-compat.js'
 export const Config = core.Config
+
+const SETTINGS_NS = settingsNamespace('vision-router')
 
 // Defense in depth for direct/programmatic callers that invoke apply() without
 // first running the Cordis Config resolver: only an explicit true enables the
@@ -58,11 +73,27 @@ export function apply(ctx, config = {}) {
     hardenedConfig,
     core,
   )
-  // #182: Android/Termux cannot open /data/data for the attachment-local
-  // durability walk. Keep this workaround private to Vision Router so the
-  // host attachment service and every non-Android runtime retain their normal
-  // semantics. Once DSH accepts the save, the compatibility path is inert.
-  const attachmentCompatCtx = installAndroidAttachmentCompat(stabilizedCtx, logging.logger)
+  const runtimeConfig = {
+    ...bootConfig,
+    progressiveTools: hardenedConfig.progressiveTools === true,
+  }
+  const rc7 = isRc7ContractRuntime(stabilizedCtx)
+  const ownershipCtx = rc7 ? protectRc7ProviderOwnership(stabilizedCtx) : stabilizedCtx
+  const settingsCtx = rc7
+    ? installRc7SettingsCompatibility(ownershipCtx, { ...runtimeConfig, stealth: false }, {
+        installSettingsSection,
+        namespace: SETTINGS_NS,
+        Config: core.Config,
+      })
+    : ownershipCtx
+  // rc.6/Termux keeps the narrow process-local fallback that was required by
+  // the old attachment-local durability walk. rc.7 formalizes AttachmentId as
+  // store-owned, so never synthesize one there: host persistence errors remain
+  // authoritative and diagnosable instead of creating a false durable ref.
+  const attachmentCompatCtx = attachmentContextForContract(settingsCtx, logging.logger, {
+    installAndroidAttachmentCompat,
+  })
+
   // 启动诊断摘要只描述 composition/apply 的基础配置。设置服务可能稍后
   // 覆盖这些值；每个图片轮还会记录 current() 的实时决策，避免把这个
   // 启动快照误当成最终设置状态。
@@ -71,7 +102,8 @@ export function apply(ctx, config = {}) {
     const local = c.localOllama && typeof c.localOllama === 'object' ? c.localOllama : {}
     const lms = c.localLmStudio && typeof c.localLmStudio === 'object' ? c.localLmStudio : {}
     logging.logger.info(
-      'vision-router: base config summary — instantDescribe=%s localDescribeStyle=%s localOllama=%s localLmStudio=%s',
+      'vision-router: base config summary — contract=%s instantDescribe=%s localDescribeStyle=%s localOllama=%s localLmStudio=%s',
+      rc7 ? 'rc7' : 'rc6',
       c.instantDescribe === true ? 'on' : 'off',
       c.localDescribeStyle === 'structured' ? 'structured' : 'plain',
       local.enabled === true ? 'on' : 'off',
@@ -81,16 +113,12 @@ export function apply(ctx, config = {}) {
     /* diagnostics must never break apply */
   }
   try {
-    const runtimeConfig = {
-      ...bootConfig,
-      progressiveTools: hardenedConfig.progressiveTools === true,
-    }
     const result = core.apply(attachmentCompatCtx, runtimeConfig)
     // DSH rc.7's Settings -> Models surface is backed by the configurable
     // provider directory, not by the live adapter registry alone. Publish the
     // main DeepSeek + 自动识图 route as a derived alias of official DeepSeek so
     // a reinstall restores the expected model-group row without making an
-    // arbitrary textProvider look like DeepSeek.
+    // arbitrary textProvider look like DeepSeek. On rc.6 the helper is inert.
     installWrapperDirectoryAlias(attachmentCompatCtx, runtimeConfig, logging.logger)
     if (result && typeof result.then === 'function') {
       return result.catch((error) => {

--- a/entry.js
+++ b/entry.js
@@ -7,7 +7,6 @@
 // explicit opt-in rather than the implicit fallback.
 
 import z from '@deepseek-ai/schemastery'
-import { installSettingsSection, settingsNamespace } from '@deepseek-ai/dsh-settings'
 import * as core from './index.js'
 import { installVisionRouterFileLogging } from './lib/file-logger.js'
 import { contextWithDelegatedReplay } from './lib/replay-delegation.js'
@@ -36,8 +35,6 @@ export {
   protectRc7ProviderOwnership,
 } from './lib/dsh-contract-compat.js'
 export const Config = core.Config
-
-const SETTINGS_NS = settingsNamespace('vision-router')
 
 // Defense in depth for direct/programmatic callers that invoke apply() without
 // first running the Cordis Config resolver: only an explicit true enables the
@@ -81,8 +78,7 @@ export function apply(ctx, config = {}) {
   const ownershipCtx = rc7 ? protectRc7ProviderOwnership(stabilizedCtx) : stabilizedCtx
   const settingsCtx = rc7
     ? installRc7SettingsCompatibility(ownershipCtx, { ...runtimeConfig, stealth: false }, {
-        installSettingsSection,
-        namespace: SETTINGS_NS,
+        namespace: 'vision-router',
         Config: core.Config,
       })
     : ownershipCtx

--- a/lib/dsh-contract-compat.js
+++ b/lib/dsh-contract-compat.js
@@ -1,12 +1,32 @@
 const RC7_OWNED_ROUTES = new Set(['deepseek-official', 'deepseek-official-native'])
 
+function attachmentStoreOf(ctx) {
+  if (!ctx || typeof ctx !== 'object') return undefined
+  try {
+    if (typeof ctx.get === 'function') {
+      const store = ctx.get('attachments')
+      if (store && typeof store === 'object') return store
+    }
+  } catch {
+    // A detached/partial test context may not expose the service yet.
+  }
+  try {
+    const store = ctx.attachments
+    return store && typeof store === 'object' ? store : undefined
+  } catch {
+    return undefined
+  }
+}
+
 /**
- * DSH rc.7 added the configurable-provider directory used by Settings -> Models.
- * Older rc.6 runtimes do not expose this seam. Capability detection is more
- * reliable than parsing package versions for source builds and patched hosts.
+ * Distinguish the released rc.6/rc.7 attachment contracts, not incidental
+ * LLM capabilities. rc.6 already shipped registerConfigurableProviders(), so
+ * that method cannot identify rc.7. rc.7's AttachmentStore adds saveImages()
+ * while rc.6 exposes only validateImage/saveImage/readImage.
  */
 export function isRc7ContractRuntime(ctx) {
-  return !!ctx?.llm && typeof ctx.llm.registerConfigurableProviders === 'function'
+  const store = attachmentStoreOf(ctx)
+  return !!store && typeof store.saveImages === 'function'
 }
 
 /**
@@ -152,8 +172,9 @@ export function installRc7SettingsCompatibility(ctx, entryConfig, options = {}) 
 }
 
 /**
- * rc.6 keeps the narrow Termux fallback. rc.7 formalizes AttachmentId as
- * store-owned, so the host context must pass through untouched there.
+ * rc.6 keeps the narrow Termux fallback. rc.7's batch-capable attachment
+ * service keeps AttachmentId store-owned, so the host context passes through
+ * untouched there.
  */
 export function attachmentContextForContract(ctx, logger, options = {}) {
   if (isRc7ContractRuntime(ctx)) return ctx

--- a/lib/dsh-contract-compat.js
+++ b/lib/dsh-contract-compat.js
@@ -45,17 +45,37 @@ export function protectRc7ProviderOwnership(ctx) {
 }
 
 /**
- * Bridge rc.7's public installSettingsSection helper to core's rc.6-shaped
+ * The common rc.6/rc.7 SettingsProvider service is the stable public seam.
+ * This helper mirrors installSettingsSection's attach/detach semantics without
+ * forcing a new package-resolution edge into older rc.6 profiles.
+ */
+export function installSettingsSectionCompat(ctx, namespace, Config, entryConfig, hooks) {
+  hooks.setSource(() => entryConfig)
+  ctx.inject(['settings'], (sctx) => {
+    const scope = sctx.settings.register(namespace, Config, { base: entryConfig })
+    hooks.setSource(() => scope.get())
+    hooks.onChange()
+    const disposeWatch = scope.watch(() => hooks.onChange())
+    sctx.effect(
+      () => () => {
+        if (typeof disposeWatch === 'function') disposeWatch()
+        hooks.setSource(() => entryConfig)
+        hooks.onChange()
+      },
+      'vision-router: rc7 settings compatibility source',
+    )
+  })
+}
+
+/**
+ * Bridge rc.7's public settings-section semantics to core's rc.6-shaped
  * `ctx.inject(['settings']) -> settings.register()` callback. The stored rc.6
  * `stealth` flag is masked on rc.7 because provider takeover is not supported.
  */
 export function installRc7SettingsCompatibility(ctx, entryConfig, options = {}) {
-  const install = options.installSettingsSection
+  const install = options.installSettingsSection ?? installSettingsSectionCompat
   const ns = options.namespace
   const Config = options.Config
-  if (typeof install !== 'function') {
-    throw new TypeError('vision-router: rc7 settings compatibility requires installSettingsSection')
-  }
   if (Config === undefined) {
     throw new TypeError('vision-router: rc7 settings compatibility requires Config')
   }

--- a/lib/dsh-contract-compat.js
+++ b/lib/dsh-contract-compat.js
@@ -1,0 +1,143 @@
+const RC7_OWNED_ROUTES = new Set(['deepseek-official', 'deepseek-official-native'])
+
+/**
+ * DSH rc.7 added the configurable-provider directory used by Settings -> Models.
+ * Older rc.6 runtimes do not expose this seam. Capability detection is more
+ * reliable than parsing package versions for source builds and patched hosts.
+ */
+export function isRc7ContractRuntime(ctx) {
+  return !!ctx?.llm && typeof ctx.llm.registerConfigurableProviders === 'function'
+}
+
+/**
+ * Preserve rc.7 provider ownership: Vision Router may wrap/delegate the
+ * official provider, but cannot synthesize or replace it. Other adapters pass
+ * through unchanged.
+ */
+export function protectRc7ProviderOwnership(ctx) {
+  if (!ctx || typeof ctx !== 'object' || !ctx.llm || typeof ctx.llm !== 'object') return ctx
+  const llm = new Proxy(ctx.llm, {
+    get(target, property) {
+      if (property === 'registerAdapter') {
+        return (routes, adapter) => {
+          const list = Array.isArray(routes) ? routes : [routes]
+          if (list.some((route) => RC7_OWNED_ROUTES.has(String(route)))) {
+            const error = new Error(
+              'vision-router: DSH rc.7 owns deepseek-official; use the auto-vision wrapper instead of provider takeover',
+            )
+            error.code = 'DSH_RC7_PROVIDER_OWNERSHIP'
+            throw error
+          }
+          return target.registerAdapter(routes, adapter)
+        }
+      }
+      const value = Reflect.get(target, property, target)
+      return typeof value === 'function' ? value.bind(target) : value
+    },
+  })
+  return new Proxy(ctx, {
+    get(target, property) {
+      if (property === 'llm') return llm
+      const value = Reflect.get(target, property, target)
+      return typeof value === 'function' ? value.bind(target) : value
+    },
+  })
+}
+
+/**
+ * Bridge rc.7's public installSettingsSection helper to core's rc.6-shaped
+ * `ctx.inject(['settings']) -> settings.register()` callback. The stored rc.6
+ * `stealth` flag is masked on rc.7 because provider takeover is not supported.
+ */
+export function installRc7SettingsCompatibility(ctx, entryConfig, options = {}) {
+  const install = options.installSettingsSection
+  const ns = options.namespace
+  const Config = options.Config
+  if (typeof install !== 'function') {
+    throw new TypeError('vision-router: rc7 settings compatibility requires installSettingsSection')
+  }
+  if (Config === undefined) {
+    throw new TypeError('vision-router: rc7 settings compatibility requires Config')
+  }
+
+  let activeSource = () => ({ ...entryConfig, stealth: false })
+  const watchers = new Set()
+
+  install(ctx, ns, Config, entryConfig, {
+    setSource(source) {
+      activeSource = () => {
+        const value = typeof source === 'function' ? source() : source
+        if (!value || typeof value !== 'object') return { ...entryConfig, stealth: false }
+        return { ...value, stealth: false }
+      }
+    },
+    onChange() {
+      const next = activeSource()
+      for (const watcher of [...watchers]) {
+        try {
+          watcher(next, undefined)
+        } catch {
+          // Settings observer failures are isolated by the host as well.
+        }
+      }
+    },
+  })
+
+  const scope = {
+    get() {
+      return activeSource()
+    },
+    watch(callback) {
+      if (typeof callback !== 'function') return () => {}
+      watchers.add(callback)
+      return () => watchers.delete(callback)
+    },
+  }
+  const settingsFacade = {
+    register(namespace) {
+      if (namespace !== 'vision-router') {
+        throw new Error(`vision-router: unexpected settings namespace ${String(namespace)}`)
+      }
+      return scope
+    },
+  }
+
+  return new Proxy(ctx, {
+    get(target, property) {
+      if (property === 'inject') {
+        return (dependencies, callback) => {
+          if (
+            Array.isArray(dependencies) &&
+            dependencies.length === 1 &&
+            dependencies[0] === 'settings' &&
+            typeof callback === 'function'
+          ) {
+            const settingsCtx = new Proxy(target, {
+              get(inner, key) {
+                if (key === 'settings') return settingsFacade
+                const value = Reflect.get(inner, key, inner)
+                return typeof value === 'function' ? value.bind(inner) : value
+              },
+            })
+            callback(settingsCtx)
+            return undefined
+          }
+          return target.inject(dependencies, callback)
+        }
+      }
+      const value = Reflect.get(target, property, target)
+      return typeof value === 'function' ? value.bind(target) : value
+    },
+  })
+}
+
+/**
+ * rc.6 keeps the narrow Termux fallback. rc.7 formalizes AttachmentId as
+ * store-owned, so the host context must pass through untouched there.
+ */
+export function attachmentContextForContract(ctx, logger, options = {}) {
+  if (isRc7ContractRuntime(ctx)) return ctx
+  const install = options.installAndroidAttachmentCompat
+  if (typeof install !== 'function') return ctx
+  return install(ctx, logger, options.android)
+}

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "presets"
   ],
   "engines": {
-    "node": ">=22"
+    "node": "^22.19.0 || >=24.0.0"
   },
   "packageManager": "pnpm@11.20.0",
   "keywords": [
@@ -56,6 +56,7 @@
   "peerDependencies": {
     "@deepseek-ai/dsh-anonymous-user-id": "^0.1.0-rc.6",
     "@deepseek-ai/dsh-llm-deepseek": "^0.1.0-rc.6",
+    "@deepseek-ai/dsh-settings": "^0.1.0-rc.6",
     "sharp": ">=0.35.3 <1"
   },
   "peerDependenciesMeta": {
@@ -63,6 +64,9 @@
       "optional": true
     },
     "@deepseek-ai/dsh-llm-deepseek": {
+      "optional": true
+    },
+    "@deepseek-ai/dsh-settings": {
       "optional": true
     },
     "sharp": {
@@ -75,7 +79,7 @@
     "sharp": "^0.35.3"
   },
   "scripts": {
-    "test": "node --test tests/core.test.js tests/capability-advisory.test.js tests/vision-resilience.test.js tests/client.test.js tests/http-compat.test.js tests/catalog-corrections.test.js tests/update-check.test.js tests/self-update.test.js tests/doctor.test.js tests/doctor-cli.test.js tests/profile-pnpm-diagnostics.test.js tests/bundle-defaults.test.js tests/file-logger.test.js tests/replay-delegation.test.js tests/adversarial-hardening.test.js tests/wrapper-directory.test.js tests/logging-ui.test.js tests/manifest-dependencies.test.js tests/structured-bootstrap.test.js tests/structured-bootstrap-gate.test.js tests/local-ollama.test.js tests/zero-regression-gate.test.js tests/runtime-e2e.test.js tests/local-vision-stabilizer.test.js tests/local-connection-probe.test.js tests/repetition-guard.test.js tests/guide-scroll-gate.test.js tests/android-attachment-compat.test.js tests/free-cloud-first.test.js"
+    "test": "node --test tests/core.test.js tests/capability-advisory.test.js tests/vision-resilience.test.js tests/client.test.js tests/http-compat.test.js tests/catalog-corrections.test.js tests/update-check.test.js tests/self-update.test.js tests/doctor.test.js tests/doctor-cli.test.js tests/profile-pnpm-diagnostics.test.js tests/bundle-defaults.test.js tests/file-logger.test.js tests/replay-delegation.test.js tests/adversarial-hardening.test.js tests/wrapper-directory.test.js tests/logging-ui.test.js tests/manifest-dependencies.test.js tests/structured-bootstrap.test.js tests/structured-bootstrap-gate.test.js tests/local-ollama.test.js tests/zero-regression-gate.test.js tests/runtime-e2e.test.js tests/local-vision-stabilizer.test.js tests/local-connection-probe.test.js tests/repetition-guard.test.js tests/guide-scroll-gate.test.js tests/android-attachment-compat.test.js tests/free-cloud-first.test.js tests/rc6-rc7-compat.test.js"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
   "peerDependencies": {
     "@deepseek-ai/dsh-anonymous-user-id": "^0.1.0-rc.6",
     "@deepseek-ai/dsh-llm-deepseek": "^0.1.0-rc.6",
-    "@deepseek-ai/dsh-settings": "^0.1.0-rc.6",
     "sharp": ">=0.35.3 <1"
   },
   "peerDependenciesMeta": {
@@ -64,9 +63,6 @@
       "optional": true
     },
     "@deepseek-ai/dsh-llm-deepseek": {
-      "optional": true
-    },
-    "@deepseek-ai/dsh-settings": {
       "optional": true
     },
     "sharp": {

--- a/tests/rc6-rc7-compat.test.js
+++ b/tests/rc6-rc7-compat.test.js
@@ -8,16 +8,35 @@ import {
   protectRc7ProviderOwnership,
 } from '../lib/dsh-contract-compat.js'
 
-test('contract detection distinguishes rc6 from rc7 by the configurable-provider directory seam', () => {
-  assert.equal(isRc7ContractRuntime({ llm: {} }), false)
-  assert.equal(isRc7ContractRuntime({ llm: { registerConfigurableProviders() {} } }), true)
+function runtimeWithAttachments(attachments, llm = {}) {
+  return {
+    llm,
+    get(name) {
+      return name === 'attachments' ? attachments : undefined
+    },
+  }
+}
+
+test('contract detection follows the released attachment API, not the pre-rc7 LLM directory', () => {
+  // Official rc.6 already shipped registerConfigurableProviders(); using that
+  // as a version probe would incorrectly route every rc.6 host through rc.7.
+  const rc6 = runtimeWithAttachments(
+    { saveImage() {}, readImage() {}, validateImage() {} },
+    { registerConfigurableProviders() {} },
+  )
+  const rc7 = runtimeWithAttachments(
+    { saveImage() {}, saveImages() {}, readImage() {}, validateImage() {} },
+    { registerConfigurableProviders() {} },
+  )
+  assert.equal(isRc7ContractRuntime(rc6), false)
+  assert.equal(isRc7ContractRuntime(rc7), true)
+  assert.equal(isRc7ContractRuntime({ llm: { registerConfigurableProviders() {} } }), false)
 })
 
 test('rc7 provider ownership blocks only synthetic official routes', () => {
   const registered = []
   const ctx = {
     llm: {
-      registerConfigurableProviders() {},
       registerAdapter(routes, adapter) {
         registered.push({ routes, adapter })
         return () => {}
@@ -90,8 +109,8 @@ test('rc7 settings bridge uses the common public SettingsProvider seam and masks
 })
 
 test('attachment compatibility remains rc6-only and rc7 keeps host-owned refs', () => {
-  const rc6 = { llm: {} }
-  const rc7 = { llm: { registerConfigurableProviders() {} } }
+  const rc6 = runtimeWithAttachments({ saveImage() {}, readImage() {}, validateImage() {} })
+  const rc7 = runtimeWithAttachments({ saveImage() {}, saveImages() {}, readImage() {}, validateImage() {} })
   let installs = 0
   const installAndroidAttachmentCompat = (ctx) => {
     installs += 1
@@ -102,6 +121,16 @@ test('attachment compatibility remains rc6-only and rc7 keeps host-owned refs', 
   assert.equal(wrappedRc6.compat, true)
   assert.equal(wrappedRc7, rc7)
   assert.equal(installs, 1)
+})
+
+test('settings card registration is a structural superset of rc6 list and rc7 keyed slots', async () => {
+  const source = await readFile(new URL('../lib/client.js', import.meta.url), 'utf8')
+  const block = source.match(/name: 'settings\.plugin\.item',[\s\S]{0,260}VisionRouterCardMemoized/)
+  assert.ok(block, 'settings.plugin.item registration must exist')
+  assert.match(block[0], /key: 'vision-router'/)
+  assert.match(block[0], /id: 'vision-router'/)
+  // rc.7 only requires key; rc.6 only requires id. The slot runtime ignores
+  // the non-applicable extra metadata rather than rejecting it.
 })
 
 test('manifest keeps the rc6 host peers and does not add an rc7-only package edge', async () => {

--- a/tests/rc6-rc7-compat.test.js
+++ b/tests/rc6-rc7-compat.test.js
@@ -38,39 +38,55 @@ test('rc7 provider ownership blocks only synthetic official routes', () => {
   )
 })
 
-test('rc7 settings bridge uses the public helper, masks legacy stealth, and preserves live updates', () => {
-  let hooks
-  let registeredNs
+test('rc7 settings bridge uses the common public SettingsProvider seam and masks legacy stealth', () => {
+  let value = { foo: 'user', stealth: true }
+  let serviceWatcher
   let observed
-  const ctx = {
-    inject() {
-      throw new Error('real settings inject must not be used on rc7')
+  let cleanup
+  const scope = {
+    get() {
+      return value
+    },
+    watch(callback) {
+      serviceWatcher = callback
+      return () => {
+        serviceWatcher = undefined
+      }
     },
   }
-  const wrapped = installRc7SettingsCompatibility(
-    ctx,
-    { foo: 'base', stealth: true },
-    {
-      Config: { name: 'fake-schema' },
-      namespace: 'vision-router',
-      installSettingsSection(_ctx, ns, _schema, _entry, nextHooks) {
-        registeredNs = ns
-        hooks = nextHooks
-        hooks.setSource(() => ({ foo: 'user', stealth: true }))
-      },
+  const ctx = {
+    inject(dependencies, callback) {
+      assert.deepEqual(dependencies, ['settings'])
+      callback({
+        settings: {
+          register(namespace, _Config, options) {
+            assert.equal(namespace, 'vision-router')
+            assert.deepEqual(options.base, { foo: 'base', stealth: true })
+            return scope
+          },
+        },
+        effect(factory) {
+          cleanup = factory()
+        },
+      })
     },
-  )
+  }
+  const wrapped = installRc7SettingsCompatibility(ctx, { foo: 'base', stealth: true }, {
+    Config: { name: 'fake-schema' },
+    namespace: 'vision-router',
+  })
   wrapped.inject(['settings'], (sctx) => {
-    const scope = sctx.settings.register('vision-router')
-    assert.deepEqual(scope.get(), { foo: 'user', stealth: false })
-    scope.watch((next) => {
+    const compatScope = sctx.settings.register('vision-router')
+    assert.deepEqual(compatScope.get(), { foo: 'user', stealth: false })
+    compatScope.watch((next) => {
       observed = next
     })
   })
-  assert.equal(registeredNs, 'vision-router')
-  hooks.setSource(() => ({ foo: 'changed', stealth: true }))
-  hooks.onChange()
+  value = { foo: 'changed', stealth: true }
+  serviceWatcher()
   assert.deepEqual(observed, { foo: 'changed', stealth: false })
+  cleanup()
+  assert.equal(serviceWatcher, undefined)
 })
 
 test('attachment compatibility remains rc6-only and rc7 keeps host-owned refs', () => {
@@ -88,13 +104,12 @@ test('attachment compatibility remains rc6-only and rc7 keeps host-owned refs', 
   assert.equal(installs, 1)
 })
 
-test('manifest keeps rc6 host peers while adding the rc6+ public settings seam', async () => {
+test('manifest keeps the rc6 host peers and does not add an rc7-only package edge', async () => {
   const pkg = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8'))
   assert.equal(pkg.engines.node, '^22.19.0 || >=24.0.0')
-  assert.equal(pkg.peerDependencies['@deepseek-ai/dsh-settings'], '^0.1.0-rc.6')
-  assert.equal(pkg.peerDependenciesMeta['@deepseek-ai/dsh-settings'].optional, true)
   assert.equal(pkg.peerDependencies['@deepseek-ai/dsh-llm-deepseek'], '^0.1.0-rc.6')
   assert.equal(pkg.peerDependencies['@deepseek-ai/dsh-anonymous-user-id'], '^0.1.0-rc.6')
+  assert.equal(pkg.peerDependencies['@deepseek-ai/dsh-settings'], undefined)
 })
 
 test('bundle patch no longer mutates host attachment-local limits', async () => {

--- a/tests/rc6-rc7-compat.test.js
+++ b/tests/rc6-rc7-compat.test.js
@@ -1,0 +1,103 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import {
+  attachmentContextForContract,
+  installRc7SettingsCompatibility,
+  isRc7ContractRuntime,
+  protectRc7ProviderOwnership,
+} from '../lib/dsh-contract-compat.js'
+
+test('contract detection distinguishes rc6 from rc7 by the configurable-provider directory seam', () => {
+  assert.equal(isRc7ContractRuntime({ llm: {} }), false)
+  assert.equal(isRc7ContractRuntime({ llm: { registerConfigurableProviders() {} } }), true)
+})
+
+test('rc7 provider ownership blocks only synthetic official routes', () => {
+  const registered = []
+  const ctx = {
+    llm: {
+      registerConfigurableProviders() {},
+      registerAdapter(routes, adapter) {
+        registered.push({ routes, adapter })
+        return () => {}
+      },
+    },
+  }
+  const wrapped = protectRc7ProviderOwnership(ctx)
+  const adapter = {}
+  wrapped.llm.registerAdapter(['vision-http'], adapter)
+  assert.deepEqual(registered, [{ routes: ['vision-http'], adapter }])
+  assert.throws(
+    () => wrapped.llm.registerAdapter(['deepseek-official-native'], {}),
+    (error) => error?.code === 'DSH_RC7_PROVIDER_OWNERSHIP',
+  )
+  assert.throws(
+    () => wrapped.llm.registerAdapter(['deepseek-official'], {}),
+    (error) => error?.code === 'DSH_RC7_PROVIDER_OWNERSHIP',
+  )
+})
+
+test('rc7 settings bridge uses the public helper, masks legacy stealth, and preserves live updates', () => {
+  let hooks
+  let registeredNs
+  let observed
+  const ctx = {
+    inject() {
+      throw new Error('real settings inject must not be used on rc7')
+    },
+  }
+  const wrapped = installRc7SettingsCompatibility(
+    ctx,
+    { foo: 'base', stealth: true },
+    {
+      Config: { name: 'fake-schema' },
+      namespace: 'vision-router',
+      installSettingsSection(_ctx, ns, _schema, _entry, nextHooks) {
+        registeredNs = ns
+        hooks = nextHooks
+        hooks.setSource(() => ({ foo: 'user', stealth: true }))
+      },
+    },
+  )
+  wrapped.inject(['settings'], (sctx) => {
+    const scope = sctx.settings.register('vision-router')
+    assert.deepEqual(scope.get(), { foo: 'user', stealth: false })
+    scope.watch((next) => {
+      observed = next
+    })
+  })
+  assert.equal(registeredNs, 'vision-router')
+  hooks.setSource(() => ({ foo: 'changed', stealth: true }))
+  hooks.onChange()
+  assert.deepEqual(observed, { foo: 'changed', stealth: false })
+})
+
+test('attachment compatibility remains rc6-only and rc7 keeps host-owned refs', () => {
+  const rc6 = { llm: {} }
+  const rc7 = { llm: { registerConfigurableProviders() {} } }
+  let installs = 0
+  const installAndroidAttachmentCompat = (ctx) => {
+    installs += 1
+    return { ...ctx, compat: true }
+  }
+  const wrappedRc6 = attachmentContextForContract(rc6, undefined, { installAndroidAttachmentCompat })
+  const wrappedRc7 = attachmentContextForContract(rc7, undefined, { installAndroidAttachmentCompat })
+  assert.equal(wrappedRc6.compat, true)
+  assert.equal(wrappedRc7, rc7)
+  assert.equal(installs, 1)
+})
+
+test('manifest keeps rc6 host peers while adding the rc6+ public settings seam', async () => {
+  const pkg = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8'))
+  assert.equal(pkg.engines.node, '^22.19.0 || >=24.0.0')
+  assert.equal(pkg.peerDependencies['@deepseek-ai/dsh-settings'], '^0.1.0-rc.6')
+  assert.equal(pkg.peerDependenciesMeta['@deepseek-ai/dsh-settings'].optional, true)
+  assert.equal(pkg.peerDependencies['@deepseek-ai/dsh-llm-deepseek'], '^0.1.0-rc.6')
+  assert.equal(pkg.peerDependencies['@deepseek-ai/dsh-anonymous-user-id'], '^0.1.0-rc.6')
+})
+
+test('bundle patch no longer mutates host attachment-local limits', async () => {
+  const patch = await readFile(new URL('../cordis.patch.yml', import.meta.url), 'utf8')
+  assert.doesNotMatch(patch, /^\s*- id:\s*attachment-local/m)
+})


### PR DESCRIPTION
## rc.6 + rc.7 compatibility pass

This PR is rebuilt from current `main`, so #177 (`freeCloudFirst` + OCR hardening), #200 (catalog refresh / partial provider failures), and later main behavior are preserved instead of being replaced by an older rc.7 copy of `index.js` / `lib/client.js`.

### Runtime split
The host-side version split is based on a **released attachment-contract difference**, not a guessed version string or the LLM configurable-provider directory:
- **rc.6** `AttachmentStore` exposes `validateImage` / `saveImage` / `readImage` and does **not** expose `saveImages`.
- **rc.7** adds `AttachmentStore.saveImages()`.

This matters because rc.6 already shipped `registerConfigurableProviders()`, so using that LLM method as an rc.7 probe would misclassify rc.6. A regression test now models that exact rc.6 shape.

Behavior:
- **DSH rc.6** keeps the existing compatibility behavior: legacy settings path, optional stealth takeover path, and the narrow Android/Termux process-local attachment fallback.
- **DSH rc.7**:
  - uses the public `SettingsProvider.register/get/watch` seam shared by both releases, with a compatibility bridge for live attach/detach semantics;
  - masks legacy `stealth` and blocks synthetic/replacement registration of `deepseek-official` / `deepseek-official-native`; the supported `+ Auto Vision` wrapper remains the integration path;
  - keeps `AttachmentId` store-owned and does not enable the rc.6 synthetic Android fallback;
  - continues publishing the wrapper through the configurable-provider directory used by the Models surface.

### Client slot compatibility
The existing settings-card registration intentionally carries both `key: 'vision-router'` and `id: 'vision-router'`:
- rc.6 declares `settings.plugin.item` as a **list** slot and requires `id`;
- rc.7 declares it as a **keyed** slot and requires `key`.
The slot runtime checks the required field for its own kind and ignores the non-applicable extra metadata, so the same client bundle works on both releases. This is pinned by a regression test.

### Packaging / host ownership
- keeps the rc.6 `dsh-llm-deepseek` and `dsh-anonymous-user-id` host peers, so the rc.6 compatibility path remains loadable;
- adds no rc.7-only package dependency;
- uses the Node range already required by the rc.6 DSH workspace as well as rc.7: `^22.19.0 || >=24.0.0`;
- stops globally overriding `attachment-local` image-admission limits from the plugin bundle.

### Regression safety
The compatibility split is isolated to `entry.js` + `lib/dsh-contract-compat.js`; `index.js` and `lib/client.js` stay on current-main behavior. The CI suite now also installs the packed plugin against the **actual published rc.6 and rc.7 package graphs**.

### Validation
CI run #595: ✅ all jobs green
- Node 22 full tests: ✅
- Node 24 full tests: ✅
- Ubuntu pack / host-sharp verification: ✅
- macOS pack / host-sharp verification: ✅
- Windows pack / host-sharp verification: ✅
- published DSH `0.1.0-rc.6` contract smoke: ✅ (`saveImages` absent → rc.6 path)
- published DSH `0.1.0-rc.7` contract smoke: ✅ (`saveImages` present → rc.7 path)

### Known host limitation
Current DSH `attachment-local` can still hit an inaccessible ancestor during its durability walk on **rc.7 Termux**. rc.7 intentionally does not hide that host failure by fabricating a process-local `AttachmentId`; rc.6 retains the existing narrow workaround. This is an upstream host limitation, not a remaining rc.6/rc.7 detection ambiguity in this PR.