### PR TITLE
fix: preserve rc.8 client wrappers and release v1.7.3

### DIFF
--- a/lib/client-presentation-boundary.js
+++ b/lib/client-presentation-boundary.js
@@ -177,27 +177,47 @@ export const CLIENT_PRESENTATION_PRELUDE = String.raw`(function(){
   }
 
   function patchLoader(loader) {
-    if (!loader || typeof loader.load !== 'function' || loader.load.__visionRouterPresentationBoundary) return;
-    var original = loader.load;
-    function load(spec) {
-      if (spec && spec.id === TARGET && typeof spec.factory === 'function') {
-        var factory = spec.factory;
-        spec = Object.assign({}, spec, {
-          factory: function(require) {
-            var React = require('react');
-            var presentation = createPresentation(React);
-            function scopedRequire(id) {
-              if (id === LEGACY_ATTACHMENT_VALUE) return presentation;
-              return require(id);
+    if (!loader || (typeof loader !== 'object' && typeof loader !== 'function')) return;
+
+    if (typeof loader.load === 'function' && !loader.load.__visionRouterPresentationBoundary) {
+      var original = loader.load;
+      function load(spec) {
+        if (spec && spec.id === TARGET && typeof spec.factory === 'function') {
+          var factory = spec.factory;
+          spec = Object.assign({}, spec, {
+            factory: function(require) {
+              var React = require('react');
+              var presentation = createPresentation(React);
+              function scopedRequire(id) {
+                if (id === LEGACY_ATTACHMENT_VALUE) return presentation;
+                return require(id);
+              }
+              return factory(scopedRequire);
             }
-            return factory(scopedRequire);
-          }
-        });
+          });
+        }
+        return original.call(this, spec);
       }
-      return original.call(this, spec);
+      Object.defineProperty(load, '__visionRouterPresentationBoundary', { value: true });
+      loader.load = load;
     }
-    Object.defineProperty(load, '__visionRouterPresentationBoundary', { value: true });
-    loader.load = load;
+
+    // rc.8's parser installs a queue-mode facade first. When the Web shell
+    // later calls create(), ClientModuleSystem switches that *same object* to
+    // live mode by assigning a brand-new loader.load function. That assignment
+    // necessarily erases every queue-time wrapper. Wrap create itself so the
+    // boundary is re-applied immediately after the official queue -> live
+    // transition and before lazy third-party bundles can register.
+    if (typeof loader.create === 'function' && !loader.create.__visionRouterPresentationBoundary) {
+      var originalCreate = loader.create;
+      function create() {
+        var result = originalCreate.apply(this, arguments);
+        patchLoader(loader);
+        return result;
+      }
+      Object.defineProperty(create, '__visionRouterPresentationBoundary', { value: true });
+      loader.create = create;
+    }
   }
 
   function install() {
@@ -232,10 +252,10 @@ export function injectClientPresentationBoundary(html) {
   if (typeof html !== 'string' || html.includes(CLIENT_PRESENTATION_MARK)) return html
   const safe = CLIENT_PRESENTATION_PRELUDE.replace(/<\/script/gi, '<\\/script')
   const script = `<script ${CLIENT_PRESENTATION_MARK}>${safe}</script>`
-  // Same ordering rule as the live-model prelude: client-modules prepends the
-  // real `window.__ModuleLoader__` bootstrap after <head> before this plugin's
-  // later index tap runs. Inject at </head>, not <head>, or that bootstrap
-  // overwrites our patched loader and the rc.8 ImageGallery boundary vanishes.
+  // DSH's client-modules index tap prepends the queue-mode loader bootstrap at
+  // <head>. Run after that parser bootstrap so we can wrap both load() and the
+  // later create() transition. The create wrapper re-applies the boundary when
+  // rc.8 replaces loader.load while entering live mode.
   const closeHead = html.indexOf('</head>')
   if (closeHead !== -1) return `${html.slice(0, closeHead)}${script}${html.slice(closeHead)}`
   return `${html}${script}`

--- a/lib/live-model-client-prelude.js
+++ b/lib/live-model-client-prelude.js
@@ -516,31 +516,51 @@ export const LIVE_MODEL_CLIENT_PRELUDE = String.raw`(function(){
   }
 
   function patchLoader(loader) {
-    if (!loader || typeof loader.load !== 'function' || loader.load.__visionRouterLiveModels) return;
-    var original = loader.load;
-    function load(spec) {
-      if (spec && spec.id === 'dsh-vision-router' && typeof spec.factory === 'function') {
-        var factory = spec.factory;
-        spec = Object.assign({}, spec, {
-          factory: function(require) {
-            var exports = factory(require);
-            if (exports && typeof exports.apply === 'function' && !exports.apply.__visionRouterLiveModels) {
-              var apply = exports.apply;
-              var wrappedApply = function(ctx) {
-                var rest = Array.prototype.slice.call(arguments, 1);
-                return apply.apply(exports, [wrapContext(ctx)].concat(rest));
-              };
-              Object.defineProperty(wrappedApply, '__visionRouterLiveModels', { value: true });
-              exports.apply = wrappedApply;
+    if (!loader || (typeof loader !== 'object' && typeof loader !== 'function')) return;
+
+    if (typeof loader.load === 'function' && !loader.load.__visionRouterLiveModels) {
+      var original = loader.load;
+      function load(spec) {
+        if (spec && spec.id === 'dsh-vision-router' && typeof spec.factory === 'function') {
+          var factory = spec.factory;
+          spec = Object.assign({}, spec, {
+            factory: function(require) {
+              var exports = factory(require);
+              if (exports && typeof exports.apply === 'function' && !exports.apply.__visionRouterLiveModels) {
+                var apply = exports.apply;
+                var wrappedApply = function(ctx) {
+                  var rest = Array.prototype.slice.call(arguments, 1);
+                  return apply.apply(exports, [wrapContext(ctx)].concat(rest));
+                };
+                Object.defineProperty(wrappedApply, '__visionRouterLiveModels', { value: true });
+                exports.apply = wrappedApply;
+              }
+              return exports;
             }
-            return exports;
-          }
-        });
+          });
+        }
+        return original.call(loader, spec);
       }
-      return original.call(loader, spec);
+      Object.defineProperty(load, '__visionRouterLiveModels', { value: true });
+      loader.load = load;
     }
-    Object.defineProperty(load, '__visionRouterLiveModels', { value: true });
-    loader.load = load;
+
+    // rc.8 boot has two loader phases on the same object. The parser first
+    // exposes queue-mode load(); later ClientModuleSystem.create() assigns a
+    // new live-mode load() before any lazy community bundle arrives. A wrapper
+    // installed only during parsing is therefore silently discarded. Wrap the
+    // transition itself and immediately re-apply this factory/context boundary
+    // to the new live sink.
+    if (typeof loader.create === 'function' && !loader.create.__visionRouterLiveModels) {
+      var originalCreate = loader.create;
+      function create() {
+        var result = originalCreate.apply(this, arguments);
+        patchLoader(loader);
+        return result;
+      }
+      Object.defineProperty(create, '__visionRouterLiveModels', { value: true });
+      loader.create = create;
+    }
   }
 
   function install() {
@@ -574,13 +594,10 @@ export const LIVE_MODEL_CLIENT_PRELUDE = String.raw`(function(){
 export function injectLiveModelClientPrelude(html) {
   if (typeof html !== 'string' || html.includes(CLIENT_PRELUDE_MARK)) return html
   const script = `<script ${CLIENT_PRELUDE_MARK}>${LIVE_MODEL_CLIENT_PRELUDE.replace(/<\/script/gi, '<\\/script')}</script>`
-  // DSH's client-modules index tap is registered before out-of-tree plugins
-  // and prepends its `window.__ModuleLoader__` queue immediately after <head>.
-  // Inserting our prelude at the same head-open anchor puts us BEFORE that
-  // bootstrap; DSH then replaces the loader object and silently erases every
-  // wrapper installed here. Put the prelude at the end of <head> instead: the
-  // official queue/preloads already exist and our loader wrapper survives into
-  // dynamic plugin activation, while the Vite shell still starts in <body>.
+  // DSH's client-modules index tap prepends its queue-mode facade immediately
+  // after <head>. Run after that parser bootstrap so we can wrap both load()
+  // and create(); the create wrapper then re-attaches us after rc.8 swaps in
+  // its live registration sink, before lazy third-party bundles arrive.
   const closeHead = html.indexOf('</head>')
   if (closeHead !== -1) return `${html.slice(0, closeHead)}${script}${html.slice(closeHead)}`
   return `${html}${script}`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-vision-router",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Eyes for text-only DeepSeek Harness agents: built-in free vision chain (no key) + pixel-level vision tools (Q&A, grounding, crop, pixel diff, colors, OCR, SVG trace, cutout, screenshots). One-command install, no Python, image turns work like ordinary tool-calling turns.",
   "license": "MIT",
   "repository": {

--- a/tests/bundle-defaults.test.js
+++ b/tests/bundle-defaults.test.js
@@ -46,7 +46,7 @@ test('entry contract exposes the custom depth tier to every settings entry point
   assert.equal(custom.visionDepthMaxCalls, 7)
 })
 
-test('release line stays on package identity 1.7.2', async () => {
+test('release line stays on package identity 1.7.3', async () => {
   const pkg = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8'))
-  assert.equal(pkg.version, '1.7.2')
+  assert.equal(pkg.version, '1.7.3')
 })

--- a/tests/client-presentation-boundary.test.js
+++ b/tests/client-presentation-boundary.test.js
@@ -24,10 +24,27 @@ function fakeReact() {
 
 function materializePresentation(order) {
   let registered
+  const pendingQueue = []
   const loader = {
+    mode: 'queue',
+    pendingQueue,
     load(spec) {
-      registered = spec
+      pendingQueue.push(spec)
       return spec
+    },
+    create() {
+      assert.equal(this.mode, 'queue')
+      const pending = this.pendingQueue.splice(0)
+      this.mode = 'live'
+      // This assignment is what rc.8 ClientModuleSystem performs. It used to
+      // erase both Vision Router parser-time load wrappers before our lazy
+      // bundle arrived.
+      this.load = (spec) => {
+        registered = spec
+        return spec
+      }
+      for (const spec of pending) this.load(spec)
+      return { mode: 'live' }
     },
   }
   const window = { __ModuleLoader__: loader }
@@ -45,6 +62,7 @@ function materializePresentation(order) {
     clearTimeout() {},
   }
   for (const source of order) vm.runInNewContext(source, context)
+  loader.create()
 
   const requested = []
   const React = fakeReact()
@@ -59,6 +77,7 @@ function materializePresentation(order) {
     },
   })
 
+  assert.equal(loader.mode, 'live')
   assert.equal(typeof registered.factory, 'function')
   const exports = registered.factory((id) => {
     requested.push(id)
@@ -68,7 +87,7 @@ function materializePresentation(order) {
   return { exports, requested }
 }
 
-test('presentation prelude owns the legacy ImageGallery value without requiring DSH ui-attachment', () => {
+test('presentation prelude survives rc8 loader.create without requiring DSH ui-attachment', () => {
   const { exports, requested } = materializePresentation([CLIENT_PRESENTATION_PRELUDE])
   assert.equal(typeof exports.ImageGallery, 'function')
   assert.equal(exports.empty, null)
@@ -76,7 +95,7 @@ test('presentation prelude owns the legacy ImageGallery value without requiring 
   assert.ok(!requested.includes(LEGACY_ATTACHMENT_VALUE))
 })
 
-test('presentation and live-model preludes compose in either installation order', () => {
+test('presentation and live-model preludes compose across rc8 loader.create in either order', () => {
   for (const order of [
     [CLIENT_PRESENTATION_PRELUDE, LIVE_MODEL_CLIENT_PRELUDE],
     [LIVE_MODEL_CLIENT_PRELUDE, CLIENT_PRESENTATION_PRELUDE],
@@ -88,13 +107,14 @@ test('presentation and live-model preludes compose in either installation order'
   }
 })
 
-test('index transforms run after the DSH module-loader bootstrap and before shell startup', () => {
-  // This is the ordering produced by rc.8 client-modules before out-of-tree
-  // bundle taps run. Both Vision Router preludes must come AFTER this script;
-  // otherwise DSH assigns a new window.__ModuleLoader__ and erases our wrappers.
+test('index transforms run after the DSH queue-loader bootstrap and before shell startup', () => {
+  // rc.8 first creates the parser queue facade in <head>; the shell later
+  // calls its create(), which replaces load() while retaining the same object.
+  // Both Vision Router preludes must run after the parser bootstrap so they can
+  // wrap create() as well as the initial queue-mode load().
   const dshBootstrapped = [
     '<!doctype html><html><head>',
-    '<script data-dsh-module-bootstrap>window.__ModuleLoader__={load(){}}</script>',
+    '<script data-dsh-module-bootstrap>window.__ModuleLoader__={mode:"queue",load(){},create(){}}</script>',
     '</head><body><script type="module" src="/assets/app.js"></script></body></html>',
   ].join('')
 
@@ -107,7 +127,7 @@ test('index transforms run after the DSH module-loader bootstrap and before shel
     const preludeAt = output.indexOf(marker)
     const closeHeadAt = output.indexOf('</head>')
     assert.ok(bootstrapAt !== -1)
-    assert.ok(preludeAt > bootstrapAt, `${marker} must run after DSH creates its loader`)
+    assert.ok(preludeAt > bootstrapAt, `${marker} must run after DSH creates its queue loader`)
     assert.ok(preludeAt < closeHeadAt, `${marker} must still run before the shell in body`)
   }
 })

--- a/tests/settings-section-order.test.js
+++ b/tests/settings-section-order.test.js
@@ -13,13 +13,31 @@ function runPreludeRegistration(existingEntries = [], registration = {
   let registeredOptions
   let registeredDictionaries
 
+  // Model the exact rc.8 loader lifecycle that exposed the production bug:
+  // parser boot installs queue-mode load(), our prelude wraps it, then the
+  // shell's create() transition replaces load() with a fresh live sink before
+  // lazy community bundles such as dsh-vision-router are fetched.
+  const pendingQueue = []
   const loader = {
+    mode: 'queue',
+    pendingQueue,
     load(spec) {
-      loadedSpec = spec
+      pendingQueue.push(spec)
+    },
+    create() {
+      assert.equal(this.mode, 'queue')
+      const pending = this.pendingQueue.splice(0)
+      this.mode = 'live'
+      this.load = (spec) => {
+        loadedSpec = spec
+      }
+      for (const spec of pending) this.load(spec)
+      return { mode: 'live' }
     },
   }
   const window = { __ModuleLoader__: loader }
   vm.runInNewContext(LIVE_MODEL_CLIENT_PRELUDE, { window })
+  loader.create()
 
   loader.load({
     id: 'dsh-vision-router',
@@ -46,6 +64,7 @@ function runPreludeRegistration(existingEntries = [], registration = {
     },
   })
 
+  assert.ok(loadedSpec, 'lazy Vision Router bundle must reach the live registration sink')
   const exported = loadedSpec.factory(() => undefined)
   const ctx = {
     remote: {},
@@ -68,17 +87,18 @@ function runPreludeRegistration(existingEntries = [], registration = {
     get() { return undefined },
   }
   exported.apply(ctx)
-  return { registeredOptions, registeredDictionaries }
+  return { registeredOptions, registeredDictionaries, loader }
 }
 
-test('Vision Router settings section is moved after DSH built-ins into a stable extension band', () => {
-  const { registeredOptions } = runPreludeRegistration([
+test('Vision Router settings section survives rc8 loader.create and moves after DSH built-ins', () => {
+  const { registeredOptions, loader } = runPreludeRegistration([
     { options: { id: 'general', order: 0 } },
     { options: { id: 'models', order: 10 } },
     { options: { id: 'plugins', order: 15 } },
     { options: { id: 'agent-presets', order: 20 } },
   ])
 
+  assert.equal(loader.mode, 'live')
   assert.equal(registeredOptions.id, 'vision-router')
   assert.ok(registeredOptions.order >= 1_000_000)
   assert.notEqual(registeredOptions.order, 12)
@@ -103,7 +123,7 @@ test('settings order wrapper does not rewrite other plugin section registrations
   assert.equal(registeredOptions.order, 12)
 })
 
-test('client copy keeps standard capped at 2 while custom zero remains unlimited', () => {
+test('client copy keeps standard capped at 2 while custom zero remains unlimited after live transition', () => {
   const { registeredDictionaries } = runPreludeRegistration()
 
   assert.match(registeredDictionaries.zh.hintVisionDepthMaxCalls, /留空或填 0 = 不限制/)


### PR DESCRIPTION
## Root cause

The production screenshot showing `General -> Models -> Vision Router -> Plugins -> Agent Presets` proves the browser still sees Vision Router's original `settings.section` order `12`.

PR #258 fixed where our parser preludes are injected, but missed the second half of DSH rc.8's loader lifecycle. rc.8 first exposes a queue-mode `window.__ModuleLoader__.load()`. During shell boot, `ClientModuleSystem` keeps the same loader object but replaces `target.load` with a new live-registration function inside `create()`. Our parser-time wrappers were therefore erased before lazy community bundles such as `dsh-vision-router` arrived.

That makes the bug broader than Settings ordering: the live-model/context wrapper and the rc.8 ImageGallery presentation compatibility boundary can both disappear at the same queue -> live transition.

## Fix

- wrap the official loader `create()` transition in both Vision Router browser preludes;
- immediately re-apply each narrowly scoped `load()` wrapper after rc.8 installs its live registration sink;
- keep the two wrappers composable in either installation order;
- replace the old mock-only Settings test with a queue -> create -> live -> lazy Vision Router fixture matching rc.8's real lifecycle;
- make the presentation-boundary test exercise the same transition;
- prepare `1.7.3` as the hotfix release identity.

No DSH code is patched and no global plugin behavior is changed. The wrappers still affect only the `dsh-vision-router` client factory / its one legacy attachment value edge.