### PR TITLE
fix: move depth tier and custom guidance into the main settings with user-friendly copy

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -231,16 +231,17 @@ window.__ModuleLoader__.load({
       numDownscaleMaxPixels: '图片像素上限',
       numCacheTtlSeconds: '缓存有效期（秒）',
       numCacheMaxEntries: '最大缓存数量',
-      selectVisionDepth: '看图深度档位',
-      guidanceOverridesLabel: '引导文案覆盖',
-      guidanceOverridesHint: '按类别（场景/内容）覆盖深挖引导文案；留空 = 使用内置引导。例如 document → "重点关注合同条款与签名"。',
-      guidanceOverridePlaceholder: '覆盖文案（留空使用内置）',
-      addGuidanceOverride: '+ 添加引导覆盖',
-      selectKind: '选择类别…',
-      visionDepthFast: 'fast（深挖最多 1 次）',
-      visionDepthStandard: 'standard（1-2 次，默认）',
-      visionDepthDeep: 'deep（2-4 次充分深挖）',
-      hintVisionDepth: '控制结构化预识别后的深挖深度：fast=深挖最多 1 次（最省）；standard=1-2 次（默认，与关闭时行为一致）；deep=2-4 次（充分深挖）。档位只定深度上限，具体问什么由模型按你的问题决定。',
+      selectVisionDepth: '看图深度',
+      groupDeepDive: '识图深度（可选）',
+      guidanceOverridesLabel: '自定义识图引导（可选）',
+      guidanceOverridesHint: '一般不需要设置。识图时默认按图片类型自动使用内置引导；你可以为某个图片类型（如文档、界面、人物）写一句自己的引导语，让视觉模型按你的要求细看。例如选「document（文档）」，填「重点关注合同条款与签名」。',
+      guidanceOverridePlaceholder: '输入自定义引导语（留空 = 使用内置）',
+      addGuidanceOverride: '+ 添加一条自定义引导',
+      selectKind: '选择图片类型…',
+      visionDepthFast: '快速（最多再细看 1 次）',
+      visionDepthStandard: '标准（细看 1-2 次，默认）',
+      visionDepthDeep: '细致（细看 2-4 次）',
+      hintVisionDepth: '选择看图时的精细度：快速最省（最多再细看 1 次）、标准为默认（细看 1-2 次）、细致看得最细（细看 2-4 次）。档位只限制「再细看几次」，具体看什么由模型按你的问题决定。',
       numHintTimeoutMs: '单个视觉请求超时；默认 120000。',
       numHintVisionTaskTimeoutMs: '一次识图任务（含全部 provider、回退与重试）共享的总时限；默认 45000。认证失败/限流会立即熔断对应后端。',
       numHintOcrTimeoutMs: '一次 OCR 任务的总时限；本地 tesseract 最多用 12 秒，视觉模型回退只用剩余部分；默认 30000。',
@@ -490,16 +491,17 @@ window.__ModuleLoader__.load({
       numDownscaleMaxPixels: 'Image pixel limit',
       numCacheTtlSeconds: 'Cache TTL (seconds)',
       numCacheMaxEntries: 'Maximum cached answers',
-      selectVisionDepth: 'Vision depth tier',
-      guidanceOverridesLabel: 'Guidance copy overrides',
-      guidanceOverridesHint: 'Override the deep-dive guidance copy per kind (scene or content). Empty = built-in guidance. E.g. document → "Focus on contract clauses and signatures."',
-      guidanceOverridePlaceholder: 'Override copy (empty = built-in)',
-      addGuidanceOverride: '+ Add guidance override',
-      selectKind: 'Select kind…',
-      visionDepthFast: 'fast (at most 1 deep-dive)',
-      visionDepthStandard: 'standard (1-2 calls, default)',
-      visionDepthDeep: 'deep (2-4 calls, thorough)',
-      hintVisionDepth: 'Controls how deep the deep-dive goes after the structured pre-scan: fast = at most 1 deep-dive call (cheapest); standard = 1-2 calls (default, identical to current behavior); deep = 2-4 calls (thorough). The tier only caps depth; what to ask is decided by the model based on your question.',
+      selectVisionDepth: 'Vision depth',
+      groupDeepDive: 'Deep-dive guidance (optional)',
+      guidanceOverridesLabel: 'Custom vision guidance (optional)',
+      guidanceOverridesHint: 'Usually nothing to set here. Vision uses built-in guidance per image type by default; you can write a custom guidance line for a specific type (e.g. document, UI, person) so the vision model looks the way you want. Example: pick "document（文档）" and enter "Focus on contract clauses and signatures."',
+      guidanceOverridePlaceholder: 'Enter custom guidance (empty = built-in)',
+      addGuidanceOverride: '+ Add a custom guidance line',
+      selectKind: 'Select image type…',
+      visionDepthFast: 'Quick (at most 1 more look)',
+      visionDepthStandard: 'Standard (1-2 looks, default)',
+      visionDepthDeep: 'Thorough (2-4 looks)',
+      hintVisionDepth: 'How thoroughly to look after the structured pre-scan: Quick is cheapest (at most 1 more look), Standard is the default (1-2 looks), Thorough looks the closest (2-4 looks). The tier only caps how many extra looks are allowed; what the model looks for is driven by your question.',
       numHintTimeoutMs: 'Per vision-call deadline; default 120000.',
       numHintVisionTaskTimeoutMs: 'One vision task (all providers, fallbacks and retries) shares this wall-clock budget; default 45000. Auth failures and rate limits trip their backend immediately.',
       numHintOcrTimeoutMs: 'Total budget for one OCR task: tesseract gets at most 12s, the vision fallback only the remainder; default 30000.',
@@ -2761,7 +2763,7 @@ window.__ModuleLoader__.load({
               : null,
         )
       }
-      // 引导文案覆盖编辑器：每行 [类别 select] [文案 input] [移除]，+ 添加。
+      // 自定义识图引导编辑器：每行 [图片类型 select] [引导语 input] [移除]，+ 添加。
       const GUIDANCE_KIND_OPTIONS = [
         { value: 'code', label: 'code（代码）' },
         { value: 'document', label: 'document（文档）' },
@@ -3553,6 +3555,20 @@ window.__ModuleLoader__.load({
                 ),
               ),
               TOGGLE_KEYS.map((key) => toggleField(key)),
+              // 深度档位与自定义引导只作用于结构化预识别流程：跟随该开关
+              // 显示在主设置区（而不是埋在「高级设置」里），用户开启后能
+              // 直接看到、不用翻折叠区。
+              format('structuredVisionBootstrap') === true
+                ? h('div', { className: 'vr-group' },
+                    h('p', { className: 'vr-group-title' }, t('groupDeepDive')),
+                    SELECT_KEYS.map((key) => selectField(key, t(LABEL_KEY[key]), t(HINT_KEY[key]), [
+                      { value: 'fast', label: t('visionDepthFast') },
+                      { value: 'standard', label: t('visionDepthStandard') },
+                      { value: 'deep', label: t('visionDepthDeep') },
+                    ])),
+                    guidanceOverridesEditor(),
+                  )
+                : null,
               // Local vision is a primary capability. Keep the heavy editors
               // collapsed by default, but make the entry obvious at a glance.
               h('div', {
@@ -3638,12 +3654,6 @@ window.__ModuleLoader__.load({
             h('p', { className: 'vr-group-title' }, t('groupPerformance')),
             PERFORMANCE_TOGGLE_KEYS.map((key) => toggleField(key)),
             NUMBER_KEYS.map((key) => textField(key, t(LABEL_KEY[key]), t(HINT_KEY[key]), false)),
-            SELECT_KEYS.map((key) => selectField(key, t(LABEL_KEY[key]), t(HINT_KEY[key]), [
-              { value: 'fast', label: t('visionDepthFast') },
-              { value: 'standard', label: t('visionDepthStandard') },
-              { value: 'deep', label: t('visionDepthDeep') },
-            ])),
-            guidanceOverridesEditor(),
           ),
           h('div', { className: 'vr-group' },
             h('p', { className: 'vr-group-title' }, t('groupCompatibility')),

--- a/tests/depth-tier.test.js
+++ b/tests/depth-tier.test.js
@@ -122,10 +122,18 @@ test('index.js integration: deep quota consumed only after evidence (mixed x dep
   assert.equal(index.includes('state.followupCompleted = true'), true) // 仍在，但移到产出证据分支内
 })
 
-test('client.js integration: visionDepth select rendered in Performance group', () => {
+test('client.js integration: visionDepth select and custom guidance live in the main deep-dive group', () => {
   const client = readFileSync(new URL('../lib/client.js', import.meta.url), 'utf8')
   assert.equal(client.includes("const SELECT_KEYS = ['visionDepth']"), true)
   assert.equal(client.includes('selectField(key, t(LABEL_KEY[key]), t(HINT_KEY[key]), ['), true)
-  assert.equal(client.includes("selectVisionDepth: '看图深度档位'"), true)
-  assert.equal(client.includes("selectVisionDepth: 'Vision depth tier'"), true)
+  assert.equal(client.includes("selectVisionDepth: '看图深度'"), true)
+  assert.equal(client.includes("selectVisionDepth: 'Vision depth'"), true)
+  assert.equal(client.includes("guidanceOverridesLabel: '自定义识图引导（可选）'"), true)
+  assert.equal(client.includes("guidanceOverridesLabel: 'Custom vision guidance (optional)'"), true)
+  // 深度档位与自定义引导跟随结构化预识别开关显示在主设置区（不埋在高级设置）。
+  assert.equal(
+    client.includes("format('structuredVisionBootstrap') === true\n                ? h('div', { className: 'vr-group' }"),
+    true,
+  )
+  assert.equal(client.includes("t('groupDeepDive')"), true)
 })


### PR DESCRIPTION
Two usability fixes for the #178 depth-guidance UI:

1. The "看图深度档位" (vision depth) selector and the guidance override
   editor were rendered inside the collapsed "高级设置 → 性能" group, so
   users could not find them. They are now shown in the main settings area,
   gated on the "结构化预识别" toggle (the features only apply to that
   flow), with a new "识图深度（可选）" group title.

2. The "引导文案覆盖" copy was jargon ("按类别（场景/内容）覆盖深挖引导
   文案"). Rewritten in plain language: "自定义识图引导（可选）" with a
   concrete example, friendlier option labels for the depth tier
   (快速/标准/细致 instead of fast/standard/deep), and clearer
   placeholders/buttons. Both zh and en strings updated.

Regression test updated to pin the new copy, the new location, and the
bootstrap-toggle gating.
