### PR TITLE
fix: preserve DSH rc.7 replay-v2 identity across vision twins

### DIFF
--- a/entry.js
+++ b/entry.js
@@ -10,6 +10,7 @@ import z from '@deepseek-ai/schemastery'
 import * as core from './index.js'
 import { installVisionRouterFileLogging } from './lib/file-logger.js'
 import { contextWithDelegatedReplay } from './lib/replay-delegation.js'
+import { contextWithReplayEnvelopeV2Compat } from './lib/replay-envelope-v2-compat.js'
 import { contextWithVisionExecutionPolicy } from './lib/vision-execution-policy.js'
 import { installLiveModelDiscovery } from './lib/live-model-discovery.js'
 import { installVisionModelRegistry } from './lib/vision-model-registry.js'
@@ -97,13 +98,19 @@ export function apply(ctx, config = {}) {
   // every injection callback the original child context identity unchanged.
   const localMutationCtx = installLocalMutationRouteBoundary(ctx)
   const logging = installVisionRouterFileLogging(localMutationCtx)
-  const runtimeCtx = contextWithDelegatedReplay(logging.ctx, {
+  const delegatedReplayCtx = contextWithDelegatedReplay(logging.ctx, {
     wrapperRoute:
       typeof config.wrapperRoute === 'string' && config.wrapperRoute !== ''
         ? config.wrapperRoute
         : 'deepseek-vision',
     visionConfig: config,
   })
+  // DSH rc.7 pi-ai replay v2 stores the real producer under
+  // replayState.response.{provider,model}; the older delegated-replay shim
+  // recognizes the pre-v2 top-level shape. Layer a narrow private compatibility
+  // view so resumed wrapper history keeps provider-native replay metadata rather
+  // than degrading to foreign history at the delegate boundary.
+  const runtimeCtx = contextWithReplayEnvelopeV2Compat(delegatedReplayCtx)
   // Filesystem authority is separate from browser rendering safety. Put this
   // boundary INSIDE adversarial hardening so the secure HTML renderer that the
   // outer layer installs is itself wrapped by canonical workspace containment.

--- a/lib/replay-envelope-v2-compat.js
+++ b/lib/replay-envelope-v2-compat.js
@@ -1,0 +1,102 @@
+const wrappedContexts = new WeakMap()
+
+function isRecord(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function nonEmpty(value) {
+  return typeof value === 'string' && value.length > 0
+}
+
+/**
+ * Read the producer identity from DSH rc.7's durable pi-ai replay envelope.
+ *
+ * rc.7 stores provider/model below replayState.response; older Vision Router
+ * code looked for replayState.provider/model at the top level and therefore
+ * failed to prove wrapper -> delegate ownership. Keep this parser deliberately
+ * exact so arbitrary plugin replay metadata cannot authorize a source rewrite.
+ */
+export function replayEnvelopeV2Producer(replayState) {
+  if (!isRecord(replayState) || !isRecord(replayState.response)) return undefined
+  const response = replayState.response
+  if (response.kind !== 'pi-ai' || response.version !== 2) return undefined
+  if (!nonEmpty(response.provider) || !nonEmpty(response.model)) return undefined
+  return { provider: response.provider, model: response.model }
+}
+
+/**
+ * Rebind only assistant histories whose rc.7 replay envelope proves that the
+ * currently selected delegate provider/model produced the persisted response.
+ * The durable replayState object itself is kept by identity.
+ */
+export function rebindReplayEnvelopeV2Sources(messages, delegateProvider) {
+  if (!Array.isArray(messages) || !nonEmpty(delegateProvider)) return messages
+  let changed = false
+  const rebound = messages.map((message) => {
+    if (!isRecord(message) || message.role !== 'assistant') return message
+    const source = message.source
+    if (!isRecord(source) || source.kind !== 'model') return message
+    if (!nonEmpty(source.provider) || source.provider === delegateProvider || !nonEmpty(source.model)) return message
+    const producer = replayEnvelopeV2Producer(source.replayState)
+    if (producer?.provider !== delegateProvider || producer.model !== source.model) return message
+    changed = true
+    return {
+      ...message,
+      source: {
+        ...source,
+        provider: delegateProvider,
+      },
+    }
+  })
+  return changed ? rebound : messages
+}
+
+export function rebindReplayEnvelopeV2Options(options) {
+  if (!isRecord(options)) return options
+  const messages = rebindReplayEnvelopeV2Sources(options.messages, options.provider)
+  return messages === options.messages ? options : { ...options, messages }
+}
+
+/**
+ * Private rc.7 compatibility view layered around Vision Router's existing
+ * delegated-replay context. It does not mutate the host LLM service; only
+ * stream calls made through the plugin-private Context are normalized.
+ */
+export function contextWithReplayEnvelopeV2Compat(ctx) {
+  if (!ctx || typeof ctx !== 'object') return ctx
+  const cached = wrappedContexts.get(ctx)
+  if (cached) return cached
+  const llm = ctx.llm
+  if (!llm || (typeof llm !== 'object' && typeof llm !== 'function')) return ctx
+  const stream = llm.stream
+  if (typeof stream !== 'function') return ctx
+
+  const wrappedLlm = new Proxy(llm, {
+    get(target, property) {
+      if (property === 'stream') {
+        return (options) => stream.call(target, rebindReplayEnvelopeV2Options(options))
+      }
+      const value = Reflect.get(target, property, target)
+      return typeof value === 'function' ? value.bind(target) : value
+    },
+  })
+  const wrapped = new Proxy(ctx, {
+    get(target, property) {
+      if (property === 'llm') return wrappedLlm
+      const value = Reflect.get(target, property, target)
+      return typeof value === 'function' ? value.bind(target) : value
+    },
+  })
+  wrappedContexts.set(ctx, wrapped)
+  try {
+    ctx.effect?.(
+      () => () => {
+        if (wrappedContexts.get(ctx) === wrapped) wrappedContexts.delete(ctx)
+      },
+      'vision-router: rc7 replay envelope compatibility lifecycle',
+    )
+  } catch {
+    /* lifecycle hardening must not block plugin apply */
+  }
+  return wrapped
+}

--- a/tests/native-multimodal-cold-resume-contract.mjs
+++ b/tests/native-multimodal-cold-resume-contract.mjs
@@ -68,14 +68,42 @@ function unique(values) {
   return [...new Set(values)]
 }
 
+function piReplayState() {
+  return {
+    response: {
+      kind: 'pi-ai',
+      version: 2,
+      api: 'openai-completions',
+      provider: 'native-mm',
+      model: 'mm',
+      stopReason: 'stop',
+    },
+    blocks: [{ type: 'text' }],
+  }
+}
+
 function responseChunks(text) {
   return [
     { type: 'block-start', index: 0, blockType: 'text' },
     { type: 'text-delta', index: 0, text },
     { type: 'block-end', index: 0, block: { type: 'text', text } },
     { type: 'usage', usage: { inputTokens: 10, outputTokens: 2 } },
-    { type: 'finish', reason: { kind: 'stop' } },
+    { type: 'finish', reason: { kind: 'stop' }, replayState: piReplayState() },
   ]
+}
+
+function assertDelegateReplayIdentity(messages) {
+  for (const message of messages ?? []) {
+    if (message?.role !== 'assistant' || message?.source?.kind !== 'model') continue
+    const response = message.source.replayState?.response
+    if (response?.kind !== 'pi-ai' || response?.version !== 2) continue
+    assert.equal(
+      message.source.provider,
+      response.provider,
+      `delegate received wrapper source ${String(message.source.provider)} for replay owned by ${String(response.provider)}`,
+    )
+    assert.equal(message.source.model, response.model)
+  }
 }
 
 class NativeMultimodalAdapter extends LlmAdapter {
@@ -108,6 +136,12 @@ class NativeMultimodalAdapter extends LlmAdapter {
   }
 
   async *stream(options) {
+    // Model adapters such as DSH pi-ai validate durable replay metadata against
+    // the source identity they receive. A Vision Router twin persists its
+    // public route in assistant source.provider, so the plugin must rebind that
+    // source to the real delegate provider at request time without mutating the
+    // durable session. rc.7 stores that proof under replayState.response.
+    assertDelegateReplayIdentity(options.messages)
     this.requests.push(options)
     for (const chunk of responseChunks(`${this.label}-${this.requests.length}`)) yield chunk
   }
@@ -169,6 +203,10 @@ async function textTurn(agent, text) {
   assert.equal(end?.data?.reason?.kind, 'completed', `text turn did not complete: ${JSON.stringify(end?.data?.reason)}`)
 }
 
+function replayAssistants(messages) {
+  return messages.filter((message) => message?.role === 'assistant' && message?.source?.replayState?.response?.kind === 'pi-ai')
+}
+
 const root = await mkdtemp(path.join(tmpdir(), 'vision-router-native-cold-resume-'))
 const dshHome = path.join(root, 'dsh-home')
 const sessionsRoot = path.join(dshHome, 'sessions')
@@ -205,10 +243,16 @@ try {
     refs.map((ref) => String(ref.attachmentId)).sort(),
     'native multimodal delegation must keep original durable image blocks before restart',
   )
+  const durableBefore = firstHandle.agent.session.deriveMessages()
   assert.deepEqual(
-    unique(imageIdsInMessages(firstHandle.agent.session.deriveMessages())).sort(),
+    unique(imageIdsInMessages(durableBefore)).sort(),
     refs.map((ref) => String(ref.attachmentId)).sort(),
     'the durable session surface must retain both uploaded image refs',
+  )
+  assert.ok(replayAssistants(durableBefore).length >= 2, 'fixture must persist replay-bearing assistant history')
+  assert.ok(
+    replayAssistants(durableBefore).every((message) => message.source.provider === 'native-mm-vision'),
+    'request-time replay rebinding must not mutate the durable public wrapper identity',
   )
   const persistedRoute = firstHandle.agent.session.requestHeader()?.config
   assert.equal(persistedRoute?.provider, 'native-mm-vision')
@@ -234,10 +278,15 @@ try {
     // request/header before calling resume. Exercise that same route here.
     agentOptions: { provider: persistedRoute.provider, model: persistedRoute.model },
   })
+  const durableAfter = secondHandle.agent.session.deriveMessages()
   assert.deepEqual(
-    unique(imageIdsInMessages(secondHandle.agent.session.deriveMessages())).sort(),
+    unique(imageIdsInMessages(durableAfter)).sort(),
     refs.map((ref) => String(ref.attachmentId)).sort(),
     'cold resume must reconstruct the same image-bearing conversation surface',
+  )
+  assert.ok(
+    replayAssistants(durableAfter).every((message) => message.source.provider === 'native-mm-vision'),
+    'cold restore must keep durable replay messages attributed to the public twin',
   )
 
   await textTurn(secondHandle.agent, 'continue after a full DSH restart')
@@ -248,6 +297,7 @@ try {
     refs.map((ref) => String(ref.attachmentId)).sort(),
     'the first post-restart model call must still receive historical native image blocks',
   )
+  assertDelegateReplayIdentity(secondAdapter.requests[0].messages)
 
   await imageTurn(secondHandle.agent, [refs[0]], 'new image turn after restart')
   assert.equal(secondAdapter.requests.length, 2)
@@ -255,12 +305,13 @@ try {
     imageIdsInMessages(secondAdapter.requests[1].messages).includes(String(refs[0].attachmentId)),
     'a new image turn must remain usable after cold resume',
   )
+  assertDelegateReplayIdentity(secondAdapter.requests[1].messages)
 
   await secondCtx.sessions.flush(secondHandle.agent.session)
   await secondHandle.dispose()
   await secondCtx.fiber.dispose()
 
-  console.log('native multimodal cold-resume contract: OK')
+  console.log('native multimodal cold-resume + replay-v2 contract: OK')
 } finally {
   if (previousDshHome === undefined) delete process.env.DSH_HOME
   else process.env.DSH_HOME = previousDshHome


### PR DESCRIPTION
## Problem

The cold-resume regression added in #232 ruled out ordinary durable image persistence. The next provider-specific path exposed a real rc.7 contract mismatch in Vision Router's replay delegation shim:

- DSH rc.7 pi-ai persists the real replay producer under `replayState.response.provider/model` (replay envelope v2).
- Vision Router's existing shim still looks for the older top-level `replayState.provider/model` shape.
- As a result, assistant history persisted under a public `<provider>-vision` twin is not rebound to the real delegate provider before the delegate adapter receives the next request. DSH pi-ai then treats that replay metadata as foreign/degraded history rather than same-provider replay.

This is especially relevant to resumed multimodal conversations because replay metadata is reconstructed from durable history on the first post-restart request.

## Fix

- Add a narrow rc.7 replay-envelope-v2 compatibility view.
- Recognize only `{ response: { kind: 'pi-ai', version: 2, provider, model } }` as proof of delegate ownership.
- Rebind only request-time assistant `source.provider`; preserve the durable public twin identity and the replayState object unchanged.
- Keep the existing pre-v2 delegated-replay shim intact for older contracts.

## Regression coverage

Upgrade the real DSH rc.7 cold-restart contract from #232 so the fake native multimodal adapter now emits rc.7-shaped pi-ai replay envelopes and rejects any later request whose replay-bearing assistant source is still attributed to the wrapper route.

The contract still exercises real rc.7 JSONL/Zstd persistence, attachment-local, full Context teardown/remount, multiple image turns, cold resume, a text turn after restart, and another image turn after restart. It now additionally proves replay-v2 identity survives the same boundary without mutating the durable session history.

No repository-writing workflow is introduced; the existing test-only cold-resume workflow remains read-only.