### PR TITLE
fix: eliminate CodeQL regex backtracking risks

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,6 +80,8 @@ import {
   readResponseTextBounded,
 } from './lib/http-body-limit.js'
 import { writeArtifactFile } from './lib/artifact-boundary.js'
+import { stripTrailingSlashes } from './lib/string-normalization.js'
+import { parseVersionComparator } from './lib/version-range.js'
 
 // sharp is a native module with platform-specific prebuilt binaries. It used
 // to be imported statically, so a missing, broken, or conflicting install
@@ -151,10 +153,10 @@ export function versionSatisfies(version, range) {
     const clauses = alternative.split(/\s+/)
     if (clauses.length === 0) return false
     return clauses.every((clause) => {
-      const match = clause.match(/^(>=|<=|>|<|=)?\s*(.+)$/)
-      if (!match) return false
-      const op = match[1] ?? '='
-      const other = parseVersionParts(match[2])
+      const comparator = parseVersionComparator(clause)
+      if (comparator === undefined) return false
+      const { op } = comparator
+      const other = parseVersionParts(comparator.version)
       if (other === undefined) return false
       const cmp = compareVersionParts(parts, other)
       switch (op) {
@@ -2113,7 +2115,10 @@ export async function callLocalBackend(provider, messages, options = {}) {
     if (wire.length > 0 && wire[0].role !== 'user') {
       wire.unshift({ role: 'user', content: [{ type: 'text', text: '(conversation history)' }] })
     }
-    const baseURL = String(provider.baseURL).replace(/\/+$/, '').replace(/\/v1$/, '')
+    const normalizedBaseURL = stripTrailingSlashes(String(provider.baseURL))
+    const baseURL = normalizedBaseURL.endsWith('/v1')
+      ? normalizedBaseURL.slice(0, -3)
+      : normalizedBaseURL
     return callAnthropicCompatible(
       { ...provider, baseURL },
       wire,

--- a/lib/catalog-corrections.js
+++ b/lib/catalog-corrections.js
@@ -14,6 +14,7 @@ import {
   readResponseJsonBounded,
   readResponseTextBounded,
 } from './http-body-limit.js'
+import { stripTrailingSlashes } from './string-normalization.js'
 
 export const CATALOG_ROUTING_CORRECTIONS = [
   {
@@ -250,7 +251,7 @@ export async function callAnthropicCompatible(provider, messages, options = {}) 
     ...(typeof options.top_p === 'number' ? { top_p: options.top_p } : {}),
   }
   const system = options.system && String(options.system).trim() !== '' ? options.system : undefined
-  const url = `${String(provider.baseURL).replace(/\/+$/, '')}/v1/messages`
+  const url = `${stripTrailingSlashes(provider.baseURL)}/v1/messages`
   let response
   try {
     response = await fetch(url, {

--- a/lib/live-model-discovery.js
+++ b/lib/live-model-discovery.js
@@ -4,6 +4,7 @@ import path from 'node:path'
 import process from 'node:process'
 import { resolveDshHome } from './doctor.js'
 import { MODEL_RESPONSE_MAX_BYTES, readResponseJsonBounded } from './http-body-limit.js'
+import { stripTrailingSlashes } from './string-normalization.js'
 
 export const LIVE_MODELS_PATH = '/_dsh/vision-router/live-models'
 export const LIVE_MODEL_CACHE_VERSION = 1
@@ -31,7 +32,7 @@ function normalizeBaseURL(value) {
   if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return undefined
   parsed.hash = ''
   parsed.search = ''
-  return parsed.toString().replace(/\/+$/, '')
+  return stripTrailingSlashes(parsed.toString())
 }
 
 function boundedLabel(value, max = 512) {
@@ -83,7 +84,7 @@ function credentialFingerprint(value) {
 }
 
 function listingURL(baseURL) {
-  return `${baseURL.replace(/\/+$/, '')}/models`
+  return `${stripTrailingSlashes(baseURL)}/models`
 }
 
 function sendJson(res, status, body) {

--- a/lib/ollama-cold-start.js
+++ b/lib/ollama-cold-start.js
@@ -3,6 +3,7 @@ import {
   METADATA_RESPONSE_MAX_BYTES,
   readResponseJsonBounded,
 } from './http-body-limit.js'
+import { stripTrailingSlashes } from './string-normalization.js'
 
 export const OLLAMA_WARMUP_KEEP_ALIVE = '30m'
 export const OLLAMA_WARMUP_TIMEOUT_MS = 120000
@@ -36,7 +37,7 @@ export function ollamaNativeApiUrl(baseURL, endpoint) {
     return undefined
   }
   if (url.protocol !== 'http:' && url.protocol !== 'https:') return undefined
-  let prefix = url.pathname.replace(/\/+$/, '')
+  let prefix = stripTrailingSlashes(url.pathname)
   if (prefix.endsWith('/v1')) prefix = prefix.slice(0, -3)
   else if (prefix.endsWith('/api')) prefix = prefix.slice(0, -4)
   url.pathname = `${prefix}/api/${endpoint}`.replace(/\/{2,}/g, '/')

--- a/lib/runtime-reliability.js
+++ b/lib/runtime-reliability.js
@@ -1,4 +1,5 @@
 import { createHash } from 'node:crypto'
+import { stripTrailingSlashes } from './string-normalization.js'
 
 export const DEFAULT_DESCRIBE_CACHE_ENTRIES = 200
 export const DEFAULT_DESCRIBE_CACHE_TTL_MS = 3600 * 1000
@@ -89,7 +90,7 @@ export class LiveDescribeCache {
 }
 
 function normalizedEndpoint(value) {
-  return String(value ?? '').trim().replace(/\/+$/, '')
+  return stripTrailingSlashes(String(value ?? '').trim())
 }
 
 /**

--- a/lib/string-normalization.js
+++ b/lib/string-normalization.js
@@ -1,0 +1,13 @@
+/**
+ * Remove a trailing run of `/` without a backtracking regular expression.
+ *
+ * Several endpoint builders accept configured/library-provided base URLs.
+ * Scanning backward once keeps normalization O(n) even for hostile strings
+ * such as a very long slash run followed by a non-slash character.
+ */
+export function stripTrailingSlashes(value) {
+  const text = String(value ?? '')
+  let end = text.length
+  while (end > 0 && text.charCodeAt(end - 1) === 47) end -= 1
+  return end === text.length ? text : text.slice(0, end)
+}

--- a/lib/trusted-vision-hints.js
+++ b/lib/trusted-vision-hints.js
@@ -1,4 +1,5 @@
 import { configuredProviderTransports, providerTransportFor } from './live-model-discovery.js'
+import { stripTrailingSlashes } from './string-normalization.js'
 
 const BIGMODEL_API_BASE = 'https://open.bigmodel.cn/api/paas/v4'
 
@@ -16,7 +17,7 @@ function normalizeEndpoint(value) {
     if (url.protocol !== 'https:') return undefined
     url.hash = ''
     url.search = ''
-    return url.toString().replace(/\/+$/, '')
+    return stripTrailingSlashes(url.toString())
   } catch {
     return undefined
   }

--- a/lib/update-check.js
+++ b/lib/update-check.js
@@ -1,5 +1,6 @@
 import { createRequire } from 'node:module'
 import { METADATA_RESPONSE_MAX_BYTES, readResponseJsonBounded } from './http-body-limit.js'
+import { stripTrailingSlashes } from './string-normalization.js'
 
 const require = createRequire(import.meta.url)
 const packageJson = require('../package.json')
@@ -63,7 +64,7 @@ export function normalizeRegistryBase(value) {
     if (url.protocol !== 'https:' && url.protocol !== 'http:') return fallback
     url.search = ''
     url.hash = ''
-    url.pathname = url.pathname.replace(/\/+$/, '')
+    url.pathname = stripTrailingSlashes(url.pathname)
     return url.toString().replace(/\/$/, '')
   } catch {
     return fallback

--- a/lib/version-range.js
+++ b/lib/version-range.js
@@ -1,0 +1,13 @@
+export function parseVersionComparator(clause) {
+  const value = String(clause ?? '')
+  if (value === '') return undefined
+  if (value.startsWith('>=') || value.startsWith('<=')) {
+    const version = value.slice(2)
+    return version === '' ? undefined : { op: value.slice(0, 2), version }
+  }
+  if (value[0] === '>' || value[0] === '<' || value[0] === '=') {
+    const version = value.slice(1)
+    return version === '' ? undefined : { op: value[0], version }
+  }
+  return { op: '=', version: value }
+}

--- a/tests/catalog-corrections.test.js
+++ b/tests/catalog-corrections.test.js
@@ -70,6 +70,10 @@ test('anthropicMediaType normalizes jpg to jpeg and passes others through', () =
 })
 
 test('stripTrailingSlashes handles adversarial slash runs without backtracking semantics', () => {
+  assert.equal(stripTrailingSlashes(''), '')
+  assert.equal(stripTrailingSlashes('////'), '')
+  assert.equal(stripTrailingSlashes('https://example.test/v1／'), 'https://example.test/v1／')
+
   const trailing = `https://example.test${'/'.repeat(100_000)}`
   assert.equal(stripTrailingSlashes(trailing), 'https://example.test')
 

--- a/tests/catalog-corrections.test.js
+++ b/tests/catalog-corrections.test.js
@@ -7,6 +7,7 @@ import {
   toAnthropicMessages,
   callAnthropicCompatible,
 } from '../lib/catalog-corrections.js'
+import { stripTrailingSlashes } from '../lib/string-normalization.js'
 import { VISION_FAILURE_KINDS } from '../lib/vision-resilience.js'
 
 const brokenFacts = { api: 'openai-completions', baseUrl: 'https://opencode.ai/zen/go/v1' }
@@ -66,6 +67,14 @@ test('anthropicMediaType normalizes jpg to jpeg and passes others through', () =
   assert.equal(anthropicMediaType('image/jpg'), 'image/jpeg')
   assert.equal(anthropicMediaType('image/png'), 'image/png')
   assert.equal(anthropicMediaType(''), '')
+})
+
+test('stripTrailingSlashes handles adversarial slash runs without backtracking semantics', () => {
+  const trailing = `https://example.test${'/'.repeat(100_000)}`
+  assert.equal(stripTrailingSlashes(trailing), 'https://example.test')
+
+  const nonTrailing = `https://example.test/${'/'.repeat(100_000)}x`
+  assert.equal(stripTrailingSlashes(nonTrailing), nonTrailing)
 })
 
 test('toAnthropicMessages builds system, merges roles, and maps blocks', async () => {

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -1,6 +1,7 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import sharp from 'sharp'
+import { parseVersionComparator } from '../lib/version-range.js'
 import {
   mediaTypeOf,
   sniffMediaType,
@@ -2606,9 +2607,30 @@ test('versionSatisfies evaluates the plugin peer range shape', () => {
   // Alternatives and bare versions.
   assert.equal(versionSatisfies('0.34.5', '>=0.35.3 <1 || 0.34.5'), true)
   assert.equal(versionSatisfies('0.34.5', '0.34.5'), true)
+  assert.equal(versionSatisfies('0.35.3', '<=0.35.3'), true)
+  assert.equal(versionSatisfies('0.35.3', '>0.35.2'), true)
+  assert.equal(versionSatisfies('0.35.3', '>0.35.3'), false)
+  assert.equal(versionSatisfies('0.35.3', '=0.35.3'), true)
   assert.equal(versionSatisfies('0.34.5', ''), false)
   assert.equal(versionSatisfies('0.34.5', undefined), false)
   assert.equal(versionSatisfies(undefined, range), false)
+})
+
+test('version comparator parsing is linear and malformed ranges fail safe', () => {
+  assert.deepEqual(parseVersionComparator('>=0.35.3'), { op: '>=', version: '0.35.3' })
+  assert.deepEqual(parseVersionComparator('<=1'), { op: '<=', version: '1' })
+  assert.deepEqual(parseVersionComparator('>0.35.3'), { op: '>', version: '0.35.3' })
+  assert.deepEqual(parseVersionComparator('<1'), { op: '<', version: '1' })
+  assert.deepEqual(parseVersionComparator('=0.35.3'), { op: '=', version: '0.35.3' })
+  assert.deepEqual(parseVersionComparator('0.35.3'), { op: '=', version: '0.35.3' })
+
+  const adversarial = `>=${'1'.repeat(100_000)}x`
+  assert.equal(parseVersionComparator(adversarial).version.length, 100_001)
+  assert.equal(versionSatisfies('1.0.0', adversarial), false)
+
+  for (const malformed of ['>=', '<=', '>', '<', '=', '==1', '=>1', '>>1']) {
+    assert.equal(versionSatisfies('1.0.0', malformed), false)
+  }
 })
 
 // ── vision-backend capability recognition (Zhipu feedback) ──────────────────

--- a/tests/local-ollama.test.js
+++ b/tests/local-ollama.test.js
@@ -378,6 +378,45 @@ test('callLocalBackend speaks Anthropic Messages when format=anthropic (dispatch
   }
 })
 
+test('callLocalBackend normalizes Anthropic baseURL suffixes in linear time', async () => {
+  const original = globalThis.fetch
+  const captured = []
+  globalThis.fetch = async (url) => {
+    captured.push(String(url))
+    return new Response(JSON.stringify({ content: [{ type: 'text', text: 'ok' }] }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })
+  }
+  try {
+    const baseURLs = [
+      'http://localhost:11434/v1',
+      'http://localhost:11434/v1/',
+      'http://localhost:11434/v1////',
+      'http://localhost:11434////',
+      '',
+      `http://localhost:11434/v1${'/'.repeat(100_000)}`,
+    ]
+    for (const baseURL of baseURLs) {
+      await callLocalBackend(
+        { name: 'local', baseURL, model: 'm', format: 'anthropic' },
+        [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }],
+        {},
+      )
+    }
+    assert.deepEqual(captured, [
+      'http://localhost:11434/v1/messages',
+      'http://localhost:11434/v1/messages',
+      'http://localhost:11434/v1/messages',
+      'http://localhost:11434/v1/messages',
+      '/v1/messages',
+      'http://localhost:11434/v1/messages',
+    ])
+  } finally {
+    globalThis.fetch = original
+  }
+})
+
 test('callLocalBackend openai format stays on the pure OpenAI transport', async () => {
   const original = globalThis.fetch
   let captured


### PR DESCRIPTION
## Summary

- resolve CodeQL code scanning alerts #1, #2, and #3
- replace the version comparator regular expression with the deterministic `parseVersionComparator` parser
- replace unsafe trailing-slash regular expressions with a shared backward-scan helper
- normalize the local Anthropic `/v1` suffix with `endsWith()` and `slice()`

## Security and compatibility

The new comparator parser uses fixed prefix checks and slicing. URL normalization scans each string backward once, so both implementations are O(n) and do not use equivalent backtracking regular expressions.

Existing range behavior remains intact for `>=`, `<=`, `>`, `<`, `=`, bare versions, `||` alternatives, prereleases, and malformed fail-safe inputs. URL behavior remains intact for `/v1`, `/v1/`, repeated trailing slashes, and empty values.

## Tests

- `pnpm test` — 790 tests passed
- syntax checks passed for all modified JavaScript files
- added adversarial regression coverage with approximately 100,000-character comparator and slash-run inputs
- added malformed comparator and base URL boundary coverage