### PR TITLE
chore: reset sponsor button setup

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,0 @@
-custom:
-  - https://github.com/ysr666/dsh-vision-router/blob/main/SPONSOR.md


### PR DESCRIPTION
Temporarily removes `.github/FUNDING.yml` so the repository's built-in **Set up sponsor button** flow can recreate it and register the sponsorship configuration through GitHub's own setup UI.

`SPONSOR.md` and the WeChat/Alipay QR assets remain untouched.