### PR TITLE
Close remaining adversarial context/runtime findings

### DIFF
--- a/lib/local-vision-stabilizer.js
+++ b/lib/local-vision-stabilizer.js
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { promisify } from 'node:util'
 import { sameOriginRequest } from './adversarial-hardening.js'
+import { normalizeRuntimeVisionConfig } from './runtime-config-normalizer.js'
 
 /**
  * Narrow runtime guard around the local-vision features merged in #141.
@@ -42,6 +43,7 @@ export async function triggerDesktopScreenshotPermission({
 }
 
 export function installLocalVisionStabilizer(ctx, config = {}, core) {
+  config = normalizeRuntimeVisionConfig(config)
   if (!ctx || typeof ctx !== 'object') return { ctx, bootConfig: config }
 
   let rawScope
@@ -63,7 +65,7 @@ export function installLocalVisionStabilizer(ctx, config = {}, core) {
   const actualConfig = () => {
     try {
       const value = rawScope && typeof rawScope.get === 'function' ? rawScope.get() : config
-      return value && typeof value === 'object' ? value : config
+      return normalizeRuntimeVisionConfig(value && typeof value === 'object' ? value : config)
     } catch {
       return config
     }

--- a/lib/replay-delegation.js
+++ b/lib/replay-delegation.js
@@ -1,8 +1,12 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
+import { normalizeRuntimeVisionConfig } from './runtime-config-normalizer.js'
 
 const wrappedContexts = new WeakMap()
 const wrapperDelegateScope = new AsyncLocalStorage()
 const visionToolScope = new AsyncLocalStorage()
+// One shared adapter object can legitimately be registered into more than one
+// DSH Context. The wrapper closes over ctx, so cache by BOTH identities; an
+// adapter-only cache leaks the first context's settings/catalog into the next.
 const dynamicWrapperAdapters = new WeakMap()
 
 const NATIVE_DEEPSEEK_ROUTE = 'deepseek-official-native'
@@ -74,6 +78,7 @@ function effectiveVisionConfig(ctx, fallbackConfig) {
  * host LLM registry.
  */
 export function configuredVisionAdapterModels(config = {}) {
+  config = normalizeRuntimeVisionConfig(config)
   const allowed = new Map()
   const add = (provider, model) => {
     if (!isNonEmptyString(provider) || provider === VISION_HTTP_ROUTE || !isNonEmptyString(model)) return
@@ -91,7 +96,7 @@ export function configuredVisionAdapterModels(config = {}) {
       if (!entry || !isNonEmptyString(entry.provider) || !isNonEmptyString(entry.model)) continue
       usedRows = true
       add(entry.provider, entry.model)
-      for (const fallback of entry.fallbacks ?? []) add(entry.provider, fallback)
+      for (const fallback of entry.fallbacks) add(entry.provider, fallback)
     }
   }
 
@@ -100,7 +105,7 @@ export function configuredVisionAdapterModels(config = {}) {
   if (!usedRows) {
     const provider = isNonEmptyString(config.provider) ? config.provider : VISION_HTTP_ROUTE
     if (isNonEmptyString(config.model)) add(provider, config.model)
-    for (const fallback of config.fallbacks ?? []) add(provider, fallback)
+    for (const fallback of config.fallbacks) add(provider, fallback)
   }
   return allowed
 }
@@ -197,7 +202,12 @@ async function mainWrapperModel(ctx, fallbackWrapperRoute, model, signal) {
 
 function dynamicWrapperAdapter(adapter, ctx, fallbackWrapperRoute) {
   if (!adapter || (typeof adapter !== 'object' && typeof adapter !== 'function')) return adapter
-  const cached = dynamicWrapperAdapters.get(adapter)
+  let byContext = dynamicWrapperAdapters.get(adapter)
+  if (byContext === undefined) {
+    byContext = new WeakMap()
+    dynamicWrapperAdapters.set(adapter, byContext)
+  }
+  const cached = byContext.get(ctx)
   if (cached) return cached
 
   const stream = adapter.stream
@@ -282,7 +292,7 @@ function dynamicWrapperAdapter(adapter, ctx, fallbackWrapperRoute) {
       return typeof value === 'function' ? value.bind(target) : value
     },
   })
-  dynamicWrapperAdapters.set(adapter, wrapped)
+  byContext.set(ctx, wrapped)
   return wrapped
 }
 

--- a/lib/runtime-config-normalizer.js
+++ b/lib/runtime-config-normalizer.js
@@ -1,0 +1,54 @@
+export const MAX_RUNTIME_PROVIDER_ROWS = 32
+export const MAX_RUNTIME_FALLBACKS_PER_ROW = 32
+export const MAX_RUNTIME_MODEL_ID_CHARS = 512
+
+function plainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function validIdentifier(value) {
+  return typeof value === 'string' && value.length > 0 && value.length <= MAX_RUNTIME_MODEL_ID_CHARS
+}
+
+function normalizeFallbacks(value) {
+  if (!Array.isArray(value)) return []
+  const out = []
+  for (const fallback of value) {
+    if (!validIdentifier(fallback)) continue
+    out.push(fallback)
+    if (out.length >= MAX_RUNTIME_FALLBACKS_PER_ROW) break
+  }
+  return out
+}
+
+/**
+ * Normalize only the provider/model chain fields that runtime code iterates.
+ *
+ * Settings normally validates these fields through Schemastery, but direct
+ * apply() callers, migrations, corrupted profile data, or a future settings
+ * bridge can still hand runtime code a structurally invalid object. Keep the
+ * authorization parser and the execution parser on one bounded shape instead
+ * of letting each boundary improvise its own coercion rules.
+ */
+export function normalizeRuntimeVisionConfig(value) {
+  const source = plainObject(value) ? value : {}
+  const providers = []
+  if (Array.isArray(source.providers)) {
+    for (const entry of source.providers) {
+      if (!plainObject(entry) || !validIdentifier(entry.provider) || !validIdentifier(entry.model)) continue
+      providers.push({
+        ...entry,
+        provider: entry.provider,
+        model: entry.model,
+        fallbacks: normalizeFallbacks(entry.fallbacks),
+      })
+      if (providers.length >= MAX_RUNTIME_PROVIDER_ROWS) break
+    }
+  }
+
+  return {
+    ...source,
+    providers,
+    fallbacks: normalizeFallbacks(source.fallbacks),
+  }
+}

--- a/lib/tesseract-exec-compat.js
+++ b/lib/tesseract-exec-compat.js
@@ -1,19 +1,24 @@
-import { createRequire, syncBuiltinESMExports } from 'node:module'
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 import { tmpdir } from 'node:os'
 import { promisify } from 'node:util'
 
-const require = createRequire(import.meta.url)
-const childProcess = require('node:child_process')
-
-// Install state is keyed by the concrete child_process module object. This
-// keeps tests injectable and, more importantly, lets multiple Vision Router
-// contexts share one process-level shim without overwriting each other.
+// Install state is keyed by the concrete execFile function object. Multiple
+// Vision Router contexts therefore share one custom-promisify shim without
+// replacing child_process.execFile or affecting callback-style callers.
 const installStates = new WeakMap()
 
+function bytesView(input) {
+  if (Buffer.isBuffer(input)) return input
+  if (ArrayBuffer.isView(input)) {
+    return Buffer.from(input.buffer, input.byteOffset, input.byteLength)
+  }
+  if (input instanceof ArrayBuffer) return Buffer.from(input)
+  return Buffer.from(input)
+}
+
 function extensionForBytes(input) {
-  const bytes = Buffer.from(input)
+  const bytes = bytesView(input)
   if (bytes.length >= 8 && bytes.subarray(0, 8).equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))) return '.png'
   if (bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) return '.jpg'
   if (bytes.length >= 12 && bytes.toString('ascii', 0, 4) === 'RIFF' && bytes.toString('ascii', 8, 12) === 'WEBP') return '.webp'
@@ -24,150 +29,123 @@ function extensionForBytes(input) {
   return '.img'
 }
 
-function cleanupTempDir(dir) {
-  if (!dir) return
-  try {
-    rmSync(dir, { recursive: true, force: true, maxRetries: 3, retryDelay: 50 })
-  } catch {
-    // Cleanup is best-effort. Never turn a successful OCR result into a tool
-    // failure because antivirus/indexing briefly held the temporary file.
-  }
+function isCompatCall(file, args, options) {
+  const isTesseract = typeof file === 'string' && /(^|[\\/])tesseract(?:\.exe)?$/i.test(file)
+  const readsStdin = Array.isArray(args) && (args[0] === 'stdin' || args[0] === '-')
+  const hasInput =
+    options &&
+    typeof options === 'object' &&
+    Object.prototype.hasOwnProperty.call(options, 'input') &&
+    options.input !== undefined &&
+    options.input !== null
+  return isTesseract && readsStdin && hasInput
+}
+
+function nativePromisified(execFileImpl, originalCustom) {
+  if (typeof originalCustom === 'function') return originalCustom
+  return (file, args, options) => new Promise((resolve, reject) => {
+    execFileImpl(file, args, options, (error, stdout, stderr) => {
+      if (error) {
+        if (error && typeof error === 'object') {
+          try {
+            error.stdout = stdout
+            error.stderr = stderr
+          } catch {
+            /* preserve the original error */
+          }
+        }
+        reject(error)
+        return
+      }
+      resolve({ stdout, stderr })
+    })
+  })
 }
 
 /**
- * Wrap callback-style execFile so the legacy `options.input` shape used by
- * Vision Router's OCR helper becomes a real seekable input file for Tesseract.
- * Async child_process.execFile does not consume an `input` option, so without
- * this boundary no bytes/EOF reach the child and it waits until timeout.
+ * Create an async-only compatibility layer for promisify(execFile).
  *
- * The wrapper can be deactivated. Deactivation turns it into an inert
- * delegator to the function it originally wrapped. This matters when another
- * plugin loads after Vision Router and captures this wrapper: unloading Vision
- * Router must not clobber the later plugin's process-level patch, and the
- * captured Vision Router layer must not spring back to life if that later
- * plugin subsequently restores what it captured.
+ * Node's async execFile ignores an `options.input` field. Vision Router's OCR
+ * caller historically supplied image bytes that way, so Tesseract waited on
+ * stdin until timeout. Instead of replacing execFile process-wide, intercept
+ * only its custom promisified form, materialize the one OCR input with
+ * fs/promises, delegate to the native promisified implementation, then remove
+ * the temporary directory asynchronously.
  */
-export function createTesseractExecFileCompat(execFileImpl) {
+export function createTesseractPromisifyCompat(execFileImpl, originalCustom, options = {}) {
   if (typeof execFileImpl !== 'function') {
-    throw new TypeError('createTesseractExecFileCompat: execFileImpl must be a function')
+    throw new TypeError('createTesseractPromisifyCompat: execFileImpl must be a function')
   }
 
+  const delegate = nativePromisified(execFileImpl, originalCustom)
+  const makeTempDir = options.mkdtemp ?? mkdtemp
+  const writeTempFile = options.writeFile ?? writeFile
+  const removeTempDir = options.rm ?? rm
+  const tempDir = options.tempDir ?? tmpdir()
   let active = true
 
-  function tesseractExecFileCompat(file, args, options, callback) {
-    if (!active) return execFileImpl.apply(this, arguments)
-
-    const isTesseract = typeof file === 'string' && /(^|[\\/])tesseract(?:\.exe)?$/i.test(file)
-    const readsStdin = Array.isArray(args) && (args[0] === 'stdin' || args[0] === '-')
-    const hasInput =
-      options &&
-      typeof options === 'object' &&
-      Object.prototype.hasOwnProperty.call(options, 'input') &&
-      options.input !== undefined &&
-      options.input !== null
-
-    if (!isTesseract || !readsStdin || !hasInput || typeof callback !== 'function') {
-      return execFileImpl.apply(this, arguments)
+  async function tesseractPromisifyCompat(file, args, execOptions) {
+    if (!active || !isCompatCall(file, args, execOptions)) {
+      return delegate(file, args, execOptions)
     }
 
-    const bytes = Buffer.from(options.input)
+    const bytes = bytesView(execOptions.input)
     let dir
-    let inputPath
     try {
-      dir = mkdtempSync(path.join(tmpdir(), 'dsh-vision-router-ocr-'))
-      inputPath = path.join(dir, `input${extensionForBytes(bytes)}`)
-      writeFileSync(inputPath, bytes)
-    } catch (error) {
-      cleanupTempDir(dir)
-      throw error
-    }
+      dir = await makeTempDir(path.join(tempDir, 'dsh-vision-router-ocr-'))
+      const inputPath = path.join(dir, `input${extensionForBytes(bytes)}`)
+      await writeTempFile(inputPath, bytes)
 
-    const { input: _ignoredInput, ...restOptions } = options
-    const nextOptions = { ...restOptions, windowsHide: true }
-    const nextArgs = [inputPath, ...args.slice(1)]
-
-    try {
-      return execFileImpl.call(this, file, nextArgs, nextOptions, (error, stdout, stderr) => {
-        cleanupTempDir(dir)
-        callback(error, stdout, stderr)
-      })
-    } catch (error) {
-      cleanupTempDir(dir)
-      throw error
+      const { input: _ignoredInput, ...restOptions } = execOptions
+      const nextOptions = { ...restOptions, windowsHide: true }
+      const nextArgs = [inputPath, ...args.slice(1)]
+      return await delegate(file, nextArgs, nextOptions)
+    } finally {
+      if (dir) {
+        try {
+          await removeTempDir(dir, { recursive: true, force: true, maxRetries: 3, retryDelay: 50 })
+        } catch {
+          // Cleanup is best-effort. Antivirus/indexing may briefly hold the
+          // file; never turn a successful OCR result into a tool failure.
+        }
+      }
     }
   }
 
-  Object.defineProperty(tesseractExecFileCompat, 'deactivate', {
+  Object.defineProperty(tesseractPromisifyCompat, 'deactivate', {
     configurable: false,
     enumerable: false,
-    value() {
-      active = false
-    },
+    value() { active = false },
   })
-  Object.defineProperty(tesseractExecFileCompat, 'active', {
+  Object.defineProperty(tesseractPromisifyCompat, 'active', {
     configurable: false,
     enumerable: false,
-    get() {
-      return active
-    },
+    get() { return active },
   })
 
-  // Native execFile's custom promisify resolves { stdout, stderr }. Preserve
-  // that contract because index.js destructures this exact shape.
-  Object.defineProperty(tesseractExecFileCompat, promisify.custom, {
-    configurable: true,
-    value(file, args, options) {
-      return new Promise((resolve, reject) => {
-        tesseractExecFileCompat(file, args, options, (error, stdout, stderr) => {
-          if (error) {
-            if (error && typeof error === 'object') {
-              try {
-                error.stdout = stdout
-                error.stderr = stderr
-              } catch {
-                // Preserve the original error if it is frozen/read-only.
-              }
-            }
-            reject(error)
-            return
-          }
-          resolve({ stdout, stderr })
-        })
-      })
-    },
-  })
-
-  return tesseractExecFileCompat
+  return tesseractPromisifyCompat
 }
 
 /**
- * Install the narrow shim for the Vision Router context lifetime.
- * syncBuiltinESMExports updates index.js's already-imported execFile binding.
- *
- * Cleanup is chain-safe: only restore the original function when our wrapper
- * is still the process-level top layer. If another plugin patched execFile
- * later, leave that patch installed and merely deactivate our captured layer.
+ * Install the narrow promisify compatibility for the Vision Router context.
+ * Callback-style child_process.execFile is never replaced. Cleanup is
+ * chain-safe: if another plugin replaces execFile[promisify.custom] later, its
+ * value remains authoritative while our captured wrapper becomes inert.
  */
 export function installTesseractExecFileCompat(ctx, options = {}) {
-  const moduleObject = options.childProcessModule ?? childProcess
-  const syncBuiltin = options.syncBuiltinESMExports ?? syncBuiltinESMExports
+  const moduleObject = options.childProcessModule ?? awaitableChildProcess()
   if (!moduleObject || typeof moduleObject !== 'object' || typeof moduleObject.execFile !== 'function') {
     throw new TypeError('installTesseractExecFileCompat: childProcessModule.execFile must be a function')
   }
 
-  let state = installStates.get(moduleObject)
+  const execFileImpl = moduleObject.execFile
+  let state = installStates.get(execFileImpl)
   if (state === undefined) {
-    const originalExecFile = moduleObject.execFile
-    const patchedExecFile = createTesseractExecFileCompat(originalExecFile)
-    moduleObject.execFile = patchedExecFile
-    try { syncBuiltin() } catch { /* keep the CJS patch even if ESM sync is unavailable */ }
-    state = {
-      count: 0,
-      originalExecFile,
-      patchedExecFile,
-      syncBuiltin,
-    }
-    installStates.set(moduleObject, state)
+    const originalCustom = execFileImpl[promisify.custom]
+    const patchedCustom = createTesseractPromisifyCompat(execFileImpl, originalCustom, options)
+    execFileImpl[promisify.custom] = patchedCustom
+    state = { count: 0, execFileImpl, originalCustom, patchedCustom }
+    installStates.set(execFileImpl, state)
   }
   state.count += 1
 
@@ -178,22 +156,27 @@ export function installTesseractExecFileCompat(ctx, options = {}) {
     state.count = Math.max(0, state.count - 1)
     if (state.count !== 0) return
 
-    // Always deactivate first. A later plugin may have captured this function
-    // and still legitimately sit above us in the patch chain.
-    try { state.patchedExecFile.deactivate?.() } catch { /* best effort */ }
-
-    if (moduleObject.execFile === state.patchedExecFile) {
-      moduleObject.execFile = state.originalExecFile
+    try { state.patchedCustom.deactivate?.() } catch { /* best effort */ }
+    if (state.execFileImpl[promisify.custom] === state.patchedCustom) {
+      if (state.originalCustom === undefined) delete state.execFileImpl[promisify.custom]
+      else state.execFileImpl[promisify.custom] = state.originalCustom
     }
-    // Sync the ESM binding to whatever function is CURRENTLY authoritative:
-    // either the original function or a later plugin's wrapper. This avoids
-    // leaving index.js pinned to our now-inert layer after unload.
-    try { state.syncBuiltin() } catch { /* best effort */ }
-    installStates.delete(moduleObject)
+    installStates.delete(state.execFileImpl)
   }
 
   if (ctx && typeof ctx.effect === 'function') {
-    ctx.effect(() => dispose, 'vision-router: tesseract execFile input compatibility')
+    ctx.effect(() => dispose, 'vision-router: tesseract promisify input compatibility')
   }
   return dispose
+}
+
+// Lazy CommonJS acquisition avoids touching the process-level API during module
+// evaluation and keeps tests able to inject a fake child_process module.
+function awaitableChildProcess() {
+  // createRequire is avoided deliberately: importing the builtin here is safe
+  // and the function runs only when install() actually needs the default.
+  // eslint/oxlint environments used by the project allow require through the
+  // global process main module only inconsistently, so keep this tiny dynamic
+  // bridge in one place.
+  return globalThis.process?.getBuiltinModule?.('child_process')
 }

--- a/lib/tesseract-exec-compat.js
+++ b/lib/tesseract-exec-compat.js
@@ -1,7 +1,11 @@
 import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 import { tmpdir } from 'node:os'
+import { createRequire } from 'node:module'
 import { promisify } from 'node:util'
+
+const require = createRequire(import.meta.url)
+const childProcess = require('node:child_process')
 
 // Install state is keyed by the concrete execFile function object. Multiple
 // Vision Router contexts therefore share one custom-promisify shim without
@@ -133,7 +137,7 @@ export function createTesseractPromisifyCompat(execFileImpl, originalCustom, opt
  * value remains authoritative while our captured wrapper becomes inert.
  */
 export function installTesseractExecFileCompat(ctx, options = {}) {
-  const moduleObject = options.childProcessModule ?? awaitableChildProcess()
+  const moduleObject = options.childProcessModule ?? childProcess
   if (!moduleObject || typeof moduleObject !== 'object' || typeof moduleObject.execFile !== 'function') {
     throw new TypeError('installTesseractExecFileCompat: childProcessModule.execFile must be a function')
   }
@@ -168,15 +172,4 @@ export function installTesseractExecFileCompat(ctx, options = {}) {
     ctx.effect(() => dispose, 'vision-router: tesseract promisify input compatibility')
   }
   return dispose
-}
-
-// Lazy CommonJS acquisition avoids touching the process-level API during module
-// evaluation and keeps tests able to inject a fake child_process module.
-function awaitableChildProcess() {
-  // createRequire is avoided deliberately: importing the builtin here is safe
-  // and the function runs only when install() actually needs the default.
-  // eslint/oxlint environments used by the project allow require through the
-  // global process main module only inconsistently, so keep this tiny dynamic
-  // bridge in one place.
-  return globalThis.process?.getBuiltinModule?.('child_process')
 }

--- a/tests/runtime-boundary-fixes.test.js
+++ b/tests/runtime-boundary-fixes.test.js
@@ -113,7 +113,7 @@ test('tesseract promisify compatibility materializes asynchronously and cleans u
     },
     async writeFile(file, bytes) {
       events.push('write-start')
-      assert.equal(file, '/virtual-tmp/ocr-123/input.png')
+      assert.match(file, /ocr-123[\\/]input\.png$/)
       assert.equal(bytes, pngBytes, 'Buffer input should not be copied before async materialization')
       await new Promise((resolve) => setImmediate(() => {
         eventLoopYielded = true
@@ -138,7 +138,7 @@ test('tesseract promisify compatibility materializes asynchronously and cleans u
   assert.deepEqual(result, { stdout: 'OCR_OK', stderr: '' })
   assert.equal(eventLoopYielded, true, 'large OCR staging must yield instead of blocking the event loop')
   assert.deepEqual(events, ['mkdir', 'write-start', 'write-end', 'delegate', 'rm'])
-  assert.equal(delegatedArgs[0], '/virtual-tmp/ocr-123/input.png')
+  assert.match(delegatedArgs[0], /ocr-123[\\/]input\.png$/)
   assert.equal(Object.prototype.hasOwnProperty.call(delegatedOptions, 'input'), false)
   assert.equal(delegatedOptions.timeout, 1500)
   assert.equal(delegatedOptions.windowsHide, true)

--- a/tests/runtime-boundary-fixes.test.js
+++ b/tests/runtime-boundary-fixes.test.js
@@ -1,13 +1,24 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { existsSync, readFileSync } from 'node:fs'
 import { promisify } from 'node:util'
 
 import { createCoalescingRunner } from '../lib/adapter-update-coalescer.js'
 import {
-  createTesseractExecFileCompat,
+  createTesseractPromisifyCompat,
   installTesseractExecFileCompat,
 } from '../lib/tesseract-exec-compat.js'
+import {
+  configuredVisionAdapterModels,
+  contextWithDelegatedReplay,
+} from '../lib/replay-delegation.js'
+import {
+  MAX_RUNTIME_FALLBACKS_PER_ROW,
+  MAX_RUNTIME_MODEL_ID_CHARS,
+  MAX_RUNTIME_PROVIDER_ROWS,
+  normalizeRuntimeVisionConfig,
+} from '../lib/runtime-config-normalizer.js'
+import { createSessionVisionStateStore } from '../lib/session-vision-state.js'
+import { installLocalVisionStabilizer } from '../lib/local-vision-stabilizer.js'
 import {
   installLocalMutationRouteBoundary,
   isLocalUiRequest,
@@ -78,112 +89,252 @@ const pngBytes = Buffer.from([
   0x00, 0x00, 0x00, 0x00,
 ])
 
-test('tesseract execFile compatibility materializes input bytes and preserves promisify shape', async () => {
-  let materializedPath
+test('tesseract promisify compatibility materializes asynchronously and cleans up', async () => {
+  const events = []
+  let delegatedArgs
   let delegatedOptions
+  let eventLoopYielded = false
 
-  const fakeExecFile = (_file, args, options, callback) => {
-    materializedPath = args[0]
-    delegatedOptions = options
-    assert.notEqual(materializedPath, 'stdin')
-    assert.match(materializedPath, /input\.png$/)
-    assert.equal(existsSync(materializedPath), true)
-    assert.deepEqual(readFileSync(materializedPath), pngBytes)
-    callback(null, 'OCR_OK', '')
-    return { pid: 1 }
+  const fakeExecFile = () => {
+    throw new Error('callback execFile must not be used when a native custom promisify exists')
   }
+  const originalCustom = async (_file, args, options) => {
+    events.push('delegate')
+    delegatedArgs = args
+    delegatedOptions = options
+    return { stdout: 'OCR_OK', stderr: '' }
+  }
+  const wrapped = createTesseractPromisifyCompat(fakeExecFile, originalCustom, {
+    tempDir: '/virtual-tmp',
+    async mkdtemp(prefix) {
+      events.push('mkdir')
+      assert.match(prefix, /dsh-vision-router-ocr-$/)
+      return '/virtual-tmp/ocr-123'
+    },
+    async writeFile(file, bytes) {
+      events.push('write-start')
+      assert.equal(file, '/virtual-tmp/ocr-123/input.png')
+      assert.equal(bytes, pngBytes, 'Buffer input should not be copied before async materialization')
+      await new Promise((resolve) => setImmediate(() => {
+        eventLoopYielded = true
+        resolve()
+      }))
+      events.push('write-end')
+    },
+    async rm(dir, options) {
+      events.push('rm')
+      assert.equal(dir, '/virtual-tmp/ocr-123')
+      assert.equal(options.recursive, true)
+      assert.equal(options.force, true)
+    },
+  })
 
-  const wrapped = createTesseractExecFileCompat(fakeExecFile)
-  const result = await promisify(wrapped)(
+  const result = await wrapped(
     'tesseract',
     ['stdin', 'stdout', '-l', 'chi_sim+eng', '--psm', '6'],
     { timeout: 1500, maxBuffer: 1024, input: pngBytes },
   )
 
   assert.deepEqual(result, { stdout: 'OCR_OK', stderr: '' })
+  assert.equal(eventLoopYielded, true, 'large OCR staging must yield instead of blocking the event loop')
+  assert.deepEqual(events, ['mkdir', 'write-start', 'write-end', 'delegate', 'rm'])
+  assert.equal(delegatedArgs[0], '/virtual-tmp/ocr-123/input.png')
   assert.equal(Object.prototype.hasOwnProperty.call(delegatedOptions, 'input'), false)
   assert.equal(delegatedOptions.timeout, 1500)
   assert.equal(delegatedOptions.windowsHide, true)
-  assert.equal(existsSync(materializedPath), false, 'temporary OCR input must be removed after success')
 })
 
-test('tesseract execFile compatibility removes materialized input after failure', async () => {
-  let materializedPath
-
-  const fakeExecFile = (_file, args, _options, callback) => {
-    materializedPath = args[0]
-    assert.equal(existsSync(materializedPath), true)
-    assert.deepEqual(readFileSync(materializedPath), pngBytes)
-    callback(new Error('fake tesseract failure'), '', 'boom')
-    return { pid: 2 }
-  }
-
-  const wrapped = createTesseractExecFileCompat(fakeExecFile)
-  await assert.rejects(
-    promisify(wrapped)(
-      'tesseract',
-      ['stdin', 'stdout', '-l', 'chi_sim+eng', '--psm', '6'],
-      { timeout: 1500, maxBuffer: 1024, input: pngBytes },
-    ),
-    /fake tesseract failure/,
+test('tesseract promisify compatibility cleans up after delegated failure', async () => {
+  const events = []
+  const wrapped = createTesseractPromisifyCompat(
+    () => {},
+    async () => {
+      events.push('delegate')
+      throw new Error('fake tesseract failure')
+    },
+    {
+      tempDir: '/virtual-tmp',
+      async mkdtemp() { events.push('mkdir'); return '/virtual-tmp/ocr-fail' },
+      async writeFile() { events.push('write') },
+      async rm() { events.push('rm') },
+    },
   )
 
-  assert.equal(existsSync(materializedPath), false, 'temporary OCR input must be removed after failure')
+  await assert.rejects(
+    wrapped('tesseract', ['stdin', 'stdout'], { input: pngBytes }),
+    /fake tesseract failure/,
+  )
+  assert.deepEqual(events, ['mkdir', 'write', 'delegate', 'rm'])
 })
 
-test('non-tesseract execFile calls are delegated unchanged', () => {
+test('non-tesseract promisified execFile calls keep native semantics', async () => {
   const calls = []
-  const fakeExecFile = function (...args) {
-    calls.push(args)
-    return { pid: 3 }
-  }
-  const wrapped = createTesseractExecFileCompat(fakeExecFile)
-  const callback = () => {}
   const options = { timeout: 99, input: Buffer.from('not for us') }
+  const wrapped = createTesseractPromisifyCompat(
+    () => {},
+    async (...args) => {
+      calls.push(args)
+      return { stdout: 'native', stderr: '' }
+    },
+    {
+      async mkdtemp() { throw new Error('must not materialize non-tesseract calls') },
+    },
+  )
 
-  const child = wrapped('powershell.exe', ['-NoProfile'], options, callback)
-
-  assert.deepEqual(child, { pid: 3 })
+  const result = await wrapped('powershell.exe', ['-NoProfile'], options)
+  assert.deepEqual(result, { stdout: 'native', stderr: '' })
   assert.equal(calls.length, 1)
   assert.equal(calls[0][0], 'powershell.exe')
   assert.deepEqual(calls[0][1], ['-NoProfile'])
   assert.equal(calls[0][2], options)
-  assert.equal(calls[0][3], callback)
 })
 
-test('tesseract installer unload does not clobber a later process-level execFile patch', () => {
-  const hostCalls = []
-  const hostExecFile = function (...args) {
-    hostCalls.push(args)
-    return { pid: 4 }
-  }
-  const fakeChildProcess = { execFile: hostExecFile }
-  let syncCalls = 0
+test('tesseract installer never replaces execFile and unload preserves a later custom promisify patch', async () => {
+  const originalCallbackExecFile = function () { return { pid: 4 } }
+  const originalCustom = async () => ({ stdout: 'original', stderr: '' })
+  originalCallbackExecFile[promisify.custom] = originalCustom
+  const fakeChildProcess = { execFile: originalCallbackExecFile }
+
   const dispose = installTesseractExecFileCompat(undefined, {
     childProcessModule: fakeChildProcess,
-    syncBuiltinESMExports() { syncCalls += 1 },
+    tempDir: '/virtual-tmp',
+    async mkdtemp() { return '/virtual-tmp/ocr-installer' },
+    async writeFile() {},
+    async rm() {},
   })
-  const visionPatch = fakeChildProcess.execFile
-  assert.notEqual(visionPatch, hostExecFile)
-  assert.equal(visionPatch.active, true)
 
-  const laterPatch = function (...args) {
-    return visionPatch.apply(this, args)
-  }
-  fakeChildProcess.execFile = laterPatch
+  assert.equal(fakeChildProcess.execFile, originalCallbackExecFile, 'callback API identity must stay native')
+  const visionCustom = originalCallbackExecFile[promisify.custom]
+  assert.notEqual(visionCustom, originalCustom)
+  assert.equal(visionCustom.active, true)
 
+  const laterCustom = async () => ({ stdout: 'later', stderr: '' })
+  originalCallbackExecFile[promisify.custom] = laterCustom
   dispose()
 
-  assert.equal(fakeChildProcess.execFile, laterPatch, 'later patch must remain authoritative')
-  assert.equal(visionPatch.active, false, 'captured Vision Router wrapper becomes inert')
-  assert.ok(syncCalls >= 2, 'ESM binding is resynced to the current authoritative patch')
+  assert.equal(originalCallbackExecFile[promisify.custom], laterCustom, 'later plugin custom promisify remains authoritative')
+  assert.equal(visionCustom.active, false, 'captured Vision Router custom promisify becomes inert')
+  assert.deepEqual(await visionCustom('node', ['--version'], {}), { stdout: 'original', stderr: '' })
+})
 
-  const callback = () => {}
-  hostCalls.length = 0
-  visionPatch('tesseract', ['stdin', 'stdout'], { input: pngBytes }, callback)
-  const seenArgs = hostCalls[0]
-  assert.equal(seenArgs[1][0], 'stdin')
-  assert.equal(seenArgs[2].input, pngBytes)
+test('one shared wrapper adapter never captures another DSH context', async () => {
+  const sharedAdapter = {
+    async *stream() { yield { type: 'finish', reason: { kind: 'stop' } } },
+    async listModels() { return [] },
+    async resolveModel(_provider, model) { return { provider: 'core-wrapper', id: model } },
+  }
+
+  function harness(route, retryPolicy) {
+    let registered
+    const officialAdapter = {
+      async listModels(provider) {
+        return [{ provider, id: 'deepseek-v4-pro', name: route, inputModalities: ['text'] }]
+      },
+      async resolveModel(provider, model) {
+        return { provider, id: model, name: route, inputModalities: ['text'] }
+      },
+    }
+    const ctx = {
+      get(name) {
+        if (name !== 'settings') return undefined
+        return { get: () => ({ wrapperRoute: route }) }
+      },
+      llm: {
+        registration(provider) {
+          return provider === 'deepseek-official' ? { retryPolicy, adapter: officialAdapter } : undefined
+        },
+        registerAdapter(_providers, adapter) { registered = adapter; return () => {} },
+        async *stream() { yield { type: 'finish', reason: { kind: 'stop' } } },
+      },
+    }
+    const wrapped = contextWithDelegatedReplay(ctx, { wrapperRoute: route })
+    wrapped.llm.registerAdapter([route], sharedAdapter)
+    return () => registered
+  }
+
+  const adapterA = harness('alpha-vision', 'alpha-retry')()
+  const adapterB = harness('beta-vision', 'beta-retry')()
+
+  assert.notEqual(adapterA, adapterB, 'the same source adapter needs one proxy per owning context')
+  assert.equal(adapterA.providerRetryPolicy(), 'alpha-retry')
+  assert.equal(adapterB.providerRetryPolicy(), 'beta-retry')
+  assert.equal((await adapterA.listModels())[0].provider, 'alpha-vision')
+  assert.equal((await adapterB.listModels())[0].provider, 'beta-vision')
+})
+
+test('runtime vision config normalization is bounded and makes malformed fallbacks non-iterable-safe', () => {
+  const tooLong = 'x'.repeat(MAX_RUNTIME_MODEL_ID_CHARS + 1)
+  const rows = Array.from({ length: MAX_RUNTIME_PROVIDER_ROWS + 10 }, (_, i) => ({
+    provider: `provider-${i}`,
+    model: `model-${i}`,
+    fallbacks: Array.from({ length: MAX_RUNTIME_FALLBACKS_PER_ROW + 10 }, (_x, j) => `fallback-${j}`),
+  }))
+  rows.unshift({ provider: 'bad', model: tooLong, fallbacks: ['must-not-survive'] })
+  const normalized = normalizeRuntimeVisionConfig({ providers: rows, fallbacks: { malformed: true } })
+
+  assert.equal(normalized.providers.length, MAX_RUNTIME_PROVIDER_ROWS)
+  assert.ok(normalized.providers.every((row) => row.fallbacks.length <= MAX_RUNTIME_FALLBACKS_PER_ROW))
+  assert.deepEqual(normalized.fallbacks, [])
+  assert.ok(normalized.providers.every((row) => row.model !== tooLong))
+
+  assert.doesNotThrow(() => configuredVisionAdapterModels({
+    providers: [{ provider: 'zhipu', model: 'glm-4.6v-flash', fallbacks: { malformed: true } }],
+    fallbacks: { malformed: true },
+  }))
+  const allowed = configuredVisionAdapterModels({
+    providers: [{ provider: 'zhipu', model: 'glm-4.6v-flash', fallbacks: { malformed: true } }],
+  })
+  assert.deepEqual([...allowed.get('zhipu')], ['glm-4.6v-flash'])
+})
+
+test('live Settings values are normalized before the core can iterate the vision chain', () => {
+  const rawScope = {
+    get() {
+      return {
+        providers: [{ provider: 'zhipu', model: 'glm', fallbacks: { malformed: true } }],
+        fallbacks: { malformed: true },
+      }
+    },
+    watch() { return () => {} },
+  }
+  const child = {
+    settings: {
+      register() { return rawScope },
+    },
+  }
+  const ctx = {
+    tools: { register() { return () => {} } },
+    llm: {},
+    inject(_deps, callback) { return callback(child) },
+    effect() { return () => {} },
+  }
+  const { ctx: stabilized, bootConfig } = installLocalVisionStabilizer(
+    ctx,
+    { providers: [{ provider: 'p', model: 'm', fallbacks: { malformed: true } }] },
+    {},
+  )
+  assert.deepEqual(bootConfig.providers[0].fallbacks, [])
+
+  let scope
+  stabilized.inject(['settings'], (injected) => {
+    scope = injected.settings.register('vision-router', {}, {})
+  })
+  assert.deepEqual(scope.get().providers[0].fallbacks, [])
+  assert.deepEqual(scope.get().fallbacks, [])
+})
+
+test('apply-level vision state stores isolate identical session ids across DSH contexts', () => {
+  const first = createSessionVisionStateStore()
+  const second = createSessionVisionStateStore()
+  const sessionA = { id: 'session-1' }
+  const sessionB = { id: 'session-1' }
+
+  first.setDescription(sessionA, 'sha256:image', 'only in first apply')
+  first.recordAttachments(sessionA, [{ attachmentId: 'sha256:image', marker: 'A' }])
+
+  assert.equal(first.getDescription(sessionA, 'sha256:image'), 'only in first apply')
+  assert.equal(second.getDescription(sessionB, 'sha256:image'), undefined)
+  assert.equal(second.lookupAttachment(sessionB, 'sha256:image'), undefined)
 })
 
 test('loopback transport detection covers IPv4, IPv6 and IPv4-mapped IPv6 only', () => {
@@ -289,8 +440,6 @@ test('local mutation boundary preserves injected child identity and rejects remo
   assert.equal(res.status, 403, 'reverse-proxy-local transport with an external Host stays remote')
   assert.equal(calls, 1)
 
-  // Capability+method specific: GET on the mutation route itself is still the
-  // real handler's responsibility.
   res = responseRecorder()
   await registered.handler(
     { method: 'GET', socket: { remoteAddress: '10.0.0.8' }, headers: { host: 'router.example.com' } },


### PR DESCRIPTION
## Scope

Close the original adversarial findings 13–16 after re-checking them against current main. This deliberately does not duplicate the unrelated resource-hardening batch already merged on main.

## Root-cause results

- **13 confirmed:** `dynamicWrapperAdapters` was keyed only by the source adapter even though the proxy closes over a DSH Context. Reusing one adapter object across contexts could make the second context inherit the first context's settings/catalog/retry-policy view.
- **14 confirmed and broader than one throw:** execution and authorization each interpreted runtime provider/fallback config separately. A malformed hot/programmatic value such as `fallbacks: {}` could throw, and independent parsers could later disagree about what is executable vs authorized.
- **15 already neutralized by #208 architecture:** Vision Router now creates its session-vision state store inside each `core.apply()`. DSH only requires session-id uniqueness inside one SessionStore, so same ids across profiles are safe because their Vision Router stores are distinct. This PR adds a regression instead of adding redundant production namespacing.
- **16 confirmed:** the Tesseract workaround used synchronous temp-file I/O and replaced process-level `child_process.execFile`. The real compatibility need exists only for `promisify(execFile)` with the legacy Tesseract `options.input` call shape.

## Fixes

- Cache dynamic wrapper proxies by **adapter + context**, both weakly held.
- Add one bounded runtime vision-chain normalizer (32 rows, 32 fallbacks per row, 512-char identifiers) and use it at both authorization and core-facing live-settings boundaries.
- Keep finding 15 as a regression-only invariant: two apply-level stores with the same `session-1` cannot cross-read visual memory.
- Replace the process-wide execFile wrapper with an async `execFile[util.promisify.custom]` compatibility layer. Callback `execFile` identity is untouched; only Tesseract stdin + `options.input` is asynchronously materialized with `fs/promises`, then asynchronously cleaned up. Cleanup remains chain-safe if another plugin later replaces the custom promisify function.

## Regression coverage

- one shared adapter object registered into two contexts gets distinct proxies and context-correct retry/model metadata;
- malformed fallback objects do not throw, oversized/overlong runtime chains are bounded, and live Settings are normalized before core reads them;
- identical session ids in two Vision Router apply-level stores remain isolated;
- OCR temp staging yields to the event loop, cleans after success/failure, leaves non-Tesseract calls native, never replaces callback execFile, and does not clobber a later custom-promisify patch.

## Validation

Final head `c3e687c64434cd25e186774b1cbeaf56580bcafe` passed CI #745:

- Node 22 and Node 24 full `pnpm test`;
- DSH `0.1.0-rc.6` and `0.1.0-rc.7` contract smoke;
- Ubuntu, macOS, and Windows cross-platform runtime regressions;
- packed-plugin installation into the DSH-like host with shared `sharp` on all three platforms.

The first Windows pass caught one regression-test bug only: the OCR staging assertion hard-coded POSIX `/` separators. Product behavior and every other new invariant passed; the assertion was made path-neutral and the final head is fully green.