### PR TITLE
release: v1.7.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-vision-router",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "description": "Eyes for text-only DeepSeek Harness agents: built-in free vision chain (no key) + pixel-level vision tools (Q&A, grounding, crop, pixel diff, colors, OCR, SVG trace, cutout, screenshots). One-command install, no Python, image turns work like ordinary tool-calling turns.",
   "license": "MIT",
   "repository": {

--- a/tests/bundle-defaults.test.js
+++ b/tests/bundle-defaults.test.js
@@ -46,7 +46,7 @@ test('entry contract exposes the custom depth tier to every settings entry point
   assert.equal(custom.visionDepthMaxCalls, 7)
 })
 
-test('release line stays on package identity 1.7.5', async () => {
+test('release line stays on package identity 1.7.6', async () => {
   const pkg = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8'))
-  assert.equal(pkg.version, '1.7.5')
+  assert.equal(pkg.version, '1.7.6')
 })


### PR DESCRIPTION
## Summary

Prepare the v1.7.6 hotfix release after #274 fixed the DSH 0.1.1 `prepareCall()` adapter-contract crash affecting Vision Router-owned wrapper/twin routes.

## Changes

- bump package identity from 1.7.5 to 1.7.6;
- advance the release identity regression to 1.7.6;
- keep the release payload otherwise unchanged so this remains a focused compatibility hotfix.

## Release note

v1.7.6 fixes `registration.adapter.prepareCall is not a function` on DSH 0.1.1 when using Vision Router wrapped/Auto Vision models. The underlying #274 compatibility fix already passed the full CI, native multimodal cold-resume, large-image stress, Node 22/24, and cross-platform host-sharp gates before merge.

Tagging remains manual after this release PR passes CI and lands on `main`.