### PR TITLE
fix: raise default vision turn budget to 180s

### DIFF
--- a/entry.js
+++ b/entry.js
@@ -60,13 +60,14 @@ export const SETTINGS_CONTRACT_REVISION = 4
 // for the settings namespace, so composition config and settings validation
 // agree on the same default.
 core.Config.set('progressiveTools', z.boolean().default(false))
-// Keep the three timeout layers coherent: one provider call may use up to 120s,
-// one visual task (including fallbacks) shares 120s, and one visual turn shares
-// 120s. The runtime policy below reserves the final quarter of a multi-backend
-// task for fallback, so raising the task ceiling does not revive the historical
-// "120s per backend" stall that #117 removed.
+// Keep the timeout layers coherent: one provider call may use up to 120s, one
+// visual task (including fallbacks) shares 120s, while one image turn gets 180s
+// total so a slow first look does not consume the entire 1+x evidence budget.
+// The runtime policy below still reserves the final quarter of a multi-backend
+// task for fallback, so this does not revive the historical "120s per backend"
+// stall that #117 removed.
 core.Config.set('visionTaskTimeoutMs', z.number().step(1000).min(1000).max(180000).default(120000))
-core.Config.set('visionTurnBudgetMs', z.number().step(1000).min(10000).max(600000).default(120000))
+core.Config.set('visionTurnBudgetMs', z.number().step(1000).min(10000).max(600000).default(180000))
 
 // Both visible entry points — Settings > Vision Router and the legacy
 // Settings > Plugins compatibility card — edit the same Host-owned namespace.
@@ -179,7 +180,7 @@ export function apply(ctx, config = {}) {
     visionTurnBudgetMs:
       Number.isFinite(Number(bootConfig.visionTurnBudgetMs))
         ? Number(bootConfig.visionTurnBudgetMs)
-        : 120000,
+        : 180000,
   }
   // The batch-attachment API is the released, non-incidental discriminator
   // between the minimum Host contract and the newer Host-owned integration

--- a/lib/structured-flow-hardening.js
+++ b/lib/structured-flow-hardening.js
@@ -14,7 +14,7 @@ const STRUCTURED_EVIDENCE_TOOLS = new Set([
   'vision_long_screenshot_ocr',
 ])
 
-const DEFAULT_TURN_BUDGET_MS = 90_000
+const DEFAULT_TURN_BUDGET_MS = 180_000
 const MAX_TURN_BUDGET_MS = 600_000
 const MAX_GUIDANCE_OVERRIDES = 14
 const MAX_GUIDANCE_CHARS = 2_000

--- a/lib/vision-turn-budget-client-prelude.js
+++ b/lib/vision-turn-budget-client-prelude.js
@@ -5,7 +5,7 @@ export const VISION_TURN_BUDGET_CLIENT_PRELUDE = String.raw`(function(){
   var TARGET = 'dsh-vision-router';
   var SETTINGS_SECTION_ID = 'vision-router';
   var FIELD = 'visionTurnBudgetMs';
-  var DEFAULT_MS = 120000;
+  var DEFAULT_MS = 180000;
   var MIN_MS = 10000;
   var MAX_MS = 600000;
   var contexts = typeof WeakMap === 'function' ? new WeakMap() : undefined;
@@ -16,7 +16,7 @@ export const VISION_TURN_BUDGET_CLIENT_PRELUDE = String.raw`(function(){
     if (next.zh && typeof next.zh === 'object') {
       next.zh = Object.assign({}, next.zh, {
         visionTurnBudgetTitle: '单轮视觉工具总预算',
-        visionTurnBudgetHint: '从本轮第一次 Vision Router 视觉工具调用开始计算，限制本轮全部视觉工具的总执行时间。普通模型思考、原生多模态直接看图不会启动此计时。默认 120000 毫秒。',
+        visionTurnBudgetHint: '从本轮第一次 Vision Router 视觉工具调用开始计算，限制本轮全部视觉工具的总执行时间。普通模型思考、原生多模态直接看图不会启动此计时。默认 180000 毫秒（3 分钟）。',
         visionTurnBudgetInvalid: '请输入 10000–600000 之间的整数毫秒值。',
         visionTurnBudgetSaved: '已保存',
         visionTurnBudgetSaveFailed: '保存失败'
@@ -25,7 +25,7 @@ export const VISION_TURN_BUDGET_CLIENT_PRELUDE = String.raw`(function(){
     if (next.en && typeof next.en === 'object') {
       next.en = Object.assign({}, next.en, {
         visionTurnBudgetTitle: 'Vision tool turn budget',
-        visionTurnBudgetHint: 'Starts when the first Vision Router tool actually runs. Limits total Vision Router visual-tool execution time in the turn. Normal model thinking and native multimodal image processing do not start this timer. Default 120000 ms.',
+        visionTurnBudgetHint: 'Starts when the first Vision Router tool actually runs. Limits total Vision Router visual-tool execution time in the turn. Normal model thinking and native multimodal image processing do not start this timer. Default 180000 ms (3 minutes).',
         visionTurnBudgetInvalid: 'Enter an integer from 10000 to 600000 milliseconds.',
         visionTurnBudgetSaved: 'Saved',
         visionTurnBudgetSaveFailed: 'Save failed'

--- a/tests/vision-budget-activation.test.js
+++ b/tests/vision-budget-activation.test.js
@@ -53,6 +53,40 @@ test('long text-only turns never consume the structured vision budget', async ()
   }
 })
 
+test('default structured vision turn budget is 180 seconds, not the historical 90 seconds', async () => {
+  const originalNow = Date.now
+  let now = 1_500_000
+  Date.now = () => now
+  try {
+    const harness = boot()
+    const session = {}
+    harness.wrapped.tools.register({
+      name: 'vision_describe',
+      async execute() { return 'visible evidence' },
+    })
+
+    await preStep(harness, session, 1)
+    const result = await harness.defs.get('vision_describe').execute({}, { agent: { session } })
+    assert.equal(result, 'visible evidence')
+
+    now += 90_001
+    const afterHistoricalLimit = await preStep(harness, session, 1)
+    assert.equal(
+      afterHistoricalLimit.messages.some((message) => String(message.id).includes('structured-guard-stop')),
+      false,
+      'the old 90s fallback must no longer terminate an image turn',
+    )
+
+    now += 90_000
+    const afterNewLimit = await preStep(harness, session, 1)
+    const stop = afterNewLimit.messages.find((message) => String(message.id).includes('structured-guard-stop'))
+    assert.ok(stop)
+    assert.match(stop.content[0].text, /视觉总时间预算已耗尽/)
+  } finally {
+    Date.now = originalNow
+  }
+})
+
 test('the structured vision budget starts on the first actual visual tool call', async () => {
   const originalNow = Date.now
   let now = 2_000_000


### PR DESCRIPTION
## Summary

Fixes #293.

The user-visible turn-budget control added in #292 exposed a real default drift: the public schema/UI used 120s, while the structured-flow fallback still retained the historical 90s default. For slower vision models, multiple images, or 1+x evidence passes, that can terminate an otherwise healthy image turn too early.

This change raises and aligns the default **Vision Router visual-tool turn budget to 180 seconds (3 minutes)**.

## Behavior

- `visionTurnBudgetMs` defaults to **180000 ms** across the public schema, direct/runtime fallback, structured-flow fallback, and Web settings card.
- The budget still starts only when the **first actual Vision Router visual tool call** runs.
- Normal model thinking and Host-native multimodal direct image processing do **not** consume this timer.
- Existing explicitly saved `visionTurnBudgetMs` values are preserved.
- The hard maximum stays **600s**.
- `visionTaskTimeoutMs` stays **120s**, so one slow task/backend chain cannot consume unbounded time or revive the timeout stacking fixed in #117.

## Regression coverage

- Default-budget flow is still alive after the historical **90s** cutoff.
- It stops after the new **180s** default.
- Existing explicit-budget and text-only activation tests remain in place.

This builds directly on #292's Web/trusted-remote budget control; no release/tag/version changes in this PR.