### PR TITLE
fix: prevent settings client/Host contract drift

### DIFF
--- a/entry.js
+++ b/entry.js
@@ -40,6 +40,19 @@ core.Config.set('progressiveTools', z.boolean().default(false))
 // from multiplying them into several minutes of serial waiting.
 core.Config.set('visionTurnBudgetMs', z.number().step(1000).min(10000).max(600000).default(90000))
 
+// Settings surfaces and Host persistence must agree on this field. Keep the
+// permission on the public entry contract as well as index.js so a packaged
+// build cannot expose the new client toggle while registering an older Host
+// schema that silently recovers from the rejected settings.mutate call. This
+// deliberately repeats the default: entry.js is the final schema authority
+// loaded by Cordis and therefore the right place to close client/Host drift.
+core.Config.set('allowRemoteSettings', z.boolean().default(false))
+
+// Increment whenever the browser-visible settings contract gains a field whose
+// absence changes write semantics. Tests pin this alongside the schema so a
+// future release cannot ship a new client against an indistinguishable Host.
+export const SETTINGS_CONTRACT_REVISION = 2
+
 export * from './index.js'
 export {
   attachmentContextForContract,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-vision-router",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "Eyes for text-only DeepSeek Harness agents: built-in free vision chain (no key) + pixel-level vision tools (Q&A, grounding, crop, pixel diff, colors, OCR, SVG trace, cutout, screenshots). One-command install, no Python, image turns work like ordinary tool-calling turns.",
   "license": "MIT",
   "repository": {

--- a/tests/bundle-defaults.test.js
+++ b/tests/bundle-defaults.test.js
@@ -1,7 +1,7 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import { readFile } from 'node:fs/promises'
-import { Config } from '../entry.js'
+import { Config, SETTINGS_CONTRACT_REVISION } from '../entry.js'
 
 const bundlePatch = new URL('../cordis.patch.yml', import.meta.url)
 
@@ -19,4 +19,10 @@ test('public plugin config defaults progressive tools off', () => {
 
 test('progressive tools remain an explicit opt-in', () => {
   assert.equal(Config({ progressiveTools: true }).progressiveTools, true)
+})
+
+test('entry contract always exposes the local remote-settings permission', () => {
+  assert.equal(SETTINGS_CONTRACT_REVISION, 2)
+  assert.equal(Config({}).allowRemoteSettings, false)
+  assert.equal(Config({ allowRemoteSettings: true }).allowRemoteSettings, true)
 })

--- a/tests/bundle-defaults.test.js
+++ b/tests/bundle-defaults.test.js
@@ -26,3 +26,8 @@ test('entry contract always exposes the local remote-settings permission', () =>
   assert.equal(Config({}).allowRemoteSettings, false)
   assert.equal(Config({ allowRemoteSettings: true }).allowRemoteSettings, true)
 })
+
+test('post-release development no longer reuses the published 1.6.2 identity', async () => {
+  const pkg = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8'))
+  assert.equal(pkg.version, '1.6.3')
+})

--- a/tests/rc6-rc7-compat.test.js
+++ b/tests/rc6-rc7-compat.test.js
@@ -1,6 +1,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { readFile } from 'node:fs/promises'
+import { Config as EntryConfig, SETTINGS_CONTRACT_REVISION } from '../entry.js'
 import {
   attachmentContextForContract,
   installRc7SettingsCompatibility,
@@ -106,6 +107,36 @@ test('rc7 settings bridge uses the common public SettingsProvider seam and masks
   assert.deepEqual(observed, { foo: 'changed', stealth: false })
   cleanup()
   assert.equal(serviceWatcher, undefined)
+})
+
+test('rc7 registers the final entry settings contract including remote permission', () => {
+  let registeredConfig
+  const scope = { get() { return EntryConfig({}) }, watch() { return () => {} } }
+  const ctx = {
+    inject(dependencies, callback) {
+      assert.deepEqual(dependencies, ['settings'])
+      callback({
+        settings: {
+          register(namespace, Config) {
+            assert.equal(namespace, 'vision-router')
+            registeredConfig = Config
+            return scope
+          },
+        },
+        effect(factory) { factory() },
+      })
+    },
+  }
+
+  installRc7SettingsCompatibility(ctx, {}, {
+    Config: EntryConfig,
+    namespace: 'vision-router',
+  })
+
+  assert.equal(SETTINGS_CONTRACT_REVISION, 2)
+  assert.equal(registeredConfig, EntryConfig)
+  assert.equal(registeredConfig({}).allowRemoteSettings, false)
+  assert.equal(registeredConfig({ allowRemoteSettings: true }).allowRemoteSettings, true)
 })
 
 test('attachment compatibility remains rc6-only and rc7 keeps host-owned refs', () => {


### PR DESCRIPTION
## Root cause

The browser settings client can be newer than the already-running Host plugin after an update/reload. DSH's client SettingsScope intentionally resolves after a rejected Host mutation and performs a recovery read, so `scope.set()` can appear successful while the Host schema rejects a field. The later Vision Router readback then reports only `readback-mismatch`.

The repository also kept `package.json` at `1.6.2` after the released 1.6.2 line while #213 added `allowRemoteSettings`, making two materially different trees identify as the same plugin version.

## Fix

- make the public `entry.js` the final schema authority for the contract-critical `allowRemoteSettings` field, so the Host registration always admits the browser-visible toggle even if lower implementation files drift
- add `SETTINGS_CONTRACT_REVISION = 2` and regression coverage for the public schema
- add an rc.7 compatibility regression that verifies the real Config passed to `settings.register()` contains and accepts `allowRemoteSettings`
- advance the development package version to `1.6.3` so post-1.6.2 code is no longer indistinguishable from the released 1.6.2 package

## User impact

After installing this fixed build, the DSH Host process must be restarted once so the already-loaded old plugin module is replaced. After that, saving `allowRemoteSettings: true` is validated by the same schema registered on the Host instead of being rejected and recovered into an absent user-layer field.

## Validation

The PR adds focused runtime schema and rc.7 registration tests. Full repository CI should run on the PR before merge.