### PR TITLE
feat: harden doctor health diagnostics

### DIFF
--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -1,10 +1,14 @@
 # Vision Router doctor / repair
 
-Vision Router ships a small standalone diagnostic CLI. It does not need DSH to boot first, so it can still run when DSH exits while parsing a broken profile manifest or when an older Vision Router build left one conversation unable to cold-resume.
+Vision Router ships a standalone diagnostic CLI. It can inspect a broken DSH profile even when DSH cannot boot, and it can optionally probe a running Web instance without executing any Vision Router action.
+
+The commands have a deliberately conservative split:
+
+- `doctor` is read-only by default;
+- `repair` changes only the two known profile-level faults described below;
+- `repair-sessions` changes only exact, known Vision Router session-corruption signatures and always makes a byte-for-byte backup first.
 
 ## Normal installation stays unchanged
-
-Use DSH's own plugin command:
 
 ```sh
 npx @deepseek-ai/dsh plugin --profile web add dsh-vision-router
@@ -20,19 +24,90 @@ pnpm dsh web
 
 The doctor is a recovery/diagnostic tool, not a replacement installer.
 
-## Diagnose profiles
+## Doctor v2
+
+Run the normal health check:
 
 ```sh
 npx dsh-vision-router doctor
 ```
 
-To inspect only the Web profile:
+Or inspect one profile explicitly:
 
 ```sh
 npx dsh-vision-router doctor --profile web
 ```
 
-The command locates the DSH home (`$DSH_HOME` when set, otherwise `~/.dsh`), scans profile `package.json` files, reports UTF-8 BOM bytes, validates the JSON after ignoring a leading BOM for diagnosis, reports whether `dsh-vision-router` is present as a profile dependency and bundle layer, and flags version-pinned `minimumReleaseAgeExclude` entries in the profile's `pnpm-workspace.yaml` that would hold back the next release.
+The doctor now separates **"the profile JSON parses"** from **"Vision Router is actually healthy"**. A requested profile is unhealthy when the package is missing, declared but not installed, installed but not mounted, registered twice, or otherwise cannot form one valid activation path.
+
+It recognizes both supported profile shapes:
+
+- **bundle mode** — `dsh-vision-router` is declared in `dependencies` and registered once in `dsh.profile.bundles`;
+- **manual mode** — the dependency is declared and the profile's `cordis.patch.yml` contains one Vision Router row.
+
+It reports a hard failure for a bundle+manual double registration, duplicate bundle/manual rows, a missing installed package, or an installed/declared package with no activation row. Profiles that do not use Vision Router are shown as unrelated when scanning all profiles; they do not make another healthy Vision Router profile fail.
+
+The offline profile check also keeps the existing diagnostics for:
+
+- a leading UTF-8 BOM or otherwise invalid profile JSON;
+- stale version-pinned `minimumReleaseAgeExclude` entries;
+- coexisting vision plugins;
+- legacy profile patches that statically disable `llm-deepseek`;
+- recent structured `settings save failed field=... operation=... reason=...` records from the Vision Router log. Raw log lines, API keys and arbitrary values are not copied into the report.
+
+### Running-DSH route probe
+
+When DSH Web is reachable, doctor checks that the Vision Router exact routes are really registered. This catches the class of regressions where the plugin partly loads but routes such as `update-check` or `model-capabilities` silently disappear and the SPA fallback returns HTML instead.
+
+The probe sends an intentionally unsupported **DELETE** request to each known route. Every current Vision Router handler rejects that method with `405 Method Not Allowed` and its exact `Allow` contract **before** executing GET/POST behavior. Doctor verifies that exact method contract, so it does **not** run an update check, model discovery, connection test, settings mutation, self-update or log-opening action. Using the expected `Allow` set also prevents a generic SPA/unknown-route response from being mistaken for a registered Vision Router route.
+
+Default target:
+
+```text
+http://127.0.0.1:3080
+```
+
+Override it with:
+
+```sh
+npx dsh-vision-router doctor --runtime-url http://127.0.0.1:4000
+```
+
+or `DSH_WEB_URL`. To perform offline checks only:
+
+```sh
+npx dsh-vision-router doctor --no-runtime
+```
+
+An unreachable DSH process is advisory rather than a doctor failure; offline checks still complete. When `--profile` is used against a reachable runtime, doctor does not attribute green route health to that profile unless the runtime exposes a verified Vision Router profile identity. If ownership cannot be proven, the human report shows `? runtime profile ownership unknown` instead of a false green binding.
+
+### Local capability diagnostics
+
+Doctor reports the local platform, Node version, and whether it can find:
+
+- Tesseract (PATH plus the common Windows install location);
+- Chromium / Chrome / Edge (PATH plus common Windows and macOS locations);
+- `sharp` and selected DSH host package versions when they are present inside the inspected profile.
+
+Tesseract, Chromium and profile-local Sharp are advisory because the corresponding optional tool may be unused or supplied by the host through another resolution path.
+
+### Scan historical sessions
+
+Session scanning is opt-in because a large session store can take longer to read/decompress:
+
+```sh
+npx dsh-vision-router doctor --sessions
+```
+
+This is read-only. It looks only for the exact known Vision Router corruption signatures supported by `repair-sessions`.
+
+### Shareable JSON report
+
+```sh
+npx dsh-vision-router doctor --profile web --sessions --json
+```
+
+The JSON report is schema-versioned and includes the running Doctor/Vision Router version. It is intentionally minimized for issue reports: it does not contain the raw profile manifest, raw log lines, API keys, raw dependency specs, local dependency paths, URL credentials/query strings/fragments, session ids, or raw runtime error text. It keeps only structured diagnostic facts such as install mode, installed version, route status, failure counts, optional capability versions and known session-repair kinds.
 
 ## Repair the UTF-8 BOM startup failure
 
@@ -51,33 +126,47 @@ npx dsh-vision-router repair --profile web
 
 `repair` removes only the three-byte UTF-8 BOM prefix (`EF BB BF`) when it is present, then validates the remaining JSON. It does not reformat, regenerate, or otherwise rewrite the profile contents. If JSON is still invalid for another reason, the command reports that and stops rather than guessing a repair.
 
+`doctor --fix` remains accepted for backward compatibility, but new troubleshooting instructions should prefer the explicit `repair` command so that ordinary doctor runs stay obviously read-only.
+
 ## Repair a stale release-age exemption (the "update does nothing" gate)
 
-pnpm v11 defaults `minimumReleaseAge` to 1440 minutes: a version published less than 24 hours ago is not resolved, so `dsh plugin update` silently keeps the previous version and prints `downloaded 0 / added 0`. An exemption entry that pins a version — `dsh-vision-router@1.2.0` — only exempts that one version and goes stale on the next release, which is why "a new release is out but the update does nothing" keeps recurring.
+pnpm v11 defaults `minimumReleaseAge` to 1440 minutes. A version-pinned exemption such as `dsh-vision-router@1.2.0` exempts only that version and goes stale on the next release.
 
-The doctor flags version-pinned entries for `dsh-vision-router` and the `@deepseek-ai/*` host packages:
-
-```text
-✗ web — … — release-age exemption version-pinned (dsh-vision-router@1.2.0) — releases younger than 24h will not be picked up
-```
-
-Run:
+Doctor flags version-pinned entries for `dsh-vision-router` and `@deepseek-ai/*`. Run:
 
 ```sh
 npx dsh-vision-router repair --profile web
 ```
 
-to rewrite them to bare names (`dsh-vision-router`, `@deepseek-ai/*`), which exempt every future version, so upgrades take effect immediately again. Unrelated entries and the rest of the file are left untouched.
+to rewrite only those stale targets to bare names (`dsh-vision-router`, `@deepseek-ai/*`). Unrelated entries and the rest of the workspace file are left untouched.
 
-## Repair a conversation that only breaks after restarting DSH
+## Repair conversations that only break after restarting DSH
 
-A very early Vision Router build briefly persisted the automatic vision-tool mount reminder as a `user/message` without a message `id`. The conversation could keep working in the live process, but after DSH restarted the stricter cold-resume validator could reject that stored event with an error containing:
+Two historical Vision Router defects can leave already-persisted sessions unable to cold-resume even though current builds no longer create the bad events.
+
+### Legacy missing message id
+
+A very early build persisted the automatic vision-tool mount reminder as a `user/message` without an `id`. DSH can later reject it with an error containing:
 
 ```text
 lacks an identified message
 ```
 
-Current Vision Router builds no longer create that malformed event. To recover an already-affected conversation, **stop DSH first**, then run:
+### Duplicate structured guard-stop id
+
+Older structured-flow builds could persist the same exact guard message more than once in one turn, for example:
+
+```text
+vision-router-structured-guard-stop-1
+```
+
+DSH then sees more than one `input-message...` start when the conversation is reloaded and can fail with an error containing:
+
+```text
+received more than one start Match
+```
+
+To repair either known case, **stop DSH first**, then run:
 
 ```sh
 npx dsh-vision-router repair-sessions
@@ -85,12 +174,16 @@ npx dsh-vision-router repair-sessions
 
 The repair is intentionally narrow and fail-closed:
 
-- it scans `$DSH_HOME/sessions` for the exact historical Vision Router auto-mount reminder signature only;
-- unrelated malformed messages are not changed;
-- both raw `session.jsonl` and DSH's default checksummed `session.jsonl.zstd` format are supported;
-- unchanged Zstandard frames stay byte-for-byte identical;
-- torn/incomplete logs are refused so DSH can perform its own crash recovery first;
-- the source file identity is checked again immediately before replacement, so a live writer causes the operation to abort instead of racing;
-- every changed log receives a byte-for-byte backup next to the original before replacement, and the repaired log is re-read and verified before success is reported.
+- the old missing-id repair still matches only the exact historical Vision Router auto-mount reminder;
+- duplicate guard repair recognizes only Vision Router `user/message` events with the exact historical guard id shape, plugin source and one of the exact known budget/depth exhaustion texts;
+- the first legitimate guard is preserved; later exact duplicates keep their original event and `seq`, but receive deterministic unique recovery ids so the durable event stream is not shortened;
+- if the same guard id appears with a different/near-miss shape or text, automatic repair aborts instead of deleting data;
+- raw `session.jsonl` and DSH's checksummed `session.jsonl.zstd` are supported;
+- duplicate detection is preserved across separate Zstandard frames, and packed chunk rows are understood when validating the contiguous durable `seq` stream;
+- unaffected Zstandard frames remain byte-for-byte identical;
+- mutation refuses torn/incomplete logs so DSH can perform its own crash recovery first; read-only `doctor --sessions` treats only an incomplete live tail as advisory while committed structural corruption remains a failure;
+- source file identity is rechecked immediately before replacement so a live writer aborts the operation;
+- every changed log receives a byte-for-byte backup next to the original before replacement;
+- the repaired file is re-read and verified before success is reported.
 
-After the command reports a repaired session, restart DSH and reopen the conversation. Running `repair-sessions` again is idempotent: already-repaired logs are left untouched.
+After repair, restart DSH and reopen the affected conversation. Running `repair-sessions` again is idempotent.

--- a/lib/doctor-cli.js
+++ b/lib/doctor-cli.js
@@ -3,10 +3,11 @@
 import { realpathSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { doctorProfiles, resolveDshHome } from './doctor.js'
+import { inspectPlatform, probeRuntime, supportReport } from './doctor-runtime.js'
 import { repairLegacySessionLogs } from './legacy-session-repair.js'
 
 function usage() {
-  return `dsh-vision-router doctor [--profile <name>] [--fix]\ndsh-vision-router repair [--profile <name>]\ndsh-vision-router repair-sessions\n\nChecks DSH profile manifests even when DSH itself cannot boot.\n\nCommands:\n  doctor           Diagnose profile package.json files, coexisting vision plugins, and the pnpm v11 release-age update gate.\n  repair           Diagnose and safely repair: remove a leading UTF-8 BOM, and rewrite version-pinned minimumReleaseAgeExclude entries to bare names.\n  repair-sessions  Offline repair for the known legacy Vision Router auto-mount message-id defect. Stop DSH first. Only exact affected session events are changed; every changed log gets a byte-for-byte backup.\n\nOptions:\n  --profile <name>  Check only one profile (for example: web).\n  --fix             With doctor, remove a leading UTF-8 BOM and rewrite version-pinned release-age exemptions when found.\n  --help            Show this help.\n`
+  return `dsh-vision-router doctor [--profile <name>] [--json] [--sessions] [--runtime-url <url>] [--no-runtime] [--fix]\ndsh-vision-router repair [--profile <name>]\ndsh-vision-router repair-sessions\n\nChecks installation, profile composition, runtime routes, recent settings-save failures and local vision capabilities.\n\nCommands:\n  doctor           Read-only health report by default. --fix is kept for compatibility but prefer the explicit repair command.\n  repair           Safely remove a leading UTF-8 BOM and rewrite stale version-pinned minimumReleaseAgeExclude entries.\n  repair-sessions  Offline repair for exact known Vision Router session corruptions, including the legacy missing-id reminder and duplicate structured guard-stop messages. Stop DSH first.\n\nOptions:\n  --profile <name>       Check only one profile (for example: web).\n  --json                 Emit a shareable, secret-minimized JSON diagnostic report.\n  --sessions             Also scan session logs for exact known Vision Router corruption signatures (read-only; may take longer).\n  --runtime-url <url>    Probe a running DSH web instance (default: DSH_WEB_URL or http://127.0.0.1:3080).\n  --no-runtime           Skip the read-only runtime route probe.\n  --fix                  Backward-compatible doctor repair mode; prefer \`repair\`.\n  --help                 Show this help.\n`
 }
 
 function parseArgs(argv) {
@@ -15,6 +16,10 @@ function parseArgs(argv) {
   if (args[0] && !args[0].startsWith('-')) command = args.shift()
   let profile
   let fix = command === 'repair'
+  let json = false
+  let sessions = false
+  let runtime = command === 'doctor'
+  let runtimeUrl
 
   for (let index = 0; index < args.length; index += 1) {
     const value = args[index]
@@ -22,6 +27,34 @@ function parseArgs(argv) {
     if (value === '--fix') {
       if (command === 'repair-sessions') throw new Error('--fix is not used with repair-sessions')
       fix = true
+      continue
+    }
+    if (value === '--json') {
+      if (command !== 'doctor') throw new Error('--json is only used with doctor')
+      json = true
+      continue
+    }
+    if (value === '--sessions') {
+      if (command !== 'doctor') throw new Error('--sessions is only used with doctor')
+      sessions = true
+      continue
+    }
+    if (value === '--no-runtime') {
+      if (command !== 'doctor') throw new Error('--no-runtime is only used with doctor')
+      runtime = false
+      continue
+    }
+    if (value === '--runtime-url') {
+      if (command !== 'doctor') throw new Error('--runtime-url is only used with doctor')
+      runtimeUrl = args[index + 1]
+      index += 1
+      if (!runtimeUrl) throw new Error('--runtime-url requires a URL')
+      continue
+    }
+    if (value.startsWith('--runtime-url=')) {
+      if (command !== 'doctor') throw new Error('--runtime-url is only used with doctor')
+      runtimeUrl = value.slice('--runtime-url='.length)
+      if (!runtimeUrl) throw new Error('--runtime-url requires a URL')
       continue
     }
     if (value === '--profile') {
@@ -40,13 +73,16 @@ function parseArgs(argv) {
     throw new Error(`unknown argument: ${value}`)
   }
 
-  if (command !== 'doctor' && command !== 'repair' && command !== 'repair-sessions') {
-    throw new Error(`unknown command: ${command}`)
-  }
+  if (!['doctor', 'repair', 'repair-sessions'].includes(command)) throw new Error(`unknown command: ${command}`)
   if (profile && (!/^[A-Za-z0-9._-]+$/.test(profile) || profile === '.' || profile === '..')) {
     throw new Error(`invalid profile name: ${profile}`)
   }
-  return { command, profile, fix }
+  if (runtimeUrl) {
+    let parsed
+    try { parsed = new URL(runtimeUrl) } catch { throw new Error(`invalid runtime URL: ${runtimeUrl}`) }
+    if (!['http:', 'https:'].includes(parsed.protocol)) throw new Error(`invalid runtime URL protocol: ${parsed.protocol}`)
+  }
+  return { command, profile, fix, json, sessions, runtime, runtimeUrl }
 }
 
 function visionPluginLabel(plugin) {
@@ -56,37 +92,38 @@ function visionPluginLabel(plugin) {
 }
 
 function statusLine(profile) {
-  const prefix = profile.validJson ? '✓' : '✗'
-  const parts = [`${prefix} ${profile.name}`]
-  if (!profile.exists) {
-    parts.push('package.json not found')
-    return parts.join(' — ')
-  }
-  if (profile.hasBom) {
-    parts.push(profile.repaired ? 'UTF-8 BOM removed' : 'UTF-8 BOM detected')
-  } else {
-    parts.push('no BOM')
-  }
+  if (!profile.installation?.applicable) return `– ${profile.name} — Vision Router not installed in this profile`
+  const healthy = profile.exists
+    && profile.validJson
+    && (!profile.hasBom || profile.repaired)
+    && profile.installation?.ok !== false
+    && (!profile.workspace || profile.workspace.pinned.length === 0 || profile.workspace.rewritten)
+  const parts = [`${healthy ? '✓' : '✗'} ${profile.name}`]
+  if (!profile.exists) return `${parts[0]} — package.json not found`
+  if (profile.hasBom) parts.push(profile.repaired ? 'UTF-8 BOM removed' : 'UTF-8 BOM detected')
   parts.push(profile.validJson ? 'JSON valid' : `JSON invalid: ${profile.jsonError}`)
   if (profile.validJson) {
-    parts.push(profile.pluginDependency ? `dependency ${profile.pluginDependency}` : 'Vision Router dependency not present')
-    parts.push(profile.pluginBundle ? 'bundle registered' : 'bundle not registered')
+    const mode = profile.installation?.mode ?? 'unknown'
+    const version = profile.installedPlugin?.version ? `@${profile.installedPlugin.version}` : ''
+    parts.push(`install ${mode}${version}`)
     if (profile.coexistingVisionPlugins?.length > 0) {
-      const listed = profile.coexistingVisionPlugins.slice(0, 4).map(visionPluginLabel).join(', ')
-      parts.push(
-        `other vision plugin(s) present: ${listed} — coexistence is not automatically a conflict, ` +
-        'but if pnpm install/update logs name one of them, that existing profile dependency may be the blocker',
-      )
+      parts.push(`other vision plugin(s): ${profile.coexistingVisionPlugins.slice(0, 4).map(visionPluginLabel).join(', ')}`)
     }
   }
   const workspace = profile.workspace
   if (workspace?.exists && workspace.pinned.length > 0) {
     const listed = workspace.pinned.slice(0, 3).join(', ')
     parts.push(workspace.rewritten
-      ? `release-age exemption rewritten to bare name (${listed})`
-      : `release-age exemption version-pinned (${listed}) — releases younger than 24h will not be picked up`)
+      ? `release-age exemption repaired (${listed})`
+      : `release-age exemption version-pinned (${listed})`)
   }
   return parts.join(' — ')
+}
+
+function printProfileDetails(profile, io) {
+  io.log(statusLine(profile))
+  for (const error of profile.installation?.errors ?? []) io.error(`  ✗ ${error}`)
+  for (const warning of profile.installation?.warnings ?? []) io.log(`  ! ${warning}`)
 }
 
 function runSessionRepair(dshHome, io) {
@@ -97,37 +134,27 @@ function runSessionRepair(dshHome, io) {
     io.error(`dsh-vision-router: session repair failed: ${error instanceof Error ? error.message : String(error)}`)
     return 1
   }
-
   io.log(`DSH home: ${dshHome}`)
   io.log(`Session root: ${report.sessionsRoot}`)
   if (!report.exists) {
     io.log('✓ No DSH session store found; nothing to repair.')
     return 0
   }
-
   for (const item of report.reports) {
-    const seqs = item.affectedSeqs.join(', ')
-    io.log(
-      `✓ Repaired session ${item.sessionId} (${item.encoding}) at event seq ${seqs}; ` +
-      `backup: ${item.backupPath}`,
-    )
+    const kinds = [...new Set((item.repairs ?? []).map((repair) => repair.kind))].join(', ')
+    io.log(`✓ Repaired session ${item.sessionId} (${item.encoding}) at event seq ${item.affectedSeqs.join(', ')}${kinds ? ` [${kinds}]` : ''}; backup: ${item.backupPath}`)
   }
-  for (const failure of report.errors) {
-    io.error(`✗ ${failure.path} — ${failure.error}`)
-  }
-
+  for (const failure of report.errors) io.error(`✗ ${failure.path} — ${failure.error}`)
   if (report.repaired === 0 && report.errors.length === 0) {
-    io.log(`✓ Scanned ${report.scanned} session log(s); no legacy Vision Router message-id corruption found.`)
+    io.log(`✓ Scanned ${report.scanned} session log(s); no known Vision Router session corruption found.`)
   } else if (report.repaired > 0) {
     io.log(`Repaired ${report.repaired} session log(s). Restart DSH and reopen the affected conversation.`)
   }
-  if (report.errors.length > 0) {
-    io.error('Some logs were not changed. Keep DSH stopped, resolve the errors above, and run the command again.')
-  }
+  if (report.errors.length > 0) io.error('Some logs were not changed. Keep DSH stopped, resolve the errors above, and run the command again.')
   return report.ok ? 0 : 1
 }
 
-export function run(argv = process.argv.slice(2), io = console, env = process.env) {
+export async function run(argv = process.argv.slice(2), io = console, env = process.env) {
   let options
   try {
     options = parseArgs(argv)
@@ -136,7 +163,6 @@ export function run(argv = process.argv.slice(2), io = console, env = process.en
     io.error(usage().trimEnd())
     return 2
   }
-
   if (options.help) {
     io.log(usage().trimEnd())
     return 0
@@ -145,55 +171,122 @@ export function run(argv = process.argv.slice(2), io = console, env = process.en
   const dshHome = resolveDshHome(env)
   if (options.command === 'repair-sessions') return runSessionRepair(dshHome, io)
 
-  let report
+  let profileReport
   try {
-    report = doctorProfiles({ dshHome, profile: options.profile, fix: options.fix })
+    profileReport = doctorProfiles({ dshHome, profile: options.profile, fix: options.fix })
   } catch (error) {
     io.error(`dsh-vision-router: doctor failed: ${error instanceof Error ? error.message : String(error)}`)
     return 1
   }
 
-  io.log(`DSH home: ${report.dshHome}`)
-  if (report.profiles.length === 0) {
-    io.error('✗ No DSH profiles found.')
-    io.error('  Expected profiles under <DSH_HOME>/profiles. If you use a custom home, set DSH_HOME first.')
+  if (profileReport.profiles.length === 0) {
+    if (options.json) io.log(JSON.stringify({ schemaVersion: 1, ok: false, error: 'no DSH profiles found' }, null, 2))
+    else {
+      io.error('✗ No DSH profiles found.')
+      io.error('  Expected profiles under <DSH_HOME>/profiles. If you use a custom home, set DSH_HOME first.')
+    }
     return 1
   }
 
-  for (const profile of report.profiles) io.log(statusLine(profile))
+  let runtime
+  if (options.runtime) {
+    try {
+      runtime = await probeRuntime({
+        baseUrl: options.runtimeUrl || env.DSH_WEB_URL || 'http://127.0.0.1:3080',
+        requestedProfile: options.profile,
+        dshHome,
+        applicableProfiles: profileReport.profiles.filter((item) => item.installation?.applicable).map((item) => item.name),
+      })
+    } catch (error) {
+      io.error(`dsh-vision-router: runtime probe failed: ${error instanceof Error ? error.message : String(error)}`)
+      return 1
+    }
+  }
+  const applicableDirs = profileReport.profiles
+    .filter((item) => item.installation?.applicable && item.profileDir)
+    .map((item) => item.profileDir)
+  const platform = inspectPlatform({ profileDirs: applicableDirs })
+  let sessions
+  if (options.sessions) sessions = repairLegacySessionLogs({ dshHome, fix: false })
 
-  const pendingFix = report.profiles.some((profile) =>
+  const overallOk = profileReport.ok
+    && (runtime?.ok ?? true)
+    && (!sessions || (sessions.affected === 0 && sessions.errors.length === 0))
+
+  if (options.json) {
+    const report = supportReport({ profileReport, runtime, platform, sessions })
+    report.ok = overallOk
+    io.log(JSON.stringify(report, null, 2))
+    return overallOk ? 0 : 1
+  }
+
+  io.log(`DSH home: ${profileReport.dshHome}`)
+  for (const profile of profileReport.profiles) printProfileDetails(profile, io)
+  if (profileReport.applicableProfiles === 0) io.error('✗ Vision Router is not installed or mounted in any discovered profile.')
+
+  if (profileReport.log?.settingsSaveFailures?.length > 0) {
+    const last = profileReport.log.settingsSaveFailures.at(-1)
+    io.error(`✗ Current-run settings save failures found (${profileReport.log.settingsSaveFailures.length}); latest: field=${last.field} operation=${last.operation} reason=${last.reason}`)
+  }
+  if (profileReport.log?.historicalSettingsSaveFailures?.length > 0) {
+    io.log(`! Historical settings save failures exist (${profileReport.log.historicalSettingsSaveFailures.length}); none are attributed to the latest plugin start.`)
+  }
+
+  if (runtime) {
+    if (!runtime.reachable) io.log(`– Runtime probe: DSH not reachable at ${runtime.baseUrl}; offline checks still completed.`)
+    else {
+      for (const route of runtime.routes) {
+        io.log(`${route.ok ? '✓' : '✗'} runtime ${route.route} — ${route.ok ? 'route registered' : `status ${route.status ?? 'unreachable'}, route not confirmed`}`)
+      }
+      if (options.profile) {
+        if (runtime.ownership?.verified) io.log(`✓ runtime profile ownership — ${runtime.ownership.profile}`)
+        else io.log(`? runtime profile ownership unknown${runtime.ownership?.profile ? ` (runtime reports ${runtime.ownership.profile})` : ''}; route health is not attributed to ${options.profile}`)
+      }
+    }
+  }
+
+  io.log(`${platform.nodeSupported ? '✓' : '!'} Node ${platform.node}${platform.nodeSupported ? '' : ` — outside supported ${platform.nodeRequirement}`}`)
+  io.log(`${platform.tesseract?.version ? '✓' : '–'} Tesseract${platform.tesseract?.version ? ` — ${platform.tesseract.version}` : ' — not found (local OCR will fall back)'}`)
+  io.log(`${platform.chromium?.version ? '✓' : '–'} Chromium/Chrome${platform.chromium?.version ? ` — ${platform.chromium.version}` : ' — not found (HTML screenshot tool unavailable)'}`)
+  for (const entry of platform.sharp ?? []) {
+    const profileName = profileReport.profiles.find((profile) => entry.profileDir === profile.profileDir)?.name
+    io.log(`${entry.package?.version ? '✓' : '–'} Sharp${profileName ? ` (${profileName})` : ''}${entry.package?.version ? ` — ${entry.package.version}` : ' — not found in profile (may be host-provided)'}`)
+  }
+
+  if (sessions) {
+    if (sessions.affected > 0) {
+      io.error(`✗ Sessions: ${sessions.affected} known corrupt event(s) across ${sessions.reports.length} session log(s).`)
+      io.error('  Stop DSH, then run `npx dsh-vision-router repair-sessions`.')
+    } else if (sessions.errors.length > 0) {
+      io.error(`✗ Sessions: ${sessions.errors.length} log(s) could not be inspected safely.`)
+    } else {
+      io.log(`✓ Sessions: scanned ${sessions.scanned}; no known Vision Router corruption found.`)
+      if ((sessions.advisories?.length ?? 0) > 0) io.log(`! Sessions: ${sessions.advisories.length} live/incomplete tail(s) were skipped as advisory.`)
+    }
+  }
+
+  const pendingFix = profileReport.profiles.some((profile) =>
     (profile.hasBom && !profile.repaired)
     || (profile.workspace?.pinned.length > 0 && !profile.workspace.rewritten))
-  if (pendingFix) {
-    io.log('Run `npx dsh-vision-router repair` to fix the detected issues safely.')
+  if (pendingFix) io.log('Run `npx dsh-vision-router repair` to fix the detected profile issues safely.')
+  if (profileReport.profiles.some((profile) => !profile.validJson && profile.installation?.applicable)) {
+    io.error('At least one applicable profile is still invalid JSON. Repair only removes a leading UTF-8 BOM; it does not guess other JSON repairs.')
   }
-  if (report.profiles.some((profile) => !profile.validJson)) {
-    io.error('At least one profile is still invalid JSON. The repair command only removes a leading UTF-8 BOM; it does not rewrite other JSON content.')
-  }
-  return report.ok ? 0 : 1
+  return overallOk ? 0 : 1
 }
 
-/**
- * Whether `argv[1]` points at this module. npm's npx shim on POSIX invokes
- * the bin through a symlink in `node_modules/.bin`, so `argv[1]` carries the
- * shim path while the module loader realpaths the file and `import.meta.url`
- * carries the real target path — a plain string comparison never matches and
- * the CLI silently does nothing. Compare realpaths instead.
- */
 export function isCliEntry(entry, moduleUrl = import.meta.url) {
   if (typeof entry !== 'string' || entry.trim() === '') return false
   const real = (value) => {
-    try {
-      return realpathSync(value.startsWith('file:') ? fileURLToPath(value) : value)
-    } catch {
-      return value
-    }
+    try { return realpathSync(value.startsWith('file:') ? fileURLToPath(value) : value) } catch { return value }
   }
   return real(entry) === real(moduleUrl)
 }
 
 const entry = process.argv[1]
 if (isCliEntry(entry)) {
-  process.exitCode = run()
+  run().then((code) => { process.exitCode = code }).catch((error) => {
+    console.error(`dsh-vision-router: doctor crashed: ${error instanceof Error ? error.stack ?? error.message : String(error)}`)
+    process.exitCode = 1
+  })
 }

--- a/lib/doctor-runtime.js
+++ b/lib/doctor-runtime.js
@@ -1,0 +1,385 @@
+import { spawnSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+import os, { homedir } from 'node:os'
+import path from 'node:path'
+import { CURRENT_VERSION } from './update-check.js'
+
+export const DEFAULT_RUNTIME_URL = 'http://127.0.0.1:3080'
+const SAFE_RUNTIME_ROUTES = [
+  { route: '/_dsh/vision-router/logs', allow: ['GET', 'POST'] },
+  { route: '/_dsh/vision-router/model-capabilities', allow: ['GET'] },
+  { route: '/_dsh/vision-router/update-check', allow: ['GET'] },
+  { route: '/_dsh/vision-router/test-connection', allow: ['GET'] },
+  { route: '/_dsh/vision-router/settings-save-diagnostics', allow: ['POST'] },
+  { route: '/_dsh/vision-router/self-update', allow: ['POST'] },
+]
+
+function timeoutSignal(ms) {
+  return typeof AbortSignal.timeout === 'function' ? AbortSignal.timeout(ms) : undefined
+}
+
+function normalizeAllow(value) {
+  return String(value ?? '')
+    .split(',')
+    .map((part) => part.trim().toUpperCase())
+    .filter(Boolean)
+    .sort()
+}
+
+function safeRuntimeBase(value) {
+  let url
+  try {
+    url = new URL(String(value ?? ''))
+  } catch {
+    throw new TypeError('runtime URL must be a valid absolute http(s) URL')
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new TypeError('runtime URL must use http or https')
+  }
+  if (url.username || url.password) {
+    // Credentials in the probe target are never needed and are too easy to leak
+    // through support reports or fetch diagnostics.
+    throw new TypeError('runtime URL must not contain credentials')
+  }
+  url.hash = ''
+  return url
+}
+
+export async function probeRuntime({
+  baseUrl = DEFAULT_RUNTIME_URL,
+  requestedProfile,
+  dshHome,
+  applicableProfiles = [],
+  timeoutMs = 800,
+  fetchImpl = globalThis.fetch,
+} = {}) {
+  if (typeof fetchImpl !== 'function') throw new TypeError('runtime probe requires fetch')
+  const base = safeRuntimeBase(baseUrl)
+  const routes = await Promise.all(SAFE_RUNTIME_ROUTES.map(async ({ route, allow: expectedAllow }) => {
+    const url = new URL(route, base).href
+    try {
+      // DELETE is unsupported by every plugin-owned route and each handler
+      // rejects it before any read/mutation behavior. Exact 405 + Allow proves
+      // the route exists while keeping this probe side-effect-free.
+      const response = await fetchImpl(url, {
+        method: 'DELETE',
+        headers: { accept: 'application/json' },
+        redirect: 'manual',
+        signal: timeoutSignal(timeoutMs),
+      })
+      const expected = [...expectedAllow].sort()
+      const actual = normalizeAllow(response.headers?.get?.('allow'))
+      const registered = response.status === 405
+        && actual.length === expected.length
+        && actual.every((value, index) => value === expected[index])
+      return {
+        route,
+        status: response.status,
+        registered,
+        ok: registered,
+        expectedAllow: expected.join(', '),
+        allow: actual.join(', '),
+      }
+    } catch (error) {
+      return {
+        route,
+        ok: false,
+        registered: false,
+        unreachable: true,
+        errorCode: error instanceof Error ? error.name : 'Error',
+      }
+    }
+  }))
+
+  const reachable = routes.some((item) => !item.unreachable)
+  const routeOk = !reachable || routes.every((item) => item.ok)
+  let ownership = { verified: false, requestedProfile, reason: requestedProfile ? 'profile-unknown' : 'not-requested' }
+
+  // A DELETE contract proves route registration but not which DSH profile owns
+  // the process. Reuse the existing GET-only log metadata route as a read-only
+  // home identity proof. It never opens the log folder (that is POST only).
+  // Only a unique applicable profile in that same DSH_HOME may be attributed.
+  if (reachable && routeOk && requestedProfile && typeof dshHome === 'string') {
+    try {
+      const response = await fetchImpl(new URL('/_dsh/vision-router/logs', base).href, {
+        method: 'GET',
+        headers: { accept: 'application/json' },
+        redirect: 'manual',
+        signal: timeoutSignal(timeoutMs),
+      })
+      if (response.status === 200) {
+        const text = typeof response.text === 'function' ? await response.text() : ''
+        if (Buffer.byteLength(text) <= 16 * 1024) {
+          const body = text ? JSON.parse(text) : undefined
+          const expectedDirectory = path.resolve(dshHome, 'logs', 'vision-router')
+          const actualDirectory = typeof body?.directory === 'string' ? path.resolve(body.directory) : undefined
+          const candidates = [...new Set(applicableProfiles.filter((name) => typeof name === 'string'))]
+          if (body?.local === true && actualDirectory === expectedDirectory && candidates.length === 1 && candidates[0] === requestedProfile) {
+            ownership = { requestedProfile, verified: true, profile: requestedProfile, source: 'log-home+unique-profile' }
+          } else if (body?.local === true && actualDirectory === expectedDirectory) {
+            ownership = { requestedProfile, verified: false, reason: 'profile-ambiguous', candidateProfiles: candidates }
+          }
+        }
+      }
+    } catch {
+      // Ownership is advisory/fail-closed; route health above remains available.
+    }
+  }
+
+  return {
+    baseUrl: base.href,
+    reachable,
+    routes,
+    ownership,
+    routeOk,
+    ok: !reachable || (routeOk && (!requestedProfile || ownership.verified)),
+  }
+}
+
+function commandVersion(command, args = ['--version']) {
+  try {
+    const result = spawnSync(command, args, { encoding: 'utf8', timeout: 2_000, windowsHide: true })
+    if (result.error) return undefined
+    const output = `${result.stdout ?? ''}\n${result.stderr ?? ''}`.trim()
+    if (result.status !== 0 && output === '') return undefined
+    return { command, status: result.status, version: output.split(/\r?\n/)[0]?.trim() || undefined }
+  } catch {
+    return undefined
+  }
+}
+
+function firstCommand(candidates) {
+  for (const [command, args] of candidates) {
+    const result = commandVersion(command, args)
+    if (result) return result
+  }
+  return undefined
+}
+
+function resolvePackageVersion(profileDir, packageName) {
+  const file = path.join(profileDir, 'node_modules', ...packageName.split('/'), 'package.json')
+  if (!existsSync(file)) return undefined
+  try {
+    const value = JSON.parse(readFileSync(file, 'utf8'))
+    if (typeof value?.version === 'string') return { version: value.version, file }
+  } catch { /* advisory only */ }
+  return undefined
+}
+
+function existingExecutableCandidates(candidates) {
+  return candidates.filter(([command]) => !path.isAbsolute(command) || existsSync(command))
+}
+
+function tesseractCandidates(env = process.env) {
+  const candidates = [['tesseract', ['--version']]]
+  if (process.platform === 'win32') {
+    for (const root of [env.ProgramFiles, env['ProgramFiles(x86)']].filter(Boolean)) {
+      candidates.push([path.join(root, 'Tesseract-OCR', 'tesseract.exe'), ['--version']])
+    }
+  }
+  return existingExecutableCandidates(candidates)
+}
+
+function chromiumCandidates(env = process.env) {
+  if (process.platform === 'win32') {
+    const candidates = [
+      ['msedge.exe', ['--version']],
+      ['chrome.exe', ['--version']],
+      ['chromium.exe', ['--version']],
+    ]
+    for (const root of [env.ProgramFiles, env['ProgramFiles(x86)'], env.LOCALAPPDATA].filter(Boolean)) {
+      candidates.push(
+        [path.join(root, 'Microsoft', 'Edge', 'Application', 'msedge.exe'), ['--version']],
+        [path.join(root, 'Google', 'Chrome', 'Application', 'chrome.exe'), ['--version']],
+        [path.join(root, 'Chromium', 'Application', 'chrome.exe'), ['--version']],
+      )
+    }
+    return existingExecutableCandidates(candidates)
+  }
+  if (process.platform === 'darwin') {
+    return existingExecutableCandidates([
+      ['google-chrome', ['--version']],
+      ['chromium', ['--version']],
+      ['microsoft-edge', ['--version']],
+      ['/Applications/Google Chrome.app/Contents/MacOS/Google Chrome', ['--version']],
+      ['/Applications/Chromium.app/Contents/MacOS/Chromium', ['--version']],
+      ['/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge', ['--version']],
+    ])
+  }
+  return [
+    ['google-chrome', ['--version']],
+    ['chromium', ['--version']],
+    ['chromium-browser', ['--version']],
+    ['microsoft-edge', ['--version']],
+  ]
+}
+
+const HOST_PACKAGES = [
+  '@deepseek-ai/dsh-client-runtime',
+  '@deepseek-ai/dsh-client-ui-settings-plugins',
+  '@deepseek-ai/dsh-attachment-local',
+  '@deepseek-ai/dsh-llm-deepseek',
+]
+
+function supportedNodeVersion(version = process.versions.node) {
+  const [major, minor] = String(version).split('.').map(Number)
+  return (major === 22 && minor >= 19) || major >= 24
+}
+
+export function inspectPlatform({ profileDirs = [], env = process.env } = {}) {
+  const tesseract = firstCommand(tesseractCandidates(env))
+  const chromium = firstCommand(chromiumCandidates(env))
+  const sharp = profileDirs.map((profileDir) => ({ profileDir, package: resolvePackageVersion(profileDir, 'sharp') }))
+  const hostPackages = profileDirs.map((profileDir) => ({
+    profileDir,
+    packages: Object.fromEntries(HOST_PACKAGES.map((name) => [name, resolvePackageVersion(profileDir, name)?.version])),
+  }))
+  return {
+    platform: process.platform,
+    arch: process.arch,
+    node: process.version,
+    nodeSupported: supportedNodeVersion(),
+    nodeRequirement: '^22.19.0 || >=24.0.0',
+    release: os.release(),
+    tesseract: tesseract ?? { available: false },
+    chromium: chromium ?? { available: false },
+    sharp,
+    hostPackages,
+  }
+}
+
+export function redactPath(value, home = homedir()) {
+  if (typeof value !== 'string') return value
+  const normalizedHome = path.resolve(home)
+  const normalized = path.resolve(value)
+  return normalized === normalizedHome
+    ? '~'
+    : normalized.startsWith(`${normalizedHome}${path.sep}`)
+      ? `~${path.sep}${path.relative(normalizedHome, normalized)}`
+      : '<external-path>'
+}
+
+function redactUrl(value) {
+  if (typeof value !== 'string') return value
+  try {
+    const url = new URL(value)
+    url.username = ''
+    url.password = ''
+    url.search = ''
+    url.hash = ''
+    return `${url.origin}${url.pathname}`.replace(/\/$/, '')
+  } catch {
+    return '<invalid-url>'
+  }
+}
+
+function safeCommand(result) {
+  if (!result || typeof result !== 'object') return result
+  return {
+    status: result.status,
+    version: result.version,
+    ...(typeof result.command === 'string' ? { command: path.isAbsolute(result.command) ? redactPath(result.command) : result.command } : {}),
+  }
+}
+
+function safeInstallation(value) {
+  if (!value || typeof value !== 'object') return value
+  return {
+    applicable: value.applicable,
+    mode: value.mode,
+    ok: value.ok,
+    errors: Array.isArray(value.errors) ? value.errors.map(() => 'diagnostic') : [],
+    warnings: Array.isArray(value.warnings) ? value.warnings.map(() => 'diagnostic') : [],
+    declaredSpecKind: value.declaredSpecKind,
+    installedVersion: value.installedVersion,
+  }
+}
+
+function safeRuntime(runtime) {
+  if (!runtime) return undefined
+  return {
+    baseUrl: redactUrl(runtime.baseUrl),
+    reachable: runtime.reachable,
+    ok: runtime.ok,
+    routeOk: runtime.routeOk,
+    ownership: runtime.ownership ? {
+      requestedProfile: runtime.ownership.requestedProfile,
+      verified: runtime.ownership.verified,
+      profile: runtime.ownership.profile,
+      version: runtime.ownership.version,
+      reason: runtime.ownership.reason,
+    } : undefined,
+    routes: (runtime.routes ?? []).map((item) => ({
+      route: item.route,
+      status: item.status,
+      registered: item.registered,
+      unreachable: item.unreachable,
+      errorCode: item.errorCode,
+      expectedAllow: item.expectedAllow,
+      allow: item.allow,
+    })),
+  }
+}
+
+export function supportReport({ profileReport, runtime, platform, sessions }) {
+  const safeProfiles = profileReport.profiles.map((item) => ({
+    name: item.name,
+    exists: item.exists,
+    validJson: item.validJson,
+    hasBom: item.hasBom,
+    dependencyDeclared: Boolean(item.pluginDependency),
+    dependencySpecKind: item.installation?.declaredSpecKind,
+    pluginBundle: item.pluginBundle,
+    installedVersion: item.installedPlugin?.version,
+    installation: safeInstallation(item.installation),
+    workspacePinnedCount: item.workspace?.pinned?.length ?? 0,
+    patch: item.patch ? {
+      visionRouterRows: item.patch.visionRouterRows,
+      manualVisionRouter: item.patch.manualVisionRouter,
+      disablesOfficialDeepSeek: item.patch.disablesOfficialDeepSeek,
+    } : undefined,
+  }))
+  return {
+    schemaVersion: 1,
+    doctorVersion: CURRENT_VERSION,
+    generatedAt: new Date().toISOString(),
+    ok: profileReport.ok && (runtime?.ok ?? true) && (sessions?.ok ?? true),
+    dshHome: redactPath(profileReport.dshHome),
+    profiles: safeProfiles,
+    log: {
+      exists: profileReport.log?.exists,
+      currentSettingsFailureCount: profileReport.log?.settingsSaveFailures?.length ?? 0,
+      historicalSettingsFailureCount: profileReport.log?.historicalSettingsSaveFailures?.length ?? 0,
+      recentErrorCount: profileReport.log?.recentErrors?.length ?? 0,
+      startupScoped: profileReport.log?.startupScoped,
+      startupVersion: profileReport.log?.startupVersion,
+    },
+    runtime: safeRuntime(runtime),
+    sessions: sessions ? {
+      scanned: sessions.scanned,
+      affected: sessions.affected,
+      repaired: sessions.repaired,
+      errorCount: sessions.errors?.length ?? 0,
+      advisoryCount: sessions.advisories?.length ?? 0,
+      repairs: sessions.reports?.flatMap((item) => (item.repairs ?? []).map((repair) => ({ kind: repair.kind }))) ?? [],
+    } : undefined,
+    platform: {
+      platform: platform.platform,
+      arch: platform.arch,
+      node: platform.node,
+      nodeSupported: platform.nodeSupported,
+      nodeRequirement: platform.nodeRequirement,
+      release: platform.release,
+      tesseract: safeCommand(platform.tesseract),
+      chromium: safeCommand(platform.chromium),
+      sharp: platform.sharp.map((entry) => ({
+        profile: safeProfiles.find((profile) => entry.profileDir?.endsWith(path.sep + profile.name))?.name,
+        version: entry.package?.version,
+      })),
+      hostPackages: (platform.hostPackages ?? []).map((entry) => ({
+        profile: safeProfiles.find((profile) => entry.profileDir?.endsWith(path.sep + profile.name))?.name,
+        packages: entry.packages,
+      })),
+    },
+  }
+}

--- a/lib/doctor.js
+++ b/lib/doctor.js
@@ -1,12 +1,20 @@
-import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
+import { closeSync, existsSync, openSync, readFileSync, readSync, readdirSync, realpathSync, statSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import path from 'node:path'
 import { inspectCoexistingVisionPlugins } from './profile-pnpm-diagnostics.js'
+import { compareSemver, parseSemver } from './update-check.js'
 
 const UTF8_BOM = Buffer.from([0xef, 0xbb, 0xbf])
 const PLUGIN_NAME = 'dsh-vision-router'
 const HOST_PATTERN = /^@deepseek-ai\/.+/
 const WORKSPACE_FILENAME = 'pnpm-workspace.yaml'
+const PROFILE_PATCH_FILENAME = 'cordis.patch.yml'
+const LOG_RELATIVE_PATH = path.join('logs', 'vision-router', 'vision-router.log')
+const LOG_BACKUP_RELATIVE_PATH = path.join('logs', 'vision-router', 'vision-router.1.log')
+const PROFILE_INPUT_MAX_BYTES = 1024 * 1024
+const INSTALLED_MANIFEST_MAX_BYTES = 256 * 1024
+const LOG_LINE_LIMIT = 800
+const STARTUP_MARKER = 'vision-router: diagnostics log enabled at '
 
 function expandHome(value, home = homedir()) {
   if (value === '~') return home
@@ -27,8 +35,135 @@ export function hasUtf8Bom(buffer) {
     && buffer[2] === UTF8_BOM[2]
 }
 
+function readFileBounded(filePath, maxBytes = PROFILE_INPUT_MAX_BYTES) {
+  const stat = statSync(filePath)
+  if (stat.size > maxBytes) {
+    const error = new Error(`file exceeds the ${maxBytes}-byte doctor safety limit`)
+    error.code = 'DOCTOR_INPUT_TOO_LARGE'
+    throw error
+  }
+  return readFileSync(filePath)
+}
+
+function readJsonIfPresent(filePath, maxBytes = INSTALLED_MANIFEST_MAX_BYTES) {
+  if (!existsSync(filePath)) return undefined
+  try {
+    const value = JSON.parse(readFileBounded(filePath, maxBytes).toString('utf8'))
+    return value && typeof value === 'object' && !Array.isArray(value) ? value : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function dependencySpecKind(value) {
+  if (typeof value !== 'string' || value.trim() === '') return undefined
+  const spec = value.trim()
+  if (/^(?:file|link):/i.test(spec) || /^[./\\]/.test(spec)) return 'local-path'
+  if (/^(?:https?|git(?:\+https?)?|ssh):/i.test(spec) || spec.startsWith('git@')) return 'remote-vcs'
+  if (/^(?:github|gitlab|bitbucket):/i.test(spec)) return 'hosted-vcs'
+  if (/^(?:workspace:|npm:)/i.test(spec)) return 'npm-alias'
+  return 'registry'
+}
+
+function compareParsed(a, b) {
+  return compareSemver(`${a.major}.${a.minor}.${a.patch}${a.prerelease?.length ? '-' + a.prerelease.map((x) => x.value).join('.') : ''}`,
+    `${b.major}.${b.minor}.${b.patch}${b.prerelease?.length ? '-' + b.prerelease.map((x) => x.value).join('.') : ''}`)
+}
+
+function versionCore(value) {
+  const parsed = parseSemver(value)
+  return parsed ? `${parsed.major}.${parsed.minor}.${parsed.patch}` : undefined
+}
+
+function comparatorSatisfied(version, token) {
+  const parsedVersion = parseSemver(version)
+  if (!parsedVersion) return undefined
+  const match = /^(>=|<=|>|<|=|\^|~)?\s*(v?\d+(?:\.\d+){0,2}(?:-[0-9A-Za-z.-]+)?|\*|x|X)$/.exec(token)
+  if (!match) return undefined
+  const op = match[1] || '='
+  const raw = match[2]
+  if (/^(?:\*|x)$/i.test(raw)) return true
+  const numericParts = raw.replace(/^v/i, '').split('-')[0].split('.')
+  const normalized = numericParts.length === 1 ? `${numericParts[0]}.0.0`
+    : numericParts.length === 2 ? `${numericParts[0]}.${numericParts[1]}.0`
+      : raw.replace(/^v/i, '')
+  const target = parseSemver(normalized)
+  if (!target) return undefined
+  const cmp = compareParsed(parsedVersion, target)
+  if (cmp === undefined) return undefined
+  if (op === '^') {
+    const upper = target.major > 0
+      ? { ...target, major: target.major + 1, minor: 0, patch: 0, prerelease: [] }
+      : target.minor > 0
+        ? { ...target, minor: target.minor + 1, patch: 0, prerelease: [] }
+        : { ...target, patch: target.patch + 1, prerelease: [] }
+    return cmp >= 0 && compareParsed(parsedVersion, upper) < 0
+  }
+  if (op === '~') {
+    const upper = { ...target, minor: target.minor + 1, patch: 0, prerelease: [] }
+    return cmp >= 0 && compareParsed(parsedVersion, upper) < 0
+  }
+  if (op === '>=') return cmp >= 0
+  if (op === '<=') return cmp <= 0
+  if (op === '>') return cmp > 0
+  if (op === '<') return cmp < 0
+  return cmp === 0
+}
+
+export function registrySpecSatisfiesVersion(spec, version) {
+  if (dependencySpecKind(spec) !== 'registry' || !parseSemver(version)) return undefined
+  const text = String(spec).trim()
+  if (/^(?:latest|next|beta|alpha|canary)$/i.test(text)) return undefined
+  const parsedVersion = parseSemver(version)
+  const alternatives = text.split('||').map((part) => part.trim()).filter(Boolean)
+  if (alternatives.length === 0) return undefined
+  let understood = false
+  const result = alternatives.some((alternative) => {
+    // Wildcard forms such as 1.7.x and 1.x.
+    const wildcard = /^(\d+)(?:\.(\d+|x|X|\*))?(?:\.(\d+|x|X|\*))?$/.exec(alternative)
+    if (wildcard && [wildcard[2], wildcard[3]].some((v) => /^(?:x|X|\*)$/.test(v || ''))) {
+      understood = true
+      if (parsedVersion.prerelease.length > 0) return false
+      if (parsedVersion.major !== Number(wildcard[1])) return false
+      if (wildcard[2] && !/^(?:x|X|\*)$/.test(wildcard[2]) && parsedVersion.minor !== Number(wildcard[2])) return false
+      return true
+    }
+    const tokens = alternative.split(/\s+/).filter(Boolean)
+    if (tokens.length === 0) return false
+    const outcomes = tokens.map((token) => comparatorSatisfied(version, token))
+    if (outcomes.some((value) => value === undefined)) return false
+    understood = true
+    // npm does not admit a prerelease into a stable-only range unless the
+    // range itself names a prerelease for the same core tuple.
+    if (parsedVersion.prerelease.length > 0) {
+      const core = versionCore(version)
+      const namesSamePrereleaseCore = tokens.some((token) => {
+        const match = token.match(/v?(\d+\.\d+\.\d+)-[0-9A-Za-z.-]+/)
+        return match?.[1] === core
+      })
+      if (!namesSamePrereleaseCore) return false
+    }
+    return outcomes.every(Boolean)
+  })
+  return understood ? result : undefined
+}
+
 export function inspectProfileManifest(manifestPath, { fix = false } = {}) {
-  const original = readFileSync(manifestPath)
+  let original
+  try {
+    original = readFileBounded(manifestPath)
+  } catch (error) {
+    return {
+      path: manifestPath,
+      hasBom: false,
+      repaired: false,
+      validJson: false,
+      jsonError: error instanceof Error ? error.message : String(error),
+      oversized: error?.code === 'DOCTOR_INPUT_TOO_LARGE',
+      pluginBundleCount: 0,
+      pluginBundle: false,
+    }
+  }
   const bom = hasUtf8Bom(original)
   const bytes = bom ? original.subarray(UTF8_BOM.length) : original
   let repaired = false
@@ -60,29 +195,24 @@ export function inspectProfileManifest(manifestPath, { fix = false } = {}) {
     validJson: jsonError === undefined,
     jsonError,
     manifest,
-    pluginDependency: typeof dependencies?.['dsh-vision-router'] === 'string'
-      ? dependencies['dsh-vision-router']
+    pluginDependency: typeof dependencies?.[PLUGIN_NAME] === 'string'
+      ? dependencies[PLUGIN_NAME]
       : undefined,
-    pluginBundle: Array.isArray(bundles) && bundles.includes('dsh-vision-router'),
+    pluginBundle: Array.isArray(bundles) && bundles.includes(PLUGIN_NAME),
+    pluginBundleCount: Array.isArray(bundles) ? bundles.filter((name) => name === PLUGIN_NAME).length : 0,
   }
 }
 
-/**
- * Check a profile's pnpm-workspace.yaml for version-pinned
- * `minimumReleaseAgeExclude` entries. pnpm v11 defaults `minimumReleaseAge`
- * to 1440 minutes, so versions published less than 24h ago are not resolved
- * and `update` silently keeps the previous version. An exemption entry with a
- * pinned version (`dsh-vision-router@1.2.0`) only exempts that one version
- * and goes stale on the next release; a bare name or org pattern exempts
- * every future version. With `fix`, version-pinned entries for this plugin
- * and the `@deepseek-ai/*` host packages are rewritten to the bare name or
- * org pattern (duplicates are dropped); every other line is left untouched.
- */
 export function inspectProfileWorkspace(workspacePath, { fix = false } = {}) {
   if (!existsSync(workspacePath)) {
     return { path: workspacePath, exists: false, pinned: [], rewritten: false }
   }
-  const original = readFileSync(workspacePath, 'utf8')
+  let original
+  try {
+    original = readFileBounded(workspacePath).toString('utf8')
+  } catch (error) {
+    return { path: workspacePath, exists: true, pinned: [], rewritten: false, error: error instanceof Error ? error.message : String(error), oversized: error?.code === 'DOCTOR_INPUT_TOO_LARGE' }
+  }
   const lines = original.split('\n')
   const items = []
   let blockIndent = -1
@@ -160,6 +290,215 @@ export function inspectProfileWorkspace(workspacePath, { fix = false } = {}) {
   }
 }
 
+function stripYamlComment(line) {
+  let quote
+  for (let index = 0; index < line.length; index += 1) {
+    const char = line[index]
+    if ((char === '"' || char === "'") && line[index - 1] !== '\\') {
+      quote = quote === char ? undefined : quote ?? char
+      continue
+    }
+    if (char === '#' && quote === undefined) return line.slice(0, index)
+  }
+  return line
+}
+
+export function inspectProfilePatch(patchPath) {
+  if (!existsSync(patchPath)) {
+    return {
+      path: patchPath,
+      exists: false,
+      visionRouterRows: 0,
+      manualVisionRouter: false,
+      disablesOfficialDeepSeek: false,
+    }
+  }
+  let text
+  try {
+    text = readFileBounded(patchPath).toString('utf8')
+  } catch (error) {
+    return { path: patchPath, exists: true, visionRouterRows: 0, manualVisionRouter: false, disablesOfficialDeepSeek: false, error: error instanceof Error ? error.message : String(error), oversized: error?.code === 'DOCTOR_INPUT_TOO_LARGE' }
+  }
+  const lines = text.split(/\r?\n/).map(stripYamlComment)
+  let visionRouterRows = 0
+  let disablesOfficialDeepSeek = false
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index]
+    if (/^\s*name\s*:\s*['"]?dsh-vision-router['"]?\s*$/.test(line)) visionRouterRows += 1
+    if (!/^\s*-?\s*id\s*:\s*['"]?llm-deepseek['"]?\s*$/.test(line)) continue
+    for (let cursor = index + 1; cursor < Math.min(lines.length, index + 12); cursor += 1) {
+      if (/^\s*-\s+id\s*:/.test(lines[cursor])) break
+      if (/^\s*disabled\s*:\s*true\s*$/.test(lines[cursor])) {
+        disablesOfficialDeepSeek = true
+        break
+      }
+    }
+  }
+  return {
+    path: patchPath,
+    exists: true,
+    visionRouterRows,
+    manualVisionRouter: visionRouterRows > 0,
+    disablesOfficialDeepSeek,
+  }
+}
+
+function inspectInstalledPackage(profileDir) {
+  const packageDir = path.join(profileDir, 'node_modules', PLUGIN_NAME)
+  const manifestPath = path.join(packageDir, 'package.json')
+  if (!existsSync(packageDir)) return { present: false, packageDir, manifestPath, errors: [] }
+  const errors = []
+  let manifest
+  try {
+    manifest = JSON.parse(readFileBounded(manifestPath, INSTALLED_MANIFEST_MAX_BYTES).toString('utf8'))
+  } catch (error) {
+    errors.push(`installed package manifest is unreadable: ${error instanceof Error ? error.message : String(error)}`)
+  }
+  if (manifest && manifest.name !== PLUGIN_NAME) errors.push(`installed package identity is ${String(manifest.name ?? 'missing')}, expected ${PLUGIN_NAME}`)
+  const version = typeof manifest?.version === 'string' ? manifest.version : undefined
+  if (manifest && !version) errors.push('installed package manifest has no version')
+  const entry = typeof manifest?.main === 'string' && manifest.main !== '' ? manifest.main : undefined
+  if (entry && !existsSync(path.resolve(packageDir, entry))) errors.push(`installed package main target is missing (${entry})`)
+  const bundlePatch = typeof manifest?.dsh?.bundle?.patch === 'string' && manifest.dsh.bundle.patch !== ''
+    ? manifest.dsh.bundle.patch
+    : undefined
+  if (bundlePatch && !existsSync(path.resolve(packageDir, bundlePatch))) errors.push(`installed bundle patch target is missing (${bundlePatch})`)
+  let realPath
+  try { realPath = realpathSync(packageDir) } catch { realPath = packageDir }
+  return { present: true, packageDir, manifestPath, realPath, version, name: manifest?.name, entry, bundlePatch, errors }
+}
+
+export function classifyProfileInstallation(profile, { requested = false } = {}) {
+  const dependency = Boolean(profile?.pluginDependency)
+  const bundle = profile?.pluginBundle === true
+  const manual = profile?.patch?.manualVisionRouter === true
+  const installed = profile?.installedPlugin?.present === true
+  const evidence = dependency || bundle || manual || installed
+  const applicable = requested || evidence
+  const errors = []
+  const warnings = []
+  let mode = 'not-installed'
+
+  if (!applicable) return { applicable: false, mode, ok: true, errors, warnings }
+  if (!profile?.exists) errors.push('profile package.json does not exist')
+  else if (!profile?.validJson) errors.push('profile manifest is not usable')
+  if (profile?.patch?.error) errors.push(`cordis.patch.yml is not usable: ${profile.patch.error}`)
+  if (profile?.workspace?.error) errors.push(`pnpm-workspace.yaml is not usable: ${profile.workspace.error}`)
+
+  if (requested && !evidence) errors.push('Vision Router is not installed or mounted in the requested profile')
+  if (bundle && manual) {
+    mode = 'duplicate'
+    errors.push('Vision Router is registered by both dsh.profile.bundles and cordis.patch.yml; this can activate the plugin twice')
+  } else if (bundle) {
+    mode = 'bundle'
+  } else if (manual) {
+    mode = 'manual'
+  } else if (dependency || installed) {
+    mode = 'unmounted'
+    errors.push('Vision Router is installed/declared but is not registered as a bundle or manual cordis.patch.yml row')
+  }
+
+  if (bundle && !dependency) errors.push('Vision Router bundle is registered but package.json does not declare the dependency')
+  if (manual && !dependency) errors.push('Vision Router has a manual cordis.patch.yml row but package.json does not declare the dependency')
+  if (Number(profile?.pluginBundleCount ?? 0) > 1) errors.push(`dsh.profile.bundles contains Vision Router ${profile.pluginBundleCount} times`)
+  if (dependency && !installed) errors.push('Vision Router is declared in package.json but node_modules/dsh-vision-router is missing')
+  if (profile?.patch?.visionRouterRows > 1) errors.push(`cordis.patch.yml contains ${profile.patch.visionRouterRows} Vision Router rows`)
+  for (const error of profile?.installedPlugin?.errors ?? []) errors.push(error)
+  if (dependency && installed && profile.installedPlugin?.version) {
+    const satisfies = registrySpecSatisfiesVersion(profile.pluginDependency, profile.installedPlugin.version)
+    if (satisfies === false) {
+      errors.push(`declared Vision Router version ${profile.pluginDependency} does not match installed ${profile.installedPlugin.version}`)
+    }
+  }
+  if (profile?.patch?.disablesOfficialDeepSeek) {
+    warnings.push('cordis.patch.yml statically disables llm-deepseek; legacy stealth patches can make the official model disappear when Vision Router is disabled')
+  }
+  return {
+    applicable,
+    mode,
+    ok: errors.length === 0,
+    errors,
+    warnings,
+    declaredSpecKind: dependencySpecKind(profile?.pluginDependency),
+    installedVersion: profile?.installedPlugin?.version,
+    installTarget: profile?.installedPlugin?.realPath,
+  }
+}
+
+function readTail(file, maxBytes) {
+  if (!existsSync(file)) return { file, exists: false, text: '' }
+  let fd
+  try {
+    const stat = statSync(file)
+    const size = Math.min(stat.size, maxBytes)
+    const buffer = Buffer.alloc(size)
+    fd = openSync(file, 'r')
+    if (size > 0) readSync(fd, buffer, 0, size, Math.max(0, stat.size - size))
+    let text = buffer.toString('utf8')
+    if (stat.size > maxBytes) {
+      const newline = text.indexOf('\n')
+      if (newline >= 0) text = text.slice(newline + 1)
+    }
+    return { file, exists: true, text, truncated: stat.size > maxBytes }
+  } catch (error) {
+    return { file, exists: true, text: '', readError: error instanceof Error ? error.message : String(error) }
+  } finally {
+    if (fd !== undefined) closeSync(fd)
+  }
+}
+
+function structuredLogDiagnostics(lines, latestStartupIndex) {
+  const currentSettingsSaveFailures = []
+  const historicalSettingsSaveFailures = []
+  const recentErrors = []
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index]
+    const save = /settings save failed\s+field=([^\s]+)\s+operation=([^\s]+)\s+reason=([^\s]+)/i.exec(line)
+    if (save) {
+      const item = { field: save[1], operation: save[2], reason: save[3] }
+      if (latestStartupIndex >= 0 && index > latestStartupIndex) currentSettingsSaveFailures.push(item)
+      else historicalSettingsSaveFailures.push(item)
+    }
+    if (/\b(?:ERROR|FATAL)\b/i.test(line)) {
+      const code = /\b(?:code|reason)=([^\s]+)/i.exec(line)?.[1]
+      recentErrors.push({ code })
+    }
+  }
+  return {
+    settingsSaveFailures: currentSettingsSaveFailures.slice(-20),
+    historicalSettingsSaveFailures: historicalSettingsSaveFailures.slice(-20),
+    recentErrors: recentErrors.slice(-20),
+  }
+}
+
+export function inspectVisionRouterLog(dshHome, { maxBytes = 2 * 1024 * 1024 } = {}) {
+  const file = path.join(dshHome, LOG_RELATIVE_PATH)
+  const backup = path.join(dshHome, LOG_BACKUP_RELATIVE_PATH)
+  const older = readTail(backup, maxBytes)
+  const current = readTail(file, maxBytes)
+  if (!older.exists && !current.exists) {
+    return { file, backup, exists: false, settingsSaveFailures: [], historicalSettingsSaveFailures: [], recentErrors: [] }
+  }
+  const lines = `${older.text}${older.text && current.text ? '\n' : ''}${current.text}`
+    .split(/\r?\n/).filter(Boolean).slice(-LOG_LINE_LIMIT)
+  let latestStartupIndex = -1
+  let startupVersion
+  for (let index = 0; index < lines.length; index += 1) {
+    if (!lines[index].includes(STARTUP_MARKER)) continue
+    latestStartupIndex = index
+    startupVersion = /\(plugin=([^\s)]+)/.exec(lines[index])?.[1]
+  }
+  return {
+    file,
+    backup,
+    exists: true,
+    readError: current.readError ?? older.readError,
+    startupScoped: latestStartupIndex >= 0,
+    startupVersion,
+    ...structuredLogDiagnostics(lines, latestStartupIndex),
+  }
+}
+
 export function listProfileNames(dshHome, requestedProfile) {
   if (requestedProfile) return [requestedProfile]
   const profilesDir = path.join(dshHome, 'profiles')
@@ -177,11 +516,7 @@ export function listProfileNames(dshHome, requestedProfile) {
     .sort()
 }
 
-export function doctorProfiles({
-  dshHome = resolveDshHome(),
-  profile,
-  fix = false,
-} = {}) {
+export function doctorProfiles({ dshHome = resolveDshHome(), profile, fix = false } = {}) {
   const names = listProfileNames(dshHome, profile)
   const profiles = []
 
@@ -189,35 +524,61 @@ export function doctorProfiles({
     const profileDir = path.join(dshHome, 'profiles', name)
     const manifestPath = path.join(profileDir, 'package.json')
     const workspacePath = path.join(profileDir, WORKSPACE_FILENAME)
+    const patchPath = path.join(profileDir, PROFILE_PATCH_FILENAME)
+    const patch = inspectProfilePatch(patchPath)
+    const installedPlugin = inspectInstalledPackage(profileDir)
+    const workspace = inspectProfileWorkspace(workspacePath, { fix })
     if (!existsSync(manifestPath)) {
-      profiles.push({
+      const item = {
         name,
+        profileDir,
         path: manifestPath,
         exists: false,
         validJson: false,
         jsonError: 'profile package.json does not exist',
-      })
+        patch,
+        installedPlugin,
+        workspace,
+        pluginBundleCount: 0,
+        pluginBundle: false,
+      }
+      item.installation = classifyProfileInstallation(item, { requested: profile === name })
+      profiles.push(item)
       continue
     }
     const manifestReport = inspectProfileManifest(manifestPath, { fix })
-    profiles.push({
+    const item = {
       name,
+      profileDir,
       exists: true,
       ...manifestReport,
-      coexistingVisionPlugins: manifestReport.validJson
-        ? inspectCoexistingVisionPlugins(profileDir)
-        : [],
-      workspace: inspectProfileWorkspace(workspacePath, { fix }),
-    })
+      coexistingVisionPlugins: manifestReport.validJson ? inspectCoexistingVisionPlugins(profileDir) : [],
+      workspace,
+      patch,
+      installedPlugin,
+    }
+    item.installation = classifyProfileInstallation(item, { requested: profile === name })
+    profiles.push(item)
   }
+
+  const applicable = profiles.filter((item) => item.installation?.applicable)
+  const profileHealthy = (item) => item.exists
+    && item.validJson
+    && (!item.hasBom || item.repaired)
+    && (!item.workspace || (item.workspace.error === undefined && (item.workspace.pinned.length === 0 || item.workspace.rewritten)))
+    && item.patch?.error === undefined
+    && item.installation?.ok !== false
+  const log = inspectVisionRouterLog(dshHome)
 
   return {
     dshHome,
     requestedProfile: profile,
     fix,
     profiles,
-    ok: profiles.length > 0 && profiles.every((item) =>
-      item.exists && item.validJson && (!item.hasBom || item.repaired)
-      && (!item.workspace || item.workspace.pinned.length === 0 || item.workspace.rewritten)),
+    applicableProfiles: applicable.length,
+    log,
+    ok: applicable.length > 0
+      && applicable.every(profileHealthy)
+      && (log.settingsSaveFailures?.length ?? 0) === 0,
   }
 }

--- a/lib/legacy-session-repair.js
+++ b/lib/legacy-session-repair.js
@@ -3,9 +3,7 @@ import {
   copyFileSync,
   constants as fsConstants,
   existsSync,
-  fstatSync,
   fsyncSync,
-  lstatSync,
   openSync,
   readdirSync,
   readFileSync,
@@ -27,6 +25,11 @@ const DEFAULT_MAX_LOG_BYTES = 256 * 1024 * 1024
 const DEFAULT_MAX_FRAME_PLAINTEXT_BYTES = 128 * 1024 * 1024
 const SESSION_FILENAMES = new Set(['session.jsonl', 'session.jsonl.zstd'])
 const REMINDER_PREFIX = '视觉深看工具已挂载：'
+const GUARD_STOP_ID = /^vision-router-structured-guard-stop-(?:\d+|undefined)$/
+const GUARD_STOP_TEXTS = new Set([
+  '本轮视觉总时间预算已耗尽。不要再调用视觉工具；请基于已经获得的证据作答，并明确仍存在的不确定性。',
+  '本轮识图深度配额已耗尽。不要再调用视觉工具；请基于已经获得的证据作答，并明确仍存在的不确定性。',
+])
 const CHECKSUM_OPTIONS = {
   params: { [zlibConstants.ZSTD_c_checksumFlag]: 1 },
 }
@@ -39,11 +42,6 @@ function stableRepairId(sessionId, seq) {
   return `vision-router-recovered-auto-mount:${sessionId}:${seq}`
 }
 
-/**
- * Exact signature of the pre-fix auto-mount reminder that Vision Router wrote
- * as a durable user/message without an id. Keep this deliberately narrow: a
- * generic malformed message still belongs to DSH's corruption diagnostics.
- */
 export function isLegacyVisionRouterAutoMountEvent(event) {
   if (!isRecord(event) || event.type !== 'user/message') return false
   if (!Number.isSafeInteger(event.seq) || event.seq < 0) return false
@@ -71,7 +69,24 @@ export function repairLegacyVisionRouterEvent(event, sessionId) {
   }
 }
 
-/** Locate complete Zstandard frames without decompressing them. */
+export function isStructuredGuardStopEvent(event) {
+  if (!isRecord(event) || event.type !== 'user/message') return false
+  if (!Number.isSafeInteger(event.seq) || event.seq < 0) return false
+  const data = event.data
+  if (!isRecord(data) || data.role !== 'user' || typeof data.id !== 'string' || !GUARD_STOP_ID.test(data.id)) return false
+  if (Object.keys(data).some((key) => !['id', 'role', 'content', 'source'].includes(key))) return false
+  if (!isRecord(data.source) || data.source.kind !== 'plugin' || data.source.plugin !== 'dsh-vision-router') return false
+  if (!Array.isArray(data.content) || data.content.length !== 1) return false
+  const block = data.content[0]
+  if (!isRecord(block) || Object.keys(block).some((key) => !['type', 'text'].includes(key))) return false
+  return block.type === 'text' && typeof block.text === 'string' && GUARD_STOP_TEXTS.has(block.text)
+}
+
+function guardStopSignature(event) {
+  if (!isStructuredGuardStopEvent(event)) return undefined
+  return { id: event.data.id, text: event.data.content[0].text }
+}
+
 export function scanZstdFrameRanges(buffer) {
   const frames = []
   let offset = 0
@@ -109,9 +124,7 @@ export function scanZstdFrameRanges(buffer) {
       const lastBlock = (blockHeader & 1) !== 0
       const blockType = (blockHeader >>> 1) & 0x03
       const blockSize = blockHeader >>> 3
-      if (blockType === 0x03) {
-        throw new Error(`reserved Zstandard block type at byte ${offset - 3}`)
-      }
+      if (blockType === 0x03) throw new Error(`reserved Zstandard block type at byte ${offset - 3}`)
       const payloadBytes = blockType === 0x01 ? 1 : blockSize
       if (buffer.length - offset < payloadBytes) return { frames, tornStart: start }
       offset += payloadBytes
@@ -134,45 +147,181 @@ function parseHeaderLine(line) {
   } catch {
     throw new Error('session header is not valid JSON')
   }
-  if (!isRecord(header) || header.type !== 'session' || typeof header.id !== 'string' || header.id === '') {
+  if (!isRecord(header) || header.type !== 'session') {
+    throw new Error('session header is not a session record')
+  }
+  if (header.version !== 0) {
+    throw new Error(`unsupported session format version ${String(header.version)}; refusing automatic repair`)
+  }
+  if (typeof header.id !== 'string' || header.id === '') {
     throw new Error('session header does not contain a valid id')
+  }
+  if (!Number.isSafeInteger(header.createdAt) || header.createdAt < 0) {
+    throw new Error('session header createdAt is invalid')
+  }
+  if (!Number.isSafeInteger(header.delegationDepth) || header.delegationDepth < 0) {
+    throw new Error('session header delegationDepth is invalid')
   }
   return header
 }
 
-function repairEventLines(text, sessionId) {
-  if (!text.endsWith('\n')) throw new Error('logical session frame ends with a torn JSONL record')
+function messageIdOf(row) {
+  if (!isRecord(row)) return undefined
+  if (row.type === 'user/message') return typeof row.data?.id === 'string' ? row.data.id : undefined
+  if (row.type === 'assistant/message' || row.type === 'tool/result') {
+    return typeof row.data?.message?.id === 'string' ? row.data.message.id : undefined
+  }
+  return undefined
+}
+
+function packedRowMemberCount(row) {
+  if (!isRecord(row)) return undefined
+  const payload = row.type === 'tool-call-chunks' ? row.data?.args
+    : row.type === 'text-chunks' || row.type === 'reasoning-chunks' ? row.data?.texts
+      : undefined
+  if (payload === undefined) return undefined
+  if (!Number.isSafeInteger(row.seq0) || row.seq0 < 0 || !Number.isSafeInteger(row.time0)) {
+    throw new Error(`malformed ${row.type} storage row envelope`)
+  }
+  if (!isRecord(row.data) || !Array.isArray(payload) || payload.length === 0 || payload.some((v) => typeof v !== 'string')) {
+    throw new Error(`malformed ${row.type} storage row payload`)
+  }
+  if (!Array.isArray(row.data.dt) || row.data.dt.length !== payload.length - 1 || row.data.dt.some((v) => !Number.isSafeInteger(v))) {
+    throw new Error(`malformed ${row.type} storage row timestamp gaps`)
+  }
+  if (!Number.isSafeInteger(row.seq0 + payload.length - 1)) {
+    throw new Error(`malformed ${row.type} storage row seq range`)
+  }
+  return payload.length
+}
+
+function seqRangeOfStorageRow(row) {
+  const packed = packedRowMemberCount(row)
+  if (packed !== undefined) return { first: row.seq0, last: row.seq0 + packed - 1 }
+  if (!isRecord(row) || !Number.isSafeInteger(row.seq) || row.seq < 0) {
+    throw new Error('session storage record has an invalid seq')
+  }
+  return { first: row.seq, last: row.seq }
+}
+
+function parseEventLines(text, { frameLabel = 'session frame' } = {}) {
+  if (!text.endsWith('\n')) throw new Error(`logical ${frameLabel} ends with a torn JSONL record`)
+  const rows = []
   const lines = text.split('\n')
-  const changedSeqs = []
   for (let index = 0; index < lines.length - 1; index += 1) {
     const line = lines[index]
     if (line === '') continue
-    let row
     try {
-      row = JSON.parse(line)
+      rows.push({ line, row: JSON.parse(line) })
     } catch {
-      throw new Error(`session event line ${index + 1} is not valid JSON`)
+      throw new Error(`${frameLabel} event line ${index + 1} is not valid JSON`)
     }
-    if (!isLegacyVisionRouterAutoMountEvent(row)) continue
-    lines[index] = JSON.stringify(repairLegacyVisionRouterEvent(row, sessionId))
-    changedSeqs.push(row.seq)
   }
-  return { text: lines.join('\n'), changedSeqs }
+  return rows
+}
+
+function scanRows(frames) {
+  let expectedSeq = 0
+  const usedIds = new Map()
+  const guardFirst = new Map()
+  const eventsBySeq = new Map()
+  for (const rows of frames) {
+    for (const item of rows) {
+      const row = item.row
+      const range = seqRangeOfStorageRow(row)
+      if (range.first !== expectedSeq) {
+        throw new Error(`session seq is not contiguous: expected ${expectedSeq}, got ${range.first}`)
+      }
+      expectedSeq = range.last + 1
+      if (packedRowMemberCount(row) !== undefined) continue
+
+      const id = messageIdOf(row)
+      if (id) {
+        const existing = usedIds.get(id)
+        if (!existing) usedIds.set(id, { seq: row.seq, row })
+        else if (existing.seq !== row.seq) {
+          const firstExact = isStructuredGuardStopEvent(existing.row)
+          const nextExact = isStructuredGuardStopEvent(row)
+          const sameKnownGuard = firstExact && nextExact
+            && existing.row.data.content[0].text === row.data.content[0].text
+            && GUARD_STOP_ID.test(id)
+          if (!sameKnownGuard) {
+            throw new Error(`duplicate message id ${id} is not the exact known Vision Router guard corruption; refusing automatic repair`)
+          }
+        }
+      }
+      if (isStructuredGuardStopEvent(row) && !guardFirst.has(row.data.id)) {
+        guardFirst.set(row.data.id, { seq: row.seq, text: row.data.content[0].text })
+      }
+      eventsBySeq.set(row.seq, row)
+    }
+  }
+  return { usedIds, guardFirst, eventsBySeq }
+}
+
+function generatedGuardRepairId(sessionId, seq) {
+  return `vision-router-recovered-structured-guard:${sessionId}:${seq}`
+}
+
+function assertGeneratedIdAvailable(id, seq, state) {
+  const collision = state.usedIds.get(id)
+  if (collision && collision.seq !== seq) {
+    throw new Error(`recovered Vision Router message id ${id} collides with an existing message; refusing automatic repair`)
+  }
+  state.usedIds.set(id, { seq })
+}
+
+function repairStorageRows(rows, sessionId, state) {
+  const output = []
+  const changedSeqs = []
+  const repairs = []
+  for (const item of rows) {
+    let row = item.row
+    const originalLine = item.line
+
+    if (isLegacyVisionRouterAutoMountEvent(row)) {
+      const id = stableRepairId(sessionId, row.seq)
+      assertGeneratedIdAvailable(id, row.seq, state)
+      row = repairLegacyVisionRouterEvent(row, sessionId)
+      changedSeqs.push(row.seq)
+      repairs.push({ kind: 'legacy-auto-mount-id', seq: row.seq })
+    }
+
+    if (isStructuredGuardStopEvent(row)) {
+      const first = state.guardFirst.get(row.data.id)
+      if (first && first.seq !== row.seq) {
+        if (first.text !== row.data.content[0].text) {
+          throw new Error(`duplicate Vision Router guard id ${row.data.id} changed text; refusing automatic repair`)
+        }
+        const oldId = row.data.id
+        const newId = generatedGuardRepairId(sessionId, row.seq)
+        assertGeneratedIdAvailable(newId, row.seq, state)
+        row = { ...row, data: { ...row.data, id: newId } }
+        changedSeqs.push(row.seq)
+        repairs.push({ kind: 'duplicate-structured-guard-stop', seq: row.seq })
+      }
+    }
+
+    output.push(row === item.row ? originalLine : JSON.stringify(row))
+  }
+  return { text: `${output.join('\n')}\n`, changedSeqs, repairs }
 }
 
 function inspectRawArtifact(buffer) {
-  if (!buffer.toString('utf8').endsWith('\n')) {
+  const text = buffer.toString('utf8')
+  if (!text.endsWith('\n')) {
     throw new Error('raw session log has an incomplete final record; let DSH finish crash recovery first')
   }
-  const text = buffer.toString('utf8')
   const newline = text.indexOf('\n')
   if (newline < 0) throw new Error('raw session log has no header line')
   const header = parseHeaderLine(text.slice(0, newline))
-  const repaired = repairEventLines(text.slice(newline + 1), header.id)
+  const rows = parseEventLines(text.slice(newline + 1), { frameLabel: 'raw session log' })
+  const state = scanRows([rows])
+  const repaired = repairStorageRows(rows, header.id, state)
   const output = repaired.changedSeqs.length === 0
     ? buffer
     : Buffer.from(`${text.slice(0, newline + 1)}${repaired.text}`, 'utf8')
-  return { sessionId: header.id, output, changedSeqs: repaired.changedSeqs }
+  return { sessionId: header.id, output, changedSeqs: repaired.changedSeqs, repairs: repaired.repairs }
 }
 
 function decodeZstdFrame(buffer, range, maxOutputLength) {
@@ -192,14 +341,23 @@ function inspectZstdArtifact(buffer, maxFramePlaintextBytes) {
     throw new Error('Zstandard session header frame is not exactly one JSONL line')
   }
   const header = parseHeaderLine(headerText.slice(0, -1))
+
+  const decoded = scan.frames.slice(1).map((frame, index) => {
+    const plain = decodeZstdFrame(buffer, frame, maxFramePlaintextBytes)
+    return {
+      frame,
+      rows: parseEventLines(plain.toString('utf8'), { frameLabel: `Zstandard frame ${index + 1}` }),
+    }
+  })
+  const state = scanRows(decoded.map((item) => item.rows))
   const chunks = [buffer.subarray(scan.frames[0].start, scan.frames[0].end)]
   const changedSeqs = []
-
-  for (const frame of scan.frames.slice(1)) {
-    const original = buffer.subarray(frame.start, frame.end)
-    const plain = decodeZstdFrame(buffer, frame, maxFramePlaintextBytes)
-    const repaired = repairEventLines(plain.toString('utf8'), header.id)
+  const repairs = []
+  for (const item of decoded) {
+    const original = buffer.subarray(item.frame.start, item.frame.end)
+    const repaired = repairStorageRows(item.rows, header.id, state)
     changedSeqs.push(...repaired.changedSeqs)
+    repairs.push(...repaired.repairs)
     chunks.push(repaired.changedSeqs.length === 0
       ? original
       : zstdCompressSync(Buffer.from(repaired.text, 'utf8'), CHECKSUM_OPTIONS))
@@ -209,6 +367,7 @@ function inspectZstdArtifact(buffer, maxFramePlaintextBytes) {
     sessionId: header.id,
     output: changedSeqs.length === 0 ? buffer : Buffer.concat(chunks.map((chunk) => Buffer.from(chunk))),
     changedSeqs,
+    repairs,
   }
 }
 
@@ -251,11 +410,6 @@ function temporaryPathFor(filePath) {
   return `${filePath}.vision-router-repair-${process.pid}-${randomBytes(4).toString('hex')}.tmp`
 }
 
-/**
- * Inspect or repair one DSH JSONL session artifact. Repair is offline-only:
- * the file identity is rechecked immediately before replacement and a full
- * byte-for-byte backup is created first.
- */
 export function inspectLegacySessionArtifact(filePath, {
   fix = false,
   maxLogBytes = DEFAULT_MAX_LOG_BYTES,
@@ -277,6 +431,7 @@ export function inspectLegacySessionArtifact(filePath, {
       sessionId: inspected.sessionId,
       encoding: zstd ? 'zstd' : 'none',
       affectedSeqs: inspected.changedSeqs,
+      repairs: inspected.repairs,
       repaired: false,
     }
   }
@@ -302,14 +457,14 @@ export function inspectLegacySessionArtifact(filePath, {
       maxFramePlaintextBytes,
     })
     if (verified.affectedSeqs.length !== 0) {
-      throw new Error('repaired session log still contains the legacy malformed reminder')
+      throw new Error('repaired session log still contains a known Vision Router corruption signature')
     }
   } catch (error) {
     rmSync(tempPath, { force: true })
     try {
       copyFileSync(backupPath, filePath)
     } catch {
-      // Keep the original error; the backup path is returned in its message below.
+      // Preserve the original error; the backup path is included below.
     }
     const message = error instanceof Error ? error.message : String(error)
     throw new Error(`${message} (backup: ${backupPath})`)
@@ -320,6 +475,7 @@ export function inspectLegacySessionArtifact(filePath, {
     sessionId: inspected.sessionId,
     encoding: zstd ? 'zstd' : 'none',
     affectedSeqs: inspected.changedSeqs,
+    repairs: inspected.repairs,
     repaired: true,
     backupPath,
   }
@@ -354,31 +510,30 @@ export function repairLegacySessionLogs({
     throw new TypeError('repairLegacySessionLogs requires dshHome')
   }
   const sessionsRoot = path.join(dshHome, 'sessions')
+  const artifacts = listSessionArtifacts(sessionsRoot)
   const reports = []
   const errors = []
-  for (const filePath of listSessionArtifacts(sessionsRoot)) {
+  const advisories = []
+  for (const filePath of artifacts) {
     try {
-      const report = inspectLegacySessionArtifact(filePath, {
-        fix,
-        maxLogBytes,
-        maxFramePlaintextBytes,
-      })
+      const report = inspectLegacySessionArtifact(filePath, { fix, maxLogBytes, maxFramePlaintextBytes })
       if (report.affectedSeqs.length > 0 || report.repaired) reports.push(report)
     } catch (error) {
-      errors.push({
-        path: filePath,
-        error: error instanceof Error ? error.message : String(error),
-      })
+      const message = error instanceof Error ? error.message : String(error)
+      const incompleteLiveTail = !fix && /(?:incomplete final record|incomplete final frame|torn JSONL record)/i.test(message)
+      if (incompleteLiveTail) advisories.push({ path: filePath, kind: 'incomplete-live-tail' })
+      else errors.push({ path: filePath, error: message })
     }
   }
   return {
     sessionsRoot,
     exists: existsSync(sessionsRoot),
-    scanned: listSessionArtifacts(sessionsRoot).length,
+    scanned: artifacts.length,
     affected: reports.reduce((sum, item) => sum + item.affectedSeqs.length, 0),
     repaired: reports.filter((item) => item.repaired).length,
     reports,
     errors,
+    advisories,
     ok: errors.length === 0,
   }
 }

--- a/package.json
+++ b/package.json
@@ -59,15 +59,9 @@
     "sharp": ">=0.35.3 <1"
   },
   "peerDependenciesMeta": {
-    "@deepseek-ai/dsh-anonymous-user-id": {
-      "optional": true
-    },
-    "@deepseek-ai/dsh-llm-deepseek": {
-      "optional": true
-    },
-    "sharp": {
-      "optional": true
-    }
+    "@deepseek-ai/dsh-anonymous-user-id": { "optional": true },
+    "@deepseek-ai/dsh-llm-deepseek": { "optional": true },
+    "sharp": { "optional": true }
   },
   "devDependencies": {
     "@deepseek-ai/dsh-anonymous-user-id": "^0.1.0-rc.6",
@@ -75,12 +69,10 @@
     "sharp": "^0.35.3"
   },
   "scripts": {
-    "test": "node --test tests/core.test.js tests/capability-advisory.test.js tests/vision-execution-policy.test.js tests/vision-backend-diagnostics.test.js tests/vision-backend-smoke-test.test.js tests/live-model-discovery.test.js tests/live-model-credential-resolution.test.js tests/vision-model-registry.test.js tests/live-model-client-stability.test.js tests/provider-directory-fallback.test.js tests/settings-section-order.test.js tests/attachment-admission-policy.test.js tests/vision-resilience.test.js tests/client.test.js tests/client-presentation-boundary.test.js tests/remote-settings-bridge.test.js tests/remote-settings-risk-confirmation.test.js tests/local-remote-settings-permission.test.js tests/rc6-real-settings-persistence.test.js tests/artifact-path-security.test.js tests/http-compat.test.js tests/catalog-corrections.test.js tests/update-check.test.js tests/self-update.test.js tests/doctor.test.js tests/doctor-cli.test.js tests/legacy-session-repair.test.js tests/profile-pnpm-diagnostics.test.js tests/bundle-defaults.test.js tests/file-logger.test.js tests/replay-delegation.test.js tests/adversarial-hardening.test.js tests/wrapper-directory.test.js tests/logging-ui.test.js tests/manifest-dependencies.test.js tests/structured-bootstrap.test.js tests/structured-bootstrap-gate.test.js tests/local-ollama.test.js tests/ollama-cold-start.test.js tests/ollama-cold-start-loaded.test.js tests/zero-regression-gate.test.js tests/runtime-e2e.test.js tests/local-vision-stabilizer.test.js tests/local-connection-probe.test.js tests/repetition-guard.test.js tests/guide-scroll-gate.test.js tests/android-attachment-compat.test.js tests/free-cloud-first.test.js tests/rc6-rc7-compat.test.js tests/native-image-coexistence.test.js tests/pi-ai-bridge-wire-compat.test.js tests/mixed-router.test.js tests/depth-tier.test.js tests/depth-quota-behavior.test.js tests/structured-flow-hardening.test.js tests/vision-budget-activation.test.js tests/runtime-boundary-fixes.test.js tests/tesseract-node24-boot.test.js tests/session-vision-state.test.js tests/session-vision-state-integration.test.js tests/image-resource-governor.test.js tests/pixel-diff-stream.test.js tests/large-image-resource-integration.test.js tests/structured-guard-idempotency.test.js tests/qa-top5-reliability.test.js tests/qa-screenshot-runtime.test.js tests/qa-runtime-identity.test.js tests/qa-turn-budget-cancellation.test.js tests/qa-cancellation-publication.test.js tests/qa-reliability-tail.test.js tests/qa-endpoint-route-alias.test.js"
+    "test": "node --test tests/core.test.js tests/capability-advisory.test.js tests/vision-execution-policy.test.js tests/vision-backend-diagnostics.test.js tests/vision-backend-smoke-test.test.js tests/live-model-discovery.test.js tests/live-model-credential-resolution.test.js tests/vision-model-registry.test.js tests/live-model-client-stability.test.js tests/provider-directory-fallback.test.js tests/settings-section-order.test.js tests/attachment-admission-policy.test.js tests/vision-resilience.test.js tests/client.test.js tests/client-presentation-boundary.test.js tests/remote-settings-bridge.test.js tests/remote-settings-risk-confirmation.test.js tests/local-remote-settings-permission.test.js tests/rc6-real-settings-persistence.test.js tests/artifact-path-security.test.js tests/http-compat.test.js tests/catalog-corrections.test.js tests/update-check.test.js tests/self-update.test.js tests/doctor.test.js tests/doctor-cli.test.js tests/legacy-session-repair.test.js tests/profile-pnpm-diagnostics.test.js tests/doctor-v2.test.js tests/doctor-cli-v2.test.js tests/doctor-runtime.test.js tests/session-repair-v2.test.js tests/bundle-defaults.test.js tests/file-logger.test.js tests/replay-delegation.test.js tests/adversarial-hardening.test.js tests/wrapper-directory.test.js tests/logging-ui.test.js tests/manifest-dependencies.test.js tests/structured-bootstrap.test.js tests/structured-bootstrap-gate.test.js tests/local-ollama.test.js tests/ollama-cold-start.test.js tests/ollama-cold-start-loaded.test.js tests/zero-regression-gate.test.js tests/runtime-e2e.test.js tests/local-vision-stabilizer.test.js tests/local-connection-probe.test.js tests/repetition-guard.test.js tests/guide-scroll-gate.test.js tests/android-attachment-compat.test.js tests/free-cloud-first.test.js tests/rc6-rc7-compat.test.js tests/native-image-coexistence.test.js tests/pi-ai-bridge-wire-compat.test.js tests/mixed-router.test.js tests/depth-tier.test.js tests/depth-quota-behavior.test.js tests/structured-flow-hardening.test.js tests/vision-budget-activation.test.js tests/runtime-boundary-fixes.test.js tests/tesseract-node24-boot.test.js tests/session-vision-state.test.js tests/session-vision-state-integration.test.js tests/image-resource-governor.test.js tests/pixel-diff-stream.test.js tests/large-image-resource-integration.test.js tests/structured-guard-idempotency.test.js tests/qa-top5-reliability.test.js tests/qa-screenshot-runtime.test.js tests/qa-runtime-identity.test.js tests/qa-turn-budget-cancellation.test.js tests/qa-cancellation-publication.test.js tests/qa-reliability-tail.test.js tests/qa-endpoint-route-alias.test.js"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "sharp"
-    ]
+    "onlyBuiltDependencies": ["sharp"]
   },
   "dsh": {
     "client": {
@@ -92,8 +84,6 @@
         "@deepseek-ai/dsh-api-remotes"
       ]
     },
-    "bundle": {
-      "patch": "./cordis.patch.yml"
-    }
+    "bundle": { "patch": "./cordis.patch.yml" }
   }
 }

--- a/tests/doctor-cli-v2.test.js
+++ b/tests/doctor-cli-v2.test.js
@@ -1,0 +1,79 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { run } from '../lib/doctor-cli.js'
+
+function fixture({ good = true } = {}) {
+  const home = mkdtempSync(path.join(tmpdir(), 'vr-cli-'))
+  const dir = path.join(home, 'profiles', 'web')
+  mkdirSync(dir, { recursive: true })
+  const manifest = good
+    ? { dependencies: { 'dsh-vision-router': '^1.7.4' }, dsh: { profile: { bundles: ['dsh-vision-router'] } } }
+    : {}
+  writeFileSync(path.join(dir, 'package.json'), JSON.stringify(manifest))
+  if (good) {
+    const pkg = path.join(dir, 'node_modules', 'dsh-vision-router')
+    mkdirSync(pkg, { recursive: true })
+    writeFileSync(path.join(pkg, 'package.json'), JSON.stringify({
+      name: 'dsh-vision-router', version: '1.7.4', main: 'entry.js', dsh: { bundle: { patch: './cordis.patch.yml' } },
+    }))
+    writeFileSync(path.join(pkg, 'entry.js'), 'export default {}\n')
+    writeFileSync(path.join(pkg, 'cordis.patch.yml'), '- insert: []\n')
+  }
+  return home
+}
+function capture() {
+  const stdout = []; const stderr = []
+  return { io: { log: (x) => stdout.push(String(x)), error: (x) => stderr.push(String(x)) }, stdout, stderr }
+}
+function sessionHeader() { return { type: 'session', version: 0, id: 's', createdAt: 1, delegationDepth: 0 } }
+function turnStart() { return { type: 'turn/start', seq: 0, time: 1, data: { turn: 1 } } }
+function guard(seq) { return { type: 'user/message', seq, time: seq + 1, data: { role: 'user', id: 'vision-router-structured-guard-stop-1', content: [{ type: 'text', text: '本轮视觉总时间预算已耗尽。不要再调用视觉工具；请基于已经获得的证据作答，并明确仍存在的不确定性。' }], source: { kind: 'plugin', plugin: 'dsh-vision-router' } } } }
+function writeSession(home, lines, torn = false) {
+  const dir = path.join(home, 'sessions', '--project--', 's')
+  mkdirSync(dir, { recursive: true })
+  let text = [JSON.stringify(sessionHeader()), ...lines.map(JSON.stringify), ''].join('\n')
+  if (torn) text = text.slice(0, -1)
+  writeFileSync(path.join(dir, 'session.jsonl'), text)
+}
+
+test('doctor returns nonzero and prints a red failure for a requested profile with no plugin', async () => {
+  const home = fixture({ good: false })
+  const cap = capture()
+  const code = await run(['doctor', '--profile', 'web', '--no-runtime'], cap.io, { DSH_HOME: home })
+  assert.equal(code, 1)
+  assert.match(cap.stdout.join('\n'), /✗ web/)
+  assert.match(cap.stderr.join('\n'), /not installed or mounted/)
+})
+
+test('doctor JSON report is parseable and healthy for a good bundle install', async () => {
+  const home = fixture({ good: true })
+  const cap = capture()
+  const code = await run(['doctor', '--profile', 'web', '--no-runtime', '--json'], cap.io, { DSH_HOME: home })
+  assert.equal(code, 0)
+  const report = JSON.parse(cap.stdout.join('\n'))
+  assert.equal(report.ok, true)
+  assert.equal(report.doctorVersion, '1.7.4')
+  assert.equal(report.profiles[0].installedVersion, '1.7.4')
+  assert.equal(report.profiles[0].installation.mode, 'bundle')
+})
+
+test('doctor --sessions treats an incomplete live tail as advisory, not Vision Router corruption', async () => {
+  const home = fixture({ good: true })
+  writeSession(home, [turnStart()], true)
+  const cap = capture()
+  const code = await run(['doctor', '--profile', 'web', '--no-runtime', '--sessions'], cap.io, { DSH_HOME: home })
+  assert.equal(code, 0)
+  assert.match(cap.stdout.join('\n'), /live\/incomplete tail/)
+})
+
+test('doctor --sessions still fails on a committed hard session corruption', async () => {
+  const home = fixture({ good: true })
+  writeSession(home, [turnStart(), { ...guard(2) }])
+  const cap = capture()
+  const code = await run(['doctor', '--profile', 'web', '--no-runtime', '--sessions'], cap.io, { DSH_HOME: home })
+  assert.equal(code, 1)
+  assert.match(cap.stderr.join('\n'), /could not be inspected safely/)
+})

--- a/tests/doctor-cli.test.js
+++ b/tests/doctor-cli.test.js
@@ -18,6 +18,20 @@ import { isCliEntry } from '../lib/doctor-cli.js'
 const modulePath = fileURLToPath(new URL('../lib/doctor-cli.js', import.meta.url))
 const moduleUrl = pathToFileURL(modulePath).href
 
+function materializeHealthyProfile(profileDir) {
+  writeFileSync(path.join(profileDir, 'package.json'), JSON.stringify({
+    dependencies: { 'dsh-vision-router': '^1.7.4' },
+    dsh: { profile: { bundles: ['dsh-vision-router'] } },
+  }, null, 2))
+  const pluginDir = path.join(profileDir, 'node_modules', 'dsh-vision-router')
+  mkdirSync(pluginDir, { recursive: true })
+  writeFileSync(path.join(pluginDir, 'package.json'), JSON.stringify({
+    name: 'dsh-vision-router', version: '1.7.4', main: 'entry.js', dsh: { bundle: { patch: './cordis.patch.yml' } },
+  }))
+  writeFileSync(path.join(pluginDir, 'entry.js'), 'export default {}\n')
+  writeFileSync(path.join(pluginDir, 'cordis.patch.yml'), '- insert: []\n')
+}
+
 test('isCliEntry matches direct invocation paths only', () => {
   assert.equal(isCliEntry(modulePath, moduleUrl), true)
   assert.equal(isCliEntry(path.join(path.dirname(modulePath), 'other.js'), moduleUrl), false)
@@ -29,17 +43,17 @@ test('doctor CLI prints a report when invoked through a symlinked bin (npx shim 
   const home = mkdtempSync(path.join(tmpdir(), 'dsh-cli-'))
   const profileDir = path.join(home, 'profiles', 'web')
   mkdirSync(profileDir, { recursive: true })
-  writeFileSync(path.join(profileDir, 'package.json'), '{}\n')
+  materializeHealthyProfile(profileDir)
 
   const binDir = mkdtempSync(path.join(tmpdir(), 'dsh-bin-'))
   const link = path.join(binDir, 'dsh-vision-router')
   symlinkSync(modulePath, link)
 
-  const result = spawnSync(process.execPath, [link, 'doctor'], {
+  const result = spawnSync(process.execPath, [link, 'doctor', '--no-runtime'], {
     encoding: 'utf8',
     env: { ...process.env, DSH_HOME: home },
   })
-  assert.equal(result.status, 0)
+  assert.equal(result.status, 0, result.stderr)
   assert.match(result.stdout, /DSH home:/)
   assert.match(result.stdout, /✓ web/)
   rmSync(binDir, { recursive: true, force: true })
@@ -51,34 +65,18 @@ test('repair-sessions CLI repairs the exact legacy reminder and prints the backu
   mkdirSync(sessionDir, { recursive: true })
   const sessionPath = path.join(sessionDir, 'session.jsonl')
   const lines = [
-    JSON.stringify({
-      type: 'session',
-      version: 0,
-      id: 'broken-session',
-      createdAt: 1,
-      delegationDepth: 0,
-    }),
+    JSON.stringify({ type: 'session', version: 0, id: 'broken-session', createdAt: 1, delegationDepth: 0 }),
     JSON.stringify({ type: 'turn/start', seq: 0, time: 1, data: { turn: 1 } }),
     JSON.stringify({
-      type: 'user/message',
-      seq: 1,
-      time: 2,
+      type: 'user/message', seq: 1, time: 2,
       data: {
         role: 'user',
-        content: [{
-          type: 'text',
-          text: '视觉深看工具已挂载：vision_describe。现在可以直接调用已启用的工具。',
-        }],
+        content: [{ type: 'text', text: '视觉深看工具已挂载：vision_describe。现在可以直接调用已启用的工具。' }],
         source: { kind: 'plugin', plugin: 'dsh-vision-router' },
       },
       surfaceOp: 'append',
     }),
-    JSON.stringify({
-      type: 'turn/end',
-      seq: 2,
-      time: 3,
-      data: { turn: 1, reason: { kind: 'completed' } },
-    }),
+    JSON.stringify({ type: 'turn/end', seq: 2, time: 3, data: { turn: 1, reason: { kind: 'completed' } } }),
     '',
   ]
   writeFileSync(sessionPath, lines.join('\n'))

--- a/tests/doctor-runtime.test.js
+++ b/tests/doctor-runtime.test.js
@@ -1,0 +1,114 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { probeRuntime, supportReport } from '../lib/doctor-runtime.js'
+
+function response(status, headers = {}) {
+  const normalized = Object.fromEntries(Object.entries(headers).map(([k, v]) => [k.toLowerCase(), v]))
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    headers: { get: (name) => normalized[name.toLowerCase()] ?? '' },
+    async text() { return headers.body ?? '' },
+  }
+}
+function routeResponse(url, extra = {}) {
+  const allow = url.includes('/logs') ? 'GET, POST'
+    : url.includes('settings-save-diagnostics') || url.includes('self-update') ? 'POST'
+      : 'GET'
+  return response(405, { allow, ...(url.includes('self-update') ? extra : {}) })
+}
+
+test('runtime probe uses a side-effect-free rejected method and catches SPA fallback as a missing route', async () => {
+  const methods = []
+  const report = await probeRuntime({ fetchImpl: async (url, init) => {
+    methods.push(init.method)
+    if (url.includes('model-capabilities')) return response(200, { 'content-type': 'text/html' })
+    return routeResponse(url)
+  } })
+  assert.ok(methods.every((method) => method === 'DELETE'))
+  assert.equal(report.reachable, true)
+  assert.equal(report.ok, false)
+})
+
+test('405 plus the exact Allow contract confirms unbound routes without executing them', async () => {
+  const report = await probeRuntime({ fetchImpl: async (url, init) => {
+    assert.equal(init.redirect, 'manual')
+    return routeResponse(url)
+  } })
+  assert.equal(report.reachable, true)
+  assert.equal(report.ok, true)
+  assert.equal(report.routes.length, 6)
+  assert.ok(report.routes.every((item) => item.registered))
+})
+
+test('requested profile requires verified runtime ownership before route health can pass', async () => {
+  const home = '/tmp/dsh-home'
+  let report = await probeRuntime({
+    requestedProfile: 'web', dshHome: home, applicableProfiles: ['web', 'desktop'],
+    fetchImpl: async (url, init) => init.method === 'GET'
+      ? response(200, { body: JSON.stringify({ ok: true, local: true, directory: `${home}/logs/vision-router` }) })
+      : routeResponse(url),
+  })
+  assert.equal(report.routeOk, true)
+  assert.equal(report.ownership.verified, false)
+  assert.equal(report.ok, false)
+
+  report = await probeRuntime({
+    requestedProfile: 'web', dshHome: home, applicableProfiles: ['web'],
+    fetchImpl: async (url, init) => init.method === 'GET'
+      ? response(200, { body: JSON.stringify({ ok: true, local: true, directory: `${home}/logs/vision-router` }) })
+      : routeResponse(url),
+  })
+  assert.equal(report.ownership.verified, true)
+  assert.equal(report.ownership.profile, 'web')
+  assert.equal(report.ok, true)
+})
+
+test('unreachable DSH is advisory so offline doctor can still succeed', async () => {
+  const report = await probeRuntime({ requestedProfile: 'web', fetchImpl: async () => { throw new TypeError('fetch failed https://secret.invalid') } })
+  assert.equal(report.reachable, false)
+  assert.equal(report.ok, true)
+})
+
+test('runtime probe rejects invalid base URLs instead of treating them as offline success', async () => {
+  await assert.rejects(() => probeRuntime({ baseUrl: 'file:///tmp/socket' }), /http or https/)
+  await assert.rejects(() => probeRuntime({ baseUrl: 'not a url' }), /valid absolute/)
+})
+
+test('support report is schema-versioned, identifies doctor version, and omits raw secrets/paths', () => {
+  const profileReport = {
+    ok: true,
+    dshHome: '/Users/alice/.dsh',
+    profiles: [{
+      name: 'web', exists: true, validJson: true, hasBom: false,
+      pluginDependency: 'file:/Users/alice/private/dsh-vision-router', pluginBundle: true,
+      installedPlugin: { version: '1.7.4' },
+      installation: { applicable: true, mode: 'bundle', ok: true, errors: [], warnings: [], declaredSpecKind: 'local-path', installTarget: '/Users/alice/private' },
+      workspace: { pinned: [] }, patch: { visionRouterRows: 0, manualVisionRouter: false, disablesOfficialDeepSeek: false },
+    }],
+    log: { exists: true, settingsSaveFailures: [], historicalSettingsSaveFailures: [], recentErrors: [], startupScoped: true, startupVersion: '1.7.4' },
+  }
+  const report = supportReport({
+    profileReport,
+    runtime: {
+      baseUrl: 'http://alice:secret@127.0.0.1:3080/private?token=secret#frag', reachable: true, ok: true, routeOk: true,
+      ownership: { verified: true, profile: 'web', version: '1.7.4' },
+      routes: [{ route: '/x', status: 405, registered: true, error: 'raw-secret-error' }],
+    },
+    sessions: {
+      ok: true, scanned: 1, affected: 1, repaired: 0, errors: [], advisories: [],
+      reports: [{ sessionId: 'private-session-id', repairs: [{ kind: 'duplicate-structured-guard-stop', seq: 9 }] }],
+    },
+    platform: { platform: 'darwin', arch: 'arm64', node: 'v22.23.0', nodeSupported: true, nodeRequirement: '^22.19.0 || >=24.0.0', release: 'x', tesseract: { available: false }, chromium: { available: false }, sharp: [], hostPackages: [] },
+  })
+  const json = JSON.stringify(report)
+  assert.equal(report.schemaVersion, 1)
+  assert.equal(report.doctorVersion, '1.7.4')
+  assert.equal(json.includes('file:/Users/alice'), false)
+  assert.equal(json.includes('/Users/alice/private'), false)
+  assert.equal(json.includes('secret@'), false)
+  assert.equal(json.includes('token=secret'), false)
+  assert.equal(json.includes('private-session-id'), false)
+  assert.equal(json.includes('raw-secret-error'), false)
+  assert.equal(report.runtime.baseUrl, 'http://127.0.0.1:3080/private')
+})

--- a/tests/doctor-v2.test.js
+++ b/tests/doctor-v2.test.js
@@ -1,0 +1,177 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { doctorProfiles, inspectProfilePatch, registrySpecSatisfiesVersion } from '../lib/doctor.js'
+
+function makeProfile({ manifest = {}, patch, installedVersion, installedManifest, workspace, name = 'web', createInstalledTargets = true } = {}) {
+  const home = mkdtempSync(path.join(tmpdir(), 'vr-doctor-'))
+  const dir = path.join(home, 'profiles', name)
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(path.join(dir, 'package.json'), JSON.stringify(manifest, null, 2) + '\n')
+  if (patch !== undefined) writeFileSync(path.join(dir, 'cordis.patch.yml'), patch)
+  if (workspace !== undefined) writeFileSync(path.join(dir, 'pnpm-workspace.yaml'), workspace)
+  if (installedVersion || installedManifest) {
+    const pkg = path.join(dir, 'node_modules', 'dsh-vision-router')
+    mkdirSync(pkg, { recursive: true })
+    const installed = installedManifest ?? {
+      name: 'dsh-vision-router', version: installedVersion,
+      main: 'entry.js', dsh: { bundle: { patch: './cordis.patch.yml' } },
+    }
+    writeFileSync(path.join(pkg, 'package.json'), JSON.stringify(installed))
+    if (createInstalledTargets && installed.main) writeFileSync(path.join(pkg, installed.main), 'export default {}\n')
+    if (createInstalledTargets && installed.dsh?.bundle?.patch) writeFileSync(path.join(pkg, installed.dsh.bundle.patch), '- insert: []\n')
+  }
+  return { home, dir }
+}
+function bundleManifest(spec = '^1.7.4') {
+  return { dependencies: { 'dsh-vision-router': spec }, dsh: { profile: { bundles: ['dsh-vision-router'] } } }
+}
+
+test('requested profile without Vision Router is unhealthy instead of a green false positive', () => {
+  const { home } = makeProfile({ manifest: {} })
+  const report = doctorProfiles({ dshHome: home, profile: 'web' })
+  assert.equal(report.ok, false)
+  assert.equal(report.profiles[0].installation.applicable, true)
+  assert.match(report.profiles[0].installation.errors.join('\n'), /not installed or mounted/)
+})
+
+test('unrelated profiles are skipped when scanning all profiles', () => {
+  const { home } = makeProfile({ manifest: bundleManifest(), installedVersion: '1.7.4' })
+  const other = path.join(home, 'profiles', 'headless')
+  mkdirSync(other, { recursive: true })
+  writeFileSync(path.join(other, 'package.json'), '{}\n')
+  const report = doctorProfiles({ dshHome: home })
+  assert.equal(report.ok, true)
+  assert.equal(report.applicableProfiles, 1)
+  assert.equal(report.profiles.find((item) => item.name === 'headless').installation.applicable, false)
+})
+
+test('bundle installation requires declaration and installed package', () => {
+  const missing = makeProfile({ manifest: bundleManifest() })
+  assert.equal(doctorProfiles({ dshHome: missing.home, profile: 'web' }).ok, false)
+  const good = makeProfile({ manifest: bundleManifest(), installedVersion: '1.7.4' })
+  const report = doctorProfiles({ dshHome: good.home, profile: 'web' })
+  assert.equal(report.ok, true)
+  assert.equal(report.profiles[0].installation.mode, 'bundle')
+})
+
+test('dependency-only install is unhealthy because the plugin is not mounted', () => {
+  const { home } = makeProfile({ manifest: { dependencies: { 'dsh-vision-router': '^1.7.4' } }, installedVersion: '1.7.4' })
+  const report = doctorProfiles({ dshHome: home, profile: 'web' })
+  assert.equal(report.ok, false)
+  assert.equal(report.profiles[0].installation.mode, 'unmounted')
+})
+
+test('manual cordis.patch.yml mode is healthy but bundle plus manual row is a duplicate-load error', () => {
+  const manualPatch = '- insert:\n    - id: vision-router\n      name: dsh-vision-router\n'
+  let profile = makeProfile({ manifest: { dependencies: { 'dsh-vision-router': '^1.7.4' } }, installedVersion: '1.7.4', patch: manualPatch })
+  assert.equal(doctorProfiles({ dshHome: profile.home, profile: 'web' }).ok, true)
+  profile = makeProfile({ manifest: bundleManifest(), installedVersion: '1.7.4', patch: manualPatch })
+  const report = doctorProfiles({ dshHome: profile.home, profile: 'web' })
+  assert.equal(report.ok, false)
+  assert.equal(report.profiles[0].installation.mode, 'duplicate')
+})
+
+test('legacy static llm-deepseek disable is detected as a warning', () => {
+  const { home, dir } = makeProfile({
+    manifest: { dependencies: { 'dsh-vision-router': '^1.7.4' } }, installedVersion: '1.7.4',
+    patch: '- insert:\n    - id: llm-deepseek\n      name: @deepseek-ai/dsh-llm-deepseek\n      disabled: true\n    - id: vision-router\n      name: dsh-vision-router\n',
+  })
+  assert.equal(inspectProfilePatch(path.join(dir, 'cordis.patch.yml')).disablesOfficialDeepSeek, true)
+  const report = doctorProfiles({ dshHome: home, profile: 'web' })
+  assert.equal(report.ok, true)
+  assert.match(report.profiles[0].installation.warnings.join('\n'), /official model disappear/)
+})
+
+test('version-pinned release-age entries remain unhealthy until repair', () => {
+  const workspace = 'minimumReleaseAgeExclude:\n  - dsh-vision-router@1.7.4\n'
+  const { home } = makeProfile({ manifest: bundleManifest(), installedVersion: '1.7.4', workspace })
+  assert.equal(doctorProfiles({ dshHome: home, profile: 'web' }).ok, false)
+  assert.equal(doctorProfiles({ dshHome: home, profile: 'web', fix: true }).ok, true)
+})
+
+test('doctor scopes settings failures to the latest plugin start and keeps older/unscoped failures advisory', () => {
+  const { home } = makeProfile({ manifest: bundleManifest(), installedVersion: '1.7.4' })
+  const logDir = path.join(home, 'logs', 'vision-router')
+  mkdirSync(logDir, { recursive: true })
+  writeFileSync(path.join(logDir, 'vision-router.1.log'), '[2026-01-01T00:00:00Z] [WARN] vision-router: settings save failed field=old operation=set reason=readback-mismatch detail=none\n')
+  writeFileSync(path.join(logDir, 'vision-router.log'), [
+    '[2026-01-01T00:00:01Z] [INFO] vision-router: diagnostics log enabled at /tmp/log (plugin=1.7.4 node=v22 platform=linux/x64)',
+    '[2025-12-31T23:59:59Z] [WARN] vision-router: settings save failed field=current operation=set reason=readback-mismatch detail=none',
+  ].join('\n'))
+  const report = doctorProfiles({ dshHome: home, profile: 'web' })
+  assert.equal(report.ok, false)
+  assert.deepEqual(report.log.settingsSaveFailures, [{ field: 'current', operation: 'set', reason: 'readback-mismatch' }])
+  assert.deepEqual(report.log.historicalSettingsSaveFailures, [{ field: 'old', operation: 'set', reason: 'readback-mismatch' }])
+})
+
+test('manual mode without a persistent dependency and duplicate bundle rows are unhealthy', () => {
+  let profile = makeProfile({ manifest: {}, installedVersion: '1.7.4', patch: '- insert:\n    - id: vision-router\n      name: dsh-vision-router\n' })
+  assert.equal(doctorProfiles({ dshHome: profile.home, profile: 'web' }).ok, false)
+  const manifest = bundleManifest(); manifest.dsh.profile.bundles.push('dsh-vision-router')
+  profile = makeProfile({ manifest, installedVersion: '1.7.4' })
+  assert.equal(doctorProfiles({ dshHome: profile.home, profile: 'web' }).ok, false)
+})
+
+test('declared registry range is checked against the materialized installed version', () => {
+  const { home } = makeProfile({ manifest: bundleManifest('^1.8.0'), installedVersion: '1.7.4' })
+  const report = doctorProfiles({ dshHome: home, profile: 'web' })
+  assert.equal(report.ok, false)
+  assert.match(report.profiles[0].installation.errors.join('\n'), /does not match installed/)
+})
+
+test('non-registry declarations report the real install target without inventing a version mismatch', () => {
+  const { home } = makeProfile({ manifest: bundleManifest('github:ysr666/dsh-vision-router'), installedVersion: '1.7.4' })
+  const report = doctorProfiles({ dshHome: home, profile: 'web' })
+  assert.equal(report.ok, true)
+  assert.equal(report.profiles[0].installation.declaredSpecKind, 'hosted-vcs')
+  assert.equal(typeof report.profiles[0].installation.installTarget, 'string')
+})
+
+test('stable registry ranges do not falsely accept prerelease installs', () => {
+  assert.equal(registrySpecSatisfiesVersion('^1.7.0', '1.8.0-rc.1'), false)
+  assert.equal(registrySpecSatisfiesVersion('^1.7.0', '1.8.0'), true)
+})
+
+test('exact prerelease declarations compare using SemVer numeric prerelease identifiers', () => {
+  assert.equal(registrySpecSatisfiesVersion('1.7.4-rc.10', '1.7.4-rc.10'), true)
+  assert.equal(registrySpecSatisfiesVersion('1.7.4-rc.10', '1.7.4-rc.2'), false)
+})
+
+test('scan-all does not hide an invalid profile that still contains Vision Router evidence', () => {
+  const { home } = makeProfile({ manifest: bundleManifest(), installedVersion: '1.7.4' })
+  const bad = path.join(home, 'profiles', 'bad')
+  mkdirSync(path.join(bad, 'node_modules', 'dsh-vision-router'), { recursive: true })
+  writeFileSync(path.join(bad, 'package.json'), '{broken')
+  writeFileSync(path.join(bad, 'node_modules', 'dsh-vision-router', 'package.json'), JSON.stringify({ name: 'dsh-vision-router', version: '1.7.4' }))
+  const report = doctorProfiles({ dshHome: home })
+  assert.equal(report.ok, false)
+  assert.equal(report.profiles.find((item) => item.name === 'bad').installation.applicable, true)
+})
+
+test('missing package.json is still relevant when a Vision Router patch or installed package exists', () => {
+  const home = mkdtempSync(path.join(tmpdir(), 'vr-doctor-missing-'))
+  const dir = path.join(home, 'profiles', 'web')
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(path.join(dir, 'cordis.patch.yml'), '- insert:\n    - id: vision-router\n      name: dsh-vision-router\n')
+  const report = doctorProfiles({ dshHome: home })
+  assert.equal(report.ok, false)
+  assert.equal(report.profiles[0].installation.applicable, true)
+})
+
+test('oversized profile inputs fail boundedly instead of being read without a safety limit', () => {
+  const { home, dir } = makeProfile({ manifest: bundleManifest(), installedVersion: '1.7.4' })
+  writeFileSync(path.join(dir, 'package.json'), ' '.repeat(1024 * 1024 + 1))
+  const report = doctorProfiles({ dshHome: home, profile: 'web' })
+  assert.equal(report.ok, false)
+  assert.equal(report.profiles[0].oversized, true)
+})
+
+test('installed package integrity rejects wrong package identity and missing bundle patch target', () => {
+  let profile = makeProfile({ manifest: bundleManifest(), installedManifest: { name: 'not-vision-router', version: '1.7.4' } })
+  assert.equal(doctorProfiles({ dshHome: profile.home, profile: 'web' }).ok, false)
+  profile = makeProfile({ manifest: bundleManifest(), createInstalledTargets: false, installedManifest: { name: 'dsh-vision-router', version: '1.7.4', dsh: { bundle: { patch: './missing.yml' } } } })
+  assert.equal(doctorProfiles({ dshHome: profile.home, profile: 'web' }).ok, false)
+})

--- a/tests/doctor.test.js
+++ b/tests/doctor.test.js
@@ -5,12 +5,30 @@ import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { doctorProfiles, hasUtf8Bom, inspectProfileManifest, inspectProfileWorkspace, resolveDshHome } from '../lib/doctor.js'
 
+function materializeVisionRouterIfDeclared(dir, manifestText) {
+  let text = Buffer.isBuffer(manifestText) ? manifestText : Buffer.from(String(manifestText))
+  if (text.length >= 3 && text[0] === 0xef && text[1] === 0xbb && text[2] === 0xbf) text = text.subarray(3)
+  let manifest
+  try { manifest = JSON.parse(text.toString('utf8')) } catch { return }
+  const declared = manifest?.dependencies?.['dsh-vision-router']
+  if (typeof declared !== 'string') return
+  const version = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(declared) ? declared : '1.7.4'
+  const pkg = path.join(dir, 'node_modules', 'dsh-vision-router')
+  mkdirSync(pkg, { recursive: true })
+  writeFileSync(path.join(pkg, 'package.json'), JSON.stringify({
+    name: 'dsh-vision-router', version, main: 'entry.js', dsh: { bundle: { patch: './cordis.patch.yml' } },
+  }))
+  writeFileSync(path.join(pkg, 'entry.js'), 'export default {}\n')
+  writeFileSync(path.join(pkg, 'cordis.patch.yml'), '- insert: []\n')
+}
+
 function fixture(manifestText, { profile = 'web', workspace } = {}) {
   const home = mkdtempSync(path.join(tmpdir(), 'dsh-doctor-'))
   const dir = path.join(home, 'profiles', profile)
   mkdirSync(dir, { recursive: true })
   const manifestPath = path.join(dir, 'package.json')
   writeFileSync(manifestPath, manifestText)
+  materializeVisionRouterIfDeclared(dir, manifestText)
   const workspacePath = path.join(dir, 'pnpm-workspace.yaml')
   if (workspace !== undefined) writeFileSync(workspacePath, workspace)
   return { home, dir, manifestPath, workspacePath }
@@ -41,25 +59,18 @@ test('inspectProfileManifest diagnoses BOM without mutating by default', () => {
 })
 
 test('doctor reports an unresolved BOM as unhealthy and repair clears it', () => {
-  const { home } = fixture(Buffer.concat([
-    Buffer.from([0xef, 0xbb, 0xbf]),
-    Buffer.from(validManifest),
-  ]))
+  const { home } = fixture(Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), Buffer.from(validManifest)]))
   const before = doctorProfiles({ dshHome: home, profile: 'web' })
   assert.equal(before.profiles[0].validJson, true)
   assert.equal(before.profiles[0].hasBom, true)
   assert.equal(before.ok, false)
-
   const after = doctorProfiles({ dshHome: home, profile: 'web', fix: true })
   assert.equal(after.profiles[0].repaired, true)
   assert.equal(after.ok, true)
 })
 
 test('inspectProfileManifest repair removes only the leading BOM', () => {
-  const { manifestPath } = fixture(Buffer.concat([
-    Buffer.from([0xef, 0xbb, 0xbf]),
-    Buffer.from(validManifest),
-  ]))
+  const { manifestPath } = fixture(Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), Buffer.from(validManifest)]))
   const result = inspectProfileManifest(manifestPath, { fix: true })
   assert.equal(result.hasBom, true)
   assert.equal(result.repaired, true)
@@ -69,10 +80,7 @@ test('inspectProfileManifest repair removes only the leading BOM', () => {
 
 test('repair does not paper over non-BOM JSON errors', () => {
   const broken = '{"name":"web", trailing}\n'
-  const { manifestPath } = fixture(Buffer.concat([
-    Buffer.from([0xef, 0xbb, 0xbf]),
-    Buffer.from(broken),
-  ]))
+  const { manifestPath } = fixture(Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), Buffer.from(broken)]))
   const result = inspectProfileManifest(manifestPath, { fix: true })
   assert.equal(result.repaired, true)
   assert.equal(result.validJson, false)
@@ -85,11 +93,9 @@ test('doctorProfiles can scan all profiles or a requested profile', () => {
   mkdirSync(secondDir, { recursive: true })
   writeFileSync(path.join(secondDir, 'package.json'), '{}\n')
   mkdirSync(path.join(first.home, 'profiles', 'node_modules'), { recursive: true })
-
   const all = doctorProfiles({ dshHome: first.home })
   assert.deepEqual(all.profiles.map((item) => item.name), ['headless', 'web'])
   assert.equal(all.ok, true)
-
   const one = doctorProfiles({ dshHome: first.home, profile: 'web' })
   assert.deepEqual(one.profiles.map((item) => item.name), ['web'])
 })
@@ -101,14 +107,8 @@ test('resolveDshHome respects DSH_HOME and expands tilde', () => {
 })
 
 const pinnedWorkspace = [
-  'packages:',
-  '  - .',
-  '',
-  'minimumReleaseAgeExclude:',
-  "  - '@deepseek-ai/cosmokit@1.8.2'",
-  '  - dsh-vision-router@1.2.0',
-  '  - unrelated-pkg@0.0.1',
-  '',
+  'packages:', '  - .', '', 'minimumReleaseAgeExclude:',
+  "  - '@deepseek-ai/cosmokit@1.8.2'", '  - dsh-vision-router@1.2.0', '  - unrelated-pkg@0.0.1', '',
 ].join('\n')
 
 test('inspectProfileWorkspace flags version-pinned exemptions without mutating', () => {
@@ -125,38 +125,16 @@ test('inspectProfileWorkspace fix rewrites pinned entries to bare names and keep
   const result = inspectProfileWorkspace(workspacePath, { fix: true })
   assert.equal(result.rewritten, true)
   assert.equal(readFileSync(workspacePath, 'utf8'), [
-    'packages:',
-    '  - .',
-    '',
-    'minimumReleaseAgeExclude:',
-    "  - '@deepseek-ai/*'",
-    '  - dsh-vision-router',
-    '  - unrelated-pkg@0.0.1',
-    '',
+    'packages:', '  - .', '', 'minimumReleaseAgeExclude:', "  - '@deepseek-ai/*'", '  - dsh-vision-router', '  - unrelated-pkg@0.0.1', '',
   ].join('\n'))
 })
 
 test('inspectProfileWorkspace drops a pinned entry that duplicates an existing bare name', () => {
-  const workspace = [
-    'packages:',
-    '  - .',
-    '',
-    'minimumReleaseAgeExclude:',
-    '  - dsh-vision-router',
-    '  - dsh-vision-router@1.2.0',
-    '',
-  ].join('\n')
+  const workspace = ['packages:', '  - .', '', 'minimumReleaseAgeExclude:', '  - dsh-vision-router', '  - dsh-vision-router@1.2.0', ''].join('\n')
   const { workspacePath } = fixture(validManifest, { workspace })
   const result = inspectProfileWorkspace(workspacePath, { fix: true })
   assert.equal(result.rewritten, true)
-  assert.equal(readFileSync(workspacePath, 'utf8'), [
-    'packages:',
-    '  - .',
-    '',
-    'minimumReleaseAgeExclude:',
-    '  - dsh-vision-router',
-    '',
-  ].join('\n'))
+  assert.equal(readFileSync(workspacePath, 'utf8'), ['packages:', '  - .', '', 'minimumReleaseAgeExclude:', '  - dsh-vision-router', ''].join('\n'))
 })
 
 test('doctorProfiles treats a version-pinned exemption as unhealthy until repaired', () => {
@@ -164,26 +142,14 @@ test('doctorProfiles treats a version-pinned exemption as unhealthy until repair
   const before = doctorProfiles({ dshHome: home, profile: 'web' })
   assert.equal(before.ok, false)
   assert.deepEqual(before.profiles[0].workspace.pinned, ['@deepseek-ai/cosmokit@1.8.2', 'dsh-vision-router@1.2.0'])
-
   const after = doctorProfiles({ dshHome: home, profile: 'web', fix: true })
   assert.equal(after.ok, true)
   assert.equal(after.profiles[0].workspace.rewritten, true)
 })
 
 test('doctorProfiles stays healthy with bare names or no workspace file', () => {
-  const bare = fixture(validManifest, {
-    workspace: [
-      'packages:',
-      '  - .',
-      '',
-      'minimumReleaseAgeExclude:',
-      "  - '@deepseek-ai/*'",
-      '  - dsh-vision-router',
-      '',
-    ].join('\n'),
-  })
+  const bare = fixture(validManifest, { workspace: ['packages:', '  - .', '', 'minimumReleaseAgeExclude:', "  - '@deepseek-ai/*'", '  - dsh-vision-router', ''].join('\n') })
   assert.equal(doctorProfiles({ dshHome: bare.home, profile: 'web' }).ok, true)
-
   const none = fixture(validManifest)
   assert.equal(doctorProfiles({ dshHome: none.home, profile: 'web' }).ok, true)
   assert.equal(doctorProfiles({ dshHome: none.home, profile: 'web' }).profiles[0].workspace.exists, false)

--- a/tests/profile-pnpm-diagnostics.test.js
+++ b/tests/profile-pnpm-diagnostics.test.js
@@ -11,22 +11,13 @@ import {
 } from '../lib/profile-pnpm-diagnostics.js'
 import { runDshPluginUpdate } from '../lib/self-update.js'
 
-function profileFixture({
-  dependencies = {},
-  installed = {},
-} = {}) {
+function profileFixture({ dependencies = {}, installed = {} } = {}) {
   const profileDir = mkdtempSync(path.join(tmpdir(), 'vision-profile-diag-'))
-  writeFileSync(
-    path.join(profileDir, 'package.json'),
-    JSON.stringify({ dependencies }, null, 2),
-  )
+  writeFileSync(path.join(profileDir, 'package.json'), JSON.stringify({ dependencies }, null, 2))
   for (const [name, version] of Object.entries(installed)) {
     const dir = path.join(profileDir, 'node_modules', name)
     mkdirSync(dir, { recursive: true })
-    writeFileSync(
-      path.join(dir, 'package.json'),
-      JSON.stringify({ name, version }),
-    )
+    writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ name, version }))
   }
   return profileDir
 }
@@ -35,59 +26,46 @@ function dshHomeFixture({ dependencies = {}, installed = {} } = {}) {
   const dshHome = mkdtempSync(path.join(tmpdir(), 'vision-profile-home-'))
   const profileDir = path.join(dshHome, 'profiles', 'web')
   mkdirSync(profileDir, { recursive: true })
-  writeFileSync(
-    path.join(profileDir, 'package.json'),
-    JSON.stringify({ dependencies }, null, 2),
-  )
+  const hasVisionRouter = typeof dependencies['dsh-vision-router'] === 'string'
+  writeFileSync(path.join(profileDir, 'package.json'), JSON.stringify({
+    dependencies,
+    ...(hasVisionRouter ? { dsh: { profile: { bundles: ['dsh-vision-router'] } } } : {}),
+  }, null, 2))
   for (const [name, version] of Object.entries(installed)) {
     const dir = path.join(profileDir, 'node_modules', name)
     mkdirSync(dir, { recursive: true })
-    writeFileSync(
-      path.join(dir, 'package.json'),
-      JSON.stringify({ name, version }),
-    )
+    writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ name, version }))
+  }
+  if (hasVisionRouter) {
+    const declared = dependencies['dsh-vision-router']
+    const version = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(declared) ? declared : '1.7.4'
+    const pluginDir = path.join(profileDir, 'node_modules', 'dsh-vision-router')
+    mkdirSync(pluginDir, { recursive: true })
+    writeFileSync(path.join(pluginDir, 'package.json'), JSON.stringify({
+      name: 'dsh-vision-router', version, main: 'entry.js', dsh: { bundle: { patch: './cordis.patch.yml' } },
+    }))
+    writeFileSync(path.join(pluginDir, 'entry.js'), 'export default {}\n')
+    writeFileSync(path.join(pluginDir, 'cordis.patch.yml'), '- insert: []\n')
   }
   return { dshHome, profileDir }
 }
 
 test('doctor advisory detects coexisting vision plugins without calling them conflicts', () => {
   const profileDir = profileFixture({
-    dependencies: {
-      'dsh-vision-router': '1.5.3',
-      'dsh-vision-proxy': '^0.2.5',
-      'dsh-vision-sidecar': '0.1.0',
-      unrelated: '1.0.0',
-    },
-    installed: {
-      'dsh-vision-proxy': '0.2.5',
-    },
+    dependencies: { 'dsh-vision-router': '1.5.3', 'dsh-vision-proxy': '^0.2.5', 'dsh-vision-sidecar': '0.1.0', unrelated: '1.0.0' },
+    installed: { 'dsh-vision-proxy': '0.2.5' },
   })
-
   assert.deepEqual(inspectCoexistingVisionPlugins(profileDir), [
-    {
-      name: 'dsh-vision-proxy',
-      spec: '^0.2.5',
-      installedVersion: '0.2.5',
-    },
-    {
-      name: 'dsh-vision-sidecar',
-      spec: '0.1.0',
-      installedVersion: undefined,
-    },
+    { name: 'dsh-vision-proxy', spec: '^0.2.5', installedVersion: '0.2.5' },
+    { name: 'dsh-vision-sidecar', spec: '0.1.0', installedVersion: undefined },
   ])
 })
 
 test('doctorProfiles exposes the advisory without marking an otherwise healthy profile unhealthy', () => {
   const { dshHome } = dshHomeFixture({
-    dependencies: {
-      'dsh-vision-router': '1.5.3',
-      'dsh-vision-proxy': '0.2.5',
-    },
-    installed: {
-      'dsh-vision-proxy': '0.2.5',
-    },
+    dependencies: { 'dsh-vision-router': '1.5.3', 'dsh-vision-proxy': '0.2.5' },
+    installed: { 'dsh-vision-proxy': '0.2.5' },
   })
-
   const report = doctorProfiles({ dshHome, profile: 'web' })
   assert.equal(report.ok, true)
   assert.equal(report.profiles[0].coexistingVisionPlugins.length, 1)
@@ -96,13 +74,8 @@ test('doctorProfiles exposes the advisory without marking an otherwise healthy p
 
 test('classifies ignored build from an existing plugin as a profile-level blocker', () => {
   const profileDir = profileFixture({
-    dependencies: {
-      'dsh-vision-router': '1.5.3',
-      'dsh-vision-proxy': '0.2.5',
-    },
-    installed: {
-      'dsh-vision-proxy': '0.2.5',
-    },
+    dependencies: { 'dsh-vision-router': '1.5.3', 'dsh-vision-proxy': '0.2.5' },
+    installed: { 'dsh-vision-proxy': '0.2.5' },
   })
   const error = new Error('dsh: pnpm failed in profile directory C:\\Users\\admin\\.dsh\\profiles\\web')
   error.stderr = [
@@ -111,12 +84,7 @@ test('classifies ignored build from an existing plugin as a profile-level blocke
     'GET https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz',
     'UND_ERR_DESTROYED',
   ].join('\n')
-
-  const result = classifyProfilePnpmFailure(error, {
-    profileDir,
-    profile: 'web',
-  })
-
+  const result = classifyProfilePnpmFailure(error, { profileDir, profile: 'web' })
   assert.equal(result.kind, 'existing-profile-dependency')
   assert.equal(result.blockers.length, 1)
   assert.equal(result.blockers[0].name, 'dsh-vision-proxy')
@@ -131,29 +99,16 @@ test('classifies ignored build from an existing plugin as a profile-level blocke
 })
 
 test('does not blame another package when the ignored build is Vision Router itself', () => {
-  const profileDir = profileFixture({
-    dependencies: {
-      'dsh-vision-router': '1.5.3',
-    },
-  })
+  const profileDir = profileFixture({ dependencies: { 'dsh-vision-router': '1.5.3' } })
   const error = new Error('exit 1')
   error.stderr = 'ERR_PNPM_IGNORED_BUILDS Ignored build scripts: dsh-vision-router@1.5.3'
-
   assert.equal(classifyProfilePnpmFailure(error, { profileDir }), undefined)
 })
 
 test('does not frame Vision Router own transitive dependency sharp as a removable blocker', () => {
-  const profileDir = profileFixture({
-    dependencies: {
-      'dsh-vision-router': '1.5.3',
-    },
-  })
+  const profileDir = profileFixture({ dependencies: { 'dsh-vision-router': '1.5.3' } })
   const error = new Error('exit 1')
-  error.stderr = [
-    'ERR_PNPM_IGNORED_BUILDS Ignored build scripts: sharp@0.33.5',
-    'Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.',
-  ].join('\n')
-
+  error.stderr = ['ERR_PNPM_IGNORED_BUILDS Ignored build scripts: sharp@0.33.5', 'Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.'].join('\n')
   const result = classifyProfilePnpmFailure(error, { profileDir, profile: 'web' })
   assert.equal(result.kind, 'ignored-build-policy')
   assert.equal(result.blockers.length, 0)
@@ -164,16 +119,9 @@ test('does not frame Vision Router own transitive dependency sharp as a removabl
 })
 
 test('attributes bare-name ignored build entries for declared plugins', () => {
-  const profileDir = profileFixture({
-    dependencies: {
-      'dsh-vision-router': '1.5.3',
-      esbuild: '0.25.0',
-    },
-  })
+  const profileDir = profileFixture({ dependencies: { 'dsh-vision-router': '1.5.3', esbuild: '0.25.0' } })
   const error = new Error('exit 1')
-  error.stderr =
-    'Ignored build scripts: esbuild, core-js. Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.'
-
+  error.stderr = 'Ignored build scripts: esbuild, core-js. Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.'
   const result = classifyProfilePnpmFailure(error, { profileDir, profile: 'web' })
   assert.equal(result.kind, 'existing-profile-dependency')
   assert.equal(result.blockers.length, 1)
@@ -182,81 +130,44 @@ test('attributes bare-name ignored build entries for declared plugins', () => {
 })
 
 test('attributes a scoped dependency named in an ignored build list', () => {
-  const profileDir = profileFixture({
-    dependencies: {
-      'dsh-vision-router': '1.5.3',
-      '@scope/tool': '2.1.0',
-    },
-  })
+  const profileDir = profileFixture({ dependencies: { 'dsh-vision-router': '1.5.3', '@scope/tool': '2.1.0' } })
   const error = new Error('exit 1')
   error.stderr = 'Ignored build scripts: @scope/tool@2.1.0'
-
   const result = classifyProfilePnpmFailure(error, { profileDir, profile: 'web' })
   assert.equal(result.kind, 'existing-profile-dependency')
   assert.equal(result.blockers[0].name, '@scope/tool')
 })
 
 test('does not blame a dependency for a same-line substring match', () => {
-  const profileDir = profileFixture({
-    dependencies: {
-      'dsh-vision-router': '1.5.3',
-      'dsh-vision-proxy': '0.2.5',
-    },
-  })
+  const profileDir = profileFixture({ dependencies: { 'dsh-vision-router': '1.5.3', 'dsh-vision-proxy': '0.2.5' } })
   const error = new Error('exit 1')
   error.stderr = 'dsh-vision-proxy-core postinstall failed with exit code 1'
-
   assert.equal(classifyProfilePnpmFailure(error, { profileDir, profile: 'web' }), undefined)
 })
 
 test('does not blame a dependency named inside a registry URL on the same line', () => {
-  const profileDir = profileFixture({
-    dependencies: {
-      'dsh-vision-router': '1.5.3',
-      foo: '1.0.0',
-    },
-  })
+  const profileDir = profileFixture({ dependencies: { 'dsh-vision-router': '1.5.3', foo: '1.0.0' } })
   const error = new Error('exit 1')
   error.stderr = 'GET https://registry.npmjs.org/foo/-/foo-1.0.0.tgz ERR_PNPM_FETCH_500 registry unavailable'
-
   assert.equal(classifyProfilePnpmFailure(error, { profileDir, profile: 'web' }), undefined)
 })
 
 test('does not treat dsh-vision-routers or dsh-vision-router2 as coexisting vision plugins', () => {
-  const profileDir = profileFixture({
-    dependencies: {
-      'dsh-vision-router': '1.5.3',
-      'dsh-vision-routers': '9.9.9',
-      'dsh-vision-router2': '9.9.9',
-    },
-  })
-
+  const profileDir = profileFixture({ dependencies: { 'dsh-vision-router': '1.5.3', 'dsh-vision-routers': '9.9.9', 'dsh-vision-router2': '9.9.9' } })
   assert.deepEqual(inspectCoexistingVisionPlugins(profileDir), [])
 })
 
 test('does not blame an existing dependency merely because pnpm progress output names it', () => {
-  const profileDir = profileFixture({
-    dependencies: {
-      'dsh-vision-router': '1.5.3',
-      'some-existing-plugin': '2.0.0',
-    },
-  })
+  const profileDir = profileFixture({ dependencies: { 'dsh-vision-router': '1.5.3', 'some-existing-plugin': '2.0.0' } })
   const error = new Error('network request failed')
   error.stderr = 'Progress: resolved some-existing-plugin@2.0.0\nERR_PNPM_FETCH_500 registry unavailable'
-
   assert.equal(classifyProfilePnpmFailure(error, { profileDir, profile: 'web' }), undefined)
 })
 
 test('can attribute another declared profile dependency when its own failure line is explicit', () => {
-  const profileDir = profileFixture({
-    dependencies: {
-      'dsh-vision-router': '1.5.3',
-      'some-existing-plugin': '2.0.0',
-    },
-  })
+  const profileDir = profileFixture({ dependencies: { 'dsh-vision-router': '1.5.3', 'some-existing-plugin': '2.0.0' } })
   const error = new Error('pnpm failed')
   error.stderr = 'some-existing-plugin postinstall failed with exit code 1'
-
   const result = classifyProfilePnpmFailure(error, { profileDir, profile: 'web' })
   assert.equal(result.kind, 'existing-profile-dependency')
   assert.equal(result.blockers[0].name, 'some-existing-plugin')
@@ -265,24 +176,12 @@ test('can attribute another declared profile dependency when its own failure lin
 
 test('self updater surfaces the existing profile blocker instead of a generic Vision Router failure', async () => {
   const { dshHome } = dshHomeFixture({
-    dependencies: {
-      'dsh-vision-router': '1.5.3',
-      'dsh-vision-proxy': '0.2.5',
-    },
-    installed: {
-      'dsh-vision-proxy': '0.2.5',
-    },
+    dependencies: { 'dsh-vision-router': '1.5.3', 'dsh-vision-proxy': '0.2.5' },
+    installed: { 'dsh-vision-proxy': '0.2.5' },
   })
-
   await assert.rejects(
     () => runDshPluginUpdate(
-      {
-        available: true,
-        method: 'current-dsh-cli',
-        execPath: 'node',
-        cliEntry: '/tmp/dsh.mjs',
-        profile: 'web',
-      },
+      { available: true, method: 'current-dsh-cli', execPath: 'node', cliEntry: '/tmp/dsh.mjs', profile: 'web' },
       {
         dshHome,
         execFileImpl: async () => {

--- a/tests/session-repair-v2.test.js
+++ b/tests/session-repair-v2.test.js
@@ -1,0 +1,200 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { constants as zlibConstants, zstdCompressSync, zstdDecompressSync } from 'node:zlib'
+import {
+  inspectLegacySessionArtifact,
+  isStructuredGuardStopEvent,
+  repairLegacySessionLogs,
+  scanZstdFrameRanges,
+} from '../lib/legacy-session-repair.js'
+
+const ZSTD_OPTIONS = { params: { [zlibConstants.ZSTD_c_checksumFlag]: 1 } }
+const BUDGET_TEXT = '本轮视觉总时间预算已耗尽。不要再调用视觉工具；请基于已经获得的证据作答，并明确仍存在的不确定性。'
+
+function header(id = 'session-a') {
+  return { type: 'session', version: 0, id, createdAt: 1, delegationDepth: 0 }
+}
+function turnStart(seq = 0) { return { type: 'turn/start', seq, time: 1, data: { turn: 1 } } }
+function guard(seq, id = 'vision-router-structured-guard-stop-1', text = BUDGET_TEXT) {
+  return {
+    type: 'user/message', seq, time: seq + 1,
+    data: {
+      role: 'user', id,
+      content: [{ type: 'text', text }],
+      source: { kind: 'plugin', plugin: 'dsh-vision-router' },
+    },
+    surfaceOp: 'append',
+  }
+}
+function turnEnd(seq) { return { type: 'turn/end', seq, time: seq + 1, data: { turn: 1, reason: { kind: 'completed' } } } }
+function oldReminder(seq = 1) {
+  return {
+    type: 'user/message', seq, time: seq + 1,
+    data: {
+      role: 'user',
+      content: [{ type: 'text', text: '视觉深看工具已挂载：vision_describe。现在可以直接调用已启用的工具。' }],
+      source: { kind: 'plugin', plugin: 'dsh-vision-router' },
+    },
+    surfaceOp: 'append',
+  }
+}
+function fixture(filename = 'session.jsonl') {
+  const home = mkdtempSync(path.join(tmpdir(), 'vr-session-'))
+  const dir = path.join(home, 'sessions', '--project--', 'session-a')
+  mkdirSync(dir, { recursive: true })
+  return { home, file: path.join(dir, filename) }
+}
+function raw(events, customHeader = header()) { return [JSON.stringify(customHeader), ...events.map(JSON.stringify), ''].join('\n') }
+function decodeAllEvents(buffer) {
+  const scan = scanZstdFrameRanges(buffer)
+  return scan.frames.slice(1)
+    .map((range) => zstdDecompressSync(buffer.subarray(range.start, range.end)).toString('utf8'))
+    .join('')
+    .trimEnd().split('\n').filter(Boolean).map(JSON.parse)
+}
+
+test('structured guard matcher is deliberately exact', () => {
+  assert.equal(isStructuredGuardStopEvent(guard(1)), true)
+  assert.equal(isStructuredGuardStopEvent({ ...guard(1), data: { ...guard(1).data, source: { kind: 'plugin', plugin: 'other' } } }), false)
+  assert.equal(isStructuredGuardStopEvent(guard(1, 'vision-router-structured-guard-stop-1', 'different text')), false)
+})
+
+test('raw repair preserves seq and gives later exact guard-stop duplicates deterministic unique ids', () => {
+  const { home, file } = fixture()
+  const original = raw([turnStart(), guard(1), guard(2), guard(3), turnEnd(4)])
+  writeFileSync(file, original)
+
+  const check = repairLegacySessionLogs({ dshHome: home, fix: false })
+  assert.equal(check.affected, 2)
+  const repaired = repairLegacySessionLogs({ dshHome: home, fix: true })
+  assert.equal(repaired.ok, true)
+  assert.equal(repaired.repaired, 1)
+  assert.equal(existsSync(repaired.reports[0].backupPath), true)
+  assert.equal(readFileSync(repaired.reports[0].backupPath, 'utf8'), original)
+
+  const rows = readFileSync(file, 'utf8').trimEnd().split('\n').map(JSON.parse)
+  const events = rows.slice(1)
+  assert.deepEqual(events.map((row) => row.seq), [0, 1, 2, 3, 4])
+  assert.equal(events[1].data.id, 'vision-router-structured-guard-stop-1')
+  assert.equal(events[2].data.id, 'vision-router-recovered-structured-guard:session-a:2')
+  assert.equal(events[3].data.id, 'vision-router-recovered-structured-guard:session-a:3')
+
+  const second = repairLegacySessionLogs({ dshHome: home, fix: true })
+  assert.equal(second.affected, 0)
+  assert.equal(second.repaired, 0)
+})
+
+test('duplicate guard-stop detection works across separate Zstandard frames and preserves a DSH-valid contiguous seq stream', () => {
+  const { file } = fixture('session.jsonl.zstd')
+  const headerFrame = zstdCompressSync(`${JSON.stringify(header())}\n`, ZSTD_OPTIONS)
+  const firstFrame = zstdCompressSync(`${JSON.stringify(turnStart())}\n${JSON.stringify(guard(1))}\n`, ZSTD_OPTIONS)
+  const secondFrame = zstdCompressSync(`${JSON.stringify(guard(2))}\n${JSON.stringify(turnEnd(3))}\n`, ZSTD_OPTIONS)
+  const original = Buffer.concat([headerFrame, firstFrame, secondFrame])
+  writeFileSync(file, original)
+
+  const report = inspectLegacySessionArtifact(file, { fix: true })
+  assert.deepEqual(report.affectedSeqs, [2])
+  const repaired = readFileSync(file)
+  const scan = scanZstdFrameRanges(repaired)
+  assert.deepEqual(repaired.subarray(scan.frames[0].start, scan.frames[0].end), headerFrame)
+  assert.deepEqual(repaired.subarray(scan.frames[1].start, scan.frames[1].end), firstFrame)
+  const events = decodeAllEvents(repaired)
+  assert.deepEqual(events.map((row) => row.seq), [0, 1, 2, 3])
+  assert.equal(events[2].data.id, 'vision-router-recovered-structured-guard:session-a:2')
+})
+
+test('one legitimate guard-stop message is not modified', () => {
+  const { file } = fixture()
+  const original = raw([turnStart(), guard(1), turnEnd(2)])
+  writeFileSync(file, original)
+  const report = inspectLegacySessionArtifact(file, { fix: true })
+  assert.equal(report.repaired, false)
+  assert.deepEqual(report.affectedSeqs, [])
+  assert.equal(readFileSync(file, 'utf8'), original)
+})
+
+test('duplicate guard id with a near-miss event fails closed instead of deleting data', () => {
+  const { file } = fixture()
+  const nearMiss = guard(2)
+  nearMiss.data.content[0].text = 'user content that happens to reuse the old id'
+  const original = raw([turnStart(), guard(1), nearMiss])
+  writeFileSync(file, original)
+  assert.throws(() => inspectLegacySessionArtifact(file, { fix: true }), /refusing automatic repair/)
+  assert.equal(readFileSync(file, 'utf8'), original)
+})
+
+test('legacy missing-id repair still works alongside the new repair registry', () => {
+  const { home, file } = fixture()
+  writeFileSync(file, raw([turnStart(), oldReminder(1), turnEnd(2)]))
+  const report = repairLegacySessionLogs({ dshHome: home, fix: true })
+  assert.equal(report.repaired, 1)
+  const rows = readFileSync(file, 'utf8').trimEnd().split('\n').map(JSON.parse)
+  assert.equal(rows[2].data.id, 'vision-router-recovered-auto-mount:session-a:1')
+})
+
+test('repair refuses unknown future session format versions', () => {
+  const { file } = fixture()
+  writeFileSync(file, raw([turnStart()], { ...header(), version: 1 }))
+  assert.throws(() => inspectLegacySessionArtifact(file, { fix: true }), /unsupported session format version/)
+})
+
+test('recovered guard id collision fails closed without changing the source', () => {
+  const { file } = fixture()
+  const collision = {
+    type: 'user/message', seq: 2, time: 3,
+    data: { role: 'user', id: 'vision-router-recovered-structured-guard:session-a:3', content: [], source: { kind: 'plugin', plugin: 'other' } },
+  }
+  const original = raw([turnStart(), guard(1), collision, guard(3)])
+  writeFileSync(file, original)
+  assert.throws(() => inspectLegacySessionArtifact(file, { fix: true }), /collides with an existing message/)
+  assert.equal(readFileSync(file, 'utf8'), original)
+})
+
+test('repair refuses an already seq-gapped session instead of papering over unrelated corruption', () => {
+  const { file } = fixture()
+  writeFileSync(file, raw([turnStart(), guard(2)]))
+  assert.throws(() => inspectLegacySessionArtifact(file, { fix: true }), /seq is not contiguous/)
+})
+
+test('repair understands packed chunk storage rows when validating contiguous seq', () => {
+  const { file } = fixture()
+  const packed = {
+    type: 'text-chunks', seq0: 1, time0: 2,
+    data: { turn: 1, step: 0, index: 0, dt: [1, 1], texts: ['a', 'b', 'c'] },
+  }
+  writeFileSync(file, raw([turnStart(), packed, guard(4), guard(5), turnEnd(6)]))
+  const report = inspectLegacySessionArtifact(file, { fix: true })
+  assert.deepEqual(report.affectedSeqs, [5])
+})
+
+test('legacy auto-mount recovery id collisions fail closed', () => {
+  const { file } = fixture()
+  const collision = {
+    type: 'user/message', seq: 1, time: 2,
+    data: { role: 'user', id: 'vision-router-recovered-auto-mount:session-a:2', content: [], source: { kind: 'plugin', plugin: 'other' } },
+  }
+  const original = raw([turnStart(), collision, oldReminder(2)])
+  writeFileSync(file, original)
+  assert.throws(() => inspectLegacySessionArtifact(file, { fix: true }), /collides with an existing message/)
+  assert.equal(readFileSync(file, 'utf8'), original)
+})
+
+test('repair refuses malformed current-version session headers before touching events', () => {
+  const { file } = fixture()
+  const malformed = { type: 'session', version: 0, id: 'session-a', createdAt: -1, delegationDepth: 0 }
+  writeFileSync(file, raw([turnStart()], malformed))
+  assert.throws(() => inspectLegacySessionArtifact(file, { fix: true }), /createdAt is invalid/)
+})
+
+test('read-only session scan treats an incomplete live tail as advisory', () => {
+  const { home, file } = fixture()
+  writeFileSync(file, raw([turnStart(), guard(1)]).slice(0, -1))
+  const report = repairLegacySessionLogs({ dshHome: home, fix: false })
+  assert.equal(report.ok, true)
+  assert.equal(report.errors.length, 0)
+  assert.equal(report.advisories.length, 1)
+  assert.equal(report.advisories[0].kind, 'incomplete-live-tail')
+})


### PR DESCRIPTION
## Summary
- validate real Vision Router installation/activation instead of treating a declared dependency as healthy
- add side-effect-free runtime route probing with fail-closed profile attribution
- separate current-run settings-save failures from historical log noise
- add schema-versioned, minimized JSON support reports
- harden legacy session repair so known corruptions are repaired without breaking DSH event sequence continuity
- update existing fixtures and add focused Doctor v2 regression coverage

## Validation
- 40/40 focused Doctor v2 tests passed locally
- all candidate blobs were verified byte-for-byte before the commit
- full repository CI passed on Node 22 and Node 24
- DSH 0.1.0-rc.6 / rc.7 / rc.8 contract checks passed
- Ubuntu, macOS, and Windows host-sharp/runtime checks passed
- Native multimodal cold-resume matrix passed on rc.7 / rc.8 × Node 22 / 24
- Large-image resource stress passed, including the 100MP 1/2/4-caller RSS stress case

This supersedes the test-only validation approach used in #268; this PR contains only the real source, tests, and documentation changes.