### PR TITLE
release: v2.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,17 +56,17 @@ jobs:
           }
 
           # Release identity and artifact verification are hard gates. README /
-          # CHANGELOG freshness is useful documentation hygiene, but must not
-          # make an otherwise verified hotfix impossible to publish. Keep those
-          # checks visible as warnings and let the release-note step fall back
-          # to the immutable commit list when a changelog section is absent.
+          # release-note freshness is useful documentation hygiene, but must not
+          # make an otherwise verified hotfix impossible to publish. A curated
+          # docs/releases/<tag>.md file takes precedence over CHANGELOG.md.
           for f in README.md README.zh.md; do
             if ! grep -q "$EXPECTED_TAG" "$f"; then
               echo "::warning::$f does not yet mention $EXPECTED_TAG"
             fi
           done
-          if ! awk -v v="$EXPECTED_TAG" '$0 == "## " v { found=1 } END { exit found ? 0 : 1 }' CHANGELOG.md; then
-            echo "::warning::CHANGELOG.md has no section for $EXPECTED_TAG; release notes will use the commit list"
+          CURATED_NOTES="docs/releases/$EXPECTED_TAG.md"
+          if [ ! -s "$CURATED_NOTES" ] && ! awk -v v="$EXPECTED_TAG" '$0 == "## " v { found=1 } END { exit found ? 0 : 1 }' CHANGELOG.md; then
+            echo "::warning::no curated release notes or CHANGELOG.md section for $EXPECTED_TAG; release notes will use the commit list"
           fi
 
           node <<'NODE'
@@ -212,18 +212,23 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          {
-            echo "# $RELEASE_TAG"
-            echo
-          } > release-notes.md
-          CHANGELOG_SECTION="$(mktemp)"
-          awk -v v="$RELEASE_TAG" '$0 == "## " v { flag=1; next } /^## / && flag { exit } flag' CHANGELOG.md > "$CHANGELOG_SECTION"
-          if [ -s "$CHANGELOG_SECTION" ]; then
-            cat "$CHANGELOG_SECTION" >> release-notes.md
+          CURATED_NOTES="docs/releases/$RELEASE_TAG.md"
+          if [ -s "$CURATED_NOTES" ]; then
+            cat "$CURATED_NOTES" > release-notes.md
           else
-            echo "> Hotfix release; see the immutable commit list below for the exact changes." >> release-notes.md
+            {
+              echo "# $RELEASE_TAG"
+              echo
+            } > release-notes.md
+            CHANGELOG_SECTION="$(mktemp)"
+            awk -v v="$RELEASE_TAG" '$0 == "## " v { flag=1; next } /^## / && flag { exit } flag' CHANGELOG.md > "$CHANGELOG_SECTION"
+            if [ -s "$CHANGELOG_SECTION" ]; then
+              cat "$CHANGELOG_SECTION" >> release-notes.md
+            else
+              echo "> Release notes were not curated for this tag; see the immutable commit list below for the exact changes." >> release-notes.md
+            fi
+            rm -f "$CHANGELOG_SECTION"
           fi
-          rm -f "$CHANGELOG_SECTION"
           {
             echo
             echo "## Commits"

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/ysr666/dsh-vision-router/releases/tag/v1.7.1"><img src="https://img.shields.io/badge/release-v1.7.1-5B4CF0?style=flat-square" alt="Release v1.7.1" /></a>
-  <a href="tests"><img src="https://img.shields.io/badge/verified-657%20tests-2EA44F?style=flat-square" alt="Verified: 657 tests" /></a>
+  <a href="https://github.com/ysr666/dsh-vision-router/releases/tag/v2.0.0"><img src="https://img.shields.io/badge/release-v2.0.0-5B4CF0?style=flat-square" alt="Release v2.0.0" /></a>
+  <a href="tests"><img src="https://img.shields.io/badge/verified-Node%2022%20%2B%2024-2EA44F?style=flat-square" alt="Verified: Node 22 + 24" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-2EA44F?style=flat-square" alt="License: MIT" /></a>
   <a href="package.json"><img src="https://img.shields.io/badge/Node.js-%3E%3D22-339933?style=flat-square&amp;logo=nodedotjs&amp;logoColor=white" alt="Node.js >=22" /></a>
   <img src="https://img.shields.io/badge/runtime-no%20Python-8A2BE2?style=flat-square" alt="No Python" />
@@ -29,9 +29,9 @@
 <p align="center">💬 <strong>QQ community group: 1105463028</strong></p>
 
 > [!WARNING]
-> 📌 **Announcement (v1.7.1)**
+> 📌 **Announcement (v2.0.0)**
 >
-> **v1.7.1:** Remote settings can now be enabled after an explicit risk confirmation.
+> **v2.0.0:** Capability-aware Auto routing + benchmarks, explicit 👁 Vision, and Settings 2.0. [What’s new →](docs/releases/v2.0.0.md)
 
 <p align="center">
   <img src="assets/vision-demo.gif" width="640" alt="Demo: paste an image, the agent locates the send button with vision_ground / vision_crop / vision_pixel_diff and answers with coordinates" />
@@ -160,7 +160,7 @@ With “👁 Vision” enabled, paste or upload an image normally. By default th
 
 If the session already contains images, DSH may reject switching from a vision wrapper back to a text-only route. Vision Router does not bypass that Host rule: it shows a transient error using the same interaction style as the stock model selector, keeps the real current model unchanged, and leaves `👁 Vision ✓` reflecting the actual state so the session stays usable.
 
-The built-in anonymous OVH vision fallback is already configured, so normal image use needs no signup or API key. **The lower-right chat picker selects only the brain/conversation model**; vision backends do not belong there. Advanced options live under **Settings → Plugins → Plugin config → 视觉路由（自动识图）**: each vision-backend row may select any callable generative user model already configured under **Settings → Models**. DSH image-capability metadata is advisory only: undeclared or text-only-labelled models remain selectable and show a warning. At runtime Vision Router always tries the provider's registered DSH adapter first — including WebSocket, RPC and private transports — and falls through on a real failure. The direct compatibility bridge is used only when an http(s) OpenAI Chat Completions endpoint is positively identified. Leaving every user row empty is valid; the OVH chain remains the final fallback. `Vision HTTP` is an internal transport route, not a model group users should select.
+The built-in anonymous OVH vision fallback is already configured, so normal image use needs no signup or API key. **The lower-right chat picker selects only the brain/conversation model**; vision backends do not belong there. Advanced options live under **Settings → Vision Router**: each vision-backend row may select any callable generative user model already configured under **Settings → Models**. DSH image-capability metadata is advisory only: undeclared or text-only-labelled models remain selectable and show a warning. At runtime Vision Router always tries the provider's registered DSH adapter first — including WebSocket, RPC and private transports — and falls through on a real failure. The direct compatibility bridge is used only when an http(s) OpenAI Chat Completions endpoint is positively identified. Leaving every user row empty is valid; the OVH chain remains the final fallback. `Vision HTTP` is an internal transport route, not a model group users should select.
 
 ### See it in action
 
@@ -194,6 +194,8 @@ Any of these channels can join the vision chain as an `httpProviders` entry (key
 
 ## Highlights
 
+- **Capability-aware Auto routing.** Keep configured order for deterministic control, or explicitly enable Auto to prioritize already-configured models using measured capability evidence. Auto never infers capability from model names, and enabling Auto alone does not start benchmarks.
+- **Verifiable model profiling.** Exact Test Vision sends one request to one exact model; Quick and Full benchmark OCR / general / structured / document / grounding capabilities. Background profiling is separately authorized and yields to real foreground vision work.
 - **Original pixels, real answers.** The vision chain reads the image at original resolution (auto-downscaled only to protect latency/quota); the agent's question travels with the image, so answers are about *your* question, not a generic description.
 - **Automatic failover with classified errors.** Region blocks, ToS filtering, 402 quota, 429 rate limits, context overflow, network failures — the chain walks providers one by one and only reports after all of them failed, with actionable advice. A 429 immediately advances to the next backend and opens a Retry-After-aware cooldown instead of sleeping inside the request.
 - **Image memory.** Vision answers are cached by attachment content hash; later text turns substitute the recorded description (marked as untrusted evidence), so DeepSeek genuinely remembers earlier images without re-spending vision calls.
@@ -311,29 +313,28 @@ The settings card uses provider + model dropdowns; an empty model means every mo
 
 ## Web settings
 
-The Web profile registers a **视觉路由（自动识图）** card under **Settings → Plugins → Plugin config**. Its top callout spells out the only step most users need: **return to chat → choose your normal conversation model → click “👁 Vision” beside the composer → confirm ✓ → send the image**. The remaining controls are advanced customization:
+The Web profile registers a first-class **Settings → Vision Router** surface. Its General page keeps model choice and v2 routing authority together; Vision Strategy, Local & Device, Advanced and Diagnostics separate tool behavior, local backends, sensitive/performance controls and troubleshooting.
 
-- **Auto-create vision wrappers**: enabled by default; follows the live model catalog with no restart, and confidently owned internal wrappers are hidden from the stock picker;
-- **Manual auto-vision scope (optional)**: only for disabling auto-wrap or limiting selected models;
-- **Vision backend chain**: the real image-capable models used by `vision_describe` and friends; the built-in free Qwen is normally enough, and text-only models should not be placed here;
-- switches for legacy whole-turn routing, vision tools, image-block rewriting and stealth mode (official DeepSeek route only);
-- timeout, wrapper/chain route names, proxy and other advanced parameters;
-- every field shows an overridden badge with one-click reset plus discard/save;
-- a **Test connection** button prioritizes an enabled local backend, verifies that its configured model appears in `/v1/models`, and otherwise probes the first usable vision provider;
-- artifact-producing tools render dedicated call cards with result facts and open-file buttons.
+- **Vision model chain**: the real image-capable models used by `vision_describe` and friends; the built-in free chain remains the final fallback;
+- **Model selection**: keep the configured order, or explicitly enable capability-aware Auto with Balanced / Quality / Speed / Local preference;
+- **Background capability data**: `off`, `local-free`, or `all`; this is separately authorized and never turns on merely because Auto was enabled;
+- **Test Vision / Benchmark**: exact one-request image verification plus Quick (~3 requests, OCR + General) and Full (~6 requests, Structured + OCR + Document + Grounding + General) profiling; benchmark work continues if Settings is closed;
+- **Local & Device**: Ollama / LM Studio and privacy-gated desktop screenshot controls;
+- **Advanced / Diagnostics**: timeout, wrapper scope, proxy/network, compatibility, version, runtime status and troubleshooting.
 
 <p align="center">
-  <img src="assets/vision-settings.png" width="72%" alt="The vision-router card in Settings > Plugins > Plugin config." />
+  <img src="assets/vision-settings.png" width="72%" alt="The Vision Router settings surface." />
 </p>
-
-> PR [#8](https://github.com/ysr666/dsh-vision-router/pull/8) upgrades the panel with catalog-driven model dropdowns, add/remove fallback rows, and proxy settings.
 
 ## Configuration
 
-Everything is optional; defaults work out of the box. Edit via the Web card or a profile patch:
+Everything is optional; defaults work out of the box. Prefer **Settings → Vision Router**; profile overrides remain available for advanced deployments:
 
 | Field | Default | Meaning |
 |---|---|---|
+| `routingMode` | `ordered` | `ordered` keeps the configured model-chain order; `auto` delegates prioritization to measured capability evidence. Auto is never enabled by migration |
+| `routingPreference` | `balanced` | Auto preference: `balanced`, `quality`, `speed`, or `local`; changes ordering only among already-authorized candidates |
+| `backgroundBenchmarking` | `off` | background capability profiling authority: `off`, `local-free`, or `all`; enabling Auto does not change it, and authorized background work runs only while Auto is active |
 | `provider` / `model` | `vision-http` / `ovh/Qwen2.5-VL-72B-Instruct` | shorthand **vision backend** route (adapter-backed provider + model that genuinely accepts images) |
 | `fallbacks` | `[]` | backup image models for the shorthand vision provider |
 | `providers` | built-in free `vision-http` pair | multi-provider **vision backend** chain `{ provider, model, fallbacks[] }`, tried in order; do not put text-only models here |
@@ -349,26 +350,21 @@ Everything is optional; defaults work out of the box. Edit via the Web card or a
 | `rewriteImages` | `true` | rewrite image blocks in the model input (cached description or tool-hint marker); the UI log keeps images |
 | `desktopScreenshot` | `false` | privacy opt-in for the model-callable `vision_screenshot` desktop-capture tool; checked live before every capture |
 | `freeFallback` | `true` | append the anonymous OVH models after explicit local/custom HTTP backends; turning this off never disables an explicitly configured local backend |
-| `localOllama` | `{ enabled: false, baseURL: 'http://127.0.0.1:11434/v1', model: 'qwen2.5vl', format: 'openai' }` | **Local vision backend (merged from dsh-vision)**: when enabled, `local-ollama` leads the HTTP vision chain; skipped automatically when Ollama is down; `format` selects `openai` (`/chat/completions`) or `anthropic` (`/messages`); optional `temperature` / `top_p` are sent only when explicitly set. v1.7 prewarms loopback models and renews a 30-minute residency so cold loading is not charged to the normal inference deadline |
-| `localLmStudio` | `{ enabled: false, baseURL: 'http://localhost:1234/v1', model: '', format: 'openai' }` | **Local LM Studio backend (merged from dsh-vision)**: follows Ollama and precedes custom/cloud HTTP backends; enabling it requires the real model identifier shown in LM Studio Developer or returned by `/v1/models`; supports the same optional sampling fields, while `format: 'anthropic'` requires LM Studio 0.4.1+ |
-| `instantDescribe` | `false` | **Instant local translation (merged from dsh-vision)**: when on and at least one local backend is usable, uncached image blocks are recognized before the first model step; Ollama is tried before LM Studio with a shared timeout budget, multi-image batches run concurrently (up to 3), and failures fall back to the static tool-hint marker |
-| `localDescribeStyle` | `plain` | **Local recognition output style (merged from dsh-vision)**: `plain` = flat description; `structured` = structured recognition (【初步判断】/【细节】/【空间结构】/【原图尺寸】), better for screenshot analysis |
+| `localOllama` | `{ enabled: false, baseURL: 'http://127.0.0.1:11434/v1', model: 'qwen2.5vl', format: 'openai' }` | local vision backend; when enabled, `local-ollama` leads the HTTP vision chain, is skipped automatically when down, and supports OpenAI or Anthropic wire format |
+| `localLmStudio` | `{ enabled: false, baseURL: 'http://localhost:1234/v1', model: '', format: 'openai' }` | local LM Studio backend after Ollama; enter the exact model identifier from LM Studio Developer or `/v1/models` |
+| `visionTurnBudgetMs` | `0` | whole-turn vision wall-clock budget; `0` means unlimited. Concrete provider calls/tools still keep their own hard deadlines |
 | `downscale` / `downscaleMaxPixels` | `true` / `4000000` | pre-call downscale and its pixel budget (latency guard) |
 | `cache` / `cacheTtlSeconds` / `cacheMaxEntries` | `true` / `3600` / `200` | vision answer cache |
 | `timeoutMs` | `120000` | per vision call deadline |
 | `artifactsDir` | `.dsh-vision-router/artifacts` | artifact directory (relative to the session workspace) |
 | `proxy` / `proxyHosts` | `''` / openrouter hosts | optional proxy for vision provider hosts only |
-| `catalogCorrections` | `true` | built-in catalog-routing corrections: when the installed pi-ai catalog routes a known model to the wrong wire protocol (e.g. `opencode-go/qwen3.6-plus` to OpenAI chat completions while OpenCode Go only serves it on `/v1/messages`), the plugin answers that backend directly over the corrected protocol. Each correction disarms itself once the catalog is fixed upstream |
+| `catalogCorrections` | `true` | built-in catalog-routing corrections for known upstream wire-protocol mismatches; each correction disarms itself once the catalog is fixed upstream |
 
 ### Local Ollama vision backend (merged from dsh-vision)
 
 > **Incremental author**: [shaoqiuyuavailable](https://github.com/shaoqiuyuavailable) (router local-vision increment)
 >
-> **Design credit**: the local vision backends (Ollama / LM Studio dual backends, instant recognition,
-> structured output, screenshot identification, same-image memory dedup, failure-fallback placeholder,
-> concurrency anti-snowball, timeout protection) inherit their design from
-> [dsh-vision](https://github.com/shaoqiuyuavailable/text-llm-vision/tree/dsh-vision) —
-> merged into the HTTP vision chain here, with per-level fallback and dual-protocol support added on top.
+> **Design credit**: the local vision backends (Ollama / LM Studio dual backends, structured recognition, screenshot identification, same-image memory dedup, failure fallback, concurrency protection and timeout handling) inherit their design from [dsh-vision](https://github.com/shaoqiuyuavailable/text-llm-vision/tree/dsh-vision) — merged into the HTTP vision chain here, with per-level fallback and dual-protocol support added on top.
 
 An optional keyless local-first vision path for private, free, offline recognition. It plugs into the existing HTTP vision chain as `local-ollama`; if it fails, any configured cloud backends can still be tried unless you deliberately configure a local-only chain.
 
@@ -379,31 +375,27 @@ An optional keyless local-first vision path for private, free, offline recogniti
 ollama pull qwen2.5vl
 ```
 
-**2. Enable it** — in the settings card's "Local vision" group, or via a profile patch:
+**2. Enable it** — under **Settings → Vision Router → Local & Device**, or via a profile patch:
 
 ```yaml
 - id: vision-router
   config:
     localOllama:
       enabled: true
-      baseURL: 'http://127.0.0.1:11434/v1'   # OpenAI-compatible endpoint
+      baseURL: 'http://127.0.0.1:11434/v1'
       model: 'qwen2.5vl'
-      temperature: 0.5                        # optional; low temperature is steadier for recognition
-      top_p: 0.8                              # optional; unset = server default
-    instantDescribe: true                     # recognize images on the first model step
-    localDescribeStyle: 'structured'          # 'plain' | 'structured'
+      temperature: 0.5
+      top_p: 0.8
 ```
 
 **3. What happens**
 
 - When enabled, `local-ollama` heads the HTTP vision chain. For a strict local-only setup, remove cloud vision rows/custom HTTP endpoints and turn off `freeFallback`.
-- **v1.7 cold-start handling:** the selected loopback Ollama model is prewarmed through Ollama's native API and kept resident for 30 minutes. If it is cold when Ollama is the primary image backend, loading completes before the normal vision-task budget starts; a short `/api/ps` probe keeps a dead service on the fast fallback path. Remote Ollama URLs are never auto-warmed.
-- **LM Studio works the same way** — enable `localLmStudio` in the same "Local vision" group with its OpenAI-compatible endpoint (default `http://localhost:1234/v1`) and enter the exact model identifier shown in Developer or `/v1/models`. It sits after `local-ollama` and before custom/cloud HTTP backends.
+- The selected loopback Ollama model is prewarmed through Ollama's native API and kept resident for 30 minutes. If it is cold when Ollama is the primary image backend, loading completes before the normal vision-task budget starts; a short `/api/ps` probe keeps a dead service on the fast fallback path. Remote Ollama URLs are never auto-warmed.
+- **LM Studio works the same way** — enable `localLmStudio` with its OpenAI-compatible endpoint (default `http://localhost:1234/v1`) and enter the exact model identifier shown in Developer or `/v1/models`. It sits after `local-ollama` and before custom/cloud HTTP backends.
 - Each local backend can speak **OpenAI or Anthropic format** via `format` (default `openai`). Anthropic mode routes to `/v1/messages` with `anthropic-version` and base64 image sources; `x-api-key` is sent only when a key is configured. LM Studio needs version 0.4.1 or newer for this endpoint.
 - If a local backend is down or the call times out, its entry is skipped automatically and the chain falls through to the cloud backends — no call breaks.
-- `instantDescribe` tries enabled local backends in order (Ollama, then LM Studio) before the first model step. Multiple uncached images run concurrently (up to 3); one failed image does not block the others, and attachment-memory hits are reused without another local request.
 - `vision_screenshot` is disabled by default. After the separate Desktop screenshot opt-in, `identify=true` uses the same Ollama → LM Studio fallback.
-- Verify runtime decisions with `image turn — instantDescribe=… localBackends=…` and results with `instant local describe recognized N/M uncached image(s), C cached, F failed attempts` in the log.
 
 ## Requirements
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -16,8 +16,8 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/ysr666/dsh-vision-router/releases/tag/v1.7.1"><img src="https://img.shields.io/badge/release-v1.7.1-5B4CF0?style=flat-square" alt="Release v1.7.1" /></a>
-  <a href="tests"><img src="https://img.shields.io/badge/verified-657%20tests-2EA44F?style=flat-square" alt="Verified: 657 tests" /></a>
+  <a href="https://github.com/ysr666/dsh-vision-router/releases/tag/v2.0.0"><img src="https://img.shields.io/badge/release-v2.0.0-5B4CF0?style=flat-square" alt="Release v2.0.0" /></a>
+  <a href="tests"><img src="https://img.shields.io/badge/verified-Node%2022%20%2B%2024-2EA44F?style=flat-square" alt="Verified: Node 22 + 24" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-2EA44F?style=flat-square" alt="License: MIT" /></a>
   <a href="package.json"><img src="https://img.shields.io/badge/Node.js-%3E%3D22-339933?style=flat-square&amp;logo=nodedotjs&amp;logoColor=white" alt="Node.js >=22" /></a>
   <img src="https://img.shields.io/badge/runtime-no%20Python-8A2BE2?style=flat-square" alt="No Python" />
@@ -29,9 +29,9 @@
 <p align="center">💬 <strong>QQ 用户交流群：1105463028</strong></p>
 
 > [!WARNING]
-> 📌 **公告（v1.7.1）**
+> 📌 **公告（v2.0.0）**
 >
-> **v1.7.1：远程设置现可在风险确认后开启。**
+> **v2.0.0：Auto 能力路由+测评、输入框识图、设置 2.0。** [查看完整更新 →](docs/releases/v2.0.0.md)
 
 <p align="center">
   <img src="assets/vision-demo.gif" width="640" alt="演示：粘贴图片，Agent 用 vision_ground / vision_crop / vision_pixel_diff 定位发送按钮并给出坐标" />
@@ -158,7 +158,7 @@ pnpm dsh plugin --profile web add dsh-vision-router
 
 如果当前 session 已经包含图片，DSH 可能拒绝从识图 route 切回不接受图片的纯文本 route。此时 Vision Router 不绕过 Host 约束：会显示与原生模型选择器一致的临时错误提示，真实模型保持不变，`👁 识图 ✓` 也继续反映真实状态，可继续使用或稍后重试。
 
-默认已经有内置 OVH 匿名视觉兜底，无需注册、无需 Key。**聊天页右下角只选择“脑子/会话模型”**；视觉模型不要在那里选。高级配置在 **设置 → 插件 → 插件配置 → 视觉路由（自动识图）**：视觉后端链每一行都可以选择 **设置 → 模型** 中任意可调用的生成式用户模型。DSH 的图片能力声明现在只作提示：未声明图片能力、甚至被标成仅文本的模型也会列出并给出警告。运行时永远先通过该供应商已注册的 DSH adapter 实际调用，因此 WebSocket、RPC 和私有协议都保留原生传输；只有明确识别为 http(s) OpenAI Chat Completions 的渠道才可能进入 HTTP 直连兼容兜底。实际调用失败后自动尝试下一后端；一行都不填也可以，OVH 免费链会固定在最后兜底。插件内部的 `Vision HTTP` 只是传输实现，不是用户需要选择的模型组。
+默认已经有内置 OVH 匿名视觉兜底，无需注册、无需 Key。**聊天页右下角只选择“脑子/会话模型”**；视觉模型不要在那里选。高级配置在 **设置 → Vision Router**：视觉后端链每一行都可以选择 **设置 → 模型** 中任意可调用的生成式用户模型。DSH 的图片能力声明现在只作提示：未声明图片能力、甚至被标成仅文本的模型也会列出并给出警告。运行时永远先通过该供应商已注册的 DSH adapter 实际调用，因此 WebSocket、RPC 和私有协议都保留原生传输；只有明确识别为 http(s) OpenAI Chat Completions 的渠道才可能进入 HTTP 直连兼容兜底。实际调用失败后自动尝试下一后端；一行都不填也可以，OVH 免费链会固定在最后兜底。插件内部的 `Vision HTTP` 只是传输实现，不是用户需要选择的模型组。
 
 ### 实际效果
 
@@ -181,7 +181,7 @@ pnpm dsh plugin --profile web add dsh-vision-router
 | Intern AI（上海AI实验室） | `internvl-latest` · `internvl3.5-latest` | 30 RPM，**9000 万 token/月** | ✅ | chat.intern-ai.org.cn |
 | Groq | `meta-llama/llama-4-scout-17b-16e-instruct`（原生多模态，最多 5 张图） | 30 RPM / 14,400 次/天，免卡 | ❌ 需代理 | console.groq.com |
 | Google AI Studio | `gemini-2.5-flash` · `gemini-2.5-flash-lite` | 10–30 RPM / 500–1,500 次/天 | ❌ 需代理 | aistudio.google.com |
-| NVIDIA NIM | `meta-llama/llama-3.2-11b-vision-instruct` · `nvidia/nemotron-nano-12b-v2-vl` | 40 RPM，免卡 | ⚠️ | build.nvidia.com |
+| NVIDIA NIM | `meta/llama-3.2-11b-vision-instruct` · `nvidia/nemotron-nano-12b-v2-vl` | 40 RPM，免卡 | ⚠️ | build.nvidia.com |
 | OpenCode Zen | `mimo-v2.5-free`（视觉 + 代码） | 30 RPM / 500 次/天 | ⚠️ | opencode.ai/zen |
 | OpenRouter | `google/gemma-4-26b-a4b-it:free` · `google/gemma-4-31b-it:free` | 未充值账户 50 次/天 | ❌ 需代理 | openrouter.ai |
 
@@ -192,6 +192,8 @@ pnpm dsh plugin --profile web add dsh-vision-router
 
 ## 亮点
 
+- **能力感知 Auto 路由。** 想要确定性就继续按配置顺序；想自动选择时再显式开启 Auto，只在已配置模型和已有实测证据上调整优先级。不会通过模型名猜能力，单纯开启 Auto 也不会自动发起测评。
+- **可验证的模型测评。** 「测试识图」只向当前精确模型发一次请求；Quick / Full 分别测 OCR、通用理解，以及结构化、文档、定位等能力。后台能力数据是独立授权，并会给真实前台识图让路。
 - **原图像素，真实答案。** 视觉链按原始分辨率读图（仅为保护延迟/额度自动缩放）；你的问题随图一起发送，答案围绕*你的问题*，而不是一段泛泛的描述。
 - **自动降级 + 分类报错。** 地区限制、ToS 风控、402 额度、429 限流、上下文超长、网络故障——链路逐供应商尝试，全部失败才报错并给出可操作的建议。遇到 429 会立即尝试下一后端，并按 Retry-After 开启冷却，不会在单次请求内睡眠等待。
 - **图片记忆。** 视觉答案按附件内容哈希缓存；后续文字轮用记录的描述替换历史图片（标注为不可信证据），DeepSeek 真正“记得”之前发过的图，且不重复消耗视觉调用。
@@ -223,7 +225,7 @@ Agent 仅根据参考图复刻 UI，再用 `vision_pixel_diff` 验证最终结�
   <img src="assets/vision-tools-zh.svg" width="100%" alt="DSH Vision Router 的 11 个图像处理工具。" />
 </p>
 
-图中展示 11 个图像处理工具；另有负责持久展示图片的 `vision_present` 与可选 1+x 结构化首遍识别的 `vision_bootstrap`，默认深看工具集共 13 个。若启动时显式开启隐私敏感的 `vision_screenshot`，则额外增加为第 14 个工具。
+图中展示 11 个图像处理工具；另有 `vision_materialize`、负责持久展示图片的 `vision_present` 与可选 1+x 结构化首遍识别的 `vision_bootstrap`，默认深看工具集共 14 个。若启动时显式开启隐私敏感的 `vision_screenshot`，则额外增加为第 15 个工具。
 
 | 工具 | 作用 | 产物 |
 |---|---|---|
@@ -267,7 +269,7 @@ vision_long_screenshot_ocr image="chat-log.png" chunkHeight=1200 overlap=120
 
 视觉工具按顺序逐个尝试，全部失败才报错：
 
-1. **用户视觉模型**：设置卡里一行一个，从上到下；已启用供应商即使模型枚举部分失败也会保留在下拉中，可调用的生成式模型继续可选，图片能力声明只作提示，最终以运行时实际调用为准；
+1. **用户视觉模型**：设置页里一行一个，从上到下；已启用供应商即使模型枚举部分失败也会保留在下拉中，可调用的生成式模型继续可选，图片能力声明只作提示，最终以运行时实际调用为准；
 2. **本地 Ollama（可选，默认关）**：`localOllama.enabled` 开启后，通过本机 Ollama 做免 Key、离线识别（例如 qwen2.5vl）；
 3. **本地 LM Studio（可选，默认关）**：`localLmStudio.enabled` 排在 Ollama 之后，模型名必须填写 LM Studio Developer 页或 `/v1/models` 返回的真实标识；
 4. **高级自定义 HTTP 视觉端点**：旧配置/高级配置中的 `httpProviders` 排在本地后端之后；
@@ -292,7 +294,7 @@ vision_long_screenshot_ocr image="chat-log.png" chunkHeight=1200 overlap=120
   disabled: true
 ```
 
-官方行在场时，插件保留官方路由并使用内部 wrapper +「👁 识图」入口。反过来，隐身模式关闭但官方行仍被禁用时，插件会做 keep-alive 兜底接管，保住 DeepSeek 模型（设置卡片会给出提示）；想完全恢复官方原生行，把上面的 `disabled` 改回 `false` 再重启即可。
+官方行在场时，插件保留官方路由并使用内部 wrapper +「👁 识图」入口。反过来，隐身模式关闭但官方行仍被禁用时，插件会做 keep-alive 兜底接管，保住 DeepSeek 模型（设置页会给出提示）；想完全恢复官方原生行，把上面的 `disabled` 改回 `false` 再重启即可。
 
 > 隐身模式**只作用于官方 DeepSeek 路由**。opencode 等自定义/第三方文本路由与隐身模式无关——默认也会生成内部识图 wrapper，由「👁 识图」按需使用。
 
@@ -305,39 +307,38 @@ vision_long_screenshot_ocr image="chat-log.png" chunkHeight=1200 overlap=120
 1. 关闭了自动包装，想手动指定哪些 provider / model 可以使用「👁 识图」；
 2. 自动包装保持开启，但只想让某个 provider 的部分模型生成内部识图 wrapper。
 
-设置卡片里用两个下拉（provider + 模型）配置；模型留空 = 包装该路由的全部模型，同一 provider 要限定多个模型就添加多行。修改即时生效，无需重启。若客户端无法确认 wrapper 归属或镜像关系不完整，展示层会 fail-open，不会为了“干净”而误隐藏第三方 route。
+设置页里用两个下拉（provider + 模型）配置；模型留空 = 包装该路由的全部模型，同一 provider 要限定多个模型就添加多行。修改即时生效，无需重启。若客户端无法确认 wrapper 归属或镜像关系不完整，展示层会 fail-open，不会为了“干净”而误隐藏第三方 route。
 
 ## Web 设置
 
-Web 配置页在 **设置 → 插件 → 插件配置** 下注册「视觉路由（自动识图）」卡片，顶部会直接提示最重要的使用步骤：**回到聊天页 → 选择平时使用的普通模型 → 点击输入框旁「👁 识图」→ 确认显示 ✓ → 发图**。其余设置主要用于高级定制：
+Web profile 现在提供一级 **设置 → Vision Router** 页面。常规页把识图模型与 v2 路由授权放在一起；「识图策略 / 本地与设备 / 高级 / 诊断」分别承载工具行为、本地后端、敏感/性能设置和排障。
 
-- **自动创建识图包装**：默认开启，自动发现已有模型；内部 wrapper 在能安全确认归属时从原生模型列表隐藏，模型目录变化热更新，无需重启；
-- **手动限定自动识图范围（可选）**：仅在需要关闭自动包装或限制部分模型时使用；
-- **视觉后端链**：给 `vision_describe` 等视觉工具调用的真正图片模型，默认内置免费 Qwen 即可；不要填纯文本模型；
-- 开关：整轮自动路由（旧模式）、识图工具、图片块改写、隐身模式（仅官方 DeepSeek 路由）；
-- 视觉请求超时、包装/链路由名、代理等高级参数；
-- 每个字段都有「已覆盖」徽标与一键恢复组合默认，以及放弃/保存；
-- 「测试连接」按钮优先探测已启用的本地后端，并校验所填模型是否出现在 `/v1/models`；否则探测第一个可用视觉提供方；
-- 产出制品的工具在对话里渲染专用调用卡（关键字段 + 打开文件按钮）。
+- **识图模型链**：`vision_describe` 等视觉工具真正调用的图片模型，内置免费链固定作为最终兜底；
+- **模型选择方式**：继续按配置顺序，或显式开启能力感知 Auto，并选择「综合 / 质量 / 速度 / 本地」偏好；
+- **后台补充能力数据**：`关闭 / 仅本地与免费 / 所有模型`，独立授权，不会因开启 Auto 自动开启；
+- **测试识图 / 测评**：一次精确图片验证，以及 Quick（约3次，OCR+通用）/ Full（约6次，结构化+OCR+文档+定位+通用）能力测评；关闭设置页后任务仍继续；
+- **本地与设备**：Ollama / LM Studio 与隐私敏感的桌面截屏开关；
+- **高级 / 诊断**：超时、wrapper范围、代理/网络、兼容、版本、运行状态与排障。
 
 <p align="center">
-  <img src="assets/vision-settings.png" width="72%" alt="设置 → 插件 → 插件配置 里的视觉路由卡片。" />
+  <img src="assets/vision-settings.png" width="72%" alt="Vision Router 一级设置页面。" />
 </p>
-
-> PR [#8](https://github.com/ysr666/dsh-vision-router/pull/8) 会把面板升级为目录驱动的模型下拉框、可增删的备用模型行与代理设置。
 
 ## 配置项
 
-全部可选，默认即可用。通过 Web 卡片或 profile 补丁修改：
+全部可选，默认即可用。优先使用 **设置 → Vision Router**；高级部署仍可通过 profile 补丁覆盖：
 
 | 字段 | 默认值 | 含义 |
 |---|---|---|
+| `routingMode` | `ordered` | `ordered` 按配置模型链执行；`auto` 把优先级委托给实测能力证据。升级不会自动开启 Auto |
+| `routingPreference` | `balanced` | Auto 偏好：`balanced` / `quality` / `speed` / `local`；只在已授权候选之间改变顺序 |
+| `backgroundBenchmarking` | `off` | 后台能力测评授权：`off` / `local-free` / `all`；开启 Auto 不会改变它，已授权后台任务只在 Auto 激活时运行 |
 | `provider` / `model` | `vision-http` / `ovh/Qwen2.5-VL-72B-Instruct` | 简写视觉后端链路（有适配器且真正支持图片输入的供应商 + 模型） |
 | `fallbacks` | `[]` | 简写视觉供应商的备用图片模型 |
-| `providers` | 内置免费 `vision-http` 条目 | 多供应商视觉后端链 `{ provider, model, fallbacks[] }`，按序尝试；优先于简写形式。不要填写纯文本模型 |
+| `providers` | 内置免费 `vision-http` 条目 | 多供应商视觉后端链 `{ provider, model, fallbacks[] }`，按序尝试；不要填写纯文本模型 |
 | `httpProviders` | 内置 OVH 条目 | OpenAI 兼容直连端点 `{ name, baseURL, model, apiKeyEnv, maxTokens }` |
 | `autoWrapProviders` | `true` | 自动发现当前已启用 provider / model，并热更新对应内部识图 wrapper；能确认归属时从原生模型选择器隐藏，原模型组不变 |
-| `wrappedProviders` | `[{ provider: 'deepseek-official', models: [] }]` | 可选的手动包装范围 `{ provider, models[] }`；用于关闭自动包装后手动指定，或限制某个 provider 只有部分模型可通过「👁 识图」进入 wrapper。改动即时生效，无需重启 |
+| `wrappedProviders` | `[{ provider: 'deepseek-official', models: [] }]` | 可选手动包装范围 `{ provider, models[] }`；用于关闭自动包装后手动指定，或限制某个 provider 只有部分模型可通过「👁 识图」进入 wrapper |
 | `routing` | `false` | 旧版整轮链路由（一次性整轮回答）。`false` = 工具优先流程（推荐） |
 | `reverseRouting` | `true` | 开启 `routing` 时，文字轮路由回 `textProvider` |
 | `wrapperRoute` / `chainRoute` | `deepseek-vision` / `vision-chain` | 准入包装路由名 / 降级链路由名（置空关闭） |
@@ -347,24 +348,23 @@ Web 配置页在 **设置 → 插件 → 插件配置** 下注册「视觉路由
 | `rewriteImages` | `true` | 模型输入层改写图片块（缓存描述或工具提示标记）；界面日志保留图片 |
 | `desktopScreenshot` | `false` | 模型可调用的 `vision_screenshot` 桌面截屏隐私开关；每次截屏前实时检查 |
 | `freeFallback` | `true` | 在显式本地/自定义 HTTP 后端之后追加匿名 OVH 模型；关闭它不会停用用户明确配置的本地后端 |
-| `localOllama` | `{ enabled: false, baseURL: 'http://127.0.0.1:11434/v1', model: 'qwen2.5vl', format: 'openai' }` | **本地视觉后端（并入自 dsh-vision）**：开启后 local-ollama 排在 HTTP 视觉链最前；Ollama 未运行会自动跳过；`format` 可选 `openai`（`/chat/completions`）或 `anthropic`（`/messages`）；可选的 `temperature` / `top_p` 只在显式填写时发送。v1.7 会预热本机 loopback 模型并续期 30 分钟驻留，冷加载时间不再计入正常识图截止时间 |
-| `localLmStudio` | `{ enabled: false, baseURL: 'http://localhost:1234/v1', model: '', format: 'openai' }` | **本地 LM Studio 后端（并入自 dsh-vision）**：排在 Ollama 之后、自定义/云 HTTP 后端之前；开启时必须填写 LM Studio Developer 页或 `/v1/models` 返回的真实模型标识；可选采样参数同 Ollama，`format: 'anthropic'` 需 LM Studio 0.4.1+ |
-| `instantDescribe` | `false` | **即时本地翻译（并入自 dsh-vision）**：开启且至少一个本地后端可用时，在第一模型步之前识别无缓存图片块；Ollama → LM Studio 共用总超时预算，多图并发上限 3，失败则回退静态工具标记 |
-| `localDescribeStyle` | `plain` | **本地识别输出风格（并入自 dsh-vision）**：`plain` = 平铺描述；`structured` = 结构化识别（【初步判断】/【细节】/【空间结构】/【原图尺寸】），截图分析质量更高 |
+| `localOllama` | `{ enabled: false, baseURL: 'http://127.0.0.1:11434/v1', model: 'qwen2.5vl', format: 'openai' }` | 本地视觉后端；开启后排在 HTTP 视觉链前部，服务未运行会自动跳过，支持 OpenAI / Anthropic 协议 |
+| `localLmStudio` | `{ enabled: false, baseURL: 'http://localhost:1234/v1', model: '', format: 'openai' }` | Ollama 之后的本地 LM Studio 后端；填写 Developer 页或 `/v1/models` 返回的真实模型 ID |
+| `visionTurnBudgetMs` | `0` | 整轮视觉总墙钟预算；`0` = 不设整轮上限。具体 provider调用/工具仍有自己的硬超时 |
 | `downscale` / `downscaleMaxPixels` | `true` / `4000000` | 调用前压缩及其像素预算（延迟保护） |
 | `cache` / `cacheTtlSeconds` / `cacheMaxEntries` | `true` / `3600` / `200` | 视觉答案缓存 |
 | `timeoutMs` | `120000` | 单次视觉调用超时 |
 | `artifactsDir` | `.dsh-vision-router/artifacts` | 产物目录（相对会话工作区） |
 | `proxy` / `proxyHosts` | `''` / openrouter 域名 | 仅视觉供应商域名可选的本地代理 |
-| `catalogCorrections` | `true` | 内置目录纠错：当已安装的 pi-ai 目录把已知模型路由到错误协议时（例如 `opencode-go/qwen3.6-plus` 被指向 OpenAI chat completions，而 OpenCode Go 只在 `/v1/messages` 上提供该模型），插件直接按正确协议应答该后端；上游目录修复后每条纠错自动失效 |
+| `catalogCorrections` | `true` | 内置目录纠错：当已安装目录把已知模型路由到错误协议时按正确协议应答；上游修复后对应纠错自动失效 |
 
 ### 本地 Ollama 视觉后端（并入自 dsh-vision）
 
 > **增量开发作者**：[shaoqiuyuavailable](https://github.com/shaoqiuyuavailable)（router 本地视觉增量）
 >
-> **思路来源**：本地视觉后端（Ollama / LM Studio 双后端、即时识别、结构化输出、截屏识别、同图去重记忆、失败降级占位、并发防雪崩、超时防护）的思路继承自 [dsh-vision](https://github.com/shaoqiuyuavailable/text-llm-vision/tree/dsh-vision)——本项目将其并入 HTTP 视觉链，并在此基础上扩展了逐级降级链与双协议支持。
+> **思路来源**：Ollama / LM Studio 双本地后端、结构化识别、截屏识别、同图记忆、失败降级、并发保护与超时防护等设计继承自 [dsh-vision](https://github.com/shaoqiuyuavailable/text-llm-vision/tree/dsh-vision)；本项目将其并入 HTTP 视觉链，并扩展逐级 fallback 与双协议支持。
 
-可选的本地优先视觉路径：不需要 Key，支持隐私、零费用、离线识别。它作为 HTTP 视觉链里的 `local-ollama` 接入；若本地识别失败，除非用户明确配置纯本地链，否则仍可能继续尝试已配置的云后端。
+可选的本地优先视觉路径：不需要 Key，适合隐私、零费用、离线识别。它作为 HTTP 视觉链里的 `local-ollama` 接入；若本地识别失败，除非用户明确配置纯本地链，否则仍可能继续尝试已配置的云后端。
 
 **1. 安装 Ollama 并拉取视觉模型**
 
@@ -373,31 +373,27 @@ Web 配置页在 **设置 → 插件 → 插件配置** 下注册「视觉路由
 ollama pull qwen2.5vl
 ```
 
-**2. 开启** —— 设置卡片「本地视觉」组，或 profile patch：
+**2. 开启** —— **设置 → Vision Router → 本地与设备**，或 profile patch：
 
 ```yaml
 - id: vision-router
   config:
     localOllama:
       enabled: true
-      baseURL: 'http://127.0.0.1:11434/v1'   # OpenAI 兼容端点
+      baseURL: 'http://127.0.0.1:11434/v1'
       model: 'qwen2.5vl'
-      temperature: 0.5                        # 可选；识别用低温更稳
-      top_p: 0.8                              # 可选；留空 = 服务端默认
-    instantDescribe: true                     # 图片轮第一轮即本地识别
-    localDescribeStyle: 'structured'          # 'plain' | 'structured'
+      temperature: 0.5
+      top_p: 0.8
 ```
 
 **3. 行为说明**
 
-- 开启后 `local-ollama` 排在 HTTP 视觉链最前。若要严格纯本地，请移除云视觉行/自定义 HTTP 端点，并关闭 `freeFallback`。
-- **v1.7 冷启动处理：**选中的本机 loopback Ollama 模型会通过原生 API 预热并保持 30 分钟驻留。如果模型在 Ollama 作为首个图片后端时已经冷却，加载会在正常视觉任务预算开始之前完成；短 `/api/ps` 探测保证服务未运行/挂死时仍快速进入 fallback。远程 Ollama URL 不会自动预热。
-- **LM Studio 同理**——同一「本地视觉」组里开启 `localLmStudio`，填 OpenAI 兼容端点（默认 `http://localhost:1234/v1`），并使用 Developer 页或 `/v1/models` 返回的真实模型标识。它排在 `local-ollama` 之后、自定义/云 HTTP 后端之前。
+- 开启后 `local-ollama` 排在 HTTP 视觉链前部。若要严格纯本地，请移除云视觉行/自定义 HTTP 端点，并关闭 `freeFallback`。
+- 选中的本机 loopback Ollama 模型会通过原生 API 预热并保持 30 分钟驻留。如果模型在 Ollama 作为首个图片后端时已经冷却，加载会在正常视觉任务预算开始之前完成；短 `/api/ps` 探测保证服务未运行/挂死时仍快速进入 fallback。远程 Ollama URL 不会自动预热。
+- **LM Studio 同理**——开启 `localLmStudio`，填 OpenAI 兼容端点（默认 `http://localhost:1234/v1`），并使用 Developer 页或 `/v1/models` 返回的真实模型标识。它排在 `local-ollama` 之后、自定义/云 HTTP 后端之前。
 - 每个本地后端可通过 `format` 选择 **OpenAI 或 Anthropic 格式**（默认 `openai`）。Anthropic 模式走 `/v1/messages`，带 `anthropic-version` 并把图片转为 base64 source；只有配置了 Key 才发送 `x-api-key`。LM Studio 需 0.4.1 或更高版本才提供该端点。
-- 任一本地后端未运行或调用超时时自动跳过，继续降级到云链——任何调用都不受影响。
-- `instantDescribe` 会在第一模型步之前按 Ollama → LM Studio 的顺序尝试已启用本地后端。多张无缓存图片并发识别（上限 3），单张失败不影响其余；命中附件记忆的图片不会再次请求本地服务。
+- 任一本地后端未运行或调用超时时自动跳过，继续降级到云链。
 - `vision_screenshot` 默认关闭。单独开启「桌面截屏」隐私开关后，`identify=true` 使用同样的 Ollama → LM Studio 降级顺序。
-- 日志中的 `image turn — instantDescribe=… localBackends=…` 显示实时决策；`instant local describe recognized N/M uncached image(s), C cached, F failed attempts` 显示本轮结果。
 
 ## 环境要求
 
@@ -475,7 +471,7 @@ npx @deepseek-ai/dsh plugin --profile web add dsh-vision-router@<版本号>
 pnpm dsh plugin --profile web add dsh-vision-router@<版本号>
 ```
 
-设置存放在 profile 的设置提供方里，升级不丢失。设置卡里的一键更新会自动显式安装 registry 已确认的版本，并在命令结束后核对实际安装版本——绝不只凭包管理器退出码就报成功。
+设置存放在 profile 的设置提供方里，升级不丢失。设置页的一键更新会自动显式安装 registry 已确认的版本，并在命令结束后核对实际安装版本——绝不只凭包管理器退出码就报成功。
 
 > **新版本一直不生效（`downloaded 0` / `added 0`）：** pnpm v11 会拦下发布不足 24 小时的版本；按上面方式显式安装目标版本（pnpm 会自动写入豁免），或运行 `npx dsh-vision-router repair` 修复过期的带版本号豁免条目后，更新立即生效。
 

--- a/docs/releases/v2.0.0.md
+++ b/docs/releases/v2.0.0.md
@@ -1,44 +1,87 @@
 # v2.0.0
 
-> **v1.7.7 → v2.0.0**：这是 Vision Router 第一次把“用户选模型”升级为“用户授权、实测能力驱动的模型选择”。2.0 新增能力感知 Auto 路由、可验证的 Quick / Full 测评与后台能力数据、输入框显式「👁 识图」模式，并重做 Settings 信息架构与原生多模态共存边界。默认行为仍然保守：按设置顺序执行、后台测评关闭，任何自动化都需要用户明确授权。
+> **v1.7.7 → v2.0.0**：这是 Vision Router 迄今最大的一次产品级升级。两版之间累计超过 400 个提交；重点不是“多了几个开关”，而是把视觉模型选择从静态顺序推进到一套**用户授权、实测证据驱动、可解释且可撤销**的能力路由系统，同时重做聊天页识图交互、Settings 信息架构、原生多模态共存和发布前可靠性边界。
 >
-> **v1.7.7 → v2.0.0**: Vision Router now moves from “the user picked a model” to “the user explicitly delegates model choice based on measured capability.” v2 introduces capability-aware Auto routing, verifiable Quick / Full benchmarks and background capability profiling, an explicit composer “👁 Vision” mode, a reorganized Settings experience, and stronger native-multimodal coexistence. Defaults remain conservative: configured order is authoritative and background profiling is off until explicitly enabled.
+> **v1.7.7 → v2.0.0**: this is Vision Router’s largest product-level upgrade so far, spanning more than 400 commits. The main change is not a handful of new toggles: model selection is now an **explicitly delegated, measured-evidence-driven, explainable and revocable** capability-routing system, accompanied by a new composer Vision interaction, reorganized Settings, stronger native-multimodal coexistence, and substantial release-hardening work.
+
+## 一眼看懂 2.0 / v2 at a glance
+
+- **Auto 能力路由正式落地（#142）**：不再靠模型名猜“谁更会看图”，而是只在用户已经配置并授权的候选中，根据真实能力证据选择；没有足够证据时继续尊重配置基线顺序。
+- **Capability-aware Auto routing ships (#142)**: Vision Router no longer guesses visual capability from model names. Auto may only choose among user-configured, authorized candidates with real capability evidence, and falls back to the configured baseline order when evidence is insufficient.
+
+- **设置页新增精确「测试识图」与 Quick / Full 测评**：单模型真实验证、能力轴评分、后台补测、持久化失败状态和可见进度统一进入正式产品界面；旧的模糊 backend smoke-test 路径退役。
+- **Exact Test Vision plus Quick / Full benchmarking**: per-model real verification, capability-axis scoring, optional background profiling, persistent failure states and visible progress are now first-class product surfaces. The older ambiguous backend smoke-test path is retired.
+
+- **聊天输入框旁新增显式「👁 识图」模式（#284 / #286）**：普通模型继续由 DSH 原生选择器管理；需要发图时主动开启识图即可，内部 wrapper 不再要求普通用户理解和手动选择。
+- **Explicit composer “👁 Vision” mode (#284 / #286)**: the stock DSH picker still owns the ordinary model. Users explicitly turn Vision on when needed, without having to understand or manually select internal wrapper routes.
+
+- **Settings 2.0（#285 / #299 / #301 / #303）**：设置按用户任务重新分组，Auto/模型链/偏好/后台能力数据合并到同一上下文，并解决即时路由控件与未保存表单之间的半事务陷阱。
+- **Settings 2.0 (#285 / #299 / #301 / #303)**: settings are reorganized around user tasks, Auto/model chain/preferences/background capability data are presented together, and the mixed-save trap between immediate routing controls and unsaved form drafts is closed.
+
+- **原生多模态优先保留模型控制权（#289 / #292 / #298）**：模型已经能直接看图时，原图先给模型；Vision Router 的 grounding / crop / OCR / pixel-diff 等能力退回“按需精查工具”，不再用全局 guard 强行接管。
+- **Native multimodal models retain control (#289 / #292 / #298)**: if the selected model already accepts images, raw pixels reach it first. Vision Router’s grounding, crop, OCR, pixel-diff and related capabilities become optional precision tools instead of a global takeover path.
 
 ## 能力感知 Auto 路由 / Capability-aware Auto routing
 
-- **Auto 正式成为产品能力（#142）**：路由遵循 `Authority → Evidence → Planner → Execution`。用户先决定是否授权 Auto；只有已经配置、且有可用证据的视觉模型才可能参与选择。没有可靠实测依据时，继续使用用户配置的基线顺序，不通过模型名称猜能力，也不会把“发现但未配置”的模型偷偷放进执行池。
-- **Auto is a delegated capability, not an implicit behavior (#142)**: routing follows `Authority → Evidence → Planner → Execution`. Only explicitly configured visual models with usable evidence can participate. When evidence is insufficient, Vision Router keeps the configured baseline order; it never infers capability from model names or promotes merely discovered models into the execution pool.
+- **Auto 是委托，不是默认接管（#142）**：路由遵循 `Authority → Evidence → Planner → Execution`。用户先决定是否授权 Auto；只有显式配置、当前可执行、且具有可用证据的视觉模型才可能进入选择。live `/models` 发现到但用户没有配置的模型，不会因为“看起来更强”被偷偷放进执行池。
+- **Auto is delegated authority, not implicit takeover (#142)**: routing follows `Authority → Evidence → Planner → Execution`. Only explicitly configured, executable candidates with usable evidence can participate. Models merely discovered from live `/models` data never enter execution simply because they appear stronger.
 
-- **四种明确偏好**：Auto 支持「综合 / 质量 / 速度 / 本地」偏好；偏好只在已授权的候选和已有证据上改变优先级，不扩大调用权限。原有 fallback 与用户配置顺序仍是无证据时的安全基线。
-- **Four explicit preferences**: Balanced / Quality / Speed / Local reorder only already-authorized candidates with evidence. Preferences do not grant new execution authority; the configured chain remains the safe baseline when evidence is absent.
+- **四种偏好**：Auto 支持「综合 / 质量 / 速度 / 本地」。偏好只会重新排序已经有权参与的候选，不会扩大调用权限，也不会越过用户配置的 provider/model 边界。
+- **Four preferences**: Balanced / Quality / Speed / Local only reorder candidates that already have execution authority. A preference never grants access to another provider/model or broadens the configured execution scope.
 
-- **默认零惊喜**：升级后默认仍为 `routingMode=ordered`、`routingPreference=balanced`、`backgroundBenchmarking=off`。打开 Auto 本身不会自动测评，也不会额外产生 Benchmark 请求。
-- **Conservative defaults**: upgrades still default to `routingMode=ordered`, `routingPreference=balanced`, and `backgroundBenchmarking=off`. Enabling Auto by itself does not start benchmarks or create extra Benchmark traffic.
+- **无证据时不装聪明**：如果能力数据缺失、过期或与当前 deployment fingerprint 不匹配，Auto 不用模型名称、供应商品牌或静态印象推断能力，而是回到用户配置的基线顺序。
+- **No fake confidence when evidence is missing**: absent, stale or fingerprint-mismatched capability data never triggers name- or brand-based inference. Auto falls back to the configured baseline order instead.
 
-## 测评与后台能力数据 / Benchmarking & background capability profiling
+- **默认行为保持保守**：升级后仍默认 `routingMode=ordered`、`routingPreference=balanced`、`backgroundBenchmarking=off`。仅仅打开 Auto 不会自动启动测评，也不会产生额外 Benchmark 请求。
+- **Conservative defaults remain**: upgrades still default to `routingMode=ordered`, `routingPreference=balanced`, and `backgroundBenchmarking=off`. Enabling Auto alone does not start benchmarking or create extra Benchmark traffic.
 
-- **精确「测试识图」**：设置页每个模型都可以做一次真实图片验证；一次点击只向当前精确 provider/model 发送一次请求，无 fallback、无 Auto 分数污染。明确拒绝图片时会记录为该 endpoint fingerprint 的“实测仅文本”，并停止后台继续花请求；显式成功重测可以解除同 fingerprint 的停止状态。
-- **Exact “Test Vision” verification**: one click sends exactly one real image request to the selected provider/model, with no fallback and no Auto-score side effects. Explicit image rejection becomes a persistent text-only verdict for that endpoint fingerprint and stops background spending; a later explicit successful retest can clear the same-fingerprint stop.
+## 测试识图、Benchmark 与能力证据 / Test Vision, benchmarks & capability evidence
 
-- **Quick / Full 能力测评**：Quick 约 3 次请求，测 OCR + 通用理解；Full 约 6 次请求，覆盖结构化、OCR、文档、定位、通用。弹窗直接显示请求量与预计耗时（Quick 约 1–3 分钟，Full 约 3–8 分钟）；开始后可以关闭 Settings 页面，任务仍在 DSH 后台继续。
-- **Quick / Full capability benchmarks**: Quick uses about 3 requests for OCR + General; Full uses about 6 for Structured + OCR + Document + Grounding + General. The UI shows request-count/time estimates (about 1–3 min Quick, 3–8 min Full), and benchmark work continues in DSH even after the Settings page is closed.
+- **精确「测试识图」取代模糊 Smoke Test**：每次点击只向当前精确 provider/model 发 **1 次真实图片请求**，无 fallback、无 Auto 分数污染。测试结果回答的是“这个 deployment 现在是否真的接收图片”，而不是“整条 fallback 链最终有没有成功”。
+- **Exact Test Vision replaces ambiguous smoke testing**: one click sends **exactly one real image request** to the selected provider/model, with no fallback and no Auto-score side effects. It answers whether that deployment itself currently accepts images, not whether some later fallback eventually succeeds.
 
-- **后台补充能力数据是独立授权**：`off / local-free / all` 不会因为开启 Auto 自动改变；当前实现只在 Auto 激活时运行已授权后台测评。调度按能力轴推进，前台真实识图会抢占后台任务，空闲约 30 秒后恢复；手动 Benchmark 同样优先，结束约 15 秒后后台继续。关闭后台测评会撤销后续请求与写入。
-- **Background profiling is separately authorized**: `off / local-free / all` never changes merely because Auto is enabled; authorized background profiling runs only while Auto is active. Foreground vision preempts background work and resumes after roughly 30 seconds idle; manual benchmarks also preempt it and background work resumes after roughly 15 seconds. Revoking background profiling stops future requests and writes.
+- **真实拒图会成为 endpoint-scoped 事实**：明确图片拒绝会记录为当前 endpoint fingerprint 的“实测仅文本”，并停止后台继续花请求；显式成功重测可解除同 fingerprint 的停止状态。DeepSeek 的 `UNSUPPORTED_CONTENT` / `does not accept image input` 等真实拒图形式已覆盖，同时不会把普通 400、内容策略错误或 visual-proof 失败误判成仅文本。
+- **Real image rejection becomes endpoint-scoped evidence**: an explicit rejection records the current endpoint fingerprint as measured text-only and stops further background spending. A later explicit successful retest can clear the same-fingerprint stop. Real DeepSeek forms such as `UNSUPPORTED_CONTENT` / `does not accept image input` are recognized without misclassifying generic 400s, content-policy failures or visual-proof failures as text-only.
 
-- **失败状态按正确粒度持久化**：`auth / unavailable / protocol` 对同一 deployment fingerprint 是模型级停止，重启 DSH 后不会先白花一次请求再重新失败；`visual-proof` 只停止对应能力轴，不会把支持图片的模型误判为仅文本。DeepSeek `UNSUPPORTED_CONTENT / does not accept image input` 等真实拒图措辞已纳入显式图片拒绝分类。
-- **Persistent failures use the right scope**: `auth / unavailable / protocol` stop the same deployment fingerprint model-wide across restarts, while `visual-proof` remains axis-scoped and never turns an image-capable model into “text-only.” Real DeepSeek rejection forms such as `UNSUPPORTED_CONTENT / does not accept image input` are recognized as explicit image rejection without treating generic content errors as text-only.
+- **Quick / Full 能力测评**：Quick 约 **3 次请求**，重点测 OCR + General；Full 约 **6 次请求**，覆盖 Structured + OCR + Document + Grounding + General。界面会先显示请求量与预计耗时（Quick 约 1–3 分钟，Full 约 3–8 分钟），避免用户在不知成本的情况下直接开始。
+- **Quick / Full capability benchmarks**: Quick uses about **3 requests** focused on OCR + General; Full uses about **6 requests** across Structured + OCR + Document + Grounding + General. The UI shows request-count and time estimates first (roughly 1–3 min Quick, 3–8 min Full) so users are not surprised by cost or duration.
+
+- **Benchmark 在 DSH 后台继续运行**：手动开始后可以关闭 Settings 页面；任务状态、进度和最终 profile 由 Host 侧维护，不依赖浏览器标签页存活。
+- **Benchmarks continue in the DSH process**: after a manual start, the Settings page may be closed. Task state, progress and final profile persistence are maintained on the Host side rather than depending on the browser tab.
+
+- **慢模型不再被错误的总墙钟预算吞掉**：Quick / Full 的聚合 deadline 会按 fixture 数量和单请求预算计算，仍保留单请求硬超时，但不会因为三个正常偏慢的顺序请求一起超过旧的固定总时限而把整轮成绩全部丢掉。
+- **Slow but valid models no longer lose an entire benchmark to an undersized aggregate wall-clock budget**: the job deadline scales with fixture count and per-request budget while keeping hard per-request safety limits.
+
+- **能力数据按 deployment identity 管理**：评分、新鲜度、图片输入 verdict 与 non-retryable stop 都绑定到可验证的 provider/model/endpoint fingerprint；普通设置刷新不会把同一 deployment 的失败“洗白”，endpoint 变化或显式成功重测才会建立新的事实。
+- **Capability evidence follows deployment identity**: scores, freshness, image-input verdicts and non-retryable stops bind to a verifiable provider/model/endpoint fingerprint. Ordinary settings refreshes do not erase a failure for the same deployment; endpoint changes or explicit successful retests establish new evidence.
+
+## 后台能力数据 / Background capability profiling
+
+- **后台补测单独授权**：`off / local-free / all` 与 Auto 开关互相独立；Auto 不会替用户打开后台测评。`all` 可能调用云端模型并产生 API 费用，因此首次开启会明确提示。
+- **Background profiling has separate consent**: `off / local-free / all` is independent from the Auto switch. Auto never silently enables background benchmarking, and `all` explicitly warns that cloud API usage may incur cost.
+
+- **低优先级、按能力轴推进**：后台调度不会一次性把整套 Full 测评砸向所有模型，而是逐能力轴补证据，并跳过已经完成、已经明确不支持或当前被 non-retryable stop 阻止的候选。
+- **Low-priority, axis-by-axis scheduling**: background work does not blast a full suite at every model. It fills capability evidence incrementally and skips completed, explicitly unsupported or non-retryably blocked candidates.
+
+- **前台真实识图永远优先**：用户发起视觉任务时后台测评会让路，并在约 30 秒空闲后恢复；手动 Benchmark 同样抢占后台，结束后约 15 秒恢复。关闭后台测评会撤销后续请求和写入，而不是“关了开关但队列继续跑”。
+- **Foreground work always wins**: real user vision preempts background profiling and allows it to resume after roughly 30 seconds idle. Manual benchmarks also preempt background work, with resume after roughly 15 seconds. Revoking background profiling cancels future requests and writes rather than merely hiding the toggle.
+
+- **失败按正确粒度停止**：`auth / unavailable / protocol` 对同一 deployment fingerprint 是模型级 non-retryable stop，并在 DSH 重启后继续生效；`visual-proof` 只作用于对应能力轴，不会把支持图片的模型整机判死。
+- **Failures stop at the correct scope**: `auth / unavailable / protocol` are model-wide non-retryable stops for the same deployment fingerprint and survive DSH restart. `visual-proof` remains axis-scoped and never condemns an image-capable model as a whole.
 
 ## 输入框「👁 识图」模式 / Composer “👁 Vision” mode
 
 - **聊天页新增显式识图开关（#284 / #286）**：普通聊天模型仍由 DSH 原生模型选择器负责；需要发图时用户主动开启「👁 识图」，底层切换到同一 provider/model 的 Vision Router wrapper。默认关闭，不因上传图片偷偷开启；发送后保持状态，关闭时返回同一普通模型。
 - **Explicit composer Vision toggle (#284 / #286)**: DSH’s stock picker continues to own the ordinary conversation model. Users explicitly enable Vision when needed, switching underneath to Vision Router’s matching wrapper for the same provider/model. It starts off, is never silently enabled by attaching an image, persists across sends, and returns to the same ordinary model when disabled.
 
-- **模型身份与 reasoning effort 保持一致**：只修改 reasoning effort 不会退出识图；用户手动选择另一个普通模型才会离开 wrapper。切换被 Host 拒绝时沿用原生 Toast，不绕过 DSH 安全约束，按钮始终反映真实 route。
-- **Model identity and reasoning effort stay coherent**: effort-only changes remain on the Vision wrapper; choosing a different ordinary model exits it. If the Host rejects a switch, the stock Toast path is used, DSH safety is not bypassed, and the toggle continues to reflect the real route.
+- **识图模式没有第二份“假状态”**：按钮状态从 DSH 当前真实 route 派生。只修改 reasoning effort 不会退出识图；用户手动选择另一个普通模型才会离开 wrapper。切换被 Host 拒绝时沿用原生 Toast，不绕过 DSH 安全约束，按钮继续反映真实 current。
+- **Vision mode has no second shadow state**: the button derives its state from DSH’s real current route. Effort-only changes stay on the Vision wrapper; choosing another ordinary model exits it. Rejected switches use the stock Toast path and never bypass Host safety, while the button continues to reflect the actual current route.
 
-- **内部「+ 自动识图」wrapper 从原生模型列表隐藏**：只改变 presentation，不删除 Host route。隐藏必须同时满足配置意图、route/name 和 exact-model 镜像；设置缺失、归属歧义、镜像不完整、第三方 `*-vision` lookalike 都 fail-open，宁可显示也不误藏（#288 / #291 / #294 / #300）。
-- **Internal “+ Auto Vision” wrappers are hidden from stock model presentation**: real Host routes remain intact. Hiding requires matching configuration intent, route/name identity and exact-model mirroring; missing/ambiguous settings, incomplete mirrors and third-party `*-vision` lookalikes fail open and remain visible (#288 / #291 / #294 / #300).
+- **内部「+ 自动识图」wrapper 默认隐藏**：只改变 DSH model-selection 的 presentation，不删除真实 Host route。隐藏必须同时满足配置意图、route/name 和 exact-model 镜像；设置缺失、归属歧义、镜像不完整、第三方 `*-vision` lookalike 都 fail-open，宁可显示也不误藏（#288 / #291 / #294 / #300）。
+- **Internal “+ Auto Vision” wrappers are hidden by default**: only stock model-selection presentation changes; real Host routes remain intact. Hiding requires matching configuration intent, route/name identity and exact-model mirroring. Missing/ambiguous settings, incomplete mirrors and third-party `*-vision` lookalikes fail open and remain visible (#288 / #291 / #294 / #300).
+
+- **新手路径同步简化**：Quick Start / onboarding 统一为“选普通模型 → 开启识图 → 发图”，不再要求用户从成对的普通模型与 wrapper 模型中理解该选哪一个。
+- **Onboarding is simplified**: Quick Start now consistently teaches “choose the ordinary model → enable Vision → send the image,” rather than requiring users to reason about paired ordinary/wrapper model entries.
 
 - **原生多模态 wrapper 获得当前轮真实 attachment ID**：模型已经看得到原图时，仍可按需调用 `vision_describe` / `vision_ground` 等精查工具，而不需要猜造附件 ID；跨 session 授权和 `unknown attachment id` 安全边界不放宽。
 - **Owned multimodal wrappers receive real current-turn attachment IDs** so a model that already sees raw pixels can still invoke precision tools without inventing attachment identifiers. Session-scoped authorization and the `unknown attachment id` boundary remain strict.
@@ -47,6 +90,9 @@
 
 - **原生多模态模型保持控制权（#289 / #292 / #298）**：如果当前模型本来就能直接看图，Vision Router 不再用全局 structured guard / synthetic budget message 强行接管这轮；原始图片先直接交给模型，grounding / crop / OCR / pixel-diff 等只在模型真正需要时作为精查工具参与。
 - **Native multimodal models stay in control (#289 / #292 / #298)**: when the selected model already accepts images, Vision Router no longer lets a global structured guard or synthetic budget message hijack the turn. Raw pixels reach the model first; grounding, crop, OCR, pixel diff and other tools remain optional precision aids.
+
+- **原生能力与工具增强可以共存**：能直接看图不等于失去 Vision Router 工具。模型可先看整图，再根据任务决定是否调用定位、裁剪、OCR、颜色、pixel-diff、截图等工具做更精确的二次检查。
+- **Native vision and precision tools coexist**: direct image input does not remove Vision Router’s tool layer. A multimodal model can inspect the full image first, then selectively invoke grounding, crop, OCR, color, pixel-diff, screenshot and related tools for precision work.
 
 - **整轮视觉预算默认不再误伤长推理**：`visionTurnBudgetMs` 默认改为 `0`（不设整轮总墙钟上限），预算只在真正开始视觉工作时生效；具体网络请求、工具和 Benchmark 仍各自保留硬超时与资源边界。
 - **Whole-turn vision budget no longer penalizes long reasoning by default**: `visionTurnBudgetMs` now defaults to `0` (no global wall-clock cap), while concrete network requests, tools and benchmarks retain their own hard deadlines and resource limits.
@@ -62,35 +108,59 @@
 - **发布前收口混合保存陷阱（#303）**：如果 React Settings IA 还有未保存修改，v2 的即时路由控件会要求先保存或放弃，避免出现“Auto 已落盘但刚改的模型链没保存”的半事务状态。Auto 模式下页面明确标注“配置基线顺序”，不再把显示顺序误写成下一次保证执行顺序；Ordered 下不可用的偏好/后台项也恢复明确 disabled 视觉与 ARIA 状态。
 - **Mixed-save trap closed before release (#303)**: v2 immediate routing controls are blocked while the React Settings IA still has unrelated unsaved drafts, preventing partial state such as “Auto saved, model-chain edit lost.” Auto labels the displayed chain as the configured baseline rather than a guaranteed next execution order; Ordered-only disabled controls regain clear visual and ARIA state.
 
-- **远程设置继续遵守能力边界**：远程编辑仍默认关闭、需要明确风险确认；API Key、HTTP provider 凭据、本地 Ollama / LM Studio、桌面截图等敏感配置保持本机专属。v2 的安全字段通过同一 Host 权威写入/readback 路径，不引入浏览器侧私有配置副本。
-- **Remote settings keep the existing capability boundary**: remote editing remains opt-in behind explicit risk confirmation, while API keys, HTTP-provider credentials, local Ollama / LM Studio and desktop capture stay local-only. Safe v2 fields use the same authoritative Host write/readback path rather than a browser-side shadow configuration.
+- **远程设置继续遵守能力边界**：远程编辑仍默认关闭、需要明确风险确认；API Key、HTTP provider 凭据、本地 Ollama / LM Studio、桌面截图等敏感配置保持本机专属。v2 的安全字段继续通过 Host 权威写入/readback 路径，不引入浏览器侧私有配置副本。
+- **Remote settings keep the existing capability boundary**: remote editing remains opt-in behind explicit risk confirmation, while API keys, HTTP-provider credentials, local Ollama / LM Studio and desktop capture stay local-only. Safe v2 fields continue through the authoritative Host write/readback path rather than a browser-side shadow configuration.
 
 ## 模型目录、边界与兼容 / Catalog, boundaries & compatibility
 
 - **设置可见模型成为产品权威目录（#288 / #291 / #294）**：显式配置的 Models 行存在时，以它们定义可见/可包装范围；live `/models` 发现只做受限补充，不会把用户已经删除的模型重新塞回 Auto Vision wrapper。wrapper scope、公开 model presentation 与执行权限继续分层。
 - **Settings-visible models are authoritative product catalog entries (#288 / #291 / #294)**: explicit configured model rows define visible/wrappable scope; live `/models` discovery is a bounded supplement and cannot resurrect a model the user removed back into Auto Vision wrappers. Wrapper scope, presentation and execution authority remain separate layers.
 
-- **Vision toggle DOM 根边界收紧（#300）**：增强逻辑只作用于确认属于 Vision Router / DSH 模型选择器的根节点，不会因为相似 ARIA/menu 结构去改写或隐藏第三方界面。
-- **Vision-toggle DOM root boundaries are hardened (#300)** so enhancement only touches confirmed Vision Router / DSH model-picker roots instead of rewriting unrelated third-party ARIA/menu structures.
+- **Host 声明与真实调用证据分层**：Host 元数据可以提示某模型是 text-only，但不会单独阻止用户显式 Test Vision；真实图片请求成功/拒绝才建立当前 deployment 的更强证据。这避免静态目录过期时把实际可用模型永久挡掉。
+- **Host metadata and real call evidence are layered**: Host metadata may advise that a model is text-only, but does not alone prevent an explicit Test Vision. A real image success or rejection creates stronger evidence for the current deployment, avoiding permanent false negatives from stale catalogs.
+
+- **Vision toggle DOM 根边界收紧（#300）**：增强逻辑只作用于确认属于 Vision Router / DSH 模型选择器的根节点，不会因为相似 ARIA/menu 结构去改写、隐藏或影响第三方界面。
+- **Vision-toggle DOM root boundaries are hardened (#300)** so enhancement only touches confirmed Vision Router / DSH model-picker roots instead of rewriting or hiding unrelated third-party ARIA/menu structures.
 
 - **安全与 wire 兼容修复（#295 / #296）**：风险 regex 改为有界/线性判断以通过 CodeQL 并避免病态输入放大；可选图片 metadata（如 `originalDimensions`）可以被兼容接受，但实际图片字节仍是格式、尺寸和资源准入的权威来源。
 - **Security and wire compatibility fixes (#295 / #296)** replace risky regex paths with bounded/linear checks and accept optional image metadata such as `originalDimensions` without allowing metadata to override the actual image bytes as the source of truth for format, dimensions or resource admission.
+
+- **DSH 多版本兼容继续作为硬门禁**：CI 持续验证 Node 22 / 24、DSH rc.6 / rc.7 / rc.8 contract、Ubuntu / macOS / Windows host-sharp、native multimodal cold resume 与大图资源压力；真实发布验收使用 DSH 0.1.1-rc.1。
+- **DSH compatibility remains a release gate**: CI continues to exercise Node 22/24, DSH rc.6/rc.7/rc.8 contracts, Ubuntu/macOS/Windows host-sharp, native-multimodal cold resume and large-image stress, while real-machine release acceptance was performed on DSH 0.1.1-rc.1.
 
 ## 真实验收与发布门禁 / Real-machine acceptance & release gates
 
 - **v2 在真实 DSH 0.1.1-rc.1 环境完成发布验收**：覆盖真实 DeepSeek 拒图、OpenRouter 不可用 deployment、Kimi visual-proof、GLM 慢 Quick Benchmark、前台/手动抢占、撤销后台授权、重启持久化与普通视觉执行。最终复验结果为 **GO**。
 - **v2 completed real-machine release acceptance on DSH 0.1.1-rc.1**, covering real DeepSeek image rejection, unavailable OpenRouter deployment behavior, Kimi visual-proof scoping, a real GLM Quick benchmark, foreground/manual preemption, background revocation, restart persistence and normal visual execution. Final recheck result: **GO**.
 
-- 关键复验硬指标：DeepSeek 判定“实测仅文本”后后台新增请求 **0**；Sol 同 fingerprint 重启后后台请求 **0**；Kimi visual-proof 失败轴重启后重复请求 **0** 且其他能力不被整模型封锁；GLM Quick 为 **3 个请求 / completed / profile 成功写入**。
-- Key recheck evidence: **0** new background requests after DeepSeek was measured text-only; **0** Sol background requests after restart on the same fingerprint; **0** repeat requests for Kimi’s failed visual-proof axes without model-wide lockout; GLM Quick completed with **3 requests / completed state / persisted profile update**.
+- **关键复验硬指标**：DeepSeek 判定“实测仅文本”后后台新增请求 **0**；Sol 同 fingerprint 重启后后台请求 **0**；Kimi visual-proof 失败轴重启后重复请求 **0** 且其他能力不被整模型封锁；GLM Quick 为 **3 个请求 / completed / profile 成功写入**。
+- **Key recheck evidence**: **0** new background requests after DeepSeek was measured text-only; **0** Sol background requests after restart on the same fingerprint; **0** repeat requests for Kimi’s failed visual-proof axes without model-wide lockout; GLM Quick completed with **3 requests / completed state / persisted profile update**.
 
-- CI 持续覆盖 Node 22 / Node 24、DSH rc.6 / rc.7 / rc.8 contract、Ubuntu / macOS / Windows host-sharp、native multimodal cold resume；大图资源压力与对抗式回归继续作为相关路径门禁。正式 tag 还会由 Release workflow 在不可变源码上重新运行完整 `pnpm test`，再通过 npm Trusted Publishing (OIDC) 发布并校验 tarball 身份。
-- CI continuously covers Node 22/24, DSH rc.6/rc.7/rc.8 contracts, Ubuntu/macOS/Windows host-sharp and native multimodal cold resume, with large-image stress and adversarial regressions guarding relevant paths. The final tag is verified again by the Release workflow, which reruns full `pnpm test`, publishes through npm Trusted Publishing (OIDC), and verifies the exact registry tarball identity.
+- **发布不是“CI 绿了就算完”**：正式 tag 还会由 Release workflow 在不可变源码上重新运行完整 `pnpm test`，校验 tag 与 `package.json` 版本一致、tag 可从 `main` 到达，并通过 npm Trusted Publishing (OIDC) 发布和核对 tarball 身份。
+- **Release is not merely “CI is green”**: the final immutable tag is re-verified by the Release workflow, which reruns full `pnpm test`, checks tag/package-version identity and reachability from `main`, then publishes through npm Trusted Publishing (OIDC) and verifies the exact registry tarball.
 
-## 升级说明 / Upgrade notes
+## 升级时需要知道的变化 / Upgrade notes
 
-- **没有自动开启 Auto 的迁移**：升级现有安装不会替用户改变模型选择授权。想继续按旧方式使用，保持默认“按设置顺序”即可；想使用 v2 Auto，可在 Settings → Vision Router → 常规中主动开启并按需选择后台测评权限。
-- **No migration silently enables Auto**: existing installations keep user authority unchanged. Leave “Configured order” selected for the old behavior; opt into v2 Auto explicitly from Settings → Vision Router → General, and separately choose any desired background profiling permission.
+- **不会自动打开 Auto**：现有安装升级后仍按原来的用户授权边界运行。想继续旧的行为，保持“按设置顺序”即可；想用 v2 Auto，再主动开启并单独选择后台能力数据权限。
+- **Auto is never silently enabled on upgrade**: existing installs keep the same authority boundary. Leave “Configured order” selected for the previous behavior; opt into v2 Auto explicitly and choose background capability profiling separately.
 
-- 推荐仍使用官方 DSH CLI 更新/安装；2.0.0 不要求 Python，现有识图模型、本地后端和安全远程设置配置会继续经过迁移/规范化层读取。
-- The official DSH CLI remains the recommended install/update path. v2.0.0 still requires no Python, and existing vision-model, local-backend and safe remote-settings configuration continues through the migration/normalization layer.
+- **旧 Smoke Test 心智模型已经变化**：2.0 更推荐用每行「测试识图」确认“这个模型本身能不能看图”，再用 Quick / Full 回答“它在哪些视觉任务上表现更好”。两者不会混为一个“整条链通不通”的结果。
+- **The old smoke-test mental model has changed**: use per-row Test Vision to answer “can this exact model accept images?”, then Quick / Full to answer “which visual tasks is it good at?”. Those are intentionally separate from whole-chain fallback success.
+
+- **内部 wrapper 仍然存在，只是普通模型 UI 默认不展示**：不要把“模型列表里看不到 `+ 自动识图`”理解成 route 被删除。Host route 仍用于图片准入和 Vision Router 切换，只是 presentation 层降噪。
+- **Internal wrappers still exist even though the ordinary model UI hides them by default**: absence of a `+ Auto Vision` entry does not mean the Host route was removed. It remains available for image admission and Vision Router switching; only presentation is simplified.
+
+- **后台测评可能产生真实费用**：默认 `off`。如果选择 `all`，Vision Router 会在 Auto 激活、系统空闲时对授权的云端模型补充能力证据；随时切回 `off` 可以撤销后续后台请求。
+- **Background profiling can create real API cost**: it defaults to `off`. Choosing `all` allows authorized cloud models to be profiled while Auto is active and the system is idle; switching back to `off` revokes future background requests.
+
+- **推荐仍使用官方 DSH CLI 安装/更新**。2.0.0 仍不要求 Python；既有识图模型、本地后端和安全远程设置配置继续经过迁移/规范化层读取。
+- **The official DSH CLI remains the recommended install/update path**. v2.0.0 still requires no Python, and existing vision-model, local-backend and safe remote-settings configuration continues through the migration/normalization layer.
+
+## 安装 / Install
+
+```sh
+npx @deepseek-ai/dsh plugin --profile web add dsh-vision-router
+```
+
+升级后按平时方式重新加载 / 重启 DSH Web，使 Host 重新加载插件即可。
+After upgrading, reload or restart DSH Web normally so the Host reloads the plugin.

--- a/docs/releases/v2.0.0.md
+++ b/docs/releases/v2.0.0.md
@@ -21,6 +21,9 @@
 - **原生多模态优先保留模型控制权（#289 / #292 / #298）**：模型已经能直接看图时，原图先给模型；Vision Router 的 grounding / crop / OCR / pixel-diff 等能力退回“按需精查工具”，不再用全局 guard 强行接管。
 - **Native multimodal models retain control (#289 / #292 / #298)**: if the selected model already accepts images, raw pixels reach it first. Vision Router’s grounding, crop, OCR, pixel-diff and related capabilities become optional precision tools instead of a global takeover path.
 
+- **旧会话中的一次性停止提示不会再污染后续图片轮（#302）**：历史版本持久化下来的 guard-stop 会在模型输入面被安全影子替换，不再把“本轮预算/深度已耗尽”错误重放成永久禁用视觉工具的指令。
+- **Persisted one-turn stop instructions no longer poison later image turns (#302)**: legacy guard-stop messages are safely shadowed off the model-facing session surface, so a past “this turn’s budget/depth is exhausted” instruction cannot become a permanent ban on vision tools.
+
 ## 能力感知 Auto 路由 / Capability-aware Auto routing
 
 - **Auto 是委托，不是默认接管（#142）**：路由遵循 `Authority → Evidence → Planner → Execution`。用户先决定是否授权 Auto；只有显式配置、当前可执行、且具有可用证据的视觉模型才可能进入选择。live `/models` 发现到但用户没有配置的模型，不会因为“看起来更强”被偷偷放进执行池。
@@ -97,6 +100,14 @@
 - **整轮视觉预算默认不再误伤长推理**：`visionTurnBudgetMs` 默认改为 `0`（不设整轮总墙钟上限），预算只在真正开始视觉工作时生效；具体网络请求、工具和 Benchmark 仍各自保留硬超时与资源边界。
 - **Whole-turn vision budget no longer penalizes long reasoning by default**: `visionTurnBudgetMs` now defaults to `0` (no global wall-clock cap), while concrete network requests, tools and benchmarks retain their own hard deadlines and resource limits.
 
+## 会话续接与历史兼容 / Session continuity & historical compatibility
+
+- **修复持久化 guard-stop 污染后续轮次（#302）**：历史版本曾把“本轮视觉总时间预算/深度配额已耗尽”的一次性 stop 指令持久化成 `user/message`。DSH 在后续 `deriveMessages()` 时会再次把这条历史消息交给模型，结果可能出现“第一张图正常，之后每张图都认为视觉工具永久禁止”的故障。2.0 会按 Vision Router 私有 message id 精确识别这些旧记录，并通过 DSH 的 session surface shadow 机制只替换**模型看到的投影**；人类可见的原始转写、原事件和其他普通用户消息不被删除或改写。
+- **Persisted guard-stop instructions no longer poison later turns (#302)**: older builds could persist a one-turn “vision budget/depth exhausted” stop as a `user/message`. Later `deriveMessages()` projections would feed that stale instruction back to the model, potentially making the first image work while every later image behaved as if vision tools were permanently forbidden. v2 matches only Vision Router-owned message IDs and uses DSH session-surface shadow replacement on the **model-facing projection**; the human-visible transcript, original event and ordinary user messages remain intact.
+
+- **旧的 `-undefined` 形态也可恢复**：历史上 turn id 缺失留下的 `vision-router-structured-guard-stop-undefined` 同样被精确覆盖；匹配只看插件私有 id，不按提示文本搜索，因此用户引用同一句“预算已耗尽”不会被误删。surface compaction / 重启后也会重新建立正确投影。
+- **Legacy `-undefined` IDs are covered as well**: historical `vision-router-structured-guard-stop-undefined` records are handled explicitly. Matching is based only on plugin-owned IDs, never the wording of the stop message, so a user quoting the same text is untouched; the correction also survives session-surface compaction and resume.
+
 ## 设置 2.0 / Settings 2.0
 
 - **Settings 按用户任务重组（#285 / #299）**：一级 Vision Router 设置页重构为「常规 / 识图策略 / 本地与设备 / 高级 / 诊断」，模型选择、工具策略、本地后端、性能/网络与排障各归其位。迁移层保留有效旧配置，并明确退役历史 UI 状态字段，避免“看似还在、实际已不生效”的幽灵设置。
@@ -135,6 +146,9 @@
 
 - **关键复验硬指标**：DeepSeek 判定“实测仅文本”后后台新增请求 **0**；Sol 同 fingerprint 重启后后台请求 **0**；Kimi visual-proof 失败轴重启后重复请求 **0** 且其他能力不被整模型封锁；GLM Quick 为 **3 个请求 / completed / profile 成功写入**。
 - **Key recheck evidence**: **0** new background requests after DeepSeek was measured text-only; **0** Sol background requests after restart on the same fingerprint; **0** repeat requests for Kimi’s failed visual-proof axes without model-wide lockout; GLM Quick completed with **3 requests / completed state / persisted profile update**.
+
+- **#302 发布阻塞修复也跑过完整同 SHA 门禁**：原作者提交在 Node 22 / 24、DSH rc.6 / rc.7 / rc.8、Ubuntu / macOS / Windows host-sharp、native multimodal cold resume 和大图资源压力上全部通过后才合入 `main`，再同步进 2.0.0 release branch。
+- **The #302 release-blocking fix was validated on the exact contributor SHA** across Node 22/24, DSH rc.6/rc.7/rc.8, Ubuntu/macOS/Windows host-sharp, native-multimodal cold resume and large-image stress before being merged to `main` and synchronized into the v2.0.0 release branch.
 
 - **发布不是“CI 绿了就算完”**：正式 tag 还会由 Release workflow 在不可变源码上重新运行完整 `pnpm test`，校验 tag 与 `package.json` 版本一致、tag 可从 `main` 到达，并通过 npm Trusted Publishing (OIDC) 发布和核对 tarball 身份。
 - **Release is not merely “CI is green”**: the final immutable tag is re-verified by the Release workflow, which reruns full `pnpm test`, checks tag/package-version identity and reachability from `main`, then publishes through npm Trusted Publishing (OIDC) and verifies the exact registry tarball.

--- a/docs/releases/v2.0.0.md
+++ b/docs/releases/v2.0.0.md
@@ -170,6 +170,20 @@
 - **推荐仍使用官方 DSH CLI 安装/更新**。2.0.0 仍不要求 Python；既有识图模型、本地后端和安全远程设置配置继续经过迁移/规范化层读取。
 - **The official DSH CLI remains the recommended install/update path**. v2.0.0 still requires no Python, and existing vision-model, local-backend and safe remote-settings configuration continues through the migration/normalization layer.
 
+## 设计来源与致谢 / Design attribution & acknowledgements
+
+特别感谢 **@shaoqiuyuavailable** 及其项目 **`shaoqiuyuavailable/text-llm-vision`（dsh-vision）**。v2 在 scene-aware routing、classify-first，以及 precision/depth 分层方向上的一部分思路，受到其更早的探索、讨论与持续 PR 贡献启发；相关贡献也通过 #98、#177、#178 等工作进入了项目演进过程。
+
+Special thanks to **@shaoqiuyuavailable** and **`shaoqiuyuavailable/text-llm-vision` (dsh-vision)**. Part of v2’s direction around scene-aware routing, classify-first reasoning, and precision/depth tiers was informed by that project’s earlier exploration, discussions, and continued pull-request contributions, including work represented in #98, #177 and #178.
+
+这里的归因限定在上述**概念与设计方向**。v2 的 exact-endpoint Benchmark/profile、`Authority → Evidence → Planner → Execution` 权限模型、保守证据策略、deployment fingerprint、后台测评调度与持久化、runtime execution gate，以及 Settings 中的 Auto 控制，是为 `dsh-vision-router` 独立设计和工程化实现的。
+
+This attribution is intentionally scoped to those **conceptual and design directions**. v2’s exact-endpoint Benchmark/profile system, `Authority → Evidence → Planner → Execution` authority model, conservative evidence policy, deployment fingerprints, background profiling/persistence, runtime execution gate, and Settings Auto controls were independently designed and engineered for `dsh-vision-router`.
+
+感谢所有提交 issue、PR、真机复现、兼容性反馈和对抗式测试的社区贡献者；2.0 的不少发布前边界就是由这些真实反馈推动收紧的。
+
+Thanks as well to everyone who filed issues and PRs, reproduced failures on real machines, reported compatibility problems, or stress-tested edge cases. Many of v2’s release-hardening boundaries exist because of that community feedback.
+
 ## 安装 / Install
 
 ```sh

--- a/docs/releases/v2.0.0.md
+++ b/docs/releases/v2.0.0.md
@@ -1,0 +1,96 @@
+# v2.0.0
+
+> **v1.7.7 → v2.0.0**：这是 Vision Router 第一次把“用户选模型”升级为“用户授权、实测能力驱动的模型选择”。2.0 新增能力感知 Auto 路由、可验证的 Quick / Full 测评与后台能力数据、输入框显式「👁 识图」模式，并重做 Settings 信息架构与原生多模态共存边界。默认行为仍然保守：按设置顺序执行、后台测评关闭，任何自动化都需要用户明确授权。
+>
+> **v1.7.7 → v2.0.0**: Vision Router now moves from “the user picked a model” to “the user explicitly delegates model choice based on measured capability.” v2 introduces capability-aware Auto routing, verifiable Quick / Full benchmarks and background capability profiling, an explicit composer “👁 Vision” mode, a reorganized Settings experience, and stronger native-multimodal coexistence. Defaults remain conservative: configured order is authoritative and background profiling is off until explicitly enabled.
+
+## 能力感知 Auto 路由 / Capability-aware Auto routing
+
+- **Auto 正式成为产品能力（#142）**：路由遵循 `Authority → Evidence → Planner → Execution`。用户先决定是否授权 Auto；只有已经配置、且有可用证据的视觉模型才可能参与选择。没有可靠实测依据时，继续使用用户配置的基线顺序，不通过模型名称猜能力，也不会把“发现但未配置”的模型偷偷放进执行池。
+- **Auto is a delegated capability, not an implicit behavior (#142)**: routing follows `Authority → Evidence → Planner → Execution`. Only explicitly configured visual models with usable evidence can participate. When evidence is insufficient, Vision Router keeps the configured baseline order; it never infers capability from model names or promotes merely discovered models into the execution pool.
+
+- **四种明确偏好**：Auto 支持「综合 / 质量 / 速度 / 本地」偏好；偏好只在已授权的候选和已有证据上改变优先级，不扩大调用权限。原有 fallback 与用户配置顺序仍是无证据时的安全基线。
+- **Four explicit preferences**: Balanced / Quality / Speed / Local reorder only already-authorized candidates with evidence. Preferences do not grant new execution authority; the configured chain remains the safe baseline when evidence is absent.
+
+- **默认零惊喜**：升级后默认仍为 `routingMode=ordered`、`routingPreference=balanced`、`backgroundBenchmarking=off`。打开 Auto 本身不会自动测评，也不会额外产生 Benchmark 请求。
+- **Conservative defaults**: upgrades still default to `routingMode=ordered`, `routingPreference=balanced`, and `backgroundBenchmarking=off`. Enabling Auto by itself does not start benchmarks or create extra Benchmark traffic.
+
+## 测评与后台能力数据 / Benchmarking & background capability profiling
+
+- **精确「测试识图」**：设置页每个模型都可以做一次真实图片验证；一次点击只向当前精确 provider/model 发送一次请求，无 fallback、无 Auto 分数污染。明确拒绝图片时会记录为该 endpoint fingerprint 的“实测仅文本”，并停止后台继续花请求；显式成功重测可以解除同 fingerprint 的停止状态。
+- **Exact “Test Vision” verification**: one click sends exactly one real image request to the selected provider/model, with no fallback and no Auto-score side effects. Explicit image rejection becomes a persistent text-only verdict for that endpoint fingerprint and stops background spending; a later explicit successful retest can clear the same-fingerprint stop.
+
+- **Quick / Full 能力测评**：Quick 约 3 次请求，测 OCR + 通用理解；Full 约 6 次请求，覆盖结构化、OCR、文档、定位、通用。弹窗直接显示请求量与预计耗时（Quick 约 1–3 分钟，Full 约 3–8 分钟）；开始后可以关闭 Settings 页面，任务仍在 DSH 后台继续。
+- **Quick / Full capability benchmarks**: Quick uses about 3 requests for OCR + General; Full uses about 6 for Structured + OCR + Document + Grounding + General. The UI shows request-count/time estimates (about 1–3 min Quick, 3–8 min Full), and benchmark work continues in DSH even after the Settings page is closed.
+
+- **后台补充能力数据是独立授权**：`off / local-free / all` 不会因为开启 Auto 自动改变；当前实现只在 Auto 激活时运行已授权后台测评。调度按能力轴推进，前台真实识图会抢占后台任务，空闲约 30 秒后恢复；手动 Benchmark 同样优先，结束约 15 秒后后台继续。关闭后台测评会撤销后续请求与写入。
+- **Background profiling is separately authorized**: `off / local-free / all` never changes merely because Auto is enabled; authorized background profiling runs only while Auto is active. Foreground vision preempts background work and resumes after roughly 30 seconds idle; manual benchmarks also preempt it and background work resumes after roughly 15 seconds. Revoking background profiling stops future requests and writes.
+
+- **失败状态按正确粒度持久化**：`auth / unavailable / protocol` 对同一 deployment fingerprint 是模型级停止，重启 DSH 后不会先白花一次请求再重新失败；`visual-proof` 只停止对应能力轴，不会把支持图片的模型误判为仅文本。DeepSeek `UNSUPPORTED_CONTENT / does not accept image input` 等真实拒图措辞已纳入显式图片拒绝分类。
+- **Persistent failures use the right scope**: `auth / unavailable / protocol` stop the same deployment fingerprint model-wide across restarts, while `visual-proof` remains axis-scoped and never turns an image-capable model into “text-only.” Real DeepSeek rejection forms such as `UNSUPPORTED_CONTENT / does not accept image input` are recognized as explicit image rejection without treating generic content errors as text-only.
+
+## 输入框「👁 识图」模式 / Composer “👁 Vision” mode
+
+- **聊天页新增显式识图开关（#284 / #286）**：普通聊天模型仍由 DSH 原生模型选择器负责；需要发图时用户主动开启「👁 识图」，底层切换到同一 provider/model 的 Vision Router wrapper。默认关闭，不因上传图片偷偷开启；发送后保持状态，关闭时返回同一普通模型。
+- **Explicit composer Vision toggle (#284 / #286)**: DSH’s stock picker continues to own the ordinary conversation model. Users explicitly enable Vision when needed, switching underneath to Vision Router’s matching wrapper for the same provider/model. It starts off, is never silently enabled by attaching an image, persists across sends, and returns to the same ordinary model when disabled.
+
+- **模型身份与 reasoning effort 保持一致**：只修改 reasoning effort 不会退出识图；用户手动选择另一个普通模型才会离开 wrapper。切换被 Host 拒绝时沿用原生 Toast，不绕过 DSH 安全约束，按钮始终反映真实 route。
+- **Model identity and reasoning effort stay coherent**: effort-only changes remain on the Vision wrapper; choosing a different ordinary model exits it. If the Host rejects a switch, the stock Toast path is used, DSH safety is not bypassed, and the toggle continues to reflect the real route.
+
+- **内部「+ 自动识图」wrapper 从原生模型列表隐藏**：只改变 presentation，不删除 Host route。隐藏必须同时满足配置意图、route/name 和 exact-model 镜像；设置缺失、归属歧义、镜像不完整、第三方 `*-vision` lookalike 都 fail-open，宁可显示也不误藏（#288 / #291 / #294 / #300）。
+- **Internal “+ Auto Vision” wrappers are hidden from stock model presentation**: real Host routes remain intact. Hiding requires matching configuration intent, route/name identity and exact-model mirroring; missing/ambiguous settings, incomplete mirrors and third-party `*-vision` lookalikes fail open and remain visible (#288 / #291 / #294 / #300).
+
+- **原生多模态 wrapper 获得当前轮真实 attachment ID**：模型已经看得到原图时，仍可按需调用 `vision_describe` / `vision_ground` 等精查工具，而不需要猜造附件 ID；跨 session 授权和 `unknown attachment id` 安全边界不放宽。
+- **Owned multimodal wrappers receive real current-turn attachment IDs** so a model that already sees raw pixels can still invoke precision tools without inventing attachment identifiers. Session-scoped authorization and the `unknown attachment id` boundary remain strict.
+
+## 原生多模态共存 / Native multimodal coexistence
+
+- **原生多模态模型保持控制权（#289 / #292 / #298）**：如果当前模型本来就能直接看图，Vision Router 不再用全局 structured guard / synthetic budget message 强行接管这轮；原始图片先直接交给模型，grounding / crop / OCR / pixel-diff 等只在模型真正需要时作为精查工具参与。
+- **Native multimodal models stay in control (#289 / #292 / #298)**: when the selected model already accepts images, Vision Router no longer lets a global structured guard or synthetic budget message hijack the turn. Raw pixels reach the model first; grounding, crop, OCR, pixel diff and other tools remain optional precision aids.
+
+- **整轮视觉预算默认不再误伤长推理**：`visionTurnBudgetMs` 默认改为 `0`（不设整轮总墙钟上限），预算只在真正开始视觉工作时生效；具体网络请求、工具和 Benchmark 仍各自保留硬超时与资源边界。
+- **Whole-turn vision budget no longer penalizes long reasoning by default**: `visionTurnBudgetMs` now defaults to `0` (no global wall-clock cap), while concrete network requests, tools and benchmarks retain their own hard deadlines and resource limits.
+
+## 设置 2.0 / Settings 2.0
+
+- **Settings 按用户任务重组（#285 / #299）**：一级 Vision Router 设置页重构为「常规 / 识图策略 / 本地与设备 / 高级 / 诊断」，模型选择、工具策略、本地后端、性能/网络与排障各归其位。迁移层保留有效旧配置，并明确退役历史 UI 状态字段，避免“看似还在、实际已不生效”的幽灵设置。
+- **Settings are reorganized around user tasks (#285 / #299)**: General / Vision Strategy / Local & Device / Advanced / Diagnostics separate model choice, tool strategy, local backends, performance/network controls and troubleshooting. Migration preserves meaningful existing configuration while retiring obsolete UI-state fields instead of leaving ghost settings behind.
+
+- **v2 Auto 控件进入识图模型区域（#301）**：模型链、选择方式、偏好与后台能力数据在同一上下文呈现；第一次开启 Auto 会明确说明“Auto ≠ 自动测评”，以及后台“所有模型”可能产生云端 API 费用。
+- **v2 Auto controls now live with the vision-model chain (#301)**: configured models, selection mode, preference and background capability profiling are presented together. First enable explains that “Auto ≠ automatic benchmarking” and that “All models” background profiling may incur cloud API cost.
+
+- **发布前收口混合保存陷阱（#303）**：如果 React Settings IA 还有未保存修改，v2 的即时路由控件会要求先保存或放弃，避免出现“Auto 已落盘但刚改的模型链没保存”的半事务状态。Auto 模式下页面明确标注“配置基线顺序”，不再把显示顺序误写成下一次保证执行顺序；Ordered 下不可用的偏好/后台项也恢复明确 disabled 视觉与 ARIA 状态。
+- **Mixed-save trap closed before release (#303)**: v2 immediate routing controls are blocked while the React Settings IA still has unrelated unsaved drafts, preventing partial state such as “Auto saved, model-chain edit lost.” Auto labels the displayed chain as the configured baseline rather than a guaranteed next execution order; Ordered-only disabled controls regain clear visual and ARIA state.
+
+- **远程设置继续遵守能力边界**：远程编辑仍默认关闭、需要明确风险确认；API Key、HTTP provider 凭据、本地 Ollama / LM Studio、桌面截图等敏感配置保持本机专属。v2 的安全字段通过同一 Host 权威写入/readback 路径，不引入浏览器侧私有配置副本。
+- **Remote settings keep the existing capability boundary**: remote editing remains opt-in behind explicit risk confirmation, while API keys, HTTP-provider credentials, local Ollama / LM Studio and desktop capture stay local-only. Safe v2 fields use the same authoritative Host write/readback path rather than a browser-side shadow configuration.
+
+## 模型目录、边界与兼容 / Catalog, boundaries & compatibility
+
+- **设置可见模型成为产品权威目录（#288 / #291 / #294）**：显式配置的 Models 行存在时，以它们定义可见/可包装范围；live `/models` 发现只做受限补充，不会把用户已经删除的模型重新塞回 Auto Vision wrapper。wrapper scope、公开 model presentation 与执行权限继续分层。
+- **Settings-visible models are authoritative product catalog entries (#288 / #291 / #294)**: explicit configured model rows define visible/wrappable scope; live `/models` discovery is a bounded supplement and cannot resurrect a model the user removed back into Auto Vision wrappers. Wrapper scope, presentation and execution authority remain separate layers.
+
+- **Vision toggle DOM 根边界收紧（#300）**：增强逻辑只作用于确认属于 Vision Router / DSH 模型选择器的根节点，不会因为相似 ARIA/menu 结构去改写或隐藏第三方界面。
+- **Vision-toggle DOM root boundaries are hardened (#300)** so enhancement only touches confirmed Vision Router / DSH model-picker roots instead of rewriting unrelated third-party ARIA/menu structures.
+
+- **安全与 wire 兼容修复（#295 / #296）**：风险 regex 改为有界/线性判断以通过 CodeQL 并避免病态输入放大；可选图片 metadata（如 `originalDimensions`）可以被兼容接受，但实际图片字节仍是格式、尺寸和资源准入的权威来源。
+- **Security and wire compatibility fixes (#295 / #296)** replace risky regex paths with bounded/linear checks and accept optional image metadata such as `originalDimensions` without allowing metadata to override the actual image bytes as the source of truth for format, dimensions or resource admission.
+
+## 真实验收与发布门禁 / Real-machine acceptance & release gates
+
+- **v2 在真实 DSH 0.1.1-rc.1 环境完成发布验收**：覆盖真实 DeepSeek 拒图、OpenRouter 不可用 deployment、Kimi visual-proof、GLM 慢 Quick Benchmark、前台/手动抢占、撤销后台授权、重启持久化与普通视觉执行。最终复验结果为 **GO**。
+- **v2 completed real-machine release acceptance on DSH 0.1.1-rc.1**, covering real DeepSeek image rejection, unavailable OpenRouter deployment behavior, Kimi visual-proof scoping, a real GLM Quick benchmark, foreground/manual preemption, background revocation, restart persistence and normal visual execution. Final recheck result: **GO**.
+
+- 关键复验硬指标：DeepSeek 判定“实测仅文本”后后台新增请求 **0**；Sol 同 fingerprint 重启后后台请求 **0**；Kimi visual-proof 失败轴重启后重复请求 **0** 且其他能力不被整模型封锁；GLM Quick 为 **3 个请求 / completed / profile 成功写入**。
+- Key recheck evidence: **0** new background requests after DeepSeek was measured text-only; **0** Sol background requests after restart on the same fingerprint; **0** repeat requests for Kimi’s failed visual-proof axes without model-wide lockout; GLM Quick completed with **3 requests / completed state / persisted profile update**.
+
+- CI 持续覆盖 Node 22 / Node 24、DSH rc.6 / rc.7 / rc.8 contract、Ubuntu / macOS / Windows host-sharp、native multimodal cold resume；大图资源压力与对抗式回归继续作为相关路径门禁。正式 tag 还会由 Release workflow 在不可变源码上重新运行完整 `pnpm test`，再通过 npm Trusted Publishing (OIDC) 发布并校验 tarball 身份。
+- CI continuously covers Node 22/24, DSH rc.6/rc.7/rc.8 contracts, Ubuntu/macOS/Windows host-sharp and native multimodal cold resume, with large-image stress and adversarial regressions guarding relevant paths. The final tag is verified again by the Release workflow, which reruns full `pnpm test`, publishes through npm Trusted Publishing (OIDC), and verifies the exact registry tarball identity.
+
+## 升级说明 / Upgrade notes
+
+- **没有自动开启 Auto 的迁移**：升级现有安装不会替用户改变模型选择授权。想继续按旧方式使用，保持默认“按设置顺序”即可；想使用 v2 Auto，可在 Settings → Vision Router → 常规中主动开启并按需选择后台测评权限。
+- **No migration silently enables Auto**: existing installations keep user authority unchanged. Leave “Configured order” selected for the old behavior; opt into v2 Auto explicitly from Settings → Vision Router → General, and separately choose any desired background profiling permission.
+
+- 推荐仍使用官方 DSH CLI 更新/安装；2.0.0 不要求 Python，现有识图模型、本地后端和安全远程设置配置会继续经过迁移/规范化层读取。
+- The official DSH CLI remains the recommended install/update path. v2.0.0 still requires no Python, and existing vision-model, local-backend and safe remote-settings configuration continues through the migration/normalization layer.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-vision-router",
-  "version": "1.7.7",
+  "version": "2.0.0",
   "description": "Eyes for text-only DeepSeek Harness agents: built-in free vision chain (no key) + pixel-level vision tools (Q&A, grounding, crop, pixel diff, colors, OCR, SVG trace, cutout, screenshots). One-command install, no Python, image turns work like ordinary tool-calling turns.",
   "license": "MIT",
   "repository": {

--- a/tests/bundle-defaults.test.js
+++ b/tests/bundle-defaults.test.js
@@ -97,6 +97,17 @@ test('release line stays on package identity 2.0.0', async () => {
   assert.equal(pkg.version, '2.0.0')
 })
 
+test('v2.0.0 ships curated release notes and the tag workflow consumes them first', async () => {
+  const notes = await readFile(new URL('../docs/releases/v2.0.0.md', import.meta.url), 'utf8')
+  const workflow = await readFile(new URL('../.github/workflows/release.yml', import.meta.url), 'utf8')
+
+  assert.match(notes, /^# v2\.0\.0$/m)
+  assert.match(notes, /能力感知 Auto 路由 \/ Capability-aware Auto routing/)
+  assert.match(notes, /真实验收与发布门禁 \/ Real-machine acceptance & release gates/)
+  assert.match(workflow, /CURATED_NOTES="docs\/releases\/\$RELEASE_TAG\.md"/)
+  assert.match(workflow, /cat "\$CURATED_NOTES" > release-notes\.md/)
+})
+
 test('release runtime exposes one benchmark UI and no production v2 acceptance control surface', async () => {
   const entry = await readFile(new URL('../entry.js', import.meta.url), 'utf8')
   const pkg = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8'))

--- a/tests/bundle-defaults.test.js
+++ b/tests/bundle-defaults.test.js
@@ -92,9 +92,9 @@ test('entry contract exposes the custom depth tier to every settings entry point
   assert.equal(custom.visionDepthMaxCalls, 7)
 })
 
-test('release line stays on package identity 1.7.7', async () => {
+test('release line stays on package identity 2.0.0', async () => {
   const pkg = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8'))
-  assert.equal(pkg.version, '1.7.7')
+  assert.equal(pkg.version, '2.0.0')
 })
 
 test('release runtime exposes one benchmark UI and no production v2 acceptance control surface', async () => {


### PR DESCRIPTION
## Release v2.0.0

Merged and fully validated. Follow-up release automation is being added separately so the final v2.0.0 tag can be created by GitHub Actions against the exact verified current main SHA, without requiring a local maintainer command.