### PR TITLE
fix: shadow persisted guard-stop leftovers off the model surface

### DIFF
--- a/index.js
+++ b/index.js
@@ -797,6 +797,55 @@ export function planToolResultImageShadows(events, surfaceNodes, shouldStrip) {
   return plans
 }
 
+/** Ids of guard-stop messages this plugin ever injected for a session. */
+const PERSISTED_GUARD_STOP_SURFACE_ID = /^vision-router-structured-guard-stop-(?:\d+|undefined)$/
+
+/**
+ * Plan shadow replacements that keep persisted guard-stop messages off the
+ * model surface.
+ *
+ * Guard-stop orders (turn-budget / depth-quota exhausted) were injected as
+ * `user/message` events and persisted into session history. `agent/pre-step`
+ * only sees the inbox claim — never the historical surface — so no pre-step
+ * rewrite can catch them before `Session.deriveMessages()` feeds history to
+ * the adapter. A persisted guard-stop is then replayed on EVERY later turn as
+ * a standing "never call vision tools again" order, even though the per-turn
+ * budget/depth quota resets every turn: the first image in a session is
+ * recognized, but every later image answers "本轮视觉总时间预算已耗尽…"
+ * without calling any vision tool.
+ *
+ * Same harness surface-shadow mechanism as `planToolResultImageShadows`:
+ * replace the surface node with an inert note via `surfaceOp:{op:'replace'}`
+ * + `sourceEventSeqs`, so the human transcript keeps rendering the original
+ * while every later `deriveMessages()` projection sees the replacement.
+ * Durable, replayable, survives session resume. Match by id only, never by
+ * text: ids are plugin-owned, while the instruction text can legitimately
+ * appear inside user quotes or error transcripts.
+ *
+ * @param events - the session event log array (`session.events`).
+ * @param surfaceNodes - the ordered seqs of the current surface (`session.surface.nodes`).
+ * @returns [{ seq, event, data }] where data is the inert frozen replacement
+ * message payload for the append at `seq`.
+ */
+export function planGuardStopShadows(events, surfaceNodes) {
+  const plans = []
+  for (const seq of surfaceNodes ?? []) {
+    const event = events && events[seq]
+    if (!event || event.type !== 'user/message') continue
+    const data = event.data
+    if (!data || typeof data.id !== 'string' || !PERSISTED_GUARD_STOP_SURFACE_ID.test(data.id)) continue
+    plans.push({
+      seq,
+      event,
+      data: deepFreezeLocal({
+        ...data,
+        content: [{ type: 'text', text: '[vision-router: 系统提示已过期]' }],
+      }),
+    })
+  }
+  return plans
+}
+
 /** Marker text for an image the text-only model cannot see (see vision_describe). */
 function imageMarker(id) {
   return `[attached image: ${id}] The current model cannot see images. To examine it, call vision_describe with attachmentIds: ["${id}"] and a specific question.`
@@ -4874,6 +4923,82 @@ export function apply(ctx, config = {}) {
     scan.count += newSeqs.length
   }
 
+  /**
+   * Shadow-sanitize persisted guard-stop messages off the model surface.
+   *
+   * Guard-stop orders (turn-budget / depth-quota exhausted) were injected as
+   * `user/message` events and persisted into session history. `agent/pre-step`
+   * only sees the inbox claim — never the historical surface — so a pre-step
+   * rewrite cannot catch them before `Session.deriveMessages()` feeds history
+   * to the adapter. A persisted guard-stop is then replayed on EVERY later
+   * turn as a standing "never call vision tools again" order, even though the
+   * per-turn budget/depth quota resets every turn: the first image in a
+   * session is recognized, but every later image answers "本轮视觉总时间预算
+   * 已耗尽…" without calling any vision tool.
+   *
+   * This uses the same harness surface-shadow mechanism as the tool-result
+   * image sanitizer above: replace the surface node with an inert note via
+   * `surfaceOp: {op:'replace'}` + `sourceEventSeqs`, so the human transcript
+   * keeps the original while every later `deriveMessages()` projection sees
+   * the replacement. Durable, replayable, survives session resume.
+   */
+  const guardStopSurfaceScans = new WeakMap()
+  const sanitizeSessionGuardStops = async (session) => {
+    if (!session) return
+    let events
+    let nodes
+    try {
+      events = session.events
+      nodes = session.surface && session.surface.nodes
+    } catch {
+      return // not a host Session: nothing to sanitize
+    }
+    if (!Array.isArray(events) || !Array.isArray(nodes) || nodes.length === 0) return
+    let scan = guardStopSurfaceScans.get(session)
+    if (!scan) {
+      scan = { count: 0, done: new Set() }
+      guardStopSurfaceScans.set(session, scan)
+    }
+    // Compaction replaces the surface wholesale; a shrunk node list means the
+    // positional cursor is stale, so restart from the head (same as the
+    // tool-result sanitizer above).
+    if (nodes.length < scan.count) {
+      scan.count = 0
+      scan.done = new Set()
+    }
+    if (nodes.length === scan.count) return
+    const newSeqs = nodes.slice(scan.count)
+    const plans = planGuardStopShadows(events, newSeqs)
+    for (const plan of plans) {
+      if (scan.done.has(plan.seq)) continue
+      scan.done.add(plan.seq)
+      try {
+        session.append(
+          'user/message',
+          plan.data,
+          {
+            surfaceOp: { op: 'replace', start: plan.seq, end: plan.seq },
+            sourceEventSeqs: [plan.seq],
+          },
+        )
+        ctx.logger?.info(
+          'vision-router: shadowed a persisted guard-stop message off the model surface (event seq %s)',
+          plan.seq,
+        )
+      } catch (error) {
+        // A failed shadow leaves the original event on the surface: the
+        // session stays usable (today's behavior) instead of crashing the
+        // pre-step.
+        ctx.logger?.warn(
+          'vision-router: could not shadow guard-stop at event seq %s (%s)',
+          plan.seq,
+          error && error.message ? error.message : String(error),
+        )
+      }
+    }
+    scan.count += newSeqs.length
+  }
+
   // session -> { turn, startIndex, hasImage, routed, failures, lastError }
   const turnState = new WeakMap()
 
@@ -4929,6 +5054,17 @@ export function apply(ctx, config = {}) {
     } catch (error) {
       ctx.logger?.warn(
         'vision-router: session-surface sanitization failed (%s)',
+        error && error.message ? error.message : String(error),
+      )
+    }
+    // Guard-stop leftovers are persisted user messages, so they can only be
+    // removed from the model surface through the same shadow mechanism as
+    // tool-result images (issue #74-style surface rewrite).
+    try {
+      await sanitizeSessionGuardStops(session)
+    } catch (error) {
+      ctx.logger?.warn(
+        'vision-router: guard-stop surface sanitization failed (%s)',
         error && error.message ? error.message : String(error),
       )
     }

--- a/tests/guard-stop-surface-shadow.test.js
+++ b/tests/guard-stop-surface-shadow.test.js
@@ -1,0 +1,122 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  blocksHaveImage,
+  planGuardStopShadows,
+  planToolResultImageShadows,
+} from '../index.js'
+
+// Regression: guard-stop stop orders (turn-budget / depth-quota exhausted)
+// were injected as user/message events and persisted into session history.
+// agent/pre-step only sees the inbox claim — never the historical surface —
+// so a pre-step rewrite cannot catch them before Session.deriveMessages()
+// feeds history to the adapter. A persisted guard-stop is then replayed on
+// EVERY later turn as a standing "never call vision tools again" order, even
+// though the per-turn budget/depth quota resets every turn: the first image
+// in a session is recognized, but every later image answers "本轮视觉总时间
+// 预算已耗尽…" without calling any vision tool.
+//
+// planGuardStopShadows plans a surface-shadow replacement (surfaceOp replace
+// + sourceEventSeqs) for each persisted guard-stop user/message node, so
+// every later deriveMessages() projection sees an inert note instead of the
+// standing stop order.
+
+const STOP_TEXT = '本轮视觉总时间预算已耗尽。不要再调用视觉工具；请基于已经获得的证据作答，并明确仍存在的不确定性。'
+
+function guardStopEvent(seq, id = 'vision-router-structured-guard-stop-1') {
+  return {
+    seq,
+    type: 'user/message',
+    data: {
+      role: 'user',
+      id,
+      content: [{ type: 'text', text: STOP_TEXT }],
+      source: { kind: 'plugin', plugin: 'dsh-vision-router' },
+    },
+  }
+}
+
+function plainUserEvent(seq, id) {
+  return {
+    seq,
+    type: 'user/message',
+    data: {
+      role: 'user',
+      id,
+      content: [{ type: 'text', text: '看这张图' }],
+    },
+  }
+}
+
+function toolResultEvent(seq) {
+  return {
+    seq,
+    type: 'tool/result',
+    data: {
+      message: {
+        role: 'user',
+        id: `msg-${seq}`,
+        content: [{ type: 'text', text: 'ok' }],
+      },
+    },
+  }
+}
+
+test('planGuardStopShadows plans an inert shadow for every persisted guard-stop', () => {
+  const events = [
+    guardStopEvent(0, 'vision-router-structured-guard-stop-1'),
+    plainUserEvent(1, 'user-1'),
+    guardStopEvent(2, 'vision-router-structured-guard-stop-undefined'),
+    toolResultEvent(3),
+  ]
+  const plans = planGuardStopShadows(events, [0, 1, 2, 3])
+  assert.equal(plans.length, 2)
+  assert.deepEqual(plans.map((plan) => plan.seq), [0, 2])
+  for (const plan of plans) {
+    // The replacement keeps the user-message envelope and the plugin id.
+    assert.equal(plan.data.role, 'user')
+    assert.equal(plan.data.id, plan.event.data.id)
+    assert.equal(plan.data.source.kind, 'plugin')
+    // The stop instruction is gone, replaced by an inert note.
+    assert.equal(plan.data.content.length, 1)
+    assert.equal(plan.data.content[0].type, 'text')
+    assert.equal(plan.data.content[0].text.includes('预算已耗尽'), false)
+    // The original event is untouched (the caller replaces it by appending).
+    assert.equal(plan.event.data.content[0].text, STOP_TEXT)
+    assert.equal(Object.isFrozen(plan.data), true)
+  }
+})
+
+test('planGuardStopShadows ignores ordinary user messages, tool results and missing surfaces', () => {
+  const events = [
+    plainUserEvent(0, 'user-1'),
+    toolResultEvent(1),
+    guardStopEvent(2, 'vision-router-structured-guard-stop-9'),
+  ]
+  assert.deepEqual(planGuardStopShadows(events, [0, 1]), [])
+  // A user quoting the stop text keeps their message: matching is id-only.
+  const quoted = {
+    seq: 3,
+    type: 'user/message',
+    data: { role: 'user', id: 'user-quote', content: [{ type: 'text', text: `刚才系统说了 ${STOP_TEXT} 这是什么意思？` }] },
+  }
+  assert.deepEqual(planGuardStopShadows([quoted], [3]), [])
+  assert.deepEqual(planGuardStopShadows(undefined, [0]), [])
+  assert.deepEqual(planGuardStopShadows(events, undefined), [])
+})
+
+test('planGuardStopShadows leaves image-bearing tool results to the image planner', () => {
+  // Sanity: the two planners do not overlap on event types.
+  const events = [
+    guardStopEvent(0),
+    { seq: 1, type: 'tool/result', data: { message: { role: 'user', id: 'm', content: [{ type: 'image', attachment: { attachmentId: 'sha256:x' } }] } } },
+  ]
+  const nodes = [0, 1]
+  const guardPlans = planGuardStopShadows(events, nodes)
+  const imagePlans = planToolResultImageShadows(events, nodes, () => true)
+  assert.equal(guardPlans.length, 1)
+  assert.equal(guardPlans[0].seq, 0)
+  assert.equal(imagePlans.length, 1)
+  assert.equal(imagePlans[0].seq, 1)
+  assert.equal(blocksHaveImage(events[1].data.message.content), true)
+})


### PR DESCRIPTION
## 问题 / Problem

结构化流程的停止指令（轮预算/深度配额耗尽时注入的 guard-stop 消息）被作为 user/message 事件持久化进了会话历史。agent/pre-step **只看到 inbox claim（新消息），永远看不到历史消息面**——历史由 Session.deriveMessages() 在 pre-step 之后才组装给模型，所以任何 pre-step 改写都拦不住它。

之后每一轮重放历史时，模型都会读到「不要再调用视觉工具」这条常驻指令——即使每轮的预算/深度配额早已重置。

**症状**：会话第一张图能识别，之后同一会话再发的每张图都会直接回复「本轮视觉总时间预算已耗尽。不要再调用视觉工具；请基于已经获得的证据作答……」，不再调用任何视觉工具。

本地实测：多个历史会话的 session.jsonl.zstd 中残留了 vision-router-structured-guard-stop-<turn> 的 user/message 记录（含 -undefined 形态）。

The structured guard-stop messages (turn-budget / depth-quota exhausted) were persisted into session history as user/message events. agent/pre-step **only sees the inbox claim — never the historical surface** — history reaches the model only later via Session.deriveMessages(), so no pre-step rewrite can catch them.

**Symptom**: the first image in a session is recognized, but every later image answers "本轮视觉总时间预算已耗尽…" without calling any vision tool.

## 修复 / Fix

新增 planGuardStopShadows，复用与 planToolResultImageShadows（tool-result 图片影子替换，issue #74 同一机制）完全一致的 harness 表面影子替换：把每个持久化的 guard-stop user/message 表面节点替换为一条惰性提示（surfaceOp:{op:'replace'} + sourceEventSeqs）。人可见的转写保留原文，而**每一次** deriveMessages() 投影都看到替换后的内容。持久、可重放、会话续接后依然生效。

- **只按 id 匹配，不按文本**：id（vision-router-structured-guard-stop-<turn>）是插件私有的；停止文案可能合法出现在用户引用或错误转录里，按文本匹配会误删。
- 兼容历史遗留的 -undefined turn 形态。
- sanitizeSessionGuardStops 挂在 pre-step 中、紧跟 tool-result 净化器之后，增量扫描表面节点，压缩重启处理与既有扫描器一致。

Adds planGuardStopShadows, reusing the exact harness surface-shadow mechanism as planToolResultImageShadows (issue #74): each persisted guard-stop user/message surface node is replaced with an inert note (surfaceOp:{op:'replace'} + sourceEventSeqs). The human transcript keeps the original; **every** later deriveMessages() projection sees the replacement. Durable, replayable, survives session resume.

- **Matching is id-only (never by text)**: ids are plugin-owned, while the instruction text can legitimately appear inside user quotes or error transcripts.
- Handles the legacy -undefined turn form.
- sanitizeSessionGuardStops runs in the pre-step next to the tool-result sanitizer, scanning surface nodes incrementally with the same compaction-restart handling.

## 验证 / Validation

新增 tests/guard-stop-surface-shadow.test.js（3 组用例）：每个持久化 guard-stop（含 -undefined 形态）都规划出惰性影子替换、原始事件不被改动、替换载荷 frozen；普通用户消息/引用停止文案/tool-result 不被误匹配；与图片影子规划器不重叠。

- 新增测试 3/3 通过
- 相关既有套件（core / legacy-session-repair / session-repair-v2 / structured-guard-idempotency / structured-flow-hardening / vision-budget-activation / depth-quota-behavior）184/184 通过
- 完整套件 npm test 全过（Node 25，macOS）

New tests/guard-stop-surface-shadow.test.js (3 cases): inert shadow planning for every persisted guard-stop (incl. the legacy -undefined form), original events untouched, frozen payloads; no false matches on ordinary user messages / quotes / tool results; no overlap with the image planner.

- New tests 3/3 pass; related suites (core / legacy-session-repair / session-repair-v2 / structured-guard-idempotency / structured-flow-hardening / vision-budget-activation / depth-quota-behavior) 184/184; full npm test passes (Node 25, macOS).

## AI 参与披露 / AI disclosure

- [x] AI 生成的代码由人工审阅后提交（AI-generated code was reviewed by a human before submission）

---
🤖 AI-assisted: code drafted with AI assistance and reviewed locally by the contributor.
