### PR TITLE
fix: accept originalDimensions in vision_present output

### DIFF
--- a/lib/vision-tool-runtime-boundary.js
+++ b/lib/vision-tool-runtime-boundary.js
@@ -368,6 +368,49 @@ async function executeVisionTool(def, args, exec, execute, wrappedCtx, runtimeSt
   ))
 }
 
+/**
+ * DSH's durable attachment contract adds originalDimensions when host-side
+ * normalization downsizes an image. Core 1.7.x returns that attachment
+ * envelope from vision_present while declaring a strict schema, so older
+ * declarations reject the host's legitimate field before render (#287).
+ * Patch only that one tool definition and keep every strict boundary intact.
+ */
+export function normalizeVisionPresentOutputSchema(def) {
+  if (!def || def.name !== 'vision_present') return def
+  const schema = def.output?.schema
+  const attachment = schema?.properties?.attachment
+  const properties = attachment?.properties
+  if (!properties || properties.originalDimensions !== undefined) return def
+
+  return {
+    ...def,
+    output: {
+      ...def.output,
+      schema: {
+        ...schema,
+        properties: {
+          ...schema.properties,
+          attachment: {
+            ...attachment,
+            properties: {
+              ...properties,
+              originalDimensions: {
+                type: 'object',
+                properties: {
+                  width: { type: 'integer' },
+                  height: { type: 'integer' },
+                },
+                required: ['width', 'height'],
+                additionalProperties: false,
+              },
+            },
+          },
+        },
+      },
+    },
+  }
+}
+
 function wrapTools(tools, wrappedCtx, runtimeState) {
   if (!tools || (typeof tools !== 'object' && typeof tools !== 'function')) return tools
   return new Proxy(tools, {
@@ -379,14 +422,15 @@ function wrapTools(tools, wrappedCtx, runtimeState) {
       const register = Reflect.get(target, property, target)
       if (typeof register !== 'function') return register
       return (def) => {
-        if (!def || typeof def.name !== 'string' || !def.name.startsWith('vision_') || typeof def.execute !== 'function') {
-          return register.call(target, def)
+        const normalizedDef = normalizeVisionPresentOutputSchema(def)
+        if (!normalizedDef || typeof normalizedDef.name !== 'string' || !normalizedDef.name.startsWith('vision_') || typeof normalizedDef.execute !== 'function') {
+          return register.call(target, normalizedDef)
         }
-        const execute = def.execute
+        const execute = normalizedDef.execute
         return register.call(target, {
-          ...def,
+          ...normalizedDef,
           execute(args, exec) {
-            return executeVisionTool(def, args, exec, execute, wrappedCtx, runtimeState)
+            return executeVisionTool(normalizedDef, args, exec, execute, wrappedCtx, runtimeState)
           },
         })
       }

--- a/tests/qa-runtime-identity.test.js
+++ b/tests/qa-runtime-identity.test.js
@@ -18,6 +18,67 @@ test('vision tool runtime boundary never proxies unrelated injected child contex
   assert.equal(seen, webChild, 'rc6 route/effect ownership depends on exact child identity')
 })
 
+test('vision_present registration accepts host originalDimensions without loosening strict output schema', () => {
+  let registered
+  const ctx = {
+    tools: {
+      register(def) {
+        registered = def
+        return () => {}
+      },
+    },
+  }
+  const wrapped = installVisionToolRuntimeBoundary(ctx)
+  const original = {
+    name: 'vision_present',
+    output: {
+      schema: {
+        type: 'object',
+        properties: {
+          attachment: {
+            type: 'object',
+            properties: {
+              attachmentId: { type: 'string' },
+              mediaType: { type: 'string' },
+              bytes: { type: 'number' },
+              width: { type: 'number' },
+              height: { type: 'number' },
+              name: { type: 'string' },
+            },
+            required: ['attachmentId', 'mediaType', 'bytes', 'width', 'height'],
+            additionalProperties: false,
+          },
+        },
+        required: ['attachment'],
+        additionalProperties: false,
+      },
+    },
+    async execute() { return {} },
+  }
+
+  wrapped.tools.register(original)
+
+  assert.ok(registered)
+  const attachment = registered.output.schema.properties.attachment
+  assert.equal(attachment.additionalProperties, false)
+  assert.deepEqual(attachment.required, ['attachmentId', 'mediaType', 'bytes', 'width', 'height'])
+  assert.equal(original.output.schema.properties.attachment.properties.originalDimensions, undefined)
+  assert.deepEqual(attachment.properties.originalDimensions, {
+    type: 'object',
+    properties: {
+      width: { type: 'integer' },
+      height: { type: 'integer' },
+    },
+    required: ['width', 'height'],
+    additionalProperties: false,
+  })
+  assert.equal(
+    attachment.required.includes('originalDimensions'),
+    false,
+    'originalDimensions is optional and appears only when the host downsizes the image',
+  )
+})
+
 test('entry keeps prepareCall, tool runtime, session policy bridge, structured hardening and backend runtime policy in final order', async () => {
   const source = await readFile(new URL('../entry.js', import.meta.url), 'utf8')
   const mutationAt = source.indexOf('const localMutationCtx = installLocalMutationRouteBoundary(ctx)')


### PR DESCRIPTION
Fixes #287

## What changed
- Normalize only the `vision_present` tool definition at the existing vision-tool runtime boundary.
- Declare the host attachment envelope's optional `originalDimensions` field with strict nested `width`/`height` integer properties.
- Preserve `additionalProperties: false` on both the attachment envelope and `originalDimensions`; the new field remains optional at the parent level.
- Add a regression test that exercises the actual tool-registration path and verifies the original core definition is not mutated.

## Why
DSH attachment normalization may downscale large images and return `originalDimensions: { width, height }`. `vision_present` returns the host attachment envelope, but the 1.7.x core declaration does not include that optional field, so strict tool-output validation rejects otherwise valid results before render.

The compatibility fix is intentionally scoped to `vision_present`; other vision tools do not expose the host attachment envelope through this declared output path.