### PR TITLE
chore: port #221 client depth controls onto current branch

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -241,7 +241,10 @@ window.__ModuleLoader__.load({
       visionDepthFast: '快速（最多再细看 1 次）',
       visionDepthStandard: '标准（细看 1-2 次，默认）',
       visionDepthDeep: '细致（细看 2-4 次）',
+      visionDepthCustom: '自定义（自己填次数上限）',
       hintVisionDepth: '选择看图时的精细度：快速最省（最多再细看 1 次）、标准为默认（细看 1-2 次）、细致看得最细（细看 2-4 次）。档位只限制「再细看几次」，具体看什么由模型按你的问题决定。',
+      labelVisionDepthMaxCalls: '自定义深挖次数上限',
+      hintVisionDepthMaxCalls: '选择「自定义」后填写次数上限（1-100）；留空或填 0 = 不限制深挖次数（视同标准档）。bootstrap 预识别那遍不计入，失败的调用也不占次数。',
       numHintTimeoutMs: '单个视觉请求超时；默认 120000。',
       numHintVisionTaskTimeoutMs: '一次识图任务（含全部 provider、回退与重试）共享的总时限；默认 45000。认证失败/限流会立即熔断对应后端。',
       numHintOcrTimeoutMs: '一次 OCR 任务的总时限；本地 tesseract 最多用 12 秒，视觉模型回退只用剩余部分；默认 30000。',
@@ -501,7 +504,10 @@ window.__ModuleLoader__.load({
       visionDepthFast: 'Quick (at most 1 more look)',
       visionDepthStandard: 'Standard (1-2 looks, default)',
       visionDepthDeep: 'Thorough (2-4 looks)',
+      visionDepthCustom: 'Custom (set your own cap)',
       hintVisionDepth: 'How thoroughly to look after the structured pre-scan: Quick is cheapest (at most 1 more look), Standard is the default (1-2 looks), Thorough looks the closest (2-4 looks). The tier only caps how many extra looks are allowed; what the model looks for is driven by your question.',
+      labelVisionDepthMaxCalls: 'Custom deep-dive call cap',
+      hintVisionDepthMaxCalls: 'Pick "Custom" first, then enter a cap (1-100). Empty or 0 = no cap (same as Standard). The bootstrap pre-scan does not count, and failed calls do not consume the quota.',
       numHintTimeoutMs: 'Per vision-call deadline; default 120000.',
       numHintVisionTaskTimeoutMs: 'One vision task (all providers, fallbacks and retries) shares this wall-clock budget; default 45000. Auth failures and rate limits trip their backend immediately.',
       numHintOcrTimeoutMs: 'Total budget for one OCR task: tesseract gets at most 12s, the vision fallback only the remainder; default 30000.',
@@ -665,6 +671,8 @@ window.__ModuleLoader__.load({
     const ADVANCED_TOGGLE_KEYS = [...PERFORMANCE_TOGGLE_KEYS, ...COMPATIBILITY_TOGGLE_KEYS, ...COST_TOGGLE_KEYS, ...DEVELOPER_TOGGLE_KEYS]
     const ALL_TOGGLE_KEYS = [...TOGGLE_KEYS, ...ADVANCED_TOGGLE_KEYS, ...LOCAL_TOGGLE_KEYS, ...PRIVACY_TOGGLE_KEYS]
     const NUMBER_KEYS = ['timeoutMs', 'visionTaskTimeoutMs', 'ocrTimeoutMs', 'downscaleMaxPixels', 'cacheTtlSeconds', 'cacheMaxEntries']
+    // 识图深度组的数字字段（跟随结构化预识别开关显示在主设置区，不进高级设置）。
+    const DEPTH_NUMBER_KEYS = ['visionDepthMaxCalls']
     const NUMBER_META = {
       timeoutMs: { min: 1000 },
       visionTaskTimeoutMs: { min: 1000 },
@@ -672,6 +680,7 @@ window.__ModuleLoader__.load({
       downscaleMaxPixels: { min: 1000 },
       cacheTtlSeconds: { min: 0 },
       cacheMaxEntries: { min: 1 },
+      visionDepthMaxCalls: { min: 0, max: 100 },
     }
     const TEXT_KEYS = ['wrapperRoute', 'chainRoute']
     const SELECT_KEYS = ['visionDepth']
@@ -1981,6 +1990,7 @@ window.__ModuleLoader__.load({
       wrapperRoute: 'textWrapperRoute',
       chainRoute: 'textChainRoute',
       visionDepth: 'selectVisionDepth',
+      visionDepthMaxCalls: 'labelVisionDepthMaxCalls',
       guidanceOverrides: 'guidanceOverridesLabel',
       extraVisionModels: 'extraVisionModelsLabel',
     }
@@ -2007,6 +2017,7 @@ window.__ModuleLoader__.load({
       wrapperRoute: 'textHintWrapperRoute',
       chainRoute: 'textHintChainRoute',
       visionDepth: 'hintVisionDepth',
+      visionDepthMaxCalls: 'hintVisionDepthMaxCalls',
       guidanceOverrides: 'guidanceOverridesHint',
       extraVisionModels: 'extraVisionModelsHint',
     }
@@ -2354,7 +2365,7 @@ window.__ModuleLoader__.load({
             )
             .join('\n')
         }
-        if (NUMBER_KEYS.includes(key)) return typeof value === 'number' ? String(value) : ''
+        if (NUMBER_KEYS.includes(key) || DEPTH_NUMBER_KEYS.includes(key)) return typeof value === 'number' ? String(value) : ''
         if (ALL_TOGGLE_KEYS.includes(key)) return value === true
         if (key === 'guidanceOverrides') {
           if (!Array.isArray(value)) return []
@@ -2370,7 +2381,7 @@ window.__ModuleLoader__.load({
         }
         if (key === 'localDescribeStyle') return value === 'structured' ? 'structured' : 'plain'
         if (SELECT_KEYS.includes(key)) {
-          return value === 'fast' || value === 'standard' || value === 'deep' ? value : 'standard'
+          return value === 'fast' || value === 'standard' || value === 'deep' || value === 'custom' ? value : 'standard'
         }
         return typeof value === 'string' ? value : ''
       }
@@ -2397,7 +2408,7 @@ window.__ModuleLoader__.load({
           const value = parseTextProvider(text)
           return value === undefined ? undefined : { value }
         }
-        if (NUMBER_KEYS.includes(key)) return parseNumber(text, NUMBER_META[key].min)
+        if (NUMBER_KEYS.includes(key) || DEPTH_NUMBER_KEYS.includes(key)) return parseNumber(text, NUMBER_META[key].min)
         if (key === 'guidanceOverrides') {
           const rows = Array.isArray(text) ? text : []
           const cleaned = []
@@ -2427,7 +2438,7 @@ window.__ModuleLoader__.load({
           return text === 'structured' || text === 'plain' ? { value: text } : undefined
         }
         if (SELECT_KEYS.includes(key)) {
-          return text === 'fast' || text === 'standard' || text === 'deep' ? { value: text } : undefined
+          return text === 'fast' || text === 'standard' || text === 'deep' || text === 'custom' ? { value: text } : undefined
         }
         if (key === 'proxyHosts') {
           const list = String(text ?? '')
@@ -3565,7 +3576,11 @@ window.__ModuleLoader__.load({
                       { value: 'fast', label: t('visionDepthFast') },
                       { value: 'standard', label: t('visionDepthStandard') },
                       { value: 'deep', label: t('visionDepthDeep') },
+                      { value: 'custom', label: t('visionDepthCustom') },
                     ])),
+                    format('visionDepth') === 'custom'
+                      ? DEPTH_NUMBER_KEYS.map((key) => textField(key, t(LABEL_KEY[key]), t(HINT_KEY[key]), false))
+                      : null,
                     guidanceOverridesEditor(),
                   )
                 : null,


### PR DESCRIPTION
Narrow three-way port of the original #221 `lib/client.js` changes only. Base is the current `agent/vision-depth-custom-v2` branch; the port branch is rooted at the old #221 base so GitHub can preserve all newer client UI/settings changes while applying only the Custom depth option and conditional call-cap field.