### PR TITLE
release: v1.7.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-vision-router",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "description": "Eyes for text-only DeepSeek Harness agents: built-in free vision chain (no key) + pixel-level vision tools (Q&A, grounding, crop, pixel diff, colors, OCR, SVG trace, cutout, screenshots). One-command install, no Python, image turns work like ordinary tool-calling turns.",
   "license": "MIT",
   "repository": {

--- a/tests/bundle-defaults.test.js
+++ b/tests/bundle-defaults.test.js
@@ -46,7 +46,7 @@ test('entry contract exposes the custom depth tier to every settings entry point
   assert.equal(custom.visionDepthMaxCalls, 7)
 })
 
-test('release line stays on package identity 1.7.4', async () => {
+test('release line stays on package identity 1.7.5', async () => {
   const pkg = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8'))
-  assert.equal(pkg.version, '1.7.4')
+  assert.equal(pkg.version, '1.7.5')
 })

--- a/tests/doctor-cli-v2.test.js
+++ b/tests/doctor-cli-v2.test.js
@@ -1,9 +1,11 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { run } from '../lib/doctor-cli.js'
+
+const packageVersion = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')).version
 
 function fixture({ good = true } = {}) {
   const home = mkdtempSync(path.join(tmpdir(), 'vr-cli-'))
@@ -55,7 +57,7 @@ test('doctor JSON report is parseable and healthy for a good bundle install', as
   assert.equal(code, 0)
   const report = JSON.parse(cap.stdout.join('\n'))
   assert.equal(report.ok, true)
-  assert.equal(report.doctorVersion, '1.7.4')
+  assert.equal(report.doctorVersion, packageVersion)
   assert.equal(report.profiles[0].installedVersion, '1.7.4')
   assert.equal(report.profiles[0].installation.mode, 'bundle')
 })

--- a/tests/doctor-runtime.test.js
+++ b/tests/doctor-runtime.test.js
@@ -1,6 +1,9 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
 import { probeRuntime, supportReport } from '../lib/doctor-runtime.js'
+
+const packageVersion = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')).version
 
 function response(status, headers = {}) {
   const normalized = Object.fromEntries(Object.entries(headers).map(([k, v]) => [k.toLowerCase(), v]))
@@ -103,7 +106,7 @@ test('support report is schema-versioned, identifies doctor version, and omits r
   })
   const json = JSON.stringify(report)
   assert.equal(report.schemaVersion, 1)
-  assert.equal(report.doctorVersion, '1.7.4')
+  assert.equal(report.doctorVersion, packageVersion)
   assert.equal(json.includes('file:/Users/alice'), false)
   assert.equal(json.includes('/Users/alice/private'), false)
   assert.equal(json.includes('secret@'), false)


### PR DESCRIPTION
Prepare the v1.7.5 hotfix release identity after the settings-scroll regression fix in #271.

- bump package version to 1.7.5;
- advance the release identity regression to 1.7.5;
- keep the release workflow and supply-chain gates unchanged.

The release workflow will publish from the immutable v1.7.5 tag after this PR is merged.