### PR TITLE
fix: give remote-settings Host contract a fresh v1.6.4 identity

### DIFF
--- a/entry.js
+++ b/entry.js
@@ -34,6 +34,13 @@ import {
   protectRc7ProviderOwnership,
 } from './lib/dsh-contract-compat.js'
 
+// Increment whenever the browser-visible settings contract gains a field whose
+// absence changes write semantics. This revision is also exposed as a resolved
+// schema default so a newer browser client can distinguish a genuinely updated
+// Host from a stale in-process plugin module instead of reporting a generic
+// readback mismatch after the old Host rejects a newly visible field.
+export const SETTINGS_CONTRACT_REVISION = 4
+
 // Schemastery object schemas expose set() as the supported way to replace a
 // field schema. This mutates the Config object that index.js itself later uses
 // for the settings namespace, so composition config and settings validation
@@ -59,10 +66,13 @@ core.Config.set('visionDepthMaxCalls', z.number().step(1).min(0).max(100).defaul
 // loaded by Cordis and therefore the right place to close client/Host drift.
 core.Config.set('allowRemoteSettings', z.boolean().default(false))
 
-// Increment whenever the browser-visible settings contract gains a field whose
-// absence changes write semantics. Tests pin this alongside the schema so a
-// future release cannot ship a new client against an indistinguishable Host.
-export const SETTINGS_CONTRACT_REVISION = 3
+// Internal read-only-by-convention handshake. It is not rendered by Vision
+// Router's settings UI and is not in the remote mutable allow-list; its resolved
+// default lets diagnostics prove which schema the running Host actually loaded.
+core.Config.set(
+  'settingsContractRevision',
+  z.number().step(1).min(1).max(SETTINGS_CONTRACT_REVISION).default(SETTINGS_CONTRACT_REVISION),
+)
 
 export * from './index.js'
 export {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-vision-router",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "Eyes for text-only DeepSeek Harness agents: built-in free vision chain (no key) + pixel-level vision tools (Q&A, grounding, crop, pixel diff, colors, OCR, SVG trace, cutout, screenshots). One-command install, no Python, image turns work like ordinary tool-calling turns.",
   "license": "MIT",
   "repository": {

--- a/tests/bundle-defaults.test.js
+++ b/tests/bundle-defaults.test.js
@@ -21,10 +21,11 @@ test('progressive tools remain an explicit opt-in', () => {
   assert.equal(Config({ progressiveTools: true }).progressiveTools, true)
 })
 
-test('entry contract always exposes the local remote-settings permission', () => {
-  assert.equal(SETTINGS_CONTRACT_REVISION, 3)
+test('entry contract always exposes the local remote-settings permission and handshake', () => {
+  assert.equal(SETTINGS_CONTRACT_REVISION, 4)
   assert.equal(Config({}).allowRemoteSettings, false)
   assert.equal(Config({ allowRemoteSettings: true }).allowRemoteSettings, true)
+  assert.equal(Config({}).settingsContractRevision, 4)
 })
 
 test('entry contract exposes the custom depth tier to every settings entry point', () => {
@@ -37,7 +38,7 @@ test('entry contract exposes the custom depth tier to every settings entry point
   assert.equal(custom.visionDepthMaxCalls, 7)
 })
 
-test('post-release development no longer reuses the published 1.6.2 identity', async () => {
+test('post-1.6.3 development has a distinct package identity', async () => {
   const pkg = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8'))
-  assert.equal(pkg.version, '1.6.3')
+  assert.equal(pkg.version, '1.6.4')
 })

--- a/tests/rc6-rc7-compat.test.js
+++ b/tests/rc6-rc7-compat.test.js
@@ -133,10 +133,11 @@ test('rc7 registers the final entry settings contract including remote permissio
     namespace: 'vision-router',
   })
 
-  assert.equal(SETTINGS_CONTRACT_REVISION, 3)
+  assert.equal(SETTINGS_CONTRACT_REVISION, 4)
   assert.equal(registeredConfig, EntryConfig)
   assert.equal(registeredConfig({}).allowRemoteSettings, false)
   assert.equal(registeredConfig({ allowRemoteSettings: true }).allowRemoteSettings, true)
+  assert.equal(registeredConfig({}).settingsContractRevision, 4)
   assert.equal(registeredConfig({}).visionDepth, 'standard')
   assert.equal(registeredConfig({ visionDepth: 'custom', visionDepthMaxCalls: 7 }).visionDepth, 'custom')
   assert.equal(registeredConfig({ visionDepth: 'custom', visionDepthMaxCalls: 7 }).visionDepthMaxCalls, 7)


### PR DESCRIPTION
## Root cause

`allowRemoteSettings` still reports a readback mismatch when the browser client is newer than the already-running Host plugin module. PR #219 fixed the schema itself and explicitly required one Host restart, but subsequent main changes (#220/#221/#225/#227) continued to identify as package `1.6.3`. That lets materially different Host/client trees share one package identity again, making stale in-process Host modules difficult to distinguish and easy to keep testing accidentally.

DSH SettingsScope intentionally recovers after a rejected Host mutation; the browser therefore sees an absent user-layer field and reports `allowRemoteSettings` as not written rather than surfacing the Host schema rejection directly.

## Fix

- bump the plugin package identity to `1.6.4`
- advance `SETTINGS_CONTRACT_REVISION` to 4
- expose an internal resolved `settingsContractRevision: 4` schema default so diagnostics can prove which Host settings contract is actually loaded
- keep that handshake out of Vision Router's UI and remote mutable allow-list
- extend rc.6/rc.7 and public-entry regression coverage

## User impact

After installing this build, fully stop and restart the DSH Host process once. A browser refresh alone cannot replace an already-loaded old plugin module. On the restarted Host, `allowRemoteSettings: true` is admitted by the same final `entry.js` schema registered with SettingsProvider.

No temporary GitHub Actions write workflow is used.