### PR TITLE
Harden first-batch adversarial runtime boundaries

### DIFF
--- a/lib/adapter-update-coalescer.js
+++ b/lib/adapter-update-coalescer.js
@@ -1,16 +1,31 @@
 const wrappedContexts = new WeakMap()
 
+export const DEFAULT_ADAPTER_RECONCILE_MAX_PASSES = 32
+
 /**
- * Turn a synchronous reconciliation pass into a fixed-point runner.
+ * Turn a synchronous reconciliation pass into a bounded fixed-point runner.
  *
  * Calling the returned function while a pass is already running never recurses.
  * Instead it marks the world dirty; the outer call immediately runs another
- * pass after the current one returns, repeating until no synchronous re-entry
- * occurred. This is deliberately a synchronous primitive because DSH rc.7
- * publishes llm/adapters-updated synchronously from registerAdapter().
+ * pass after the current one returns. The pass count is deliberately bounded:
+ * a foreign plugin or future host can emit llm/adapters-updated on every
+ * reconciliation attempt even when the topology never converges. Without a
+ * bound, one synchronous event can pin the Node process at 100% CPU forever.
+ *
+ * Hitting the bound fails open for availability: stop this reconciliation
+ * cycle, report the non-convergence, and let a later real topology event try
+ * again. Throwing here would turn another plugin's bad event semantics into a
+ * host-wide startup failure, which is worse than temporarily stale twins.
  */
-export function createCoalescingRunner(run) {
+export function createCoalescingRunner(run, options = {}) {
   if (typeof run !== 'function') throw new TypeError('createCoalescingRunner: run must be a function')
+
+  const maxPasses =
+    Number.isInteger(options.maxPasses) && options.maxPasses > 0
+      ? options.maxPasses
+      : DEFAULT_ADAPTER_RECONCILE_MAX_PASSES
+  const onNonConverging =
+    typeof options.onNonConverging === 'function' ? options.onNonConverging : undefined
 
   let running = false
   let dirty = false
@@ -25,12 +40,27 @@ export function createCoalescingRunner(run) {
 
     running = true
     let result
+    let passes = 0
     try {
       do {
         dirty = false
+        passes += 1
         result = run.apply(latestThis, latestArgs)
         if (result && typeof result.then === 'function') {
           throw new TypeError('createCoalescingRunner: asynchronous reconciliation is not supported')
+        }
+        if (dirty && passes >= maxPasses) {
+          // Consume the pathological re-entry marker so this invocation can
+          // return to the event loop. A later host event is still free to call
+          // the runner again from a clean state.
+          dirty = false
+          try {
+            onNonConverging?.({ passes, maxPasses, thisArg: latestThis, args: latestArgs })
+          } catch {
+            // Diagnostics must never recreate the availability failure this
+            // guard exists to prevent.
+          }
+          break
         }
       } while (dirty)
       return result
@@ -61,7 +91,22 @@ export function contextWithCoalescedAdapterUpdates(ctx) {
           if (event !== 'llm/adapters-updated' || typeof listener !== 'function') {
             return on.call(target, event, listener, ...rest)
           }
-          return on.call(target, event, createCoalescingRunner(listener), ...rest)
+          let warned = false
+          const guarded = createCoalescingRunner(listener, {
+            onNonConverging({ passes }) {
+              if (warned) return
+              warned = true
+              try {
+                target.logger?.error?.(
+                  'vision-router: adapter reconciliation did not converge after %d synchronous passes; stopping this cycle to keep the host responsive',
+                  passes,
+                )
+              } catch {
+                /* diagnostics must never break event delivery */
+              }
+            },
+          })
+          return on.call(target, event, guarded, ...rest)
         }
       }
       const value = Reflect.get(target, property, target)

--- a/lib/adversarial-hardening.js
+++ b/lib/adversarial-hardening.js
@@ -7,6 +7,9 @@ const DEFAULT_ARTIFACTS_DIR = '.dsh-vision-router/artifacts'
 const MAX_VIEWPORT_WIDTH = 4096
 const MAX_VIEWPORT_HEIGHT = 4096
 const MAX_SCREENSHOT_PIXELS = 50_000_000
+export const MAX_FULL_PAGE_WAKE_STEPS = 512
+export const MAX_FULL_PAGE_WAKE_MS = 15_000
+export const MAX_HTML_SCREENSHOT_CONCURRENT = 2
 
 function isNonEmptyString(value) {
   return typeof value === 'string' && value.trim() !== ''
@@ -115,29 +118,9 @@ function wrapRequestInterception(page, allowedRoot) {
   })
 }
 
-// Full-page wake used when the core module predates wakePageForFullCapture:
-// sweep the scrollbar so lazy images and scroll-triggered reveals below the
-// fold exist before the height is measured and the page is captured.
-async function fallbackWakePageForFullCapture(page, viewportHeight) {
-  const step = Number.isInteger(viewportHeight) && viewportHeight > 0 ? viewportHeight : 720
-  await page.evaluate(() => {
-    document.documentElement.style.scrollBehavior = 'auto'
-  })
-  const total = await page.evaluate(() =>
-    Math.max(document.documentElement.scrollHeight, document.body ? document.body.scrollHeight : 0),
-  )
-  for (let y = 0; y < total; y += step) {
-    await page.evaluate((yy) => window.scrollTo(0, yy), y)
-    await new Promise((resolve) => setTimeout(resolve, 60))
-  }
-  await page.evaluate(() => window.scrollTo(0, 0))
-  await new Promise((resolve) => setTimeout(resolve, 800))
-}
-
 /**
- * Full scrollable page height (CSS px), measured after reveals have woken.
- * The viewport height is part of the max: an empty page has zero scroll
- * height, and must not be misreported as exceeding the pixel safety limit.
+ * Full scrollable page height (CSS px). The viewport height is part of the max:
+ * an empty page has zero scroll height and must not be misreported as zero.
  */
 export async function fullPageHeightOf(page) {
   return await page.evaluate(() => Math.max(
@@ -147,16 +130,170 @@ export async function fullPageHeightOf(page) {
   ))
 }
 
+function assertSafeFullPageHeight(pageHeight, width) {
+  if (!Number.isFinite(pageHeight) || pageHeight <= 0 || width * pageHeight > MAX_SCREENSHOT_PIXELS) {
+    throw new Error(
+      `vision_html_screenshot: full-page capture exceeds the ${MAX_SCREENSHOT_PIXELS} pixel safety limit`,
+    )
+  }
+}
+
+const defaultSleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+/**
+ * Wake lazy/scroll-triggered content without turning the wake itself into a
+ * denial-of-service primitive.
+ *
+ * Safety is checked BEFORE the first scroll and after every reveal step. A
+ * malicious page with a gigantic static scrollHeight is therefore rejected in
+ * O(1) work instead of being walked tens of thousands of times before the old
+ * pixel check ran. Dynamically growing pages are bounded by both the pixel
+ * ceiling and independent step/wall-clock ceilings.
+ */
+export async function wakePageForFullCaptureBounded(
+  page,
+  viewportHeight,
+  width,
+  options = {},
+) {
+  const step = Number.isInteger(viewportHeight) && viewportHeight > 0 ? viewportHeight : 720
+  const maxSteps =
+    Number.isInteger(options.maxSteps) && options.maxSteps > 0
+      ? options.maxSteps
+      : MAX_FULL_PAGE_WAKE_STEPS
+  const maxWakeMs =
+    Number.isFinite(options.maxWakeMs) && options.maxWakeMs > 0
+      ? Number(options.maxWakeMs)
+      : MAX_FULL_PAGE_WAKE_MS
+  const sleep = typeof options.sleep === 'function' ? options.sleep : defaultSleep
+  const now = typeof options.now === 'function' ? options.now : Date.now
+
+  await page.evaluate(() => {
+    document.documentElement.style.scrollBehavior = 'auto'
+  })
+
+  let total = await fullPageHeightOf(page)
+  // Critical ordering invariant: reject an already-impossible page before any
+  // scroll/wait work is performed.
+  assertSafeFullPageHeight(total, width)
+
+  const startedAt = Number(now())
+  let steps = 0
+  for (let y = 0; y < total; y += step) {
+    if (steps >= maxSteps || Number(now()) - startedAt >= maxWakeMs) {
+      throw new Error(
+        `vision_html_screenshot: full-page wake exceeds the ${maxSteps}-step / ${maxWakeMs}ms safety limit`,
+      )
+    }
+    await page.evaluate((yy) => window.scrollTo(0, yy), y)
+    steps += 1
+    await sleep(60)
+
+    const observed = await fullPageHeightOf(page)
+    assertSafeFullPageHeight(observed, width)
+    // Scroll-triggered pages may grow while they are being woken. Continue to
+    // the newly revealed bottom, but never beyond the resource bounds above.
+    total = Math.max(total, observed)
+  }
+
+  await page.evaluate(() => window.scrollTo(0, 0))
+  const remainingWakeMs = maxWakeMs - (Number(now()) - startedAt)
+  if (remainingWakeMs <= 0) {
+    throw new Error(
+      `vision_html_screenshot: full-page wake exceeds the ${maxSteps}-step / ${maxWakeMs}ms safety limit`,
+    )
+  }
+  await sleep(Math.min(800, remainingWakeMs))
+  if (Number(now()) - startedAt > maxWakeMs) {
+    throw new Error(
+      `vision_html_screenshot: full-page wake exceeds the ${maxSteps}-step / ${maxWakeMs}ms safety limit`,
+    )
+  }
+
+  const finalHeight = await fullPageHeightOf(page)
+  assertSafeFullPageHeight(finalHeight, width)
+  return finalHeight
+}
+
+function screenshotAbortError() {
+  const error = new Error('vision_html_screenshot: browser slot wait aborted')
+  error.name = 'AbortError'
+  error.code = 'ABORT_ERR'
+  return error
+}
+
+/** Process-level FIFO cap for heavyweight headless-browser instances. */
+export class HtmlScreenshotGovernor {
+  constructor({ maxConcurrent = MAX_HTML_SCREENSHOT_CONCURRENT } = {}) {
+    this.maxConcurrent = Math.max(1, Math.floor(Number(maxConcurrent) || MAX_HTML_SCREENSHOT_CONCURRENT))
+    this.active = 0
+    this.queue = []
+  }
+
+  _grant(item) {
+    if (item.settled) return
+    item.settled = true
+    if (item.signal && item.abortHandler) item.signal.removeEventListener('abort', item.abortHandler)
+    this.active += 1
+    let released = false
+    item.resolve(() => {
+      if (released) return
+      released = true
+      this.active = Math.max(0, this.active - 1)
+      this._drain()
+    })
+  }
+
+  _drain() {
+    while (this.active < this.maxConcurrent && this.queue.length > 0) {
+      const item = this.queue.shift()
+      if (!item || item.settled) continue
+      this._grant(item)
+    }
+  }
+
+  acquire({ signal } = {}) {
+    if (signal?.aborted) return Promise.reject(screenshotAbortError())
+    return new Promise((resolve, reject) => {
+      const item = {
+        signal,
+        resolve,
+        reject,
+        settled: false,
+        abortHandler: undefined,
+      }
+      item.abortHandler = () => {
+        if (item.settled) return
+        item.settled = true
+        const index = this.queue.indexOf(item)
+        if (index >= 0) this.queue.splice(index, 1)
+        reject(screenshotAbortError())
+        this._drain()
+      }
+      if (signal) signal.addEventListener('abort', item.abortHandler, { once: true })
+      if (this.active < this.maxConcurrent && this.queue.length === 0) this._grant(item)
+      else this.queue.push(item)
+    })
+  }
+
+  stats() {
+    return {
+      maxConcurrent: this.maxConcurrent,
+      active: this.active,
+      queued: this.queue.filter((item) => !item.settled).length,
+    }
+  }
+}
+
+export const defaultHtmlScreenshotGovernor = new HtmlScreenshotGovernor()
+
 export function createSecureHtmlScreenshotExecute(ctx, core, config, deps = {}) {
   const importPuppeteer = deps.importPuppeteer ?? (() => import('puppeteer-core'))
   const fileExists = deps.existsSync ?? existsSync
   const makeDir = deps.mkdir ?? mkdir
   const saveFile = deps.writeFile ?? writeFile
   const realpath = deps.realpathSync ?? realpathSync
-  const wakeFullPage =
-    typeof core?.wakePageForFullCapture === 'function'
-      ? core.wakePageForFullCapture
-      : fallbackWakePageForFullCapture
+  const browserGovernor = deps.browserGovernor ?? defaultHtmlScreenshotGovernor
 
   return async (args, exec) => {
     const source = String(args?.source ?? '')
@@ -176,6 +313,9 @@ export function createSecureHtmlScreenshotExecute(ctx, core, config, deps = {}) 
     const width = safeViewportDimension(args?.width, 1200, MAX_VIEWPORT_WIDTH, 'width')
     const height = safeViewportDimension(args?.height, 720, MAX_VIEWPORT_HEIGHT, 'height')
     const fullPage = args?.fullPage === true
+    if (!fullPage && width * height > MAX_SCREENSHOT_PIXELS) {
+      throw new Error(`vision_html_screenshot: viewport exceeds the ${MAX_SCREENSHOT_PIXELS} pixel safety limit`)
+    }
 
     let puppeteer
     try {
@@ -194,18 +334,21 @@ export function createSecureHtmlScreenshotExecute(ctx, core, config, deps = {}) 
       )
     }
 
+    const releaseBrowserSlot = await browserGovernor.acquire({ signal: exec?.signal })
     const launchArgs = ['--disable-gpu', '--hide-scrollbars', '--incognito']
     if (fullPage) launchArgs.push('--blink-settings=imagesLazyLoadingEnabled=false')
     const launcher = puppeteer.default ?? puppeteer
     let browser
+    let png
+    let pageHeight
     try {
-      browser = await launcher.launch({ executablePath, headless: true, args: launchArgs })
-    } catch (error) {
-      const detail = error && error.message ? error.message : String(error)
-      throw new Error(`vision_html_screenshot: secure Chrome sandbox launch failed: ${detail}`)
-    }
+      try {
+        browser = await launcher.launch({ executablePath, headless: true, args: launchArgs })
+      } catch (error) {
+        const detail = error && error.message ? error.message : String(error)
+        throw new Error(`vision_html_screenshot: secure Chrome sandbox launch failed: ${detail}`)
+      }
 
-    try {
       const page = await browser.newPage()
       await page.setViewport({ width, height })
       // Puppeteer 25 exposes this API. Treat its absence as a hard failure:
@@ -218,37 +361,37 @@ export function createSecureHtmlScreenshotExecute(ctx, core, config, deps = {}) 
       await wrapRequestInterception(page, sourceRoot)
       await page.goto(pathToFileURL(targetReal).href, { waitUntil: 'networkidle0', timeout: 30000 })
 
-      let pageHeight
       if (fullPage) {
-        // Recreate the pre-hardening behavior: wake lazy/scroll-triggered
-        // content before measuring, so below-the-fold reveals are not silently
-        // missing from the capture.
-        await wakeFullPage(page, height)
-        pageHeight = await fullPageHeightOf(page)
-        if (!Number.isFinite(pageHeight) || pageHeight <= 0 || width * pageHeight > MAX_SCREENSHOT_PIXELS) {
-          throw new Error(
-            `vision_html_screenshot: full-page capture exceeds the ${MAX_SCREENSHOT_PIXELS} pixel safety limit`,
-          )
-        }
-      } else if (width * height > MAX_SCREENSHOT_PIXELS) {
-        throw new Error(`vision_html_screenshot: viewport exceeds the ${MAX_SCREENSHOT_PIXELS} pixel safety limit`)
+        pageHeight = await wakePageForFullCaptureBounded(page, height, width, {
+          sleep: deps.sleep,
+          now: deps.now,
+          maxSteps: deps.maxWakeSteps,
+          maxWakeMs: deps.maxWakeMs,
+        })
       }
 
-      const png = fullPage
+      png = fullPage
         ? await page.screenshot({ type: 'png', fullPage: true })
         : await page.screenshot({ type: 'png' })
-      const stem = fullPage ? `shot-${width}x${height}-fullpage` : `shot-${width}x${height}`
-      const dir = artifactDirectory(exec, config.artifactsDir, realpath)
-      await makeDir(dir, { recursive: true })
-      const target = path.join(dir, `${core.artifactStemOf(source, stem)}.png`)
-      if (!isPathInside(dir, target)) throw new Error('vision_html_screenshot: unsafe artifact target')
-      await saveFile(target, png)
-      const result = { path: target, width, height, bytes: png.length }
-      if (fullPage) result.pageHeight = pageHeight
-      return JSON.stringify(result)
     } finally {
-      await browser.close()
+      try {
+        if (browser) await browser.close()
+      } finally {
+        releaseBrowserSlot()
+      }
     }
+
+    // The heavyweight Chrome slot is released before filesystem artifact IO;
+    // slow antivirus/indexing must not unnecessarily serialize later captures.
+    const stem = fullPage ? `shot-${width}x${height}-fullpage` : `shot-${width}x${height}`
+    const dir = artifactDirectory(exec, config.artifactsDir, realpath)
+    await makeDir(dir, { recursive: true })
+    const target = path.join(dir, `${core.artifactStemOf(source, stem)}.png`)
+    if (!isPathInside(dir, target)) throw new Error('vision_html_screenshot: unsafe artifact target')
+    await saveFile(target, png)
+    const result = { path: target, width, height, bytes: png.length }
+    if (fullPage) result.pageHeight = pageHeight
+    return JSON.stringify(result)
   }
 }
 

--- a/lib/android-attachment-compat.js
+++ b/lib/android-attachment-compat.js
@@ -1,10 +1,21 @@
 import { createHash } from 'node:crypto'
 
 const wrappedContexts = new WeakMap()
-const MAX_TRANSIENT_ATTACHMENTS = 64
+const MIB = 1024 * 1024
+
+export const DEFAULT_ANDROID_TRANSIENT_LIMITS = Object.freeze({
+  maxEntries: 64,
+  maxBytes: 128 * MIB,
+  maxSingleBytes: 64 * MIB,
+})
 
 function nonEmptyString(value) {
   return typeof value === 'string' && value.length > 0
+}
+
+function positiveInteger(value, fallback) {
+  const n = Number(value)
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : fallback
 }
 
 export function isAndroidTermuxRuntime(options = {}) {
@@ -49,10 +60,24 @@ async function probeImage(data, injectedProbe) {
   return { width, height }
 }
 
-async function transientStoredImage(input, injectedProbe) {
+function transientTooLargeError(bytes, limit) {
+  const error = new Error(
+    `vision-router: Android attachment fallback refuses to keep a ${bytes}-byte image in process memory (limit ${limit} bytes)`,
+  )
+  error.code = 'ANDROID_TRANSIENT_ATTACHMENT_TOO_LARGE'
+  return error
+}
+
+async function transientStoredImage(input, injectedProbe, maxSingleBytes) {
   const data = input?.data
   if (!(data instanceof Uint8Array) || data.byteLength === 0) {
     throw new Error('vision-router: Android attachment fallback received empty image bytes')
+  }
+  // Enforce the byte boundary BEFORE probing with sharp. Metadata decode can
+  // itself allocate native memory, so rejecting after probeImage() would still
+  // allow a single pathological input to cross the mobile memory boundary.
+  if (data.byteLength > maxSingleBytes) {
+    throw transientTooLargeError(data.byteLength, maxSingleBytes)
   }
   const mediaType = input?.mediaType
   if (!nonEmptyString(mediaType)) {
@@ -72,13 +97,51 @@ async function transientStoredImage(input, injectedProbe) {
   return { ref, data }
 }
 
-function rememberTransient(map, stored) {
-  const id = String(stored.ref.attachmentId)
-  if (map.has(id)) map.delete(id)
-  map.set(id, stored)
-  while (map.size > MAX_TRANSIENT_ATTACHMENTS) {
-    const oldest = map.keys().next().value
-    map.delete(oldest)
+/** Byte-weighted LRU for the Android process-local durability fallback. */
+export function createTransientAttachmentCache(options = {}) {
+  const maxEntries = positiveInteger(options.maxEntries, DEFAULT_ANDROID_TRANSIENT_LIMITS.maxEntries)
+  const maxBytes = positiveInteger(options.maxBytes, DEFAULT_ANDROID_TRANSIENT_LIMITS.maxBytes)
+  const map = new Map()
+  let bytes = 0
+
+  const remove = (id) => {
+    const old = map.get(id)
+    if (old === undefined) return false
+    bytes = Math.max(0, bytes - Number(old.data?.byteLength ?? 0))
+    return map.delete(id)
+  }
+
+  const trim = () => {
+    while (map.size > maxEntries || bytes > maxBytes) {
+      const oldest = map.keys().next().value
+      if (oldest === undefined) break
+      remove(oldest)
+    }
+  }
+
+  return {
+    get(id) {
+      const stored = map.get(id)
+      if (stored === undefined) return undefined
+      // Refresh recency so an actively used image survives pressure from newer
+      // one-shot attachments.
+      map.delete(id)
+      map.set(id, stored)
+      return stored
+    },
+    set(stored) {
+      const id = String(stored?.ref?.attachmentId ?? '')
+      const weight = Number(stored?.data?.byteLength ?? 0)
+      if (id === '' || !Number.isFinite(weight) || weight <= 0 || weight > maxBytes) return false
+      remove(id)
+      map.set(id, stored)
+      bytes += weight
+      trim()
+      return map.has(id)
+    },
+    stats() {
+      return { entries: map.size, bytes, maxEntries, maxBytes }
+    },
   }
 }
 
@@ -92,10 +155,11 @@ function rememberTransient(map, stored) {
  * though the image bytes are otherwise readable.
  *
  * Keep the host service authoritative. Only when an Android runtime reaches an
- * EACCES/EPERM boundary do Vision Router's own calls fall back to a bounded,
- * process-local content-addressed attachment. The paired readImage() wrapper
- * makes the direct vision-http path and plugin-side bridge code consume those
- * bytes normally. Once upstream accepts the save, this path is never used.
+ * EACCES/EPERM boundary do Vision Router's own calls fall back to a byte- and
+ * count-bounded, process-local content-addressed attachment. The paired
+ * readImage() wrapper makes the direct vision-http path and plugin-side bridge
+ * code consume those bytes normally. Once upstream accepts the save, this path
+ * is never used.
  */
 export function installAndroidAttachmentCompat(ctx, logger, options = {}) {
   if (!ctx || typeof ctx !== 'object' || !isAndroidTermuxRuntime(options.runtime)) return ctx
@@ -112,7 +176,23 @@ export function installAndroidAttachmentCompat(ctx, logger, options = {}) {
     return ctx
   }
 
-  const transient = new Map()
+  const maxTransientBytes = positiveInteger(
+    options.maxTransientBytes,
+    DEFAULT_ANDROID_TRANSIENT_LIMITS.maxBytes,
+  )
+  const maxTransientAttachments = positiveInteger(
+    options.maxTransientAttachments,
+    DEFAULT_ANDROID_TRANSIENT_LIMITS.maxEntries,
+  )
+  const maxTransientSingleBytes = Math.min(
+    maxTransientBytes,
+    positiveInteger(options.maxTransientSingleBytes, DEFAULT_ANDROID_TRANSIENT_LIMITS.maxSingleBytes),
+  )
+  const transient = createTransientAttachmentCache({
+    maxEntries: maxTransientAttachments,
+    maxBytes: maxTransientBytes,
+  })
+
   const wrappedAttachments = new Proxy(attachments, {
     get(target, property) {
       if (property === 'saveImage') {
@@ -121,11 +201,13 @@ export function installAndroidAttachmentCompat(ctx, logger, options = {}) {
             return await target.saveImage(input)
           } catch (error) {
             if (!isPermissionBoundaryError(error)) throw error
-            const stored = await transientStoredImage(input, options.probeImage)
-            rememberTransient(transient, stored)
+            const stored = await transientStoredImage(input, options.probeImage, maxTransientSingleBytes)
+            if (!transient.set(stored)) {
+              throw transientTooLargeError(stored.data.byteLength, maxTransientBytes)
+            }
             try {
               logger?.warn?.(
-                'vision-router: Android/Termux attachment save hit an inaccessible ancestor; using a process-local image ref until DSH attachment-local is fixed upstream',
+                'vision-router: Android/Termux attachment save hit an inaccessible ancestor; using a bounded process-local image ref until DSH attachment-local is fixed upstream',
               )
             } catch {
               /* diagnostics must never block the fallback */

--- a/lib/image-resource-governor.js
+++ b/lib/image-resource-governor.js
@@ -1,3 +1,5 @@
+import { currentVisionTurnBudgetSignal } from './turn-budget-context.js'
+
 const MIB = 1024 * 1024
 
 function abortError() {
@@ -5,6 +7,13 @@ function abortError() {
   error.name = 'AbortError'
   error.code = 'ABORT_ERR'
   return error
+}
+
+function effectiveSignal(explicit) {
+  const ambient = currentVisionTurnBudgetSignal()
+  if (!explicit) return ambient
+  if (!ambient || ambient === explicit) return explicit
+  return AbortSignal.any([explicit, ambient])
 }
 
 export function estimateDecodedBytes(
@@ -162,12 +171,17 @@ export class ImageResourceGovernor {
   }
 
   acquire(bytes, { signal, exclusive = false } = {}) {
-    if (signal?.aborted) return Promise.reject(abortError())
+    // Structured 1+x installs its remaining turn deadline in AsyncLocalStorage.
+    // Even image helpers that historically passed `{}` now inherit that signal
+    // while they wait in the resource queue, so an exhausted turn cannot leave
+    // dead work queued behind another large image operation.
+    const combinedSignal = effectiveSignal(signal)
+    if (combinedSignal?.aborted) return Promise.reject(abortError())
     const request = this._normalize(bytes, exclusive)
     return new Promise((resolve, reject) => {
       const item = {
         request,
-        signal,
+        signal: combinedSignal,
         resolve,
         reject,
         settled: false,
@@ -181,7 +195,7 @@ export class ImageResourceGovernor {
         reject(abortError())
         this._drain()
       }
-      if (signal) signal.addEventListener('abort', item.abortHandler, { once: true })
+      if (combinedSignal) combinedSignal.addEventListener('abort', item.abortHandler, { once: true })
       if (this.queue.length === 0 && this._canRun(request)) {
         this._grant(item)
       } else {

--- a/lib/structured-flow-hardening.js
+++ b/lib/structured-flow-hardening.js
@@ -1,3 +1,8 @@
+import {
+  currentVisionTurnBudget,
+  runWithVisionTurnBudget,
+} from './turn-budget-context.js'
+
 const STRUCTURED_EVIDENCE_TOOLS = new Set([
   'vision_describe',
   'vision_ground',
@@ -12,6 +17,7 @@ const DEFAULT_TURN_BUDGET_MS = 90_000
 const MAX_TURN_BUDGET_MS = 600_000
 const MAX_GUIDANCE_OVERRIDES = 14
 const MAX_GUIDANCE_CHARS = 2_000
+const BUDGETED_TIMEOUT_FIELDS = ['timeoutMs', 'visionTaskTimeoutMs', 'ocrTimeoutMs']
 const GUIDANCE_KINDS = new Set([
   'code',
   'document',
@@ -117,10 +123,38 @@ function depthOf(config) {
     : 'standard'
 }
 
-function freshState(turn) {
+/**
+ * Clamp the core's own timeout settings to the remaining structured-turn
+ * deadline. This is the key bridge from the outer 1+x budget into the existing
+ * core deadline/AbortSignal machinery: fetch, llm.stream and OCR fallbacks are
+ * then genuinely cancelled at the turn boundary instead of merely being
+ * refused when the NEXT tool call starts.
+ */
+export function capConfigToVisionTurnBudget(value, now = Date.now) {
+  if (!value || typeof value !== 'object') return value
+  const budget = currentVisionTurnBudget()
+  if (!budget || !Number.isFinite(Number(budget.deadlineAt))) return value
+  const clock = typeof now === 'function' ? now : Date.now
+  const remaining = Math.max(0, Number(budget.deadlineAt) - Number(clock()))
+  const cap = Math.max(1, Math.floor(remaining))
+  let next
+  for (const field of BUDGETED_TIMEOUT_FIELDS) {
+    const current = Number(value[field])
+    if (!Number.isFinite(current) || current <= cap) continue
+    if (next === undefined) next = { ...value }
+    next[field] = cap
+  }
+  return next ?? value
+}
+
+function freshState(turn, config) {
+  const budgetMs = turnBudgetMs(config)
+  const startedAt = Date.now()
   return {
     turn,
-    startedAt: Date.now(),
+    startedAt,
+    deadlineAt: startedAt + budgetMs,
+    turnSignal: AbortSignal.timeout(budgetMs),
     bootstrapDone: false,
     bootstrapResult: undefined,
     successfulEvidenceCalls: 0,
@@ -131,26 +165,26 @@ function freshState(turn) {
   }
 }
 
-function ensureState(states, session, turn) {
+function ensureState(states, session, turn, config) {
   let state = states.get(session)
   if (!state || state.turn !== turn) {
-    state = freshState(turn)
+    state = freshState(turn, config)
     states.set(session, state)
   }
   return state
 }
 
-function currentState(states, session) {
+function currentState(states, session, config) {
   let state = states.get(session)
   if (!state) {
-    state = freshState(undefined)
+    state = freshState(undefined, config)
     states.set(session, state)
   }
   return state
 }
 
-function budgetExceeded(state, config) {
-  return Date.now() - state.startedAt >= turnBudgetMs(config)
+function budgetExceeded(state) {
+  return state.turnSignal?.aborted === true || Date.now() >= state.deadlineAt
 }
 
 function bootstrapEvidence(raw) {
@@ -286,7 +320,56 @@ function failure(code, reason) {
   return JSON.stringify({ ok: false, code, retryable: false, reason })
 }
 
-function wrapRegisteredTool(def, states, config) {
+function turnBudgetAbortError() {
+  const error = new Error('the structured-vision turn budget expired while the visual request was running')
+  error.name = 'TimeoutError'
+  error.code = 'VISION_TURN_BUDGET_EXCEEDED'
+  return error
+}
+
+async function executeWithinTurnBudget(state, execute) {
+  const signal = state.turnSignal
+  const budget = { deadlineAt: state.deadlineAt, signal }
+  return runWithVisionTurnBudget(budget, async () => {
+    if (signal?.aborted) throw turnBudgetAbortError()
+    let abortHandler
+    const aborted = new Promise((_, reject) => {
+      abortHandler = () => reject(turnBudgetAbortError())
+      signal?.addEventListener('abort', abortHandler, { once: true })
+    })
+    try {
+      // The race is a last-resort availability fence for a local helper that
+      // ignores AbortSignal. Normal network/LLM/OCR work also sees the ambient
+      // budget through capConfigToVisionTurnBudget and is cancelled at source.
+      return await Promise.race([Promise.resolve().then(execute), aborted])
+    } finally {
+      if (signal && abortHandler) signal.removeEventListener('abort', abortHandler)
+    }
+  })
+}
+
+async function runBudgetedTool(state, execute, exhaustedReason) {
+  if (budgetExceeded(state)) {
+    state.budgetExhausted = true
+    return failure('VISION_TURN_BUDGET_EXCEEDED', exhaustedReason)
+  }
+  try {
+    const result = await executeWithinTurnBudget(state, execute)
+    if (budgetExceeded(state)) {
+      state.budgetExhausted = true
+      return failure('VISION_TURN_BUDGET_EXCEEDED', exhaustedReason)
+    }
+    return result
+  } catch (error) {
+    if (error?.code === 'VISION_TURN_BUDGET_EXCEEDED' || budgetExceeded(state)) {
+      state.budgetExhausted = true
+      return failure('VISION_TURN_BUDGET_EXCEEDED', exhaustedReason)
+    }
+    throw error
+  }
+}
+
+function wrapRegisteredTool(def, states, getConfig) {
   if (!def || typeof def.execute !== 'function') return def
   if (def.name !== 'vision_bootstrap' && !STRUCTURED_EVIDENCE_TOOLS.has(def.name)) return def
 
@@ -295,7 +378,8 @@ function wrapRegisteredTool(def, states, config) {
     async execute(args, exec) {
       const session = exec?.agent?.session
       if (!session) return def.execute(args, exec)
-      const state = currentState(states, session)
+      const currentConfig = getConfig()
+      const state = currentState(states, session, currentConfig)
 
       if (def.name === 'vision_bootstrap') {
         if (state.bootstrapDone) {
@@ -304,16 +388,17 @@ function wrapRegisteredTool(def, states, config) {
             'the structured bootstrap already completed for this turn; continue with evidence tools instead of repeating it',
           )
         }
-        if (budgetExceeded(state, config)) {
-          state.budgetExhausted = true
-          return failure('VISION_TURN_BUDGET_EXCEEDED', 'the structured-vision turn budget expired before another visual request could start')
-        }
-        const result = await def.execute(args, exec)
+        const result = await runBudgetedTool(
+          state,
+          () => def.execute(args, exec),
+          'the structured-vision turn budget expired before the bootstrap could complete',
+        )
+        if (resultCode(result) === 'VISION_TURN_BUDGET_EXCEEDED') return result
         const evidence = bootstrapEvidence(result)
         if (evidence !== undefined) {
           state.bootstrapDone = true
           state.bootstrapResult = result
-          state.mixedBranches = normalizeMixedBranches(evidence, depthOf(config))
+          state.mixedBranches = normalizeMixedBranches(evidence, depthOf(getConfig()))
           state.completedBranches.clear()
           state.successfulEvidenceCalls = 0
           state.budgetExhausted = false
@@ -322,19 +407,34 @@ function wrapRegisteredTool(def, states, config) {
         return result
       }
 
-      if (!state.bootstrapDone) return def.execute(args, exec)
-      if (budgetExceeded(state, config)) {
+      // Even an out-of-order evidence call must obey the turn wall clock. The
+      // bootstrap-order guard is handled elsewhere; time accounting must not
+      // disappear merely because the model chose the wrong tool first.
+      if (!state.bootstrapDone) {
+        return runBudgetedTool(
+          state,
+          () => def.execute(args, exec),
+          'the structured-vision turn budget expired while the visual request was running',
+        )
+      }
+
+      if (budgetExceeded(state)) {
         state.budgetExhausted = true
         return failure('VISION_TURN_BUDGET_EXCEEDED', 'the structured-vision turn budget is exhausted; answer from the evidence already collected')
       }
 
-      const limit = structuredDepthLimit(depthOf(config))
+      const active = getConfig()
+      const limit = structuredDepthLimit(depthOf(active))
       if (state.successfulEvidenceCalls >= limit) {
         state.depthExhausted = true
-        return failure('VISION_DEPTH_LIMIT', `the ${depthOf(config)} depth tier allows at most ${limit} successful deep-dive call(s) in this turn`)
+        return failure('VISION_DEPTH_LIMIT', `the ${depthOf(active)} depth tier allows at most ${limit} successful deep-dive call(s) in this turn`)
       }
 
-      const result = await def.execute(args, exec)
+      const result = await runBudgetedTool(
+        state,
+        () => def.execute(args, exec),
+        'the structured-vision turn budget is exhausted; answer from the evidence already collected',
+      )
       const code = resultCode(result)
       if (code === 'VISION_DEPTH_LIMIT') state.depthExhausted = true
       if (code === 'VISION_TURN_BUDGET_EXCEEDED') state.budgetExhausted = true
@@ -344,7 +444,7 @@ function wrapRegisteredTool(def, states, config) {
   }
 }
 
-function wrapTools(tools, states, config) {
+function wrapTools(tools, states, getConfig) {
   if (!tools || (typeof tools !== 'object' && typeof tools !== 'function')) return tools
   return new Proxy(tools, {
     get(target, property) {
@@ -353,7 +453,60 @@ function wrapTools(tools, states, config) {
         return typeof value === 'function' ? value.bind(target) : value
       }
       const register = Reflect.get(target, property, target)
-      return (def) => register.call(target, wrapRegisteredTool(def, states, config))
+      return (def) => register.call(target, wrapRegisteredTool(def, states, getConfig))
+    },
+  })
+}
+
+function wrapSettingsScope(scope) {
+  if (!scope || typeof scope !== 'object') return scope
+  return new Proxy(scope, {
+    get(target, property) {
+      if (property === 'get') {
+        const get = Reflect.get(target, property, target)
+        if (typeof get !== 'function') return get
+        return (...args) => capConfigToVisionTurnBudget(get.apply(target, args))
+      }
+      const value = Reflect.get(target, property, target)
+      return typeof value === 'function' ? value.bind(target) : value
+    },
+  })
+}
+
+function wrapSettingsService(settings, setScope) {
+  if (!settings || typeof settings !== 'object') return settings
+  return new Proxy(settings, {
+    get(target, property) {
+      if (property !== 'register') {
+        const value = Reflect.get(target, property, target)
+        return typeof value === 'function' ? value.bind(target) : value
+      }
+      const register = Reflect.get(target, property, target)
+      if (typeof register !== 'function') return register
+      return (namespace, ...args) => {
+        const scope = register.call(target, namespace, ...args)
+        if (namespace !== 'vision-router') return scope
+        // Keep the uncapped scope for guard policy (depth/guidance/budget at
+        // turn start); only the core's reads during an executing tool receive
+        // the remaining-time timeout clamp.
+        setScope(scope)
+        return wrapSettingsScope(scope)
+      }
+    },
+  })
+}
+
+function wrapSettingsContext(childCtx, setScope) {
+  if (!childCtx || typeof childCtx !== 'object' || !childCtx.settings) return childCtx
+  const settings = wrapSettingsService(childCtx.settings, setScope)
+  return new Proxy(childCtx, {
+    get(target, property) {
+      if (property === 'settings') return settings
+      // Bind lifecycle methods to the exact injected child context. This keeps
+      // Cordis ownership semantics intact even though Settings itself is viewed
+      // through a narrow proxy.
+      const value = Reflect.get(target, property, target)
+      return typeof value === 'function' ? value.bind(target) : value
     },
   })
 }
@@ -361,10 +514,40 @@ function wrapTools(tools, states, config) {
 export function installStructuredFlowHardening(ctx, config = {}) {
   if (!ctx || typeof ctx !== 'object') return ctx
   const states = new WeakMap()
+  let settingsScope
+  const setSettingsScope = (scope) => { settingsScope = scope }
+  const activeConfig = () => {
+    try {
+      const value = settingsScope && typeof settingsScope.get === 'function' ? settingsScope.get() : config
+      return value && typeof value === 'object' ? value : config
+    } catch {
+      return config
+    }
+  }
+
   let wrapped
   wrapped = new Proxy(ctx, {
     get(target, property) {
-      if (property === 'tools') return wrapTools(target.tools, states, config)
+      if (property === 'tools') return wrapTools(target.tools, states, activeConfig)
+      if (property === 'inject') {
+        const inject = Reflect.get(target, property, target)
+        if (typeof inject !== 'function') return inject
+        return (dependencies, callback, ...rest) => {
+          if (
+            !Array.isArray(dependencies) ||
+            !dependencies.includes('settings') ||
+            typeof callback !== 'function'
+          ) {
+            return inject.call(target, dependencies, callback, ...rest)
+          }
+          return inject.call(
+            target,
+            dependencies,
+            (childCtx) => callback(wrapSettingsContext(childCtx, setSettingsScope)),
+            ...rest,
+          )
+        }
+      }
       if (property === 'on') {
         const on = Reflect.get(target, property, target)
         if (typeof on !== 'function') return on
@@ -374,9 +557,11 @@ export function installStructuredFlowHardening(ctx, config = {}) {
           }
           return on.call(target, event, async function guardedPreStep(payload, next) {
             const session = payload?.agent?.session
-            const state = session ? ensureState(states, session, payload?.turn) : undefined
+            const current = activeConfig()
+            const state = session ? ensureState(states, session, payload?.turn, current) : undefined
             const decision = await handler.call(this, payload, next)
-            return state ? appendGuardMessage(decision, payload, state, config) : decision
+            if (state && budgetExceeded(state)) state.budgetExhausted = true
+            return state ? appendGuardMessage(decision, payload, state, activeConfig()) : decision
           }, ...rest)
         }
       }

--- a/lib/tesseract-exec-compat.js
+++ b/lib/tesseract-exec-compat.js
@@ -7,9 +7,10 @@ import { promisify } from 'node:util'
 const require = createRequire(import.meta.url)
 const childProcess = require('node:child_process')
 
-let installs = 0
-let originalExecFile
-let patchedExecFile
+// Install state is keyed by the concrete child_process module object. This
+// keeps tests injectable and, more importantly, lets multiple Vision Router
+// contexts share one process-level shim without overwriting each other.
+const installStates = new WeakMap()
 
 function extensionForBytes(input) {
   const bytes = Buffer.from(input)
@@ -38,13 +39,24 @@ function cleanupTempDir(dir) {
  * Vision Router's OCR helper becomes a real seekable input file for Tesseract.
  * Async child_process.execFile does not consume an `input` option, so without
  * this boundary no bytes/EOF reach the child and it waits until timeout.
+ *
+ * The wrapper can be deactivated. Deactivation turns it into an inert
+ * delegator to the function it originally wrapped. This matters when another
+ * plugin loads after Vision Router and captures this wrapper: unloading Vision
+ * Router must not clobber the later plugin's process-level patch, and the
+ * captured Vision Router layer must not spring back to life if that later
+ * plugin subsequently restores what it captured.
  */
 export function createTesseractExecFileCompat(execFileImpl) {
   if (typeof execFileImpl !== 'function') {
     throw new TypeError('createTesseractExecFileCompat: execFileImpl must be a function')
   }
 
+  let active = true
+
   function tesseractExecFileCompat(file, args, options, callback) {
+    if (!active) return execFileImpl.apply(this, arguments)
+
     const isTesseract = typeof file === 'string' && /(^|[\\/])tesseract(?:\.exe)?$/i.test(file)
     const readsStdin = Array.isArray(args) && (args[0] === 'stdin' || args[0] === '-')
     const hasInput =
@@ -85,6 +97,21 @@ export function createTesseractExecFileCompat(execFileImpl) {
     }
   }
 
+  Object.defineProperty(tesseractExecFileCompat, 'deactivate', {
+    configurable: false,
+    enumerable: false,
+    value() {
+      active = false
+    },
+  })
+  Object.defineProperty(tesseractExecFileCompat, 'active', {
+    configurable: false,
+    enumerable: false,
+    get() {
+      return active
+    },
+  })
+
   // Native execFile's custom promisify resolves { stdout, stderr }. Preserve
   // that contract because index.js destructures this exact shape.
   Object.defineProperty(tesseractExecFileCompat, promisify.custom, {
@@ -116,27 +143,53 @@ export function createTesseractExecFileCompat(execFileImpl) {
 /**
  * Install the narrow shim for the Vision Router context lifetime.
  * syncBuiltinESMExports updates index.js's already-imported execFile binding.
+ *
+ * Cleanup is chain-safe: only restore the original function when our wrapper
+ * is still the process-level top layer. If another plugin patched execFile
+ * later, leave that patch installed and merely deactivate our captured layer.
  */
-export function installTesseractExecFileCompat(ctx) {
-  if (installs === 0) {
-    originalExecFile = childProcess.execFile
-    patchedExecFile = createTesseractExecFileCompat(originalExecFile)
-    childProcess.execFile = patchedExecFile
-    syncBuiltinESMExports()
+export function installTesseractExecFileCompat(ctx, options = {}) {
+  const moduleObject = options.childProcessModule ?? childProcess
+  const syncBuiltin = options.syncBuiltinESMExports ?? syncBuiltinESMExports
+  if (!moduleObject || typeof moduleObject !== 'object' || typeof moduleObject.execFile !== 'function') {
+    throw new TypeError('installTesseractExecFileCompat: childProcessModule.execFile must be a function')
   }
-  installs += 1
+
+  let state = installStates.get(moduleObject)
+  if (state === undefined) {
+    const originalExecFile = moduleObject.execFile
+    const patchedExecFile = createTesseractExecFileCompat(originalExecFile)
+    moduleObject.execFile = patchedExecFile
+    try { syncBuiltin() } catch { /* keep the CJS patch even if ESM sync is unavailable */ }
+    state = {
+      count: 0,
+      originalExecFile,
+      patchedExecFile,
+      syncBuiltin,
+    }
+    installStates.set(moduleObject, state)
+  }
+  state.count += 1
 
   let disposed = false
   const dispose = () => {
     if (disposed) return
     disposed = true
-    installs = Math.max(0, installs - 1)
-    if (installs === 0 && originalExecFile) {
-      childProcess.execFile = originalExecFile
-      syncBuiltinESMExports()
-      originalExecFile = undefined
-      patchedExecFile = undefined
+    state.count = Math.max(0, state.count - 1)
+    if (state.count !== 0) return
+
+    // Always deactivate first. A later plugin may have captured this function
+    // and still legitimately sit above us in the patch chain.
+    try { state.patchedExecFile.deactivate?.() } catch { /* best effort */ }
+
+    if (moduleObject.execFile === state.patchedExecFile) {
+      moduleObject.execFile = state.originalExecFile
     }
+    // Sync the ESM binding to whatever function is CURRENTLY authoritative:
+    // either the original function or a later plugin's wrapper. This avoids
+    // leaving index.js pinned to our now-inert layer after unload.
+    try { state.syncBuiltin() } catch { /* best effort */ }
+    installStates.delete(moduleObject)
   }
 
   if (ctx && typeof ctx.effect === 'function') {

--- a/lib/turn-budget-context.js
+++ b/lib/turn-budget-context.js
@@ -1,0 +1,24 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
+
+const turnBudgetScope = new AsyncLocalStorage()
+
+/** Run one async tool execution inside an ambient turn-level budget. */
+export function runWithVisionTurnBudget(budget, fn) {
+  if (typeof fn !== 'function') throw new TypeError('runWithVisionTurnBudget: fn must be a function')
+  return turnBudgetScope.run(budget, fn)
+}
+
+export function currentVisionTurnBudget() {
+  return turnBudgetScope.getStore()
+}
+
+export function currentVisionTurnBudgetSignal() {
+  return turnBudgetScope.getStore()?.signal
+}
+
+export function remainingVisionTurnBudgetMs(now = Date.now) {
+  const budget = turnBudgetScope.getStore()
+  if (!budget || !Number.isFinite(Number(budget.deadlineAt))) return undefined
+  const clock = typeof now === 'function' ? now : Date.now
+  return Math.max(0, Number(budget.deadlineAt) - Number(clock()))
+}

--- a/tests/adversarial-hardening.test.js
+++ b/tests/adversarial-hardening.test.js
@@ -7,10 +7,12 @@ import { pathToFileURL } from 'node:url'
 import {
   createSecureHtmlScreenshotExecute,
   fullPageHeightOf,
+  HtmlScreenshotGovernor,
   htmlRequestAllowed,
   installAdversarialHardening,
   normalizeArtifactsDir,
   sameOriginRequest,
+  wakePageForFullCaptureBounded,
 } from '../lib/adversarial-hardening.js'
 import { installLocalVisionStabilizer } from '../lib/local-vision-stabilizer.js'
 
@@ -60,7 +62,7 @@ test('secure HTML screenshot keeps Chrome sandbox enabled, forces offline mode a
     let requestHandler
     let offline = false
     let closed = false
-    const wakeCalls = []
+    const scrollTargets = []
     const page = {
       async setViewport(value) { assert.deepEqual(value, { width: 1200, height: 720 }) },
       async setOfflineMode(value) { offline = value },
@@ -70,7 +72,12 @@ test('secure HTML screenshot keeps Chrome sandbox enabled, forces offline mode a
         requestHandler = handler
       },
       async goto(url) { assert.equal(url, pathToFileURL(source).href) },
-      async evaluate() { return 1500 },
+      async evaluate(fn, arg) {
+        const sourceText = fn.toString()
+        if (sourceText.includes('scrollHeight')) return 1500
+        if (sourceText.includes('scrollTo') && arg !== undefined) scrollTargets.push(arg)
+        return undefined
+      },
       async screenshot(options) {
         assert.deepEqual(options, { type: 'png', fullPage: true })
         return Buffer.from('png-bytes')
@@ -95,7 +102,6 @@ test('secure HTML screenshot keeps Chrome sandbox enabled, forces offline mode a
       toRealPath(_fs, value) { return value },
       chromiumCandidates() { return ['/fake/chrome'] },
       artifactStemOf() { return 'page-safe-shot' },
-      wakePageForFullCapture: async (p, h) => { wakeCalls.push([p, h]) },
     }
     const execute = createSecureHtmlScreenshotExecute(
       ctx,
@@ -105,6 +111,7 @@ test('secure HTML screenshot keeps Chrome sandbox enabled, forces offline mode a
         importPuppeteer: async () => fakePuppeteer,
         existsSync(value) { return value === source || value === '/fake/chrome' },
         realpathSync(value) { return value },
+        sleep: async () => {},
       },
     )
     const result = JSON.parse(await execute(
@@ -117,11 +124,7 @@ test('secure HTML screenshot keeps Chrome sandbox enabled, forces offline mode a
     assert.equal(typeof requestHandler, 'function')
     assert.equal(closed, true)
     assert.equal(result.pageHeight, 1500)
-    // The full-page wake must run before the height is measured, or
-    // scroll-triggered content below the fold is silently missing.
-    assert.equal(wakeCalls.length, 1)
-    assert.equal(wakeCalls[0][0], page)
-    assert.equal(wakeCalls[0][1], 720)
+    assert.deepEqual(scrollTargets, [0, 720, 1440])
     assert.equal(path.relative(workspace, result.path).startsWith('..'), false)
     assert.equal((await readFile(result.path)).toString(), 'png-bytes')
   } finally {
@@ -142,18 +145,86 @@ test('fullPageHeightOf falls back to the viewport height for empty pages', async
   assert.equal(await fullPageHeightOf(page), 800)
 })
 
+test('full-page wake rejects an oversized static page before the first scroll', async () => {
+  let scrolls = 0
+  const page = {
+    async evaluate(fn, arg) {
+      const sourceText = fn.toString()
+      if (sourceText.includes('scrollHeight')) return 100_000
+      if (sourceText.includes('scrollTo') && arg !== undefined) scrolls += 1
+      return undefined
+    },
+  }
+  await assert.rejects(
+    wakePageForFullCaptureBounded(page, 720, 1200, { sleep: async () => {} }),
+    /pixel safety limit/,
+  )
+  assert.equal(scrolls, 0, 'pixel admission must happen before expensive wake scrolling')
+})
+
+test('full-page wake bounds dynamically growing pages even below the initial pixel ceiling', async () => {
+  let height = 1000
+  let scrolls = 0
+  const page = {
+    async evaluate(fn, arg) {
+      const sourceText = fn.toString()
+      if (sourceText.includes('scrollHeight')) return height
+      if (sourceText.includes('scrollTo') && arg !== undefined) {
+        scrolls += 1
+        height += 720
+      }
+      return undefined
+    },
+  }
+  await assert.rejects(
+    wakePageForFullCaptureBounded(page, 720, 320, {
+      sleep: async () => {},
+      now: () => 0,
+      maxSteps: 3,
+      maxWakeMs: 15_000,
+    }),
+    /3-step/,
+  )
+  assert.equal(scrolls, 3)
+})
+
+test('HTML screenshot governor caps active browser slots and drains FIFO', async () => {
+  const governor = new HtmlScreenshotGovernor({ maxConcurrent: 2 })
+  const releaseA = await governor.acquire()
+  const releaseB = await governor.acquire()
+  assert.deepEqual(governor.stats(), { maxConcurrent: 2, active: 2, queued: 0 })
+
+  let thirdGranted = false
+  const third = governor.acquire().then((release) => {
+    thirdGranted = true
+    return release
+  })
+  await Promise.resolve()
+  assert.equal(thirdGranted, false)
+  assert.equal(governor.stats().queued, 1)
+
+  releaseA()
+  const releaseC = await third
+  assert.equal(thirdGranted, true)
+  assert.equal(governor.stats().active, 2)
+  releaseB()
+  releaseC()
+  assert.equal(governor.stats().active, 0)
+})
+
 test('non-fullPage capture skips the scroll wake', async () => {
   const workspace = await mkdtemp(path.join(tmpdir(), 'vision-html-nofull-'))
   try {
     const source = path.join(workspace, 'page.html')
     await writeFile(source, '<html><body>Hello</body></html>')
-    const wakeCalls = []
+    let evaluateCalls = 0
     const page = {
       async setViewport() {},
       async setOfflineMode() {},
       async setRequestInterception(value) { assert.equal(value, true) },
       on() {},
       async goto(url) { assert.equal(url, pathToFileURL(source).href) },
+      async evaluate() { evaluateCalls += 1 },
       async screenshot(options) {
         assert.deepEqual(options, { type: 'png' })
         return Buffer.from('png-bytes')
@@ -177,7 +248,6 @@ test('non-fullPage capture skips the scroll wake', async () => {
       toRealPath(_fs, value) { return value },
       chromiumCandidates() { return ['/fake/chrome'] },
       artifactStemOf() { return 'page-safe-shot' },
-      wakePageForFullCapture: async (p, h) => { wakeCalls.push([p, h]) },
     }
     const execute = createSecureHtmlScreenshotExecute(
       ctx,
@@ -193,7 +263,7 @@ test('non-fullPage capture skips the scroll wake', async () => {
       { source },
       { agent: { session: { header: { cwd: workspace } } } },
     ))
-    assert.equal(wakeCalls.length, 0)
+    assert.equal(evaluateCalls, 0)
     assert.equal(result.pageHeight, undefined)
   } finally {
     await rm(workspace, { recursive: true, force: true })

--- a/tests/android-attachment-compat.test.js
+++ b/tests/android-attachment-compat.test.js
@@ -2,6 +2,7 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 
 import {
+  createTransientAttachmentCache,
   installAndroidAttachmentCompat,
   isAndroidTermuxRuntime,
   isPermissionBoundaryError,
@@ -40,6 +41,24 @@ test('non-Android runtime returns the original context unchanged', () => {
     runtime: { platform: 'linux', env: { PREFIX: '/usr' } },
   })
   assert.equal(wrapped, ctx)
+})
+
+test('byte-weighted transient cache evicts oldest entries before memory can grow unbounded', () => {
+  const cache = createTransientAttachmentCache({ maxEntries: 64, maxBytes: 5 })
+  const a = {
+    ref: { attachmentId: 'a' },
+    data: new Uint8Array([1, 2, 3, 4]),
+  }
+  const b = {
+    ref: { attachmentId: 'b' },
+    data: new Uint8Array([5, 6, 7, 8]),
+  }
+  assert.equal(cache.set(a), true)
+  assert.deepEqual(cache.stats(), { entries: 1, bytes: 4, maxEntries: 64, maxBytes: 5 })
+  assert.equal(cache.set(b), true)
+  assert.equal(cache.get('a'), undefined)
+  assert.equal(cache.get('b'), b)
+  assert.deepEqual(cache.stats(), { entries: 1, bytes: 4, maxEntries: 64, maxBytes: 5 })
 })
 
 test('Android permission failure falls back to a process-local content-addressed image', async () => {
@@ -83,6 +102,65 @@ test('Android permission failure falls back to a process-local content-addressed
   assert.equal(stored.data, bytes)
   assert.equal(delegatedReads, 0)
   assert.equal(warnings, 1)
+})
+
+test('Android transient fallback enforces total bytes by evicting old refs', async () => {
+  let delegatedReads = 0
+  const attachments = {
+    async saveImage() {
+      throw permissionFailure('EPERM')
+    },
+    async readImage(ref) {
+      delegatedReads += 1
+      return { ref, data: new Uint8Array([9]) }
+    },
+  }
+  const ctx = { get: (name) => (name === 'attachments' ? attachments : undefined) }
+  const wrapped = installAndroidAttachmentCompat(ctx, undefined, {
+    runtime: { platform: 'android', env: {} },
+    probeImage: async () => ({ width: 1, height: 1 }),
+    maxTransientBytes: 5,
+    maxTransientSingleBytes: 5,
+  })
+  const service = wrapped.get('attachments')
+  const first = await service.saveImage({ data: new Uint8Array([1, 2, 3, 4]), mediaType: 'image/png' })
+  const second = await service.saveImage({ data: new Uint8Array([5, 6, 7, 8]), mediaType: 'image/png' })
+
+  assert.notEqual(first.attachmentId, second.attachmentId)
+  const secondStored = await service.readImage(second)
+  assert.deepEqual([...secondStored.data], [5, 6, 7, 8])
+  const firstAfterEviction = await service.readImage(first)
+  assert.deepEqual([...firstAfterEviction.data], [9])
+  assert.equal(delegatedReads, 1, 'evicted refs fall back to the authoritative host store')
+})
+
+test('Android transient fallback rejects one oversized image before probing/decoding it', async () => {
+  let probeCalls = 0
+  const attachments = {
+    async saveImage() {
+      throw permissionFailure('EACCES')
+    },
+    async readImage() {
+      throw new Error('not reached')
+    },
+  }
+  const ctx = { get: (name) => (name === 'attachments' ? attachments : undefined) }
+  const wrapped = installAndroidAttachmentCompat(ctx, undefined, {
+    runtime: { platform: 'android', env: {} },
+    maxTransientBytes: 8,
+    maxTransientSingleBytes: 4,
+    probeImage: async () => {
+      probeCalls += 1
+      return { width: 1, height: 1 }
+    },
+  })
+  const service = wrapped.get('attachments')
+
+  await assert.rejects(
+    service.saveImage({ data: new Uint8Array([1, 2, 3, 4, 5]), mediaType: 'image/png' }),
+    (error) => error?.code === 'ANDROID_TRANSIENT_ATTACHMENT_TOO_LARGE',
+  )
+  assert.equal(probeCalls, 0)
 })
 
 test('successful host saves and non-permission failures keep native semantics', async () => {

--- a/tests/image-resource-governor.test.js
+++ b/tests/image-resource-governor.test.js
@@ -8,6 +8,7 @@ import {
   scaleBox,
   scaledDimensions,
 } from '../lib/image-resource-governor.js'
+import { runWithVisionTurnBudget } from '../lib/turn-budget-context.js'
 
 test('decoded working-set estimates scale with pixels and operation copies', () => {
   assert.equal(estimateDecodedBytes(100, 50, { channels: 4, copies: 1, safetyFactor: 1 }), 20_000)
@@ -109,6 +110,25 @@ test('aborting a queued request removes it without leaking a permit', async () =
   const controller = new AbortController()
   const queued = governor.acquire(40, { signal: controller.signal })
   assert.equal(governor.stats().queued, 1)
+  controller.abort()
+  await assert.rejects(queued, (error) => error && error.name === 'AbortError')
+  assert.equal(governor.stats().queued, 0)
+  release()
+  assert.equal(governor.stats().activeCount, 0)
+})
+
+test('ambient structured-turn budget aborts queued image work even without an explicit call-site signal', async () => {
+  const governor = new ImageResourceGovernor({ maxBytes: 100, maxConcurrent: 1 })
+  const release = await governor.acquire(40)
+  const controller = new AbortController()
+  let queued
+  await runWithVisionTurnBudget(
+    { deadlineAt: Date.now() + 10_000, signal: controller.signal },
+    async () => {
+      queued = governor.acquire(40)
+      assert.equal(governor.stats().queued, 1)
+    },
+  )
   controller.abort()
   await assert.rejects(queued, (error) => error && error.name === 'AbortError')
   assert.equal(governor.stats().queued, 0)

--- a/tests/runtime-boundary-fixes.test.js
+++ b/tests/runtime-boundary-fixes.test.js
@@ -4,7 +4,10 @@ import { existsSync, readFileSync } from 'node:fs'
 import { promisify } from 'node:util'
 
 import { createCoalescingRunner } from '../lib/adapter-update-coalescer.js'
-import { createTesseractExecFileCompat } from '../lib/tesseract-exec-compat.js'
+import {
+  createTesseractExecFileCompat,
+  installTesseractExecFileCompat,
+} from '../lib/tesseract-exec-compat.js'
 
 test('coalescing runner reaches a fixed point across synchronous re-entry and mid-pass topology changes', () => {
   const providers = new Set(['alpha'])
@@ -47,6 +50,33 @@ test('coalescing runner reaches a fixed point across synchronous re-entry and mi
   assert.equal(registrations.get('alpha'), 1)
   assert.equal(registrations.get('beta'), 1)
   assert.equal(maxDepth, 1, 'nested notifications must be coalesced, never recursively executed')
+})
+
+test('coalescing runner stops a permanently dirty synchronous event cycle', () => {
+  let passes = 0
+  let reported
+  let reconcile
+  reconcile = createCoalescingRunner(
+    () => {
+      passes += 1
+      // Pathological host/plugin semantics: every reconciliation publishes the
+      // same event again even though no stable fixed point is reachable.
+      reconcile()
+    },
+    {
+      maxPasses: 5,
+      onNonConverging(info) { reported = info },
+    },
+  )
+
+  reconcile()
+
+  assert.equal(passes, 5)
+  assert.equal(reported.passes, 5)
+  // A later real event gets a fresh bounded attempt instead of leaving the
+  // runner permanently wedged in a `running` state.
+  reconcile()
+  assert.equal(passes, 10)
 })
 
 const pngBytes = Buffer.from([
@@ -125,4 +155,43 @@ test('non-tesseract execFile calls are delegated unchanged', () => {
   assert.deepEqual(calls[0][1], ['-NoProfile'])
   assert.equal(calls[0][2], options)
   assert.equal(calls[0][3], callback)
+})
+
+test('tesseract installer unload does not clobber a later process-level execFile patch', () => {
+  const hostCalls = []
+  const hostExecFile = function (...args) {
+    hostCalls.push(args)
+    return { pid: 4 }
+  }
+  const fakeChildProcess = { execFile: hostExecFile }
+  let syncCalls = 0
+  const dispose = installTesseractExecFileCompat(undefined, {
+    childProcessModule: fakeChildProcess,
+    syncBuiltinESMExports() { syncCalls += 1 },
+  })
+  const visionPatch = fakeChildProcess.execFile
+  assert.notEqual(visionPatch, hostExecFile)
+  assert.equal(visionPatch.active, true)
+
+  // A later plugin captures Vision Router then becomes the top-level patch.
+  const laterPatch = function (...args) {
+    return visionPatch.apply(this, args)
+  }
+  fakeChildProcess.execFile = laterPatch
+
+  dispose()
+
+  assert.equal(fakeChildProcess.execFile, laterPatch, 'later patch must remain authoritative')
+  assert.equal(visionPatch.active, false, 'captured Vision Router wrapper becomes inert')
+  assert.ok(syncCalls >= 2, 'ESM binding is resynced to the current authoritative patch')
+
+  // If the later plugin eventually restores what it captured, the old Vision
+  // Router layer must delegate directly instead of re-enabling OCR materialize.
+  let seenArgs
+  const callback = () => {}
+  hostCalls.length = 0
+  visionPatch('tesseract', ['stdin', 'stdout'], { input: pngBytes }, callback)
+  seenArgs = hostCalls[0]
+  assert.equal(seenArgs[1][0], 'stdin')
+  assert.equal(seenArgs[2].input, pngBytes)
 })

--- a/tests/structured-flow-hardening.test.js
+++ b/tests/structured-flow-hardening.test.js
@@ -227,3 +227,82 @@ test('turn budget stops new visual calls and removes impossible followup reminde
     Date.now = originalNow
   }
 })
+
+test('running structured tool clamps core network/OCR timeouts to remaining turn budget', async () => {
+  const originalNow = Date.now
+  let now = 2_000_000
+  Date.now = () => now
+  try {
+    const handlers = new Map()
+    const defs = new Map()
+    const liveConfig = {
+      visionDepth: 'standard',
+      visionTurnBudgetMs: 10_000,
+      timeoutMs: 120_000,
+      visionTaskTimeoutMs: 45_000,
+      ocrTimeoutMs: 30_000,
+    }
+    const rawScope = {
+      get() { return liveConfig },
+      watch() { return () => {} },
+    }
+    const settingsChild = {
+      settings: {
+        register(namespace) {
+          assert.equal(namespace, 'vision-router')
+          return rawScope
+        },
+      },
+      effect(factory) { return factory() },
+    }
+    const ctx = {
+      on(event, handler) {
+        handlers.set(event, handler)
+        return () => handlers.delete(event)
+      },
+      tools: {
+        register(def) {
+          defs.set(def.name, def)
+          return () => defs.delete(def.name)
+        },
+      },
+      inject(dependencies, callback) {
+        if (dependencies.includes('settings')) callback(settingsChild)
+      },
+    }
+    const wrapped = installStructuredFlowHardening(ctx, liveConfig)
+    let coreScope
+    wrapped.inject(['settings'], (child) => {
+      coreScope = child.settings.register('vision-router', {}, { base: liveConfig })
+    })
+    wrapped.on('agent/pre-step', async (_payload, next) => next())
+
+    let observed
+    wrapped.tools.register({
+      name: 'vision_bootstrap',
+      async execute() {
+        // This is exactly what index.js's current() timeout helpers see while
+        // the tool is running through the wrapped Settings scope.
+        observed = coreScope.get()
+        return bootstrapSuccess({ visual_kind: 'general', mixed_of: [] })
+      },
+    })
+
+    const session = {}
+    const handler = handlers.get('agent/pre-step')
+    await handler(
+      { turn: 1, agent: { session }, messages: [] },
+      async () => ({ kind: 'ok', messages: [] }),
+    )
+    now += 9_750
+    const result = await defs.get('vision_bootstrap').execute({}, { agent: { session } })
+    assert.equal(JSON.parse(result).ok, true)
+    assert.ok(observed)
+    assert.equal(observed.timeoutMs, 250)
+    assert.equal(observed.visionTaskTimeoutMs, 250)
+    assert.equal(observed.ocrTimeoutMs, 250)
+    assert.equal(observed.visionTurnBudgetMs, 10_000, 'policy value itself is not rewritten')
+  } finally {
+    Date.now = originalNow
+  }
+})


### PR DESCRIPTION
## What changed

This PR fixes the first six high-priority findings from a first-principles adversarial review, keeping the scope intentionally limited to those runtime boundaries.

- Bound synchronous `llm/adapters-updated` fixed-point reconciliation so a non-converging host/plugin event cycle cannot pin the Node process forever.
- Reorder full-page HTML screenshot admission: measure and reject impossible pages before scroll/wake work, then re-check dynamically growing pages under step and wall-clock caps.
- Add a process-level FIFO concurrency governor for heavyweight headless Chrome screenshot instances.
- Make the process-level Tesseract `execFile` compatibility patch chain-safe on unload: never clobber a later plugin patch, and deactivate captured Vision Router wrappers so they cannot resurface.
- Replace the Android/Termux transient attachment count-only cache with a count + byte weighted LRU and reject an oversized single transient image before image probing/decoding.
- Turn `visionTurnBudgetMs` into a real execution deadline by propagating the remaining turn budget into the core `timeoutMs`, `visionTaskTimeoutMs`, and `ocrTimeoutMs` reads during structured tool execution, plus an ambient AbortSignal for queued image-resource work.

## Root causes

The common failure mode was not simply “missing validation”; it was resource/state admission happening at the wrong boundary:

1. reconciliation assumed synchronous event graphs always converge;
2. screenshot safety bounded the final artifact but not the work performed to discover it;
3. browser processes were outside image-memory resource governance;
4. a global compatibility patch assumed it remained top-of-chain until unload;
5. the Android fallback bounded object count rather than retained bytes;
6. the structured turn budget was an outer admission check disconnected from the core's already-correct abortable per-task deadline machinery.

## Regression coverage

Added/extended tests for:

- permanently dirty reconciliation cycles;
- static oversized and dynamically growing full-page HTML;
- browser concurrency queueing;
- later-plugin `execFile` patch preservation and inert cleanup;
- Android transient byte eviction and pre-decode single-image rejection;
- live Settings timeout clamping to the remaining structured-turn budget;
- ambient turn cancellation of queued image-resource work.

This is opened as a draft so CI can exercise the full Node 22/24 and DSH rc.6/rc.7 matrix before merge.