### PR TITLE
test: cover native multimodal sessions across a full DSH cold restart

### DIFF
--- a/.github/workflows/native-multimodal-cold-resume.yml
+++ b/.github/workflows/native-multimodal-cold-resume.yml
@@ -68,6 +68,17 @@ jobs:
               sharp: '0.35.3',
             },
           }, null, 2))
+          // Released rc.7's agent stack pulls koffi. pnpm v11 blocks native
+          // install scripts unless the exact dependency is allow-listed in the
+          // workspace settings; keep this test host as strict as a real DSH
+          // profile while allowing only that released native dependency.
+          fs.writeFileSync(path.join(hostDir, 'pnpm-workspace.yaml'), [
+            'packages:',
+            '  - .',
+            'onlyBuiltDependencies:',
+            '  - koffi',
+            '',
+          ].join('\n'))
 
           const installed = spawnSync('pnpm', ['install'], {
             cwd: hostDir,

--- a/.github/workflows/native-multimodal-cold-resume.yml
+++ b/.github/workflows/native-multimodal-cold-resume.yml
@@ -1,0 +1,87 @@
+name: Native multimodal cold resume
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  cold-resume:
+    name: DSH rc.7 / Node ${{ matrix.node }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ['22', '24']
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+        with:
+          version: 11.20.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: ${{ matrix.node }}
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Pack Vision Router
+        shell: node {0}
+        run: |
+          require('node:fs').mkdirSync('tmp-pack', { recursive: true })
+      - run: pnpm pack --pack-destination tmp-pack
+      - name: Reproduce image turns across a full DSH cold restart
+        shell: node {0}
+        env:
+          DSH_VERSION: 0.1.0-rc.7
+        run: |
+          const fs = require('node:fs')
+          const path = require('node:path')
+          const { spawnSync } = require('node:child_process')
+
+          const tgz = fs.readdirSync('tmp-pack').find((name) => name.endsWith('.tgz'))
+          if (!tgz) throw new Error('packed plugin tarball not found')
+          const tarball = path.resolve('tmp-pack', tgz).replaceAll('\\', '/')
+          const hostDir = path.join(process.env.RUNNER_TEMP, `native-mm-cold-resume-node-${process.versions.node}`)
+          fs.rmSync(hostDir, { recursive: true, force: true })
+          fs.mkdirSync(hostDir, { recursive: true })
+          const v = process.env.DSH_VERSION
+          fs.writeFileSync(path.join(hostDir, 'package.json'), JSON.stringify({
+            private: true,
+            type: 'module',
+            packageManager: 'pnpm@11.20.0',
+            dependencies: {
+              'dsh-vision-router': `file:${tarball}`,
+              '@deepseek-ai/dsh-anonymous-user-id': v,
+              '@deepseek-ai/dsh-llm-deepseek': v,
+              '@deepseek-ai/dsh-llm': v,
+              '@deepseek-ai/dsh-session': v,
+              '@deepseek-ai/dsh-attachment-local': v,
+              '@deepseek-ai/dsh-system-prompt': v,
+              '@deepseek-ai/dsh-tools': v,
+              '@deepseek-ai/dsh-agent': v,
+              '@deepseek-ai/dsh-agent-loop': v,
+              '@deepseek-ai/dsh-session-persistence-jsonl': v,
+              sharp: '0.35.3',
+            },
+          }, null, 2))
+
+          const installed = spawnSync('pnpm', ['install'], {
+            cwd: hostDir,
+            stdio: 'inherit',
+          })
+          if (installed.status !== 0) process.exit(installed.status ?? 1)
+
+          const test = spawnSync(
+            process.execPath,
+            [path.resolve('tests/native-multimodal-cold-resume-contract.mjs')],
+            {
+              cwd: process.cwd(),
+              stdio: 'inherit',
+              env: { ...process.env, DSH_CONTRACT_HOST_DIR: hostDir },
+            },
+          )
+          if (test.status !== 0) process.exit(test.status ?? 1)

--- a/.github/workflows/native-multimodal-cold-resume.yml
+++ b/.github/workflows/native-multimodal-cold-resume.yml
@@ -68,15 +68,14 @@ jobs:
               sharp: '0.35.3',
             },
           }, null, 2))
-          // Released rc.7's agent stack pulls koffi. pnpm v11 blocks native
-          // install scripts unless the exact dependency is allow-listed in the
-          // workspace settings; keep this test host as strict as a real DSH
-          // profile while allowing only that released native dependency.
+          // Released rc.7's agent stack pulls koffi. pnpm 11 replaced the old
+          // onlyBuiltDependencies setting with allowBuilds; approve only this
+          // exact released native dependency instead of disabling build safety.
           fs.writeFileSync(path.join(hostDir, 'pnpm-workspace.yaml'), [
             'packages:',
             '  - .',
-            'onlyBuiltDependencies:',
-            '  - koffi',
+            'allowBuilds:',
+            '  koffi: true',
             '',
           ].join('\n'))
 

--- a/tests/native-multimodal-cold-resume-contract.mjs
+++ b/tests/native-multimodal-cold-resume-contract.mjs
@@ -1,0 +1,268 @@
+import assert from 'node:assert/strict'
+import { createRequire } from 'node:module'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const hostDir = process.env.DSH_CONTRACT_HOST_DIR
+if (typeof hostDir !== 'string' || hostDir === '') {
+  throw new Error('DSH_CONTRACT_HOST_DIR is required')
+}
+
+const hostRequire = createRequire(path.join(hostDir, 'contract-host.cjs'))
+const importResolved = async (specifier) => import(pathToFileURL(hostRequire.resolve(specifier)).href)
+
+const llmModule = await importResolved('@deepseek-ai/dsh-llm')
+const sessionModule = await importResolved('@deepseek-ai/dsh-session')
+const attachmentModule = await importResolved('@deepseek-ai/dsh-attachment-local')
+const systemPromptModule = await importResolved('@deepseek-ai/dsh-system-prompt')
+const toolsModule = await importResolved('@deepseek-ai/dsh-tools')
+const agentModule = await importResolved('@deepseek-ai/dsh-agent')
+const agentLoopModule = await importResolved('@deepseek-ai/dsh-agent-loop')
+const persistenceModule = await importResolved('@deepseek-ai/dsh-session-persistence-jsonl')
+const plugin = await importResolved('dsh-vision-router')
+
+// Cordis is a transitive dependency of the released DSH packages. Resolve it
+// from DSH itself so this contract test cannot accidentally load a second copy.
+const llmRequire = createRequire(hostRequire.resolve('@deepseek-ai/dsh-llm'))
+const { Context } = await import(pathToFileURL(llmRequire.resolve('@deepseek-ai/cordis')).href)
+
+const LlmRuntime = llmModule.default
+const { LlmAdapter, createUserMessage } = llmModule
+const SessionStore = sessionModule.default
+const { SessionId } = sessionModule
+const LocalAttachmentStore = attachmentModule.default
+const SystemPrompt = systemPromptModule.default
+const ToolRuntime = toolsModule.default
+const AgentRegistry = agentModule.default
+const AgentLoop = agentLoopModule.default
+const JsonlSessionPersistence = persistenceModule.default
+
+const TRANSPARENT_PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+  'base64',
+)
+const RED_PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAACXBIWXMAAAPoAAAD6AG1e1JrAAAAEUlEQVQImWP4z8DwH4QZYAwAR8oH+Xm0fdIAAAAASUVORK5CYII=',
+  'base64',
+)
+
+function imageIdsInContent(content, out = []) {
+  if (!Array.isArray(content)) return out
+  for (const block of content) {
+    if (!block || typeof block !== 'object') continue
+    if (block.type === 'image' && block.attachment?.attachmentId) {
+      out.push(String(block.attachment.attachmentId))
+    }
+    if (Array.isArray(block.content)) imageIdsInContent(block.content, out)
+  }
+  return out
+}
+
+function imageIdsInMessages(messages) {
+  return messages.flatMap((message) => imageIdsInContent(message?.content, []))
+}
+
+function unique(values) {
+  return [...new Set(values)]
+}
+
+function responseChunks(text) {
+  return [
+    { type: 'block-start', index: 0, blockType: 'text' },
+    { type: 'text-delta', index: 0, text },
+    { type: 'block-end', index: 0, block: { type: 'text', text } },
+    { type: 'usage', usage: { inputTokens: 10, outputTokens: 2 } },
+    { type: 'finish', reason: { kind: 'stop' } },
+  ]
+}
+
+class NativeMultimodalAdapter extends LlmAdapter {
+  constructor(label) {
+    super()
+    this.label = label
+    this.requests = []
+  }
+
+  providerInfo(provider) {
+    return { id: provider, name: 'Native multimodal contract provider' }
+  }
+
+  listModels(provider) {
+    return Promise.resolve([{
+      provider,
+      id: 'mm',
+      name: 'mm',
+      inputModalities: ['text', 'image'],
+    }])
+  }
+
+  resolveModel(provider, model) {
+    return Promise.resolve({
+      provider,
+      id: model,
+      name: model,
+      inputModalities: ['text', 'image'],
+    })
+  }
+
+  async *stream(options) {
+    this.requests.push(options)
+    for (const chunk of responseChunks(`${this.label}-${this.requests.length}`)) yield chunk
+  }
+}
+
+async function mountHarness({ dshHome, sessionsRoot, adapter }) {
+  process.env.DSH_HOME = dshHome
+  const ctx = new Context()
+  await ctx.plugin(LlmRuntime)
+  await ctx.plugin(SessionStore)
+  await ctx.plugin(LocalAttachmentStore, { dshHome })
+  await ctx.plugin(SystemPrompt)
+  await ctx.plugin(ToolRuntime)
+  await ctx.plugin(AgentRegistry)
+  await ctx.plugin(AgentLoop, { agents: [] })
+  await ctx.plugin(JsonlSessionPersistence, { root: sessionsRoot })
+  ctx.llm.registerAdapter(['native-mm'], adapter)
+
+  const config = plugin.Config({
+    routing: false,
+    rewriteImages: true,
+    tool: true,
+    progressiveTools: false,
+    autoActivateOnImage: true,
+    autoWrapProviders: false,
+    wrappedProviders: [{ provider: 'native-mm', models: ['mm'] }],
+  })
+  await plugin.apply(ctx, config)
+
+  assert.ok(
+    ctx.llm.listProviders().some((provider) => provider.id === 'native-mm-vision'),
+    'Vision Router must register the native provider twin before the session starts',
+  )
+  const twin = await ctx.llm.resolveModelInfo('native-mm-vision', 'mm')
+  assert.ok(twin.inputModalities?.includes('image'), 'the twin must advertise image input to DSH admission')
+  return ctx
+}
+
+async function imageTurn(agent, refs, text) {
+  agent.followup(createUserMessage({
+    content: [
+      { type: 'text', text },
+      ...refs.map((attachment) => ({ type: 'image', attachment })),
+    ],
+    source: { kind: 'user' },
+  }))
+  await agent.whenIdle()
+  const end = agent.session.events.findLast((event) => event.type === 'turn/end')
+  assert.equal(end?.data?.reason?.kind, 'completed', `image turn did not complete: ${JSON.stringify(end?.data?.reason)}`)
+}
+
+async function textTurn(agent, text) {
+  agent.followup(createUserMessage({
+    content: [{ type: 'text', text }],
+    source: { kind: 'user' },
+  }))
+  await agent.whenIdle()
+  const end = agent.session.events.findLast((event) => event.type === 'turn/end')
+  assert.equal(end?.data?.reason?.kind, 'completed', `text turn did not complete: ${JSON.stringify(end?.data?.reason)}`)
+}
+
+const root = await mkdtemp(path.join(tmpdir(), 'vision-router-native-cold-resume-'))
+const dshHome = path.join(root, 'dsh-home')
+const sessionsRoot = path.join(dshHome, 'sessions')
+const sessionId = SessionId('native-mm-cold-resume')
+const previousDshHome = process.env.DSH_HOME
+
+try {
+  // Lifecycle 1: a completely new current-version session sends several image
+  // turns through a source model that is natively multimodal.
+  const firstAdapter = new NativeMultimodalAdapter('before')
+  const firstCtx = await mountHarness({ dshHome, sessionsRoot, adapter: firstAdapter })
+  const refs = await firstCtx.attachments.saveImages([
+    { data: new Uint8Array(TRANSPARENT_PNG), mediaType: 'image/png', name: 'one.png' },
+    { data: new Uint8Array(RED_PNG), mediaType: 'image/png', name: 'two.png' },
+  ])
+  assert.equal(refs.length, 2)
+  assert.equal(unique(refs.map((ref) => String(ref.attachmentId))).length, 2, 'fixture images must have distinct durable ids')
+
+  const firstHandle = await firstCtx.agents.create({
+    sessionId,
+    agentOptions: { provider: 'native-mm-vision', model: 'mm' },
+  })
+  await imageTurn(firstHandle.agent, [refs[0]], 'first image')
+  await imageTurn(firstHandle.agent, [refs[1]], 'second image')
+  await imageTurn(firstHandle.agent, refs, 'both images')
+
+  assert.equal(firstAdapter.requests.length, 3, 'each image turn should make exactly one native model call')
+  for (const request of firstAdapter.requests) {
+    assert.equal(request.provider, 'native-mm', 'the twin must delegate to the original native provider')
+    assert.equal(request.model, 'mm')
+  }
+  assert.deepEqual(
+    unique(imageIdsInMessages(firstAdapter.requests.at(-1).messages)).sort(),
+    refs.map((ref) => String(ref.attachmentId)).sort(),
+    'native multimodal delegation must keep original durable image blocks before restart',
+  )
+  assert.deepEqual(
+    unique(imageIdsInMessages(firstHandle.agent.session.deriveMessages())).sort(),
+    refs.map((ref) => String(ref.attachmentId)).sort(),
+    'the durable session surface must retain both uploaded image refs',
+  )
+  const persistedRoute = firstHandle.agent.session.requestHeader()?.config
+  assert.equal(persistedRoute?.provider, 'native-mm-vision')
+  assert.equal(persistedRoute?.model, 'mm')
+
+  await firstCtx.sessions.flush(firstHandle.agent.session)
+  await firstHandle.dispose()
+  await firstCtx.fiber.dispose()
+
+  // Lifecycle 2: destroy the entire Context, remount DSH + Vision Router from
+  // the same on-disk home, resume the same session, then keep chatting. This is
+  // the boundary that the previous mock/unit tests did not exercise.
+  const secondAdapter = new NativeMultimodalAdapter('after')
+  const secondCtx = await mountHarness({ dshHome, sessionsRoot, adapter: secondAdapter })
+  for (const ref of refs) {
+    const stored = await secondCtx.attachments.readImage(ref)
+    assert.ok(stored.data.byteLength > 0, `attachment ${String(ref.attachmentId)} did not survive restart`)
+  }
+
+  const secondHandle = await secondCtx.agents.resume({
+    resumeSessionId: sessionId,
+    // The Web host reconstructs this selection from the session's latest
+    // request/header before calling resume. Exercise that same route here.
+    agentOptions: { provider: persistedRoute.provider, model: persistedRoute.model },
+  })
+  assert.deepEqual(
+    unique(imageIdsInMessages(secondHandle.agent.session.deriveMessages())).sort(),
+    refs.map((ref) => String(ref.attachmentId)).sort(),
+    'cold resume must reconstruct the same image-bearing conversation surface',
+  )
+
+  await textTurn(secondHandle.agent, 'continue after a full DSH restart')
+  assert.equal(secondAdapter.requests.length, 1)
+  assert.equal(secondAdapter.requests[0].provider, 'native-mm')
+  assert.deepEqual(
+    unique(imageIdsInMessages(secondAdapter.requests[0].messages)).sort(),
+    refs.map((ref) => String(ref.attachmentId)).sort(),
+    'the first post-restart model call must still receive historical native image blocks',
+  )
+
+  await imageTurn(secondHandle.agent, [refs[0]], 'new image turn after restart')
+  assert.equal(secondAdapter.requests.length, 2)
+  assert.ok(
+    imageIdsInMessages(secondAdapter.requests[1].messages).includes(String(refs[0].attachmentId)),
+    'a new image turn must remain usable after cold resume',
+  )
+
+  await secondCtx.sessions.flush(secondHandle.agent.session)
+  await secondHandle.dispose()
+  await secondCtx.fiber.dispose()
+
+  console.log('native multimodal cold-resume contract: OK')
+} finally {
+  if (previousDshHome === undefined) delete process.env.DSH_HOME
+  else process.env.DSH_HOME = previousDshHome
+  await rm(root, { recursive: true, force: true })
+}


### PR DESCRIPTION
## Why

The remaining high-value suspicion behind the report "native multimodal model + several image turns + restart DSH => current conversation breaks" is the one path our existing tests still did not exercise: real DSH rc.7 JSONL/Zstd persistence, durable attachment storage, full Context teardown, remount, resume, and another model call.

Static inspection already shows current Vision Router preserves original image blocks for natively multimodal source models, while DSH stores uploads as durable attachment refs. This PR turns that into an executable regression contract rather than relying on mocks.

## Coverage

The new rc.7 contract test:

- packs and installs the actual Vision Router package into a DSH-like host;
- mounts real `dsh-session`, `dsh-session-persistence-jsonl`, `dsh-attachment-local`, `dsh-agent`, `dsh-agent-loop`, tools and prompt services;
- registers a fake **natively multimodal** provider that declares `inputModalities: [text, image]`;
- uses Vision Router's real `<provider>-vision` twin;
- stores two distinct PNGs through the real attachment backend;
- sends three image turns and proves the source provider receives the original durable image blocks;
- flushes and destroys the entire DSH Context;
- remounts DSH + Vision Router from the same DSH home and resumes the same persisted session;
- verifies the same attachment bytes and image-bearing `deriveMessages()` surface survive;
- sends a text turn after restart and proves historical image blocks still reach the native provider;
- sends another image turn after restart and proves the conversation remains usable.

Runs against released DSH `0.1.0-rc.7` on Node 22 and Node 24. The workflow is test-only and has read-only repository permissions; it never writes code back to the repository.