### PR TITLE
fix: persist exact direct-bridge failure reasons

### DIFF
--- a/lib/vision-execution-policy.js
+++ b/lib/vision-execution-policy.js
@@ -47,6 +47,12 @@ function compactFailureCode(failure) {
   return failure?.name || 'ERROR'
 }
 
+function compactDiagnosticDetail(value, maxLength = 800) {
+  const text = String(value ?? '').replace(/\s+/g, ' ').trim()
+  if (text.length <= maxLength) return text
+  return `${text.slice(0, maxLength)}…`
+}
+
 function evidenceSource(options, provider, model) {
   const resolver = typeof options.evidenceSource === 'function' ? options.evidenceSource : undefined
   if (!resolver) return 'catalog-or-configured'
@@ -342,23 +348,28 @@ function loggerWithExecutionDiagnostics(logger, diagnosticLogger) {
       if (typeof value !== 'function') return value
       return (...args) => {
         const scope = visionExecutionScope.getStore()
+        const bridgeFailureFormat = 'vision-router: vision_describe fallback [%s] (%s, %d ms): %s'
         if (
           scope &&
           property === 'warn' &&
-          typeof args[0] === 'string' &&
-          args[0].includes('vision_describe') &&
-          args[0].includes('fallback') &&
+          args[0] === bridgeFailureFormat &&
           scope.lastBridge
         ) {
-          scope.bridgeFallbackObserved = true
-          safeLog(
-            diagnosticLogger,
-            'info',
-            'vision-router: vision bridge fallback [%s/%s] source=%s',
-            scope.lastBridge.provider,
-            scope.lastBridge.model,
-            scope.lastBridge.source,
-          )
+          const backend = String(args[1] ?? '')
+          const expectedBackend = `${scope.lastBridge.provider}/${scope.lastBridge.model}`
+          if (backend === expectedBackend) {
+            scope.bridgeFallbackObserved = true
+            safeLog(
+              diagnosticLogger,
+              'info',
+              'vision-router: vision bridge failed [%s/%s] source=%s kind=%s detail=%s',
+              scope.lastBridge.provider,
+              scope.lastBridge.model,
+              scope.lastBridge.source,
+              compactDiagnosticDetail(args[2] ?? 'unknown'),
+              compactDiagnosticDetail(args[4] ?? ''),
+            )
+          }
         }
         return value.apply(target, args)
       }

--- a/tests/vision-backend-diagnostics.test.js
+++ b/tests/vision-backend-diagnostics.test.js
@@ -118,7 +118,7 @@ test('diagnostics show known-model adapter miss -> bridge attempt -> direct-brid
   assert.equal(lines.some((line) => line.includes(`vision backend success [${provider}/${model}] via=direct-bridge`) && line.includes('source=known')), true)
 })
 
-test('fallback warning marks the bridge as failed and suppresses a false direct-bridge success', async () => {
+test('exact bridge failure persists its kind/detail and later HTTP fallback is not misattributed', async () => {
   const provider = 'zhipu-glm'
   const model = 'glm-4.6v-flash'
   const fixture = diagnosticFixture({
@@ -141,9 +141,16 @@ test('fallback warning marks the bridge as failed and suppresses a false direct-
       wrapped.logger.warn(
         'vision-router: vision_describe fallback [%s] (%s, %d ms): %s',
         `${provider}/${model}`,
-        'other',
-        1,
-        'bridge request failed',
+        'auth',
+        167,
+        '401: {"error":"invalid api key"}',
+      )
+      wrapped.logger.warn(
+        'vision-router: vision_describe http fallback [%s] (%s, %d ms): %s',
+        'http:ovh/Qwen2.5-VL-72B-Instruct',
+        'rate_limit',
+        2900,
+        '429: too many requests',
       )
       return 'fallback answer'
     },
@@ -151,7 +158,12 @@ test('fallback warning marks the bridge as failed and suppresses a false direct-
 
   assert.equal(await fixture.getRegistered().execute(), 'fallback answer')
   const lines = messages(fixture.entries)
-  assert.equal(lines.some((line) => line.includes(`vision bridge fallback [${provider}/${model}]`)), true)
+  const bridgeFailures = lines.filter((line) => line.includes(`vision bridge failed [${provider}/${model}]`))
+  assert.equal(bridgeFailures.length, 1)
+  assert.equal(bridgeFailures[0].includes('source=known'), true)
+  assert.equal(bridgeFailures[0].includes('kind=auth'), true)
+  assert.equal(bridgeFailures[0].includes('401:'), true)
+  assert.equal(bridgeFailures[0].includes('429:'), false)
   assert.equal(lines.some((line) => line.includes(`vision backend success [${provider}/${model}] via=direct-bridge`)), false)
 })
 


### PR DESCRIPTION
## Root cause

The new backend provenance logger correctly showed that `zhipu-glm/glm-4.6v-flash [known]` entered the direct bridge, but it persisted only a generic `vision bridge fallback` line. The real catch already had the classified failure kind and provider message (for example HTTP 401), yet the diagnostic wrapper discarded both.

The wrapper also matched any warning containing `vision_describe` + `fallback`. That accidentally included later `vision_describe http fallback` warnings, so an OVH failure could be misattributed as a second Zhipu bridge fallback.

## Fix

- Match only the exact adapter-pair fallback format emitted by the direct-bridge catch.
- Require the warning backend key to equal the active bridge `provider/model` before attributing it.
- Persist a bounded single-line diagnostic with the real classification and provider detail:
  - `vision bridge failed [provider/model] source=known kind=auth detail=401: ...`
- Do not reinterpret later HTTP fallback warnings as bridge failures.
- Keep routing behavior unchanged; this patch is diagnostics-only.

## Regression coverage

Adds a focused test where the Zhipu bridge reports a 401 and a later OVH fallback reports a 429. The diagnostic stream must contain exactly one Zhipu bridge-failure line with the 401/auth detail and must not absorb the OVH 429.

Normal branch → commits → PR flow; no repository-writing workflow is introduced.