### PR TITLE
chore: sync latest main into v1.7.0 release branch

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,0 @@
-custom:
-  - https://github.com/ysr666/dsh-vision-router/blob/main/SPONSOR.md

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: ["https://github.com/ysr666/dsh-vision-router/blob/main/SPONSOR.md"]


### PR DESCRIPTION
Bring the two post-#250 main commits (sponsor/funding setup) into `release/1.7.0` before final release preparation. No release/tag is created by this PR.