### PR TITLE
fix: implement prepareCall on all registered LlmAdapters (0.1.1-rc.2 contract)

### DIFF
--- a/index.js
+++ b/index.js
@@ -2816,6 +2816,10 @@ export function createStealthAdapter(ctx, { native, imageMemory, pairs, chainRou
       const base = await native.resolveModel(provider, model, signal)
       return { ...base, provider, inputModalities: ['text', 'image'] }
     },
+    async prepareCall(provider, model, signal) {
+      const resolved = await this.resolveModel(provider, model, signal)
+      return { model: resolved, stream: (options) => this.stream(options) }
+    },
     ...createWrapperStreamBody(ctx, { imageMemory, delegateProvider, instantLocal, instantLocalStyle, instantLocalTimeoutMs, instantLocalMaxPixels }),
   }
 }
@@ -3294,6 +3298,10 @@ export function apply(ctx, config = {}) {
         async resolveModel(provider, model, signal) {
           return nativeAdapter.resolveModel(provider, model, signal)
         },
+        async prepareCall(provider, model, signal) {
+          const resolved = await this.resolveModel(provider, model, signal)
+          return { model: resolved, stream: (options) => this.stream(options) }
+        },
         async *stream(options) {
           yield* nativeAdapter.stream(options)
         },
@@ -3455,6 +3463,10 @@ export function apply(ctx, config = {}) {
           inputModalities: ['text', 'image'],
           context: { contextWindow: 32768 },
         }
+      },
+      async prepareCall(provider, model, signal) {
+        const resolved = await this.resolveModel(provider, model, signal)
+        return { model: resolved, stream: (options) => this.stream(options) }
       },
       async *stream(options) {
         const entry = httpEntries().find((candidate) => candidate.id === options.model)
@@ -3689,6 +3701,10 @@ export function apply(ctx, config = {}) {
           inputModalities: ['text', 'image'],
         }
       },
+      async prepareCall(provider, model, signal) {
+        const resolved = await this.resolveModel(provider, model, signal)
+        return { model: resolved, stream: (options) => this.stream(options) }
+      },
       ...createWrapperStreamBody(ctx, {
         imageMemory,
         delegateProvider: textProviderRoute(),
@@ -3816,6 +3832,10 @@ export function apply(ctx, config = {}) {
         }
         const base = await original.resolveModel(provider, model)
         return { ...base, provider: twinRoute, inputModalities: ['text', 'image'] }
+      },
+      async prepareCall(provider, model, signal) {
+        const resolved = await this.resolveModel(provider, model, signal)
+        return { model: resolved, stream: (options) => this.stream(options) }
       },
       ...createWrapperStreamBody(ctx, {
         imageMemory,
@@ -4327,6 +4347,10 @@ export function apply(ctx, config = {}) {
           inputModalities: ['text', 'image'],
           context: { contextWindow: 128000 },
         }
+      },
+      async prepareCall(provider, model, signal) {
+        const resolved = await this.resolveModel(provider, model, signal)
+        return { model: resolved, stream: (options) => this.stream(options) }
       },
       async *stream(options) {
         const failures = []


### PR DESCRIPTION
## Problem

dsh core **0.1.1-rc.2** changed the LlmAdapter contract: `dsh-agent-loop` now calls `llm.prepareCall(config, signal)` every turn, and `dsh-llm` (lib) dispatches `registration.adapter.prepareCall(provider, model, signal)`.

All adapters registered by this plugin follow the old contract shape (`providerInfo` / `providerRetryPolicy` / `listModels` / `resolveModel` / `stream`) with no `prepareCall`. Every turn routed through them fails instantly:

```
This turn failed registration.adapter.prepareCall is not a function
```

## Fix

Add `async prepareCall(provider, model, signal)` to **all six registered adapters**:

- stealth `deepseek-official` route
- native route
- `http` route
- wrapper route
- twin (`*-vision`) routes
- chain route

Implementation mirrors the official `@deepseek-ai/dsh-llm-deepseek` adapter:

```js
async prepareCall(provider, model, signal) {
  const resolved = await this.resolveModel(provider, model, signal)
  return { model: resolved, stream: (options) => this.stream(options) }
}
```

## Verification

- Local dsh web profile (0.1.1-rc.2) with this patch: turns complete with `turn/end ok:true`; zero `prepareCall` errors after the patch.
- `node --check` passes.

Relates to the same core-contract change that introduced `prepareCall` in the official adapter (see `@deepseek-ai/dsh-llm-deepseek` lib, `prepareCall` ~line 1376).