### PR TITLE
test: unpin release identity from v2.0.0

### DIFF
--- a/tests/bundle-defaults.test.js
+++ b/tests/bundle-defaults.test.js
@@ -92,9 +92,10 @@ test('entry contract exposes the custom depth tier to every settings entry point
   assert.equal(custom.visionDepthMaxCalls, 7)
 })
 
-test('release line stays on package identity 2.0.0', async () => {
+test('release line stays on the stable v2 package identity', async () => {
   const pkg = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8'))
-  assert.equal(pkg.version, '2.0.0')
+  assert.equal(pkg.name, 'dsh-vision-router')
+  assert.match(pkg.version, /^2\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/)
 })
 
 test('v2.0.0 ships curated release notes and the tag workflow consumes them first', async () => {


### PR DESCRIPTION
## Summary

Fix the Release workflow regression introduced by bumping `package.json` from `2.0.0` to `2.0.1`.

`tests/bundle-defaults.test.js` hard-coded `pkg.version === '2.0.0'`, so every later v2 patch/minor release would fail at the Release workflow `pnpm test` step even when normal PR CI had already passed.

This changes that test to verify the stable package identity instead:

- package name remains `dsh-vision-router`
- package version remains a valid v2 semver

The exact `v<package.version>` ↔ requested release tag ↔ target SHA identity remains enforced by `.github/workflows/release.yml` before tests and before publish.

No production/runtime behavior changes.