### PR TITLE
fix: keep allowRemoteSettings boolean on v1.6.4

### DIFF
--- a/lib/local-remote-settings-permission.js
+++ b/lib/local-remote-settings-permission.js
@@ -180,6 +180,13 @@ export const LOCAL_PERMISSION_CLIENT_PRELUDE = String.raw`(function(){
   var binderCache = typeof WeakMap === 'function' ? new WeakMap() : undefined;
   var contextCache = typeof WeakMap === 'function' ? new WeakMap() : undefined;
 
+  function normalizePermissionValue(value) {
+    if (typeof value === 'boolean') return value;
+    if (value === 'true') return true;
+    if (value === 'false') return false;
+    return undefined;
+  }
+
   async function writePermission(operation, value, revision) {
     if (typeof fetch !== 'function') throw new Error('Vision Router local settings transport is unavailable');
     var payload = { operation: operation };
@@ -205,9 +212,11 @@ export const LOCAL_PERMISSION_CLIENT_PRELUDE = String.raw`(function(){
     if (!scope || (typeof scope !== 'object' && typeof scope !== 'function')) return scope;
     if (scopeCache && scopeCache.has(scope)) return scopeCache.get(scope);
     var overlay;
+
     function rawSnapshot() {
       try { return typeof scope.getSnapshot === 'function' ? scope.getSnapshot() : undefined; } catch (_) { return undefined; }
     }
+
     function snapshotWithOverlay(snapshot) {
       if (!overlay || !snapshot || typeof snapshot !== 'object') return snapshot;
       var user = snapshot.user && typeof snapshot.user === 'object' && !Array.isArray(snapshot.user) ? snapshot.user : {};
@@ -230,17 +239,45 @@ export const LOCAL_PERMISSION_CLIENT_PRELUDE = String.raw`(function(){
         revision: Number.isInteger(overlay.revision) ? overlay.revision : snapshot.revision
       });
     }
+
+    // v1.6.4 rendered allowRemoteSettings with toggleField(), but accidentally
+    // omitted it from ALL_TOGGLE_KEYS. The generic parser therefore serializes
+    // true/false as "true"/"false", while the generic formatter only treats
+    // strings as displayable values. Present a narrow client-only compatibility
+    // view and keep the Host/user layer strictly boolean.
+    function snapshotForClient(snapshot) {
+      var effective = snapshotWithOverlay(snapshot);
+      if (!effective || typeof effective !== 'object' || effective.mode !== 'host') return effective;
+      var next = effective;
+      var value = effective.value;
+      if (value && typeof value === 'object' && !Array.isArray(value)
+          && Object.prototype.hasOwnProperty.call(value, FIELD)
+          && typeof value[FIELD] === 'boolean') {
+        value = Object.assign({}, value, { [FIELD]: value[FIELD] ? 'true' : '' });
+        next = Object.assign({}, next, { value: value });
+      }
+      var user = effective.user;
+      if (user && typeof user === 'object' && !Array.isArray(user)
+          && Object.prototype.hasOwnProperty.call(user, FIELD)
+          && typeof user[FIELD] === 'boolean') {
+        user = Object.assign({}, user, { [FIELD]: user[FIELD] ? 'true' : 'false' });
+        next = Object.assign({}, next, { user: user });
+      }
+      return next;
+    }
+
     var wrapped = new Proxy(scope, {
       get: function(target, property) {
-        if (property === 'getSnapshot') return function(){ return snapshotWithOverlay(rawSnapshot()); };
+        if (property === 'getSnapshot') return function(){ return snapshotForClient(rawSnapshot()); };
         if (property === 'set') {
           var set = Reflect.get(target, property, target);
           return async function(field, value) {
             var snapshot = rawSnapshot();
             if (field === FIELD && snapshot && snapshot.mode === 'host') {
-              if (typeof value !== 'boolean') throw new TypeError('allowRemoteSettings must be boolean');
-              var result = await writePermission('set', value, snapshot.revision);
-              overlay = { present: true, value: value, revision: result && result.revision };
+              var normalized = normalizePermissionValue(value);
+              if (normalized === undefined) throw new TypeError('allowRemoteSettings must be boolean');
+              var result = await writePermission('set', normalized, snapshot.revision);
+              overlay = { present: true, value: normalized, revision: result && result.revision };
               if (typeof target.load === 'function') await target.load();
               return;
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-vision-router",
-  "version": "1.6.5",
+  "version": "1.6.4",
   "description": "Eyes for text-only DeepSeek Harness agents: built-in free vision chain (no key) + pixel-level vision tools (Q&A, grounding, crop, pixel diff, colors, OCR, SVG trace, cutout, screenshots). One-command install, no Python, image turns work like ordinary tool-calling turns.",
   "license": "MIT",
   "repository": {

--- a/tests/bundle-defaults.test.js
+++ b/tests/bundle-defaults.test.js
@@ -38,7 +38,7 @@ test('entry contract exposes the custom depth tier to every settings entry point
   assert.equal(custom.visionDepthMaxCalls, 7)
 })
 
-test('the rc6 permission persistence fix has a distinct package identity', async () => {
+test('current development line stays on package identity 1.6.4', async () => {
   const pkg = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8'))
-  assert.equal(pkg.version, '1.6.5')
+  assert.equal(pkg.version, '1.6.4')
 })

--- a/tests/local-remote-settings-permission.test.js
+++ b/tests/local-remote-settings-permission.test.js
@@ -102,15 +102,24 @@ test('local permission prelude is ordered after existing live-model prelude', ()
   assert.ok(next.includes(LOCAL_REMOTE_SETTINGS_PERMISSION_PATH))
 })
 
-test('client shim bypasses stock rc6 scope only for local allowRemoteSettings', async () => {
+test('client shim normalizes the v1.6.4 stringified toggle while Host storage stays boolean', async () => {
   const loaded = []
   const loader = { load(spec) { loaded.push(spec) } }
   const fetchCalls = []
+  let revision = 7
   const context = {
     window: { __ModuleLoader__: loader },
     fetch: async (url, options) => {
-      fetchCalls.push([url, options])
-      return { ok: true, status: 200, async json() { return { ok: true, value: { operation: 'set', present: true, value: true, revision: 8 } } } }
+      const payload = JSON.parse(options.body)
+      fetchCalls.push([url, options, payload])
+      revision += 1
+      return {
+        ok: true,
+        status: 200,
+        async json() {
+          return { ok: true, value: { operation: payload.operation, present: payload.operation === 'set', ...(payload.operation === 'set' ? { value: payload.value } : {}), revision } }
+        },
+      }
     },
     Proxy, Reflect, Object, Array, WeakMap, TypeError, Error, JSON, Number, console,
   }
@@ -131,18 +140,27 @@ test('client shim bypasses stock rc6 scope only for local allowRemoteSettings', 
   exports.apply({ settingsScope: { bind() { return rawScope } } })
   const scope = appliedCtx.settingsScope.bind({ namespace: 'vision-router' })
 
-  await scope.set('allowRemoteSettings', true)
+  // v1.6.4's generic parser turns the checkbox draft true into the string "true".
+  await scope.set('allowRemoteSettings', 'true')
   assert.equal(fetchCalls.length, 1)
   assert.equal(fetchCalls[0][0], LOCAL_REMOTE_SETTINGS_PERMISSION_PATH)
+  assert.equal(fetchCalls[0][2].value, true, 'Host endpoint must receive a real boolean')
   assert.equal(normalWrites.length, 0)
   assert.equal(loads, 1)
-  assert.equal(scope.getSnapshot().user.allowRemoteSettings, true)
+  assert.equal(scope.getSnapshot().user.allowRemoteSettings, 'true', 'client readback must match the stringified save plan')
+  assert.equal(scope.getSnapshot().value.allowRemoteSettings, 'true', 'legacy formatter must render the enabled checkbox as checked')
+
+  await scope.set('allowRemoteSettings', 'false')
+  assert.equal(fetchCalls.length, 2)
+  assert.equal(fetchCalls[1][2].value, false, 'Host endpoint must receive boolean false')
+  assert.equal(scope.getSnapshot().user.allowRemoteSettings, 'false', 'readback must match the stringified false save plan')
+  assert.equal(scope.getSnapshot().value.allowRemoteSettings, '', 'legacy formatter must render false as unchecked')
 
   await scope.set('routing', true)
   assert.deepEqual(normalWrites, [['set', 'routing', true]])
 
   snapshot.mode = 'remote'
   await scope.set('allowRemoteSettings', false)
-  assert.equal(fetchCalls.length, 1)
+  assert.equal(fetchCalls.length, 2)
   assert.deepEqual(normalWrites.at(-1), ['set', 'allowRemoteSettings', false])
 })


### PR DESCRIPTION
## Root cause

The new local diagnostic log finally exposed the real failure: `allowRemoteSettings` is rendered with `toggleField()`, but it was omitted from the client toggle-key classification. The checkbox draft starts as a boolean, then the generic parser serializes it as the string `"true"` / `"false"`. DSH rc6 rejects that against the boolean schema and its SettingsScope recovery path hides the original rejection, which is why earlier versions only reported a missing user-layer readback.

After #237 added an authoritative Host path, the hidden schema mismatch became explicit as `allowRemoteSettings must be boolean`.

## Fix

- keep the package identity at **1.6.4** (revert the accidental 1.6.5 bump)
- normalize the v1.6.4 client's exact `"true"` / `"false"` serialization to real booleans before the loopback-only Host endpoint
- keep Host persistence strictly boolean
- expose a narrow client compatibility snapshot so the legacy formatter renders true as checked / false as unchecked and `commitSettingsPlan` sees a readback shape matching its stringified save plan
- leave every other setting and every remote scope on the existing stock paths
- retain loopback + localhost Host + same-origin restrictions from #237

## Regression

The client-shim test now reproduces the exact v1.6.4 stringified toggle path, asserts the Host request contains boolean `true` / `false`, verifies the client readback no longer false-fails, and confirms unrelated fields / remote scopes remain untouched.

The real rc6 SettingsProvider persistence test remains in the suite.