### PR TITLE
fix: remove legacy plugin settings entry

### DIFF
--- a/lib/live-model-client-prelude.js
+++ b/lib/live-model-client-prelude.js
@@ -460,6 +460,10 @@ export const LIVE_MODEL_CLIENT_PRELUDE = String.raw`(function(){
           if (typeof register !== 'function') return register;
           return function(options) {
             var args = Array.prototype.slice.call(arguments);
+            if (options && options.name === 'settings.plugin.item'
+                && (options.id === SETTINGS_SECTION_ID || options.key === SETTINGS_SECTION_ID)) {
+              return function(){};
+            }
             if (options && options.name === 'settings.section' && options.id === SETTINGS_SECTION_ID) {
               args[0] = Object.assign({}, options, {
                 order: settingsSectionOrder(target, SETTINGS_SECTION_ID)

--- a/tests/settings-section-order.test.js
+++ b/tests/settings-section-order.test.js
@@ -123,6 +123,28 @@ test('settings order wrapper does not rewrite other plugin section registrations
   assert.equal(registeredOptions.order, 12)
 })
 
+test('legacy Settings > Plugins compatibility entry is no longer registered', () => {
+  const { registeredOptions } = runPreludeRegistration([], {
+    name: 'settings.plugin.item',
+    key: 'vision-router',
+    id: 'vision-router',
+    order: 30,
+  })
+
+  assert.equal(registeredOptions, undefined)
+})
+
+test('legacy-entry filter does not suppress another plugin item', () => {
+  const { registeredOptions } = runPreludeRegistration([], {
+    name: 'settings.plugin.item',
+    key: 'another-plugin',
+    id: 'another-plugin',
+    order: 30,
+  })
+
+  assert.equal(registeredOptions.id, 'another-plugin')
+})
+
 test('client copy keeps standard capped at 2 while custom zero remains unlimited after live transition', () => {
   const { registeredDictionaries } = runPreludeRegistration()
 


### PR DESCRIPTION
## Summary

Remove the old `Settings → Plugins → Vision Router` compatibility entry now that `Settings → Vision Router` is the canonical settings surface.

- suppress only Vision Router's legacy `settings.plugin.item` registration;
- keep the first-class `settings.section` entry unchanged;
- add regressions proving the legacy entry is gone and other plugins are not affected.

Tracks #260. Keep the issue open until the next release is published.