### PR TITLE
release: v1.7.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-vision-router",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "description": "Eyes for text-only DeepSeek Harness agents: built-in free vision chain (no key) + pixel-level vision tools (Q&A, grounding, crop, pixel diff, colors, OCR, SVG trace, cutout, screenshots). One-command install, no Python, image turns work like ordinary tool-calling turns.",
   "license": "MIT",
   "repository": {

--- a/tests/bundle-defaults.test.js
+++ b/tests/bundle-defaults.test.js
@@ -46,7 +46,7 @@ test('entry contract exposes the custom depth tier to every settings entry point
   assert.equal(custom.visionDepthMaxCalls, 7)
 })
 
-test('release line stays on package identity 1.7.3', async () => {
+test('release line stays on package identity 1.7.4', async () => {
   const pkg = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8'))
-  assert.equal(pkg.version, '1.7.3')
+  assert.equal(pkg.version, '1.7.4')
 })


### PR DESCRIPTION
Prepare the v1.7.4 hotfix release identity after the runtime hardening and legacy settings-entry cleanup already merged to main.

- bump package version to 1.7.4;
- advance the release identity regression to 1.7.4;
- keep the tag itself manual as requested.

Release notes will fall back to the immutable commit list; README/CHANGELOG freshness remains advisory in the release workflow.