### PR TITLE
fix: make aggregate vision turn budget opt-in

### DIFF
--- a/entry.js
+++ b/entry.js
@@ -60,14 +60,15 @@ export const SETTINGS_CONTRACT_REVISION = 4
 // for the settings namespace, so composition config and settings validation
 // agree on the same default.
 core.Config.set('progressiveTools', z.boolean().default(false))
-// Keep the timeout layers coherent: one provider call may use up to 120s, one
-// visual task (including fallbacks) shares 120s, while one image turn gets 180s
-// total so a slow first look does not consume the entire 1+x evidence budget.
+// Keep the timeout layers coherent: one provider call may use up to 120s and
+// one visual task (including fallbacks) shares 120s. The whole-turn visual
+// budget is an optional user safety cap rather than an Agent lifetime policy:
+// 0 means unlimited, which is the default for long-running autonomous turns.
 // The runtime policy below still reserves the final quarter of a multi-backend
-// task for fallback, so this does not revive the historical "120s per backend"
-// stall that #117 removed.
+// task for fallback, so disabling the aggregate cap does not revive the
+// historical "120s per backend" stall that #117 removed.
 core.Config.set('visionTaskTimeoutMs', z.number().step(1000).min(1000).max(180000).default(120000))
-core.Config.set('visionTurnBudgetMs', z.number().step(1000).min(10000).max(600000).default(180000))
+core.Config.set('visionTurnBudgetMs', z.number().step(1000).min(0).max(600000).default(0))
 
 // Both visible entry points — Settings > Vision Router and the legacy
 // Settings > Plugins compatibility card — edit the same Host-owned namespace.
@@ -180,7 +181,7 @@ export function apply(ctx, config = {}) {
     visionTurnBudgetMs:
       Number.isFinite(Number(bootConfig.visionTurnBudgetMs))
         ? Number(bootConfig.visionTurnBudgetMs)
-        : 180000,
+        : 0,
   }
   // The batch-attachment API is the released, non-incidental discriminator
   // between the minimum Host contract and the newer Host-owned integration
@@ -241,7 +242,8 @@ export function apply(ctx, config = {}) {
   // Final structured-flow guard sits closest to core.apply so it sees the
   // actual tool registrations and pre-step listener. It makes bootstrap
   // one-shot, enforces fast/standard/deep/custom quotas, tracks mixed branches,
-  // rejects empty/non-evidence results, and applies one shared visual deadline.
+  // rejects empty/non-evidence results, and applies the optional turn deadline
+  // only when the user explicitly configures one.
   const structuredCtx = installStructuredFlowHardening(legacyCoreCompat.ctx, legacyCoreCompat.config)
   // Adapter reconciliation + prepareCall normalization are already installed at
   // the final Host registration boundary above. Wrapping again here would make

--- a/lib/structured-flow-hardening.js
+++ b/lib/structured-flow-hardening.js
@@ -14,7 +14,7 @@ const STRUCTURED_EVIDENCE_TOOLS = new Set([
   'vision_long_screenshot_ocr',
 ])
 
-const DEFAULT_TURN_BUDGET_MS = 180_000
+const DEFAULT_TURN_BUDGET_MS = 0
 const MAX_TURN_BUDGET_MS = 600_000
 const MAX_GUIDANCE_OVERRIDES = 14
 const MAX_GUIDANCE_CHARS = 2_000
@@ -119,8 +119,8 @@ function guidanceFor(kind, overrides) {
 
 function turnBudgetMs(config) {
   const value = Number(config?.visionTurnBudgetMs)
-  if (!Number.isFinite(value) || value < 10_000) return DEFAULT_TURN_BUDGET_MS
-  return Math.min(Math.round(value), MAX_TURN_BUDGET_MS)
+  if (!Number.isFinite(value) || value <= 0) return DEFAULT_TURN_BUDGET_MS
+  return Math.min(Math.max(Math.round(value), 10_000), MAX_TURN_BUDGET_MS)
 }
 
 function depthOf(config) {
@@ -130,11 +130,10 @@ function depthOf(config) {
 }
 
 /**
- * Clamp the core's own timeout settings to the remaining structured-turn
- * deadline. This is the key bridge from the outer 1+x budget into the existing
- * core deadline/AbortSignal machinery: fetch, llm.stream and OCR fallbacks are
- * then genuinely cancelled at the turn boundary instead of merely being
- * refused when the NEXT tool call starts.
+ * Clamp the core's own timeout settings to the remaining optional structured-
+ * turn deadline. When the whole-turn budget is disabled (the default), there
+ * is no ambient deadline and the existing per-task/provider timeouts stay
+ * authoritative.
  */
 export function capConfigToVisionTurnBudget(value, now = Date.now) {
   if (!value || typeof value !== 'object') return value
@@ -173,6 +172,7 @@ function freshState(turn, _config) {
 function activateBudget(state, config) {
   if (state.turnSignal !== undefined) return
   const budgetMs = turnBudgetMs(config)
+  if (budgetMs <= 0) return
   const startedAt = Date.now()
   state.startedAt = startedAt
   state.deadlineAt = startedAt + budgetMs

--- a/lib/vision-turn-budget-client-prelude.js
+++ b/lib/vision-turn-budget-client-prelude.js
@@ -5,7 +5,7 @@ export const VISION_TURN_BUDGET_CLIENT_PRELUDE = String.raw`(function(){
   var TARGET = 'dsh-vision-router';
   var SETTINGS_SECTION_ID = 'vision-router';
   var FIELD = 'visionTurnBudgetMs';
-  var DEFAULT_MS = 180000;
+  var DEFAULT_MS = 0;
   var MIN_MS = 10000;
   var MAX_MS = 600000;
   var contexts = typeof WeakMap === 'function' ? new WeakMap() : undefined;
@@ -15,18 +15,18 @@ export const VISION_TURN_BUDGET_CLIENT_PRELUDE = String.raw`(function(){
     var next = Object.assign({}, dictionaries);
     if (next.zh && typeof next.zh === 'object') {
       next.zh = Object.assign({}, next.zh, {
-        visionTurnBudgetTitle: '单轮视觉工具总预算',
-        visionTurnBudgetHint: '从本轮第一次 Vision Router 视觉工具调用开始计算，限制本轮全部视觉工具的总执行时间。普通模型思考、原生多模态直接看图不会启动此计时。默认 180000 毫秒（3 分钟）。',
-        visionTurnBudgetInvalid: '请输入 10000–600000 之间的整数毫秒值。',
+        visionTurnBudgetTitle: '整轮视觉工具时间上限',
+        visionTurnBudgetHint: '可选的整轮 Vision Router 视觉工具总时间上限。默认不限制；填 0 表示不限制。单次视觉任务仍受独立超时保护。',
+        visionTurnBudgetInvalid: '请输入 0，或 10000–600000 之间的整数毫秒值。',
         visionTurnBudgetSaved: '已保存',
         visionTurnBudgetSaveFailed: '保存失败'
       });
     }
     if (next.en && typeof next.en === 'object') {
       next.en = Object.assign({}, next.en, {
-        visionTurnBudgetTitle: 'Vision tool turn budget',
-        visionTurnBudgetHint: 'Starts when the first Vision Router tool actually runs. Limits total Vision Router visual-tool execution time in the turn. Normal model thinking and native multimodal image processing do not start this timer. Default 180000 ms (3 minutes).',
-        visionTurnBudgetInvalid: 'Enter an integer from 10000 to 600000 milliseconds.',
+        visionTurnBudgetTitle: 'Whole-turn vision time limit',
+        visionTurnBudgetHint: 'Optional total time limit for Vision Router visual tools across the turn. Unlimited by default; enter 0 for unlimited. Individual visual tasks still have their own timeout.',
+        visionTurnBudgetInvalid: 'Enter 0, or an integer from 10000 to 600000 milliseconds.',
         visionTurnBudgetSaved: 'Saved',
         visionTurnBudgetSaveFailed: 'Save failed'
       });
@@ -75,7 +75,7 @@ export const VISION_TURN_BUDGET_CLIENT_PRELUDE = String.raw`(function(){
       var saved = Number.isFinite(Number(savedRaw)) ? Number(savedRaw) : DEFAULT_MS;
       var text = draft === undefined ? String(saved) : draft;
       var parsed = Number(text);
-      var valid = text.trim() !== '' && Number.isInteger(parsed) && parsed >= MIN_MS && parsed <= MAX_MS;
+      var valid = text.trim() !== '' && Number.isInteger(parsed) && (parsed === 0 || (parsed >= MIN_MS && parsed <= MAX_MS));
       var dirty = valid && parsed !== saved;
       var writable = snapshot.writable === true;
       var saving = saveState.status === 'saving';
@@ -104,7 +104,7 @@ export const VISION_TURN_BUDGET_CLIENT_PRELUDE = String.raw`(function(){
               h('input', {
                 className: 'vr-input',
                 type: 'number',
-                min: MIN_MS,
+                min: 0,
                 max: MAX_MS,
                 step: 1000,
                 value: text,

--- a/tests/bundle-defaults.test.js
+++ b/tests/bundle-defaults.test.js
@@ -29,6 +29,11 @@ test('progressive tools remain an explicit opt-in', () => {
   assert.equal(Config({ progressiveTools: true }).progressiveTools, true)
 })
 
+test('public plugin config leaves the whole-turn vision budget unlimited by default', () => {
+  assert.equal(Config({}).visionTurnBudgetMs, 0)
+  assert.equal(Config({ visionTurnBudgetMs: 180000 }).visionTurnBudgetMs, 180000)
+})
+
 test('entry contract always exposes the local remote-settings permission and handshake', () => {
   assert.equal(SETTINGS_CONTRACT_REVISION, 4)
   assert.equal(Config({}).allowRemoteSettings, false)

--- a/tests/vision-budget-activation.test.js
+++ b/tests/vision-budget-activation.test.js
@@ -53,7 +53,7 @@ test('long text-only turns never consume the structured vision budget', async ()
   }
 })
 
-test('default structured vision turn budget is 180 seconds, not the historical 90 seconds', async () => {
+test('default structured vision turn budget is unlimited for long-running agent turns', async () => {
   const originalNow = Date.now
   let now = 1_500_000
   Date.now = () => now
@@ -66,28 +66,25 @@ test('default structured vision turn budget is 180 seconds, not the historical 9
     })
 
     await preStep(harness, session, 1)
-    const result = await harness.defs.get('vision_describe').execute({}, { agent: { session } })
-    assert.equal(result, 'visible evidence')
+    const first = await harness.defs.get('vision_describe').execute({}, { agent: { session } })
+    assert.equal(first, 'visible evidence')
 
-    now += 90_001
-    const afterHistoricalLimit = await preStep(harness, session, 1)
+    now += 3 * 60 * 60 * 1000
+    const afterThreeHours = await preStep(harness, session, 1)
     assert.equal(
-      afterHistoricalLimit.messages.some((message) => String(message.id).includes('structured-guard-stop')),
+      afterThreeHours.messages.some((message) => String(message.id).includes('structured-guard-stop')),
       false,
-      'the old 90s fallback must no longer terminate an image turn',
+      'the default policy must not impose an aggregate wall-clock cap on a long agent turn',
     )
 
-    now += 90_000
-    const afterNewLimit = await preStep(harness, session, 1)
-    const stop = afterNewLimit.messages.find((message) => String(message.id).includes('structured-guard-stop'))
-    assert.ok(stop)
-    assert.match(stop.content[0].text, /视觉总时间预算已耗尽/)
+    const second = await harness.defs.get('vision_describe').execute({}, { agent: { session } })
+    assert.equal(second, 'visible evidence')
   } finally {
     Date.now = originalNow
   }
 })
 
-test('the structured vision budget starts on the first actual visual tool call', async () => {
+test('an explicit structured vision budget starts on the first actual visual tool call', async () => {
   const originalNow = Date.now
   let now = 2_000_000
   Date.now = () => now

--- a/tests/vision-turn-budget-client-prelude.test.js
+++ b/tests/vision-turn-budget-client-prelude.test.js
@@ -6,13 +6,15 @@ import {
   installVisionTurnBudgetClientPrelude,
 } from '../lib/vision-turn-budget-client-prelude.js'
 
-test('turn-budget prelude exposes the existing Host field with the schema bounds', () => {
+test('turn-budget prelude exposes unlimited as the default while preserving the explicit cap range', () => {
   assert.match(VISION_TURN_BUDGET_CLIENT_PRELUDE, /visionTurnBudgetMs/)
+  assert.match(VISION_TURN_BUDGET_CLIENT_PRELUDE, /DEFAULT_MS = 0/)
   assert.match(VISION_TURN_BUDGET_CLIENT_PRELUDE, /MIN_MS = 10000/)
   assert.match(VISION_TURN_BUDGET_CLIENT_PRELUDE, /MAX_MS = 600000/)
+  assert.match(VISION_TURN_BUDGET_CLIENT_PRELUDE, /parsed === 0/)
   assert.match(VISION_TURN_BUDGET_CLIENT_PRELUDE, /scope\.set\(FIELD, parsed\)/)
-  assert.match(VISION_TURN_BUDGET_CLIENT_PRELUDE, /普通模型思考、原生多模态直接看图不会启动此计时/)
-  assert.match(VISION_TURN_BUDGET_CLIENT_PRELUDE, /native multimodal image processing do not start this timer/)
+  assert.match(VISION_TURN_BUDGET_CLIENT_PRELUDE, /默认不限制；填 0 表示不限制/)
+  assert.match(VISION_TURN_BUDGET_CLIENT_PRELUDE, /Unlimited by default; enter 0 for unlimited/)
 })
 
 test('turn-budget prelude injection is idempotent and stays inside head when available', () => {


### PR DESCRIPTION
Follow-up to #293 / #294 after re-evaluating long-running Agent turns.

## What changes
- default `visionTurnBudgetMs` to `0` (`0 = unlimited`)
- keep explicit positive whole-turn caps supported up to 600s; existing saved values such as `180000` remain honored
- keep `visionTaskTimeoutMs = 120000` and the existing provider/task cancellation protections unchanged
- do not create a turn-level deadline or clamp task timeouts when the aggregate cap is disabled
- update the Web/trusted-remote settings card so `0` is the default and is documented as unlimited

## Why
A DSH turn may legitimately run for hours and decide to call vision tools again much later. Vision Router should prevent individual visual requests/fallback chains from hanging, but should not impose a default lifetime on the Agent's entire turn.

## Regression coverage
- a default-config turn can call vision, advance the clock by 3 hours, and continue without a budget guard
- an explicit 10s turn budget still starts on the first actual visual tool call and stops later vision work
- public Config resolves `visionTurnBudgetMs` to `0` by default while preserving an explicit `180000`
- settings prelude exposes `0` as unlimited and retains the 10s–600s explicit-cap range

No package version/tag/release changes.