### PR TITLE
fix: restore widened attachment limits (valid on both rc6 and rc7)

### DIFF
--- a/cordis.patch.yml
+++ b/cordis.patch.yml
@@ -17,3 +17,15 @@
       name: dsh-vision-router
       config:
         progressiveTools: false
+
+# 放宽附件图片限制（宿主默认 5MB / 4000 万像素 → 20MB / 1 亿像素），
+# 超长聊天记录截图（vision_long_screenshot_ocr 主场景）与大尺寸设计稿/
+# 扫描图可过宿主准入。rc6 与 rc7 的 @deepseek-ai/dsh-attachment-local
+# 均接受这两个可选字段（0.1.0-rc.6 / 0.1.0-rc.7 schema 已核对），且两边
+# dsh-base bundle 都存在 `- id: attachment-local` 行，因此该补丁在两个
+# 运行时上都有效、不破坏 host-neutral 原则；字段可选，不需要可在 profile
+# 补丁层覆写。
+- id: attachment-local
+  config:
+    maxImageBytes: 20971520
+    maxImagePixels: 100000000

--- a/tests/rc6-rc7-compat.test.js
+++ b/tests/rc6-rc7-compat.test.js
@@ -141,7 +141,14 @@ test('manifest keeps the rc6 host peers and does not add an rc7-only package edg
   assert.equal(pkg.peerDependencies['@deepseek-ai/dsh-settings'], undefined)
 })
 
-test('bundle patch no longer mutates host attachment-local limits', async () => {
+test('bundle patch widens attachment limits with fields valid on both rc6 and rc7', async () => {
   const patch = await readFile(new URL('../cordis.patch.yml', import.meta.url), 'utf8')
-  assert.doesNotMatch(patch, /^\s*- id:\s*attachment-local/m)
+  // Long chat-log screenshots (vision_long_screenshot_ocr) and large design
+  // files routinely exceed the host defaults (5MB / 40MP). Both rc6 and rc7
+  // ship `- id: attachment-local` in dsh-base and accept optional
+  // maxImageBytes/maxImagePixels overrides (verified against the released
+  // 0.1.0-rc.6 / 0.1.0-rc.7 schemas), so widening them here stays host-neutral.
+  assert.match(patch, /^\s*- id:\s*attachment-local/m)
+  assert.match(patch, /maxImageBytes:\s*20971520/)
+  assert.match(patch, /maxImagePixels:\s*100000000/)
 })


### PR DESCRIPTION
#198 removed the bundle-patch widening of host attachment limits
(5MB/40MP → 20MB/100MP) to keep the patch host-neutral across rc6/rc7.
That removal was over-cautious: long chat-log screenshots (the main
vision_long_screenshot_ocr workload) and large design files routinely exceed
the host defaults, and both runtimes still accept the override — verified
against the released schemas: dsh-base 0.1.0-rc.6/rc.7 both carry the
`- id: attachment-local` row, and dsh-attachment-local 0.1.0-rc.6/rc.7 both
declare optional maxImageBytes/maxImagePixels.

This restores the widening with the verification rationale in the patch
comment, and replaces the "patch no longer mutates host limits" regression
test with one asserting the restored rows are present and host-neutral.
