### PR TITLE
fix: guard twin-route sync against synchronous llm/adapters-updated re-entry

### DIFF
--- a/index.js
+++ b/index.js
@@ -3606,7 +3606,7 @@ export function apply(ctx, config = {}) {
       }),
     }
   }
-  const syncTwins = () => {
+  const syncTwinsInner = () => {
     const wanted = new Map()
     // Default path: every live non-router provider gets a twin. The source
     // route remains untouched, including native multimodal models; this adds a
@@ -3650,6 +3650,25 @@ export function apply(ctx, config = {}) {
           error && error.message ? error.message : String(error),
         )
       }
+    }
+  }
+  // DSH core 0.1.0-rc.7 (Desktop 2.0.1): ctx.llm.registerAdapter() commits and
+  // dispatches llm/adapters-updated SYNCHRONOUSLY, so the listener below
+  // re-enters this sync while the outer pass has not yet recorded the twin in
+  // twinHandles; the nested pass then re-registers the same `*-vision` route
+  // and the strict registry throws DUPLICATE_ADAPTER ("twin route ...
+  // registration failed" warnings at every boot). The flag collapses nested
+  // passes: the outer pass already covers its snapshot, and any topology
+  // change that happens mid-pass fires its own llm/adapters-updated after
+  // this pass completes.
+  let syncingTwins = false
+  const syncTwins = () => {
+    if (syncingTwins) return
+    syncingTwins = true
+    try {
+      syncTwinsInner()
+    } finally {
+      syncingTwins = false
     }
   }
   syncTwins()

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -1059,7 +1059,7 @@ test('stealth stream keeps the log intact and hands the model a tool-hint marker
 // plugin). These tests apply the full plugin against a harness-shaped mock
 // ctx, so ordering bugs inside apply() fail loudly here instead of at boot.
 
-function mockHarnessCtx({ stockRoute = false, config0 = {}, skills = false, attachments = false, opencodeGo = false } = {}) {
+function mockHarnessCtx({ stockRoute = false, config0 = {}, skills = false, attachments = false, opencodeGo = false, syncDispatch = false } = {}) {
   const adapters = new Map() // provider -> adapter
   const registrations = new Map() // provider -> { adapter, retryPolicy }
   const directories = [] // configurable-provider registrations (directory seam)
@@ -1204,6 +1204,13 @@ function mockHarnessCtx({ stockRoute = false, config0 = {}, skills = false, atta
           }
         }
         handle.replace = () => {}
+        // DSH core 0.1.0-rc.7 dispatches llm/adapters-updated synchronously
+        // from inside registerAdapter, before the caller can record the twin
+        // in its own bookkeeping. `syncDispatch` mirrors that, so re-entrancy
+        // bugs in syncTwins reproduce in tests instead of only at boot.
+        if (syncDispatch && captured.on.has('llm/adapters-updated')) {
+          captured.on.get('llm/adapters-updated')()
+        }
         return handle
       },
       registration(provider) {
@@ -1975,6 +1982,40 @@ test('twin sync is idempotent across llm/adapters-updated events', async () => {
   assert.ok(adapters.has('opencode-go-vision'))
   const listed = await adapters.get('opencode-go-vision').listModels('opencode-go-vision')
   assert.deepEqual(listed.map((m) => m.id), ['deepseek-v4-flash', 'deepseek-v4-pro'])
+})
+
+test('twin sync survives synchronous llm/adapters-updated re-entry (rc.7 semantics)', async () => {
+  // rc.7 registerAdapter commits and dispatches llm/adapters-updated
+  // synchronously, so the listener re-enters syncTwins while the outer pass
+  // has not recorded the twin in twinHandles yet; without the re-entrancy
+  // guard the nested pass re-registers the same *-vision route and the strict
+  // registry throws DUPLICATE_ADAPTER ("twin route ... registration failed").
+  const { ctx, adapters, captured } = mockHarnessCtx({ syncDispatch: true })
+  const warns = []
+  ctx.logger = { warn: (...args) => warns.push(args), info() {}, error() {} }
+  apply(ctx, Config({ autoWrapProviders: true }))
+  assert.ok(captured.on.has('llm/adapters-updated'), 'expected the adapters-updated listener')
+  const source = {
+    providerInfo: (p) => ({ id: p, name: 'Zhipu GLM' }),
+    providerRetryPolicy: () => 'retry',
+    listModels: async (p) => [
+      { provider: p, id: 'glm-4-flash', name: 'GLM-4-Flash', inputModalities: ['text'] },
+    ],
+    resolveModel: async (p, m) => ({
+      provider: p, id: m, name: m, inputModalities: ['text'], context: { contextWindow: 100000 },
+    }),
+    stream: async function* () {
+      yield { type: 'finish', reason: { kind: 'stop' } }
+    },
+  }
+  // registering the source synchronously re-enters syncTwins (rc.7 dispatch);
+  // the twin must still land exactly once with no duplicate-registration noise
+  ctx.llm.registerAdapter(['zhipu'], source)
+  assert.ok(adapters.has('zhipu-vision'), 'expected the zhipu-vision twin')
+  const failures = warns.filter((args) => String(args[0]).includes('registration failed'))
+  assert.deepEqual(failures, [], 'no twin registration failures expected under synchronous dispatch')
+  const twinListed = await adapters.get('zhipu-vision').listModels('zhipu-vision')
+  assert.deepEqual(twinListed.map((m) => m.id), ['glm-4-flash'])
 })
 
 test('apply falls back to the visible wrapper when the stock route is still active', async () => {


### PR DESCRIPTION
## 问题 / Problem

DSH core 0.1.0-rc.7（DSH Desktop 2.0.1）把 `ctx.llm.registerAdapter()` 的提交与 `llm/adapters-updated` 事件分发改为**同步**执行，并且对重复路由严格抛 `DUPLICATE_ADAPTER`（all-or-nothing）。`syncTwins` 在 `registerAdapter` 返回**之后**才把 twin 记入 `twinHandles`，而它又监听 `llm/adapters-updated` 触发自身重入——外层注册还没记账、重入的一轮已经看到"已注册"，再次注册同一 `*-vision` 路由即被拒绝。每次启动稳定复现 5 条警告：

```
twin route zhipu-vision registration failed: an adapter for provider "zhipu-vision" is already registered  (×2)
twin route agnes-vision registration failed: an adapter for provider "agnes-vision" is already registered    (×2)
twin route modlens-zhipu-vision registration failed: an adapter for provider "modlens-zhipu-vision" is already registered  (×1)
```

（provider 名按用户实际配置而定；重入级联的告警次数与上文一致。）twinHandles 记账被破坏后，每次拓扑/设置变化都会重试并再次告警。

## 修复 / Fix

给 `syncTwins` 加一层重入保护包装（`syncingTwins` 标志 + `try/finally`）：外层 pass 已覆盖自己的快照；pass 中途发生的任何拓扑变化，会在本轮结束后由它自己触发的 `llm/adapters-updated` 再驱动一轮，因此折叠嵌套 pass 不会丢事件。行为上完全保持原语义，仅消除重入导致的重复注册。

## 测试 / Tests

- 新增回归测试 `twin sync survives synchronous llm/adapters-updated re-entry (rc.7 semantics)`：给测试 harness 的 mock `ctx.llm.registerAdapter` 增加 `syncDispatch` 选项，模拟 rc.7 的同步事件分发；断言源路由注册后 twin 恰好落地一次、零 `registration failed` 告警。**该测试在未修复的 index.js 上失败，复现出与线上一致的警告；修复后通过。**
- 全量套件：438 项，432 通过、0 失败、6 跳过（Node 24 本地验证；CI 将再跑 Node 22/24）。

## 备注 / Notes

- 该修复同时适用于 1.4.5 与 1.6.0（两者 `syncTwins` 相同）。
- 补丁由 AI 辅助生成并经过上述回归测试验证；如有任何风格或设计偏好（例如改用 claim-first 记账方式），欢迎指正。
