### PR TITLE
fix: clarify where vision models are configured

### DIFF
--- a/lib/live-model-client-prelude.js
+++ b/lib/live-model-client-prelude.js
@@ -415,6 +415,7 @@ export const LIVE_MODEL_CLIENT_PRELUDE = String.raw`(function(){
     if (next.zh && typeof next.zh === 'object') {
       next.zh = Object.assign({}, next.zh, {
         catalogPartialFailure: '部分已配置供应商的模型目录加载失败：{detail}。供应商仍会保留在识图设置中；若无法枚举模型，可选择“手动输入模型 ID”。',
+        chainHint: '请先在「设置 → 模型」中配置可用模型，再回到这里选择 Vision Router 用来读取图片的模型。将按从上到下的顺序尝试，失败时自动切换到下一个。',
         visionDepthStandard: '标准（最多再细看 2 次，默认）',
         visionDepthDeep: '细致（最多再细看 4 次）',
         hintVisionDepth: '结构化预识别之后：快速最多再细看 1 次、标准最多 2 次、细致最多 4 次；自定义可自行设置上限。档位只限制追加的证据深挖次数，具体看什么仍由模型按你的问题决定。',
@@ -424,6 +425,7 @@ export const LIVE_MODEL_CLIENT_PRELUDE = String.raw`(function(){
     if (next.en && typeof next.en === 'object') {
       next.en = Object.assign({}, next.en, {
         catalogPartialFailure: 'Some configured providers failed to load their model catalog: {detail}. The provider stays available in Vision Router; choose “Enter model ID” when its models cannot be enumerated.',
+        chainHint: 'Configure the model first in Settings → Models, then return here to choose which models Vision Router uses to read images. They are tried from top to bottom, with automatic failover.',
         visionDepthStandard: 'Standard (at most 2 more looks, default)',
         visionDepthDeep: 'Thorough (at most 4 more looks)',
         hintVisionDepth: 'After the structured pre-scan: Quick allows at most 1 more evidence look, Standard 2, Thorough 4, and Custom lets you set the cap. The tier limits only additional evidence calls; the model still decides what to inspect from your request.',

--- a/tests/settings-section-order.test.js
+++ b/tests/settings-section-order.test.js
@@ -46,12 +46,14 @@ function runPreludeRegistration(existingEntries = [], registration = {
         apply(ctx) {
           ctx.locale.register('vision-router', {
             zh: {
+              chainHint: 'old zh chain hint',
               hintVisionDepthMaxCalls: 'old zh',
               hintVisionDepth: 'old zh depth',
               visionDepthStandard: 'old zh standard',
               visionDepthDeep: 'old zh deep',
             },
             en: {
+              chainHint: 'old en chain hint',
               hintVisionDepthMaxCalls: 'old en',
               hintVisionDepth: 'old en depth',
               visionDepthStandard: 'old en standard',
@@ -143,6 +145,15 @@ test('legacy-entry filter does not suppress another plugin item', () => {
   })
 
   assert.equal(registeredOptions.id, 'another-plugin')
+})
+
+test('client copy tells users to configure models in DSH before choosing a vision chain', () => {
+  const { registeredDictionaries } = runPreludeRegistration()
+
+  assert.match(registeredDictionaries.zh.chainHint, /设置 → 模型/)
+  assert.match(registeredDictionaries.zh.chainHint, /先.*配置可用模型/)
+  assert.match(registeredDictionaries.en.chainHint, /Settings → Models/)
+  assert.match(registeredDictionaries.en.chainHint, /Configure the model first/i)
 })
 
 test('client copy keeps standard capped at 2 while custom zero remains unlimited after live transition', () => {


### PR DESCRIPTION
Clarify the Vision Router model-chain helper text before v1.7.4 is tagged.

- tell users to configure models in `Settings → Models` first;
- keep the existing top-to-bottom failover explanation;
- add the same guidance in English;
- add regression coverage for the patched locale copy.

Package identity remains v1.7.4; tagging stays manual.