### PR TITLE
fix: bridge trusted vision hints when pi-ai throws UNKNOWN_MODEL

### DIFF
--- a/lib/vision-execution-policy.js
+++ b/lib/vision-execution-policy.js
@@ -44,7 +44,7 @@ export function isLocalImageCapabilityAdmissionFailure(failure) {
   return /^pi-ai model "[^"]+" does not support image input$/.test(message)
 }
 
-/** Exact pi-ai catalog miss: also pre-wire, but safe only with live evidence. */
+/** Exact pi-ai catalog miss: also pre-wire, but safe only with trusted evidence. */
 export function isLocalUnknownModelFailure(failure, provider, model) {
   if (!failure || typeof failure !== 'object') return false
   if (failure.code !== 'UNKNOWN_MODEL' || failure.status !== undefined) return false
@@ -53,12 +53,31 @@ export function isLocalUnknownModelFailure(failure, provider, model) {
 }
 
 /**
- * Classify a terminal adapter result for compatibility-bridge policy.
+ * Classify a provider/local failure for compatibility-bridge policy.
  * `allow` means a direct bridge is safe to attempt; `deny` means the adapter
  * reached any other failure class and the original failure must propagate.
  */
 export function bridgeDispositionForFailure(failure) {
   return isLocalImageCapabilityAdmissionFailure(failure) ? 'allow' : 'deny'
+}
+
+/**
+ * Apply the same narrow bridge policy to both structured terminal chunks and
+ * errors thrown directly by an adapter's async iterator. DSH pi-ai throws its
+ * exact pre-wire UNKNOWN_MODEL from modelOf() before yielding a chunk, so a
+ * trusted/live model omitted from DSH's static catalog must not be converted
+ * into a blanket deny merely because the failure arrived through `throw`.
+ */
+export function bridgeDispositionForObservedFailure(failure, provider, model, hasBridgeEvidence = () => false) {
+  let evidence = false
+  if (isLocalUnknownModelFailure(failure, provider, model)) {
+    try {
+      evidence = hasBridgeEvidence(provider, model) === true
+    } catch {
+      evidence = false
+    }
+  }
+  return evidence ? 'allow' : bridgeDispositionForFailure(failure)
 }
 
 function policyKey(provider, model) {
@@ -144,7 +163,15 @@ function settingsWithoutBlockedProvider(settings) {
 }
 
 function llmWithExecutionPolicy(llm, options = {}) {
-  const isLiveDiscovered = typeof options.isLiveDiscovered === 'function' ? options.isLiveDiscovered : () => false
+  // PR #230 intentionally wrapped liveDiscovery.hasModel() with endpoint-scoped
+  // trusted visual hints. Keep the old option name for compatibility, but treat
+  // it as generic bridge evidence rather than endpoint-list evidence only.
+  const hasBridgeEvidence =
+    typeof options.isBridgeEvidence === 'function'
+      ? options.isBridgeEvidence
+      : typeof options.isLiveDiscovered === 'function'
+        ? options.isLiveDiscovered
+        : () => false
   if (!llm || (typeof llm !== 'object' && typeof llm !== 'function')) return llm
   return new Proxy(llm, {
     get(target, property) {
@@ -170,32 +197,49 @@ function llmWithExecutionPolicy(llm, options = {}) {
           // A new adapter attempt owns the decision for this exact pair. Never
           // let a previous fallback attempt leak its bridge permission/denial.
           clearPolicy(scope, provider, model)
-          const iterable = stream.call(target, optionsForCall)
           return {
             async *[Symbol.asyncIterator]() {
               let sawTerminalFailure = false
               try {
+                // Construct the iterable inside the guarded section too. Most
+                // adapters throw lazily during iteration, but a synchronous
+                // pre-wire refusal must receive the identical classification.
+                const iterable = stream.call(target, optionsForCall)
                 for await (const chunk of iterable) {
                   const failure = failureFromChunk(chunk)
                   if (failure !== undefined) {
                     sawTerminalFailure = true
-                    const liveCatalogMiss =
-                      isLocalUnknownModelFailure(failure, provider, model) &&
-                      isLiveDiscovered(provider, model) === true
                     setPolicy(
                       scope,
                       provider,
                       model,
-                      liveCatalogMiss ? 'allow' : bridgeDispositionForFailure(failure),
+                      bridgeDispositionForObservedFailure(
+                        failure,
+                        provider,
+                        model,
+                        hasBridgeEvidence,
+                      ),
                     )
                   }
                   yield chunk
                 }
               } catch (error) {
-                // Waterfall/plugin errors are not the known pi-ai local
-                // admission shape. Fail closed instead of authorizing a bypass.
+                // PiAiAdapter throws UNKNOWN_MODEL and local image-admission
+                // failures directly from the async iterator before any chunk.
+                // Classify that exact pre-wire shape just like a terminal
+                // failure chunk; every provider/network/auth error still denies.
                 sawTerminalFailure = true
-                setPolicy(scope, provider, model, 'deny')
+                setPolicy(
+                  scope,
+                  provider,
+                  model,
+                  bridgeDispositionForObservedFailure(
+                    error,
+                    provider,
+                    model,
+                    hasBridgeEvidence,
+                  ),
+                )
                 throw error
               } finally {
                 // A successful stream leaves no stale policy behind. Terminal
@@ -259,15 +303,16 @@ function toolsWithExecutionScope(tools) {
  *
  * The legacy core already owns the direct HTTP bridge; this boundary supplies
  * the missing provenance information without mutating DSH globally. During a
- * vision tool call it observes the structured terminal failure emitted by the
- * LLM runtime. Non-admission failures temporarily hide the private pi-ai
+ * vision tool call it observes both structured terminal failures and direct
+ * adapter throws. Non-admission failures temporarily hide the private pi-ai
  * transport/config facts that the legacy bridge requires, so it cannot retry a
  * real provider/network failure through a second path. The exact local
  * text-only image-admission failure leaves those facts visible and therefore
  * preserves the intended no-YAML compatibility bridge. A local UNKNOWN_MODEL
- * is bridge-eligible only when the Host's live endpoint discovery independently
- * saw that exact provider/model, which solves static-catalog lag without making
- * arbitrary model ids a direct-request capability.
+ * is bridge-eligible only when the Host's private registry has trusted evidence
+ * for that exact provider/model (current live discovery or an endpoint-scoped
+ * trusted hint), which solves static-catalog lag without making arbitrary model
+ * ids a direct-request capability.
  */
 export function contextWithVisionExecutionPolicy(ctx, options = {}) {
   if (!ctx || typeof ctx !== 'object') return ctx

--- a/tests/vision-execution-policy.test.js
+++ b/tests/vision-execution-policy.test.js
@@ -3,6 +3,7 @@ import test from 'node:test'
 
 import {
   bridgeDispositionForFailure,
+  bridgeDispositionForObservedFailure,
   contextWithVisionExecutionPolicy,
   isLocalImageCapabilityAdmissionFailure,
   isLocalUnknownModelFailure,
@@ -51,6 +52,27 @@ test('UNKNOWN_MODEL recognition is exact and does not trust provider-side errors
   assert.equal(isLocalUnknownModelFailure({ ...unknownModel(), status: 404 }, 'doubao', 'seed-live-only'), false)
   assert.equal(isLocalUnknownModelFailure(unknownModel('other', 'seed-live-only'), 'doubao', 'seed-live-only'), false)
   assert.equal(isLocalUnknownModelFailure({ message: 'unknown model', code: 'UNKNOWN_MODEL' }, 'doubao', 'seed-live-only'), false)
+})
+
+test('observed failure classification admits UNKNOWN_MODEL only with exact bridge evidence', () => {
+  assert.equal(
+    bridgeDispositionForObservedFailure(
+      unknownModel('zhipu-glm', 'glm-4.6v-flash'),
+      'zhipu-glm',
+      'glm-4.6v-flash',
+      (provider, model) => provider === 'zhipu-glm' && model === 'glm-4.6v-flash',
+    ),
+    'allow',
+  )
+  assert.equal(
+    bridgeDispositionForObservedFailure(
+      unknownModel('zhipu-glm', 'glm-4.6v-flash'),
+      'zhipu-glm',
+      'glm-4.6v-flash',
+      () => false,
+    ),
+    'deny',
+  )
 })
 
 function fakeContext(streamFactory) {
@@ -103,6 +125,12 @@ function fakeContext(streamFactory) {
 function terminalFailureStream(failure) {
   return (async function* () {
     yield { type: 'finish', reason: { kind: 'error', failure } }
+  })()
+}
+
+function thrownFailureStream(failure) {
+  return (async function* () {
+    throw Object.assign(new Error(failure.message), failure)
   })()
 }
 
@@ -180,6 +208,102 @@ test('live endpoint evidence authorizes only the exact local UNKNOWN_MODEL pair'
     },
   })
   assert.equal(await fixtureAllowed.getRegistered().execute(), true)
+})
+
+test('thrown UNKNOWN_MODEL keeps bridge transport visible only with trusted evidence', async () => {
+  const failure = unknownModel('doubao', 'seed-live-only')
+  const deniedFixture = fakeContext(() => thrownFailureStream(failure))
+  const denied = contextWithVisionExecutionPolicy(deniedFixture.ctx, {
+    isBridgeEvidence: () => false,
+  })
+  denied.tools.register({
+    name: 'vision_describe',
+    async execute() {
+      await assert.rejects(async () => {
+        for await (const _chunk of denied.llm.stream({ provider: 'doubao', model: 'seed-live-only', messages: [] })) {}
+      }, (error) => error?.code === 'UNKNOWN_MODEL')
+      return denied.llm.registration('doubao').adapter.config !== undefined
+    },
+  })
+  assert.equal(await deniedFixture.getRegistered().execute(), false)
+
+  const allowedFixture = fakeContext(() => thrownFailureStream(failure))
+  const allowed = contextWithVisionExecutionPolicy(allowedFixture.ctx, {
+    isBridgeEvidence: (provider, model) => provider === 'doubao' && model === 'seed-live-only',
+  })
+  allowed.tools.register({
+    name: 'vision_describe',
+    async execute() {
+      await assert.rejects(async () => {
+        for await (const _chunk of allowed.llm.stream({ provider: 'doubao', model: 'seed-live-only', messages: [] })) {}
+      }, (error) => error?.code === 'UNKNOWN_MODEL')
+      return {
+        privateConfigVisible: allowed.llm.registration('doubao').adapter.config !== undefined,
+        rawProviderVisible: allowed.get('settings').get('llm-pi-ai').providers.doubao !== undefined,
+      }
+    },
+  })
+  assert.deepEqual(await allowedFixture.getRegistered().execute(), {
+    privateConfigVisible: true,
+    rawProviderVisible: true,
+  })
+})
+
+test('thrown exact local image admission still authorizes the compatibility bridge', async () => {
+  const fixture = fakeContext(() => thrownFailureStream(localAdmission('seed')))
+  const wrapped = contextWithVisionExecutionPolicy(fixture.ctx)
+  wrapped.tools.register({
+    name: 'vision_describe',
+    async execute() {
+      await assert.rejects(async () => {
+        for await (const _chunk of wrapped.llm.stream({ provider: 'doubao', model: 'seed', messages: [] })) {}
+      }, (error) => error?.code === 'UNSUPPORTED_CONTENT')
+      return wrapped.llm.registration('doubao').adapter.config !== undefined
+    },
+  })
+  assert.equal(await fixture.getRegistered().execute(), true)
+})
+
+test('thrown provider-side errors remain fail-closed and cannot trigger a second transport', async () => {
+  const failure = {
+    message: 'provider returned 400 invalid_request',
+    code: 'INVALID_REQUEST',
+    status: 400,
+  }
+  const fixture = fakeContext(() => thrownFailureStream(failure))
+  const wrapped = contextWithVisionExecutionPolicy(fixture.ctx, {
+    isBridgeEvidence: () => true,
+  })
+  wrapped.tools.register({
+    name: 'vision_describe',
+    async execute() {
+      await assert.rejects(async () => {
+        for await (const _chunk of wrapped.llm.stream({ provider: 'doubao', model: 'seed', messages: [] })) {}
+      }, (error) => error?.code === 'INVALID_REQUEST')
+      return wrapped.llm.registration('doubao').adapter.config !== undefined
+    },
+  })
+  assert.equal(await fixture.getRegistered().execute(), false)
+})
+
+test('synchronous pre-wire UNKNOWN_MODEL receives the same evidence policy', async () => {
+  const failure = unknownModel('doubao', 'seed-live-only')
+  const fixture = fakeContext(() => {
+    throw Object.assign(new Error(failure.message), failure)
+  })
+  const wrapped = contextWithVisionExecutionPolicy(fixture.ctx, {
+    isBridgeEvidence: () => true,
+  })
+  wrapped.tools.register({
+    name: 'vision_describe',
+    async execute() {
+      await assert.rejects(async () => {
+        for await (const _chunk of wrapped.llm.stream({ provider: 'doubao', model: 'seed-live-only', messages: [] })) {}
+      }, (error) => error?.code === 'UNKNOWN_MODEL')
+      return wrapped.llm.registration('doubao').adapter.config !== undefined
+    },
+  })
+  assert.equal(await fixture.getRegistered().execute(), true)
 })
 
 test('policy state is isolated to vision tool execution and reset by the next adapter attempt', async () => {


### PR DESCRIPTION
## Root cause

`glm-4.6v-flash [known]` is correctly injected by the endpoint-scoped trusted-hint registry, and PR #230 intentionally wraps `liveDiscovery.hasModel()` so that exact trusted hint counts as bridge evidence. However DSH/pi-ai does not necessarily return a terminal failure chunk for a model missing from its configured catalog: `PiAiAdapter.modelOf()` throws `LlmError(..., 'UNKNOWN_MODEL')` directly from the async iterator before any chunk is yielded.

`vision-execution-policy.js` only applied the trusted/live evidence check to structured terminal chunks. Its `catch` path blanket-set every thrown error to `deny`, hiding the pi-ai transport/settings from `channelBridgePlan()`. The selected known model therefore never reached the direct BigModel compatibility call and Vision Router continued to OVH.

## Fix

- classify thrown adapter errors with the same narrow policy used for terminal failure chunks;
- allow exact local `UNKNOWN_MODEL` only when the private registry has exact bridge evidence (live discovery or endpoint-scoped trusted hint);
- continue allowing the exact local pre-wire image-capability rejection;
- keep provider/network/auth/HTTP failures fail-closed so they cannot be resent through a second transport;
- guard synchronous stream-construction failures as well as async-iterator throws;
- introduce `isBridgeEvidence` as the clearer option name while retaining `isLiveDiscovered` compatibility.

## Regression coverage

Adds tests proving:
- thrown `UNKNOWN_MODEL` + exact evidence keeps bridge transport visible;
- the same throw without evidence remains denied;
- thrown exact local image admission remains bridge-eligible;
- thrown provider-side 400 remains denied even with evidence;
- synchronous pre-wire `UNKNOWN_MODEL` receives the same policy;
- existing terminal-chunk behavior remains unchanged.

This follows the normal branch → commits → PR flow; no repository-writing workflow is introduced.