### PR TITLE
chore: release v1.7.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-vision-router",
-  "version": "1.7.6",
+  "version": "1.7.7",
   "description": "Eyes for text-only DeepSeek Harness agents: built-in free vision chain (no key) + pixel-level vision tools (Q&A, grounding, crop, pixel diff, colors, OCR, SVG trace, cutout, screenshots). One-command install, no Python, image turns work like ordinary tool-calling turns.",
   "license": "MIT",
   "repository": {

--- a/tests/bundle-defaults.test.js
+++ b/tests/bundle-defaults.test.js
@@ -46,7 +46,7 @@ test('entry contract exposes the custom depth tier to every settings entry point
   assert.equal(custom.visionDepthMaxCalls, 7)
 })
 
-test('release line stays on package identity 1.7.6', async () => {
+test('release line stays on package identity 1.7.7', async () => {
   const pkg = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8'))
-  assert.equal(pkg.version, '1.7.6')
+  assert.equal(pkg.version, '1.7.7')
 })


### PR DESCRIPTION
## Release

- bump package identity from `1.7.6` to `1.7.7`
- update the release identity regression gate
- no runtime code changes in this PR

This patch release ships the already-merged fixes for #276, #279 and #280. The tag-based immutable Release workflow will re-run the full suite before npm Trusted Publishing and GitHub Release creation.