### PR TITLE
fix: restore Vision Router settings page stability

### DIFF
--- a/lib/local-remote-settings-permission.js
+++ b/lib/local-remote-settings-permission.js
@@ -212,6 +212,14 @@ export const LOCAL_PERMISSION_CLIENT_PRELUDE = String.raw`(function(){
     if (!scope || (typeof scope !== 'object' && typeof scope !== 'function')) return scope;
     if (scopeCache && scopeCache.has(scope)) return scopeCache.get(scope);
     var overlay;
+    var cachedRawSnapshot;
+    var cachedOverlayKey;
+    var cachedClientSnapshot;
+
+    function overlayKey() {
+      if (!overlay) return 'none';
+      return (overlay.present ? '1' : '0') + ':' + String(overlay.value) + ':' + String(overlay.revision);
+    }
 
     function rawSnapshot() {
       try { return typeof scope.getSnapshot === 'function' ? scope.getSnapshot() : undefined; } catch (_) { return undefined; }
@@ -241,13 +249,24 @@ export const LOCAL_PERMISSION_CLIENT_PRELUDE = String.raw`(function(){
     }
 
     // v1.6.4 rendered allowRemoteSettings with toggleField(), but accidentally
-    // omitted it from ALL_TOGGLE_KEYS. The generic parser therefore serializes
-    // true/false as "true"/"false", while the generic formatter only treats
-    // strings as displayable values. Present a narrow client-only compatibility
-    // view and keep the Host/user layer strictly boolean.
+    // omitted it from ALL_TOGGLE_KEYS. Keep a client-only compatibility view,
+    // but memoize it by the underlying store snapshot and overlay state. React's
+    // external-store contract requires repeated getSnapshot() calls to return
+    // the same object until the store actually changes.
     function snapshotForClient(snapshot) {
+      var keyBefore = overlayKey();
+      if (snapshot === cachedRawSnapshot && keyBefore === cachedOverlayKey) return cachedClientSnapshot;
+
       var effective = snapshotWithOverlay(snapshot);
-      if (!effective || typeof effective !== 'object' || effective.mode !== 'host') return effective;
+      var keyAfter = overlayKey();
+      if (snapshot === cachedRawSnapshot && keyAfter === cachedOverlayKey) return cachedClientSnapshot;
+      if (!effective || typeof effective !== 'object' || effective.mode !== 'host') {
+        cachedRawSnapshot = snapshot;
+        cachedOverlayKey = keyAfter;
+        cachedClientSnapshot = effective;
+        return effective;
+      }
+
       var next = effective;
       var value = effective.value;
       if (value && typeof value === 'object' && !Array.isArray(value)
@@ -263,6 +282,10 @@ export const LOCAL_PERMISSION_CLIENT_PRELUDE = String.raw`(function(){
         user = Object.assign({}, user, { [FIELD]: user[FIELD] ? 'true' : 'false' });
         next = Object.assign({}, next, { user: user });
       }
+
+      cachedRawSnapshot = snapshot;
+      cachedOverlayKey = keyAfter;
+      cachedClientSnapshot = next;
       return next;
     }
 
@@ -278,6 +301,7 @@ export const LOCAL_PERMISSION_CLIENT_PRELUDE = String.raw`(function(){
               if (normalized === undefined) throw new TypeError('allowRemoteSettings must be boolean');
               var result = await writePermission('set', normalized, snapshot.revision);
               overlay = { present: true, value: normalized, revision: result && result.revision };
+              cachedRawSnapshot = undefined;
               if (typeof target.load === 'function') await target.load();
               return;
             }
@@ -291,6 +315,7 @@ export const LOCAL_PERMISSION_CLIENT_PRELUDE = String.raw`(function(){
             if (field === FIELD && snapshot && snapshot.mode === 'host') {
               var result = await writePermission('unset', undefined, snapshot.revision);
               overlay = { present: false, revision: result && result.revision };
+              cachedRawSnapshot = undefined;
               if (typeof target.load === 'function') await target.load();
               return;
             }

--- a/tests/local-remote-settings-permission.test.js
+++ b/tests/local-remote-settings-permission.test.js
@@ -102,7 +102,7 @@ test('local permission prelude is ordered after existing live-model prelude', ()
   assert.ok(next.includes(LOCAL_REMOTE_SETTINGS_PERMISSION_PATH))
 })
 
-test('client shim normalizes the v1.6.4 stringified toggle while Host storage stays boolean', async () => {
+test('client shim normalizes the v1.6.4 stringified toggle and keeps snapshots React-stable', async () => {
   const loaded = []
   const loader = { load(spec) { loaded.push(spec) } }
   const fetchCalls = []
@@ -140,6 +140,10 @@ test('client shim normalizes the v1.6.4 stringified toggle while Host storage st
   exports.apply({ settingsScope: { bind() { return rawScope } } })
   const scope = appliedCtx.settingsScope.bind({ namespace: 'vision-router' })
 
+  const initialSnapshot = scope.getSnapshot()
+  assert.equal(scope.getSnapshot(), initialSnapshot, 'unchanged store state must preserve getSnapshot object identity')
+  assert.equal(initialSnapshot.value.allowRemoteSettings, '', 'legacy formatter must render the disabled checkbox as unchecked')
+
   // v1.6.4's generic parser turns the checkbox draft true into the string "true".
   await scope.set('allowRemoteSettings', 'true')
   assert.equal(fetchCalls.length, 1)
@@ -147,14 +151,18 @@ test('client shim normalizes the v1.6.4 stringified toggle while Host storage st
   assert.equal(fetchCalls[0][2].value, true, 'Host endpoint must receive a real boolean')
   assert.equal(normalWrites.length, 0)
   assert.equal(loads, 1)
-  assert.equal(scope.getSnapshot().user.allowRemoteSettings, 'true', 'client readback must match the stringified save plan')
-  assert.equal(scope.getSnapshot().value.allowRemoteSettings, 'true', 'legacy formatter must render the enabled checkbox as checked')
+  const enabledSnapshot = scope.getSnapshot()
+  assert.equal(scope.getSnapshot(), enabledSnapshot, 'post-write snapshot must remain referentially stable until the store changes')
+  assert.equal(enabledSnapshot.user.allowRemoteSettings, 'true', 'client readback must match the stringified save plan')
+  assert.equal(enabledSnapshot.value.allowRemoteSettings, 'true', 'legacy formatter must render the enabled checkbox as checked')
 
   await scope.set('allowRemoteSettings', 'false')
   assert.equal(fetchCalls.length, 2)
   assert.equal(fetchCalls[1][2].value, false, 'Host endpoint must receive boolean false')
-  assert.equal(scope.getSnapshot().user.allowRemoteSettings, 'false', 'readback must match the stringified false save plan')
-  assert.equal(scope.getSnapshot().value.allowRemoteSettings, '', 'legacy formatter must render false as unchecked')
+  const disabledSnapshot = scope.getSnapshot()
+  assert.equal(scope.getSnapshot(), disabledSnapshot, 'disabled readback must also preserve snapshot identity')
+  assert.equal(disabledSnapshot.user.allowRemoteSettings, 'false', 'readback must match the stringified false save plan')
+  assert.equal(disabledSnapshot.value.allowRemoteSettings, '', 'legacy formatter must render false as unchecked')
 
   await scope.set('routing', true)
   assert.deepEqual(normalWrites, [['set', 'routing', true]])


### PR DESCRIPTION
## Regression

#239 made the Vision Router settings scope return a freshly cloned object from `getSnapshot()` on every call whenever `allowRemoteSettings` was present. DSH rc6/rc7 explicitly require the snapshot reference to stay stable until the underlying store changes. React's external-store subscription can therefore spin/re-render until the Vision Router settings surface goes blank.

## Fix

- memoize the compatibility snapshot by the raw DSH snapshot reference plus the temporary permission overlay state
- keep the v1.6.4 `"true"` / `"false"` compatibility normalization for this one field only
- keep Host persistence strictly boolean
- invalidate the compatibility cache only when the permission overlay or underlying DSH snapshot changes
- leave all other settings scopes and remote scopes untouched
- keep package version at 1.6.4

## Regression coverage

The VM client-shim test now asserts repeated `getSnapshot()` calls are referentially identical before and after permission writes, while still verifying the Host endpoint receives real booleans and the legacy v1.6.4 save/readback path remains compatible.

This specifically covers the blank-settings-page regression observed on a real DSH UI.