### PR TITLE
refactor: begin P1 direct execution-order convergence

### DIFF
--- a/.github/workflows/p1-routing-parity.yml
+++ b/.github/workflows/p1-routing-parity.yml
@@ -1,0 +1,32 @@
+name: P1 Routing Parity
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  parity:
+    name: routing-parity (${{ matrix.node }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ['22', '24']
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+        with:
+          version: 11.20.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: ${{ matrix.node }}
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Evidence collector parity and execution-order isolation
+        run: node --test tests/vision-routing-evidence-parity.test.js tests/vision-execution-order.test.js

--- a/.github/workflows/p1-routing-parity.yml
+++ b/.github/workflows/p1-routing-parity.yml
@@ -29,4 +29,4 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: Evidence collector parity and execution-order isolation
-        run: node --test tests/vision-routing-evidence-parity.test.js tests/vision-execution-order.test.js
+        run: node --test tests/vision-routing-evidence-parity.test.js tests/vision-execution-order.test.js tests/vision-execution-order-plan-parity.test.js

--- a/lib/vision-execution-order-plan.js
+++ b/lib/vision-execution-order-plan.js
@@ -1,0 +1,64 @@
+import {
+  candidateKeyForConfiguredPair,
+  configuredVisionPairs,
+} from './vision-routing-evidence.js'
+
+function pairForExecutionKey(key, configuredByKey) {
+  const configured = configuredByKey.get(key)
+  if (configured) return configured
+  // Enabled local backends already participate in the legacy tool chain. Auto
+  // may move them earlier, but may not invent arbitrary unconfigured routes.
+  if (typeof key === 'string' && key.startsWith('vision-http/local-')) {
+    const model = key.slice('vision-http/'.length)
+    return model ? { provider: 'vision-http', model } : undefined
+  }
+  return undefined
+}
+
+/**
+ * Convert planner keys into the narrow provider/model order P1 execution will
+ * eventually place in VisionExecutionOrderContext.
+ *
+ * Invariants are intentionally identical to the historical fake-settings path:
+ * - configured routes omitted by evidence are retained at the tail;
+ * - local Router backends may be moved earlier because they already exist in v1;
+ * - arbitrary unconfigured/discovered routes are never synthesized;
+ * - duplicates collapse by provider/model identity;
+ * - unchanged order returns undefined so Ordered/no-op behavior stays untouched.
+ */
+export function executionOrderForSuggestedKeys(config, suggestedOrder = []) {
+  if (!config || typeof config !== 'object' || Array.isArray(config) || !Array.isArray(suggestedOrder)) {
+    return undefined
+  }
+
+  const original = configuredVisionPairs(config)
+  const configuredByKey = new Map()
+  for (const pair of original) {
+    const key = candidateKeyForConfiguredPair(pair)
+    if (key && !configuredByKey.has(key)) configuredByKey.set(key, pair)
+  }
+
+  const next = []
+  const seen = new Set()
+  const addPair = (pair) => {
+    if (!pair) return
+    const id = `${pair.provider}\u0000${pair.model}`
+    if (seen.has(id)) return
+    seen.add(id)
+    next.push({ provider: pair.provider, model: pair.model })
+  }
+
+  for (const key of suggestedOrder) addPair(pairForExecutionKey(key, configuredByKey))
+  for (const pair of original) addPair(pair)
+  if (next.length === 0) return undefined
+
+  const originalIds = original.map((pair) => `${pair.provider}\u0000${pair.model}`)
+  const nextIds = next.map((pair) => `${pair.provider}\u0000${pair.model}`)
+  if (
+    originalIds.length === nextIds.length
+    && originalIds.every((id, index) => id === nextIds[index])
+  ) {
+    return undefined
+  }
+  return next
+}

--- a/lib/vision-execution-order.js
+++ b/lib/vision-execution-order.js
@@ -1,0 +1,38 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
+
+const executionOrderScope = new AsyncLocalStorage()
+
+function normalizedPair(pair) {
+  const provider = typeof pair?.provider === 'string' ? pair.provider.trim() : ''
+  const model = typeof pair?.model === 'string' ? pair.model.trim() : ''
+  if (provider === '' || model === '') {
+    throw new TypeError('vision execution order entries require non-empty provider and model')
+  }
+  return Object.freeze({ provider, model })
+}
+
+function normalizedOrder(order) {
+  if (!Array.isArray(order)) throw new TypeError('vision execution order must be an array')
+  return Object.freeze(order.map(normalizedPair))
+}
+
+/**
+ * Run one Router-owned visual execution with an explicit provider/model order.
+ *
+ * The scope deliberately carries ONLY detached `{ provider, model }` pairs.
+ * It contains no settings snapshot, credentials, authority, scores, evidence,
+ * Host services, or mutable caller objects.
+ */
+export function withVisionExecutionOrder(order, fn) {
+  if (typeof fn !== 'function') throw new TypeError('withVisionExecutionOrder requires a function')
+  const scopedOrder = normalizedOrder(order)
+  return executionOrderScope.run({ order: scopedOrder }, fn)
+}
+
+/**
+ * Current Router-owned visual order for this async call chain, or undefined
+ * outside an explicit visual execution scope.
+ */
+export function currentVisionExecutionOrder() {
+  return executionOrderScope.getStore()?.order
+}

--- a/lib/vision-routing-evidence.js
+++ b/lib/vision-routing-evidence.js
@@ -1,0 +1,366 @@
+import { capabilityEvidenceFingerprint } from './vision-capability-identity.js'
+import { providerTransportFor } from './live-model-discovery.js'
+
+function nonEmpty(value) {
+  return typeof value === 'string' && value.trim() !== '' ? value.trim() : undefined
+}
+
+function addCandidate(out, seen, candidate) {
+  const key = nonEmpty(candidate?.key) ?? `${nonEmpty(candidate?.provider) ?? ''}/${nonEmpty(candidate?.model) ?? ''}`
+  if (key === '/' || seen.has(key)) return
+  seen.add(key)
+  out.push({ ...candidate, key })
+}
+
+/** Configured provider/model pairs in exactly the order legacy execution sees them. */
+export function configuredVisionPairs(config) {
+  const rows = Array.isArray(config?.providers) ? config.providers : []
+  const source = rows.length > 0
+    ? rows
+    : [{ provider: config?.provider, model: config?.model, fallbacks: config?.fallbacks }]
+  const out = []
+  for (const row of source) {
+    const provider = nonEmpty(row?.provider)
+    const model = nonEmpty(row?.model)
+    if (provider === undefined || model === undefined) continue
+    out.push({ provider, model })
+    for (const fallback of Array.isArray(row?.fallbacks) ? row.fallbacks : []) {
+      const fallbackModel = nonEmpty(fallback)
+      if (fallbackModel !== undefined) out.push({ provider, model: fallbackModel })
+    }
+  }
+  return out
+}
+
+/** Planner/execution identity for one configured pair. */
+export function candidateKeyForConfiguredPair(pair) {
+  const provider = nonEmpty(pair?.provider)
+  const model = nonEmpty(pair?.model)
+  if (!provider || !model) return undefined
+  if (provider !== 'vision-http') return `${provider}/${model}`
+  if (model.startsWith('local-ollama/') || model.startsWith('local-lmstudio/')) {
+    return `vision-http/${model}`
+  }
+  return `http:${model}`
+}
+
+/** Router-generated wrapper/chain routes are execution plumbing, never evidence candidates. */
+export function generatedCapabilityRoute(provider, config) {
+  const wrapper = nonEmpty(config?.wrapperRoute) ?? 'deepseek-vision'
+  const chain = nonEmpty(config?.chainRoute) ?? 'vision-chain'
+  return provider === wrapper || provider === chain
+}
+
+async function modelInfo(ctx, provider, model) {
+  try {
+    if (typeof ctx?.llm?.resolveModelInfo === 'function') {
+      return await ctx.llm.resolveModelInfo(provider, model)
+    }
+  } catch {}
+  return undefined
+}
+
+function localCandidate(provider, routeRole = 'user') {
+  const name = nonEmpty(provider?.name)
+  const model = nonEmpty(provider?.model)
+  if (name === undefined || model === undefined) return undefined
+  return {
+    key: `vision-http/${name}/${model}`,
+    provider: 'vision-http',
+    model: `${name}/${model}`,
+    local: true,
+    privacy: 'local',
+    endpoint: nonEmpty(provider.baseURL),
+    endpointConfig: { api: 'openai-completions' },
+    endpointCredentialRef: nonEmpty(provider.apiKeyEnv),
+    evidenceScope: 'endpoint',
+    routeRole,
+  }
+}
+
+function httpCandidate(entry, routeRole = 'user') {
+  const name = nonEmpty(entry?.name)
+  const model = nonEmpty(entry?.model)
+  if (name === undefined || model === undefined) return undefined
+  const local = /^https?:\/\/(?:127\.0\.0\.1|localhost|\[::1\])(?::|\/|$)/i.test(String(entry.baseURL ?? ''))
+  return {
+    key: `http:${name}/${model}`,
+    provider: 'vision-http',
+    model: `${name}/${model}`,
+    local,
+    privacy: local ? 'local' : 'cloud',
+    endpoint: nonEmpty(entry.baseURL),
+    endpointConfig: { api: 'openai-completions' },
+    endpointCredentialRef: nonEmpty(entry.apiKeyEnv),
+    evidenceScope: 'endpoint',
+    routeRole,
+    cost: name.toLowerCase().startsWith('ovh') && !nonEmpty(entry.apiKeyEnv) ? 0 : undefined,
+  }
+}
+
+function routeIdentity(entry) {
+  const name = nonEmpty(entry?.name)
+  const model = nonEmpty(entry?.model)
+  return name && model ? `${name}/${model}` : undefined
+}
+
+function exactHttpIdentity(entry) {
+  const identity = routeIdentity(entry)
+  if (!identity) return undefined
+  return [identity, String(entry?.baseURL ?? '').replace(/\/+$/, ''), nonEmpty(entry?.apiKeyEnv) ?? ''].join('\u0000')
+}
+
+function localAndHttpSources(config, core) {
+  let locals = []
+  let http = []
+  try { locals = core.localProvidersOf(config) } catch { locals = [] }
+  try { http = core.httpProvidersOf(config) } catch { http = [] }
+  const localByRoute = new Map(
+    (Array.isArray(locals) ? locals : []).map((entry) => [routeIdentity(entry), entry]).filter(([key]) => key),
+  )
+  const httpByRoute = new Map(
+    (Array.isArray(http) ? http : []).map((entry) => [routeIdentity(entry), entry]).filter(([key]) => key),
+  )
+  return {
+    locals: Array.isArray(locals) ? locals : [],
+    http: Array.isArray(http) ? http : [],
+    localByRoute,
+    httpByRoute,
+  }
+}
+
+async function configuredAndLocalCandidates(ctx, config, core) {
+  const out = []
+  const seen = new Set()
+  const configuredHttpRoutes = new Set()
+  const sources = localAndHttpSources(config, core)
+  for (const pair of configuredVisionPairs(config)) {
+    if (generatedCapabilityRoute(pair.provider, config)) continue
+    if (pair.provider === 'vision-http') {
+      configuredHttpRoutes.add(pair.model)
+      const local = sources.localByRoute.get(pair.model)
+      if (local) {
+        const candidate = localCandidate(local, 'user')
+        if (candidate) addCandidate(out, seen, candidate)
+        continue
+      }
+      const http = sources.httpByRoute.get(pair.model)
+      if (http) {
+        const candidate = httpCandidate(http, 'user')
+        if (candidate) addCandidate(out, seen, candidate)
+      }
+      continue
+    }
+    let available = true
+    try { available = core.adapterAvailable(ctx.llm, pair.provider) } catch { available = true }
+    if (!available) continue
+    const info = await modelInfo(ctx, pair.provider, pair.model)
+    let decision
+    try {
+      decision = core.decideVisionBackendCapability(
+        info,
+        pair.provider,
+        pair.model,
+        config?.extraVisionModels,
+      )
+    } catch {
+      decision = { attemptable: true }
+    }
+    if (decision?.attemptable === false) continue
+    addCandidate(out, seen, { provider: pair.provider, model: pair.model, routeRole: 'user' })
+  }
+  for (const provider of sources.locals) {
+    const candidate = localCandidate(provider, 'user')
+    if (candidate) addCandidate(out, seen, candidate)
+  }
+  return { out, seen, configuredHttpRoutes, sources }
+}
+
+function appendHttpCandidates(config, core, out, seen, configuredHttpRoutes, sources) {
+  const explicitHttpRoutes = new Set(
+    (Array.isArray(config?.httpProviders) ? config.httpProviders : []).map(routeIdentity).filter(Boolean),
+  )
+  const builtinIds = new Set(
+    (Array.isArray(core?.DEFAULT_HTTP_PROVIDERS) ? core.DEFAULT_HTTP_PROVIDERS : [])
+      .map(exactHttpIdentity)
+      .filter(Boolean),
+  )
+  for (const entry of sources.http) {
+    const identity = routeIdentity(entry)
+    const isUserRoute = configuredHttpRoutes.has(identity) || explicitHttpRoutes.has(identity)
+    const isBuiltinFallback = !isUserRoute && builtinIds.has(exactHttpIdentity(entry))
+    const candidate = httpCandidate(entry, isBuiltinFallback ? 'fallback-only' : 'user')
+    if (candidate) addCandidate(out, seen, candidate)
+  }
+}
+
+function registeredAdapterRoute(ctx, provider) {
+  try {
+    const registration = ctx?.llm?.registration?.(provider)
+    const adapter = registration?.adapter
+    if (!adapter) return undefined
+    const adapterKind = nonEmpty(adapter?.constructor?.name) ?? 'registered-adapter'
+    return {
+      endpoint: `dsh-adapter://registered/${encodeURIComponent(provider)}`,
+      endpointConfig: { api: 'dsh-adapter', adapterKind },
+      evidenceScope: 'adapter-route',
+    }
+  } catch {
+    return undefined
+  }
+}
+
+function measuredSlice(record) {
+  if (!record || typeof record !== 'object') return undefined
+  const scores = {}
+  const measuredAtByAxis = {}
+  for (const [axis, rawScore] of Object.entries(record.scores ?? {})) {
+    const score = Number(rawScore)
+    if (!Number.isFinite(score)) continue
+    const measuredAt = Number(record?.measuredAtByAxis?.[axis] ?? record?.measuredAt)
+    if (!Number.isFinite(measuredAt) || measuredAt <= 0) continue
+    scores[axis] = score
+    measuredAtByAxis[axis] = measuredAt
+  }
+  const axes = Object.keys(scores)
+  if (axes.length === 0) return undefined
+  const timestamps = Object.values(measuredAtByAxis).filter(Number.isFinite)
+  return {
+    scores,
+    measuredAtByAxis,
+    measuredAt: timestamps.length > 0 ? Math.max(...timestamps) : undefined,
+  }
+}
+
+async function attachEndpointEvidence(ctx, candidate, store, runtimePerformanceStore) {
+  let endpoint = candidate.endpoint
+  let endpointConfig = candidate.endpointConfig
+  let endpointCredentialRef = candidate.endpointCredentialRef
+  let evidenceScope = candidate.evidenceScope
+  if (endpoint === undefined && candidate.provider !== 'vision-http') {
+    const transport = providerTransportFor(ctx, candidate.provider)
+    if (transport !== undefined) {
+      endpoint = transport.baseURL
+      endpointConfig = { api: transport.api }
+      endpointCredentialRef = nonEmpty(transport.apiKeyEnv)
+      evidenceScope = 'endpoint'
+    } else {
+      const adapterRoute = registeredAdapterRoute(ctx, candidate.provider)
+      if (adapterRoute !== undefined) {
+        endpoint = adapterRoute.endpoint
+        endpointConfig = adapterRoute.endpointConfig
+        evidenceScope = adapterRoute.evidenceScope
+      }
+    }
+  }
+  if (endpoint === undefined) return { ...candidate, benchmarkable: false }
+
+  const fingerprint = capabilityEvidenceFingerprint({
+    provider: candidate.provider,
+    model: candidate.model,
+    endpoint,
+    config: endpointConfig,
+  })
+  const rawRecord = await store.get(fingerprint)
+  const measured = measuredSlice(rawRecord)
+  const runtime = runtimePerformanceStore?.get?.(candidate.key)
+  return {
+    ...candidate,
+    endpoint,
+    endpointConfig,
+    ...(endpointCredentialRef ? { endpointCredentialRef } : {}),
+    evidenceScope: evidenceScope ?? 'endpoint',
+    benchmarkable: true,
+    endpointFingerprint: fingerprint,
+    ...(measured
+      ? {
+          measured: measured.scores,
+          measuredAt: measured.measuredAt,
+          measuredAtByAxis: measured.measuredAtByAxis,
+        }
+      : {}),
+    ...(Number.isFinite(Number(rawRecord?.benchmarkLatencyMs))
+      ? { benchmarkLatencyMs: Number(rawRecord.benchmarkLatencyMs) }
+      : {}),
+    ...(rawRecord?.benchmarkMedianLatencyMsByAxis
+      ? { benchmarkMedianLatencyMsByAxis: rawRecord.benchmarkMedianLatencyMsByAxis }
+      : {}),
+    ...(runtime?.runtimeLatencyMsByAxis ? { runtimeLatencyMsByAxis: runtime.runtimeLatencyMsByAxis } : {}),
+    ...(runtime?.observedLatencyMsByAxis
+      ? { runtimeObservedLatencyMsByAxis: runtime.observedLatencyMsByAxis }
+      : {}),
+    ...(runtime?.sampleCountByAxis ? { runtimeSampleCountByAxis: runtime.sampleCountByAxis } : {}),
+    ...(runtime?.observedAtByAxis ? { runtimeObservedAtByAxis: runtime.observedAtByAxis } : {}),
+    ...(Number.isFinite(Number(runtime?.maxAgeMs))
+      ? { runtimePerformanceMaxAgeMs: Number(runtime.maxAgeMs) }
+      : {}),
+    ...(Number.isFinite(Number(runtime?.minSamples))
+      ? { runtimePerformanceMinSamples: Number(runtime.minSamples) }
+      : {}),
+  }
+}
+
+/** Candidate discovery + endpoint identity + measured/runtime evidence, with no planner or authority work. */
+export async function collectVisionRoutingCandidates(
+  ctx,
+  config,
+  core,
+  store,
+  runtimePerformanceStore,
+) {
+  const { out, seen, configuredHttpRoutes, sources } = await configuredAndLocalCandidates(ctx, config, core)
+  appendHttpCandidates(config, core, out, seen, configuredHttpRoutes, sources)
+  const enriched = []
+  for (const candidate of out) {
+    enriched.push(await attachEndpointEvidence(ctx, candidate, store, runtimePerformanceStore))
+  }
+  return enriched
+}
+
+/** Health is evidence; failures remain uncertainty rather than planner/runtime failure. */
+export async function collectVisionRoutingHealth(candidates, healthForCandidate, context) {
+  const health = {}
+  if (typeof healthForCandidate !== 'function') return health
+  for (const candidate of candidates) {
+    try {
+      const value = await healthForCandidate(candidate, context)
+      if (value && typeof value === 'object' && !Array.isArray(value)) {
+        health[candidate.key] = value
+      }
+    } catch {}
+  }
+  return health
+}
+
+/**
+ * P1-A evidence boundary. It returns facts only: candidates, measured evidence,
+ * and health. It performs no planning, authority check, settings mutation, or execution.
+ */
+export async function collectVisionRoutingEvidence({
+  ctx,
+  config,
+  core,
+  store,
+  runtimePerformanceStore,
+  healthForCandidate,
+  healthContext,
+} = {}) {
+  const candidates = await collectVisionRoutingCandidates(
+    ctx,
+    config,
+    core,
+    store,
+    runtimePerformanceStore,
+  )
+  const measured = Object.fromEntries(
+    candidates
+      .filter((candidate) => candidate.measured)
+      .map((candidate) => [candidate.key, {
+        scores: candidate.measured,
+        measuredAt: candidate.measuredAt,
+        measuredAtByAxis: candidate.measuredAtByAxis,
+      }]),
+  )
+  const health = await collectVisionRoutingHealth(candidates, healthForCandidate, healthContext)
+  return { candidates, measured, health }
+}

--- a/tests/vision-execution-order-plan-parity.test.js
+++ b/tests/vision-execution-order-plan-parity.test.js
@@ -1,0 +1,110 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { autoExecutionConfigFor } from '../lib/vision-capability-shadow.js'
+import { configuredVisionPairs } from '../lib/vision-routing-evidence.js'
+import { executionOrderForSuggestedKeys } from '../lib/vision-execution-order-plan.js'
+
+function legacyOrder(config, suggestedOrder) {
+  const executionConfig = autoExecutionConfigFor(config, suggestedOrder)
+  return executionConfig ? configuredVisionPairs(executionConfig) : undefined
+}
+
+const cases = [
+  {
+    name: 'reorders two configured native routes',
+    config: {
+      providers: [
+        { provider: 'a', model: 'm1', fallbacks: [] },
+        { provider: 'b', model: 'm2', fallbacks: [] },
+      ],
+    },
+    suggested: ['b/m2', 'a/m1'],
+  },
+  {
+    name: 'preserves a configured route omitted by evidence',
+    config: {
+      providers: [
+        { provider: 'a', model: 'm1', fallbacks: [] },
+        { provider: 'temporarily-unavailable', model: 'm2', fallbacks: [] },
+        { provider: 'b', model: 'm3', fallbacks: [] },
+      ],
+    },
+    suggested: ['b/m3', 'a/m1'],
+  },
+  {
+    name: 'allows an already-enabled local backend to move ahead',
+    config: {
+      providers: [{ provider: 'custom', model: 'm', fallbacks: [] }],
+    },
+    suggested: ['vision-http/local-ollama/qwen2.5vl', 'custom/m'],
+  },
+  {
+    name: 'does not synthesize arbitrary unconfigured discovered adapters',
+    config: {
+      providers: [{ provider: 'custom', model: 'm', fallbacks: [] }],
+    },
+    suggested: ['discovered/not-configured', 'custom/m'],
+  },
+  {
+    name: 'does not synthesize arbitrary unconfigured direct HTTP routes',
+    config: {
+      providers: [{ provider: 'custom', model: 'm', fallbacks: [] }],
+    },
+    suggested: ['http:unconfigured/model', 'custom/m'],
+  },
+  {
+    name: 'expands legacy fallback models and can reorder them',
+    config: {
+      providers: [
+        { provider: 'a', model: 'primary', fallbacks: ['f1', 'f2'] },
+        { provider: 'b', model: 'm', fallbacks: [] },
+      ],
+    },
+    suggested: ['a/f2', 'b/m', 'a/primary', 'a/f1'],
+  },
+  {
+    name: 'deduplicates repeated planner keys',
+    config: {
+      providers: [
+        { provider: 'a', model: 'm1', fallbacks: [] },
+        { provider: 'b', model: 'm2', fallbacks: [] },
+      ],
+    },
+    suggested: ['b/m2', 'b/m2', 'a/m1'],
+  },
+  {
+    name: 'returns no scope for unchanged configured order',
+    config: {
+      providers: [
+        { provider: 'a', model: 'm1', fallbacks: [] },
+        { provider: 'b', model: 'm2', fallbacks: [] },
+      ],
+    },
+    suggested: ['a/m1', 'b/m2'],
+  },
+  {
+    name: 'preserves vision-http candidate key mapping',
+    config: {
+      providers: [
+        { provider: 'vision-http', model: 'ovh/qwen-vl', fallbacks: [] },
+        { provider: 'custom', model: 'm', fallbacks: [] },
+      ],
+    },
+    suggested: ['custom/m', 'http:ovh/qwen-vl'],
+  },
+]
+
+for (const fixture of cases) {
+  test(`explicit order mapping matches fake-settings path: ${fixture.name}`, () => {
+    assert.deepEqual(
+      executionOrderForSuggestedKeys(fixture.config, fixture.suggested),
+      legacyOrder(fixture.config, fixture.suggested),
+    )
+  })
+}
+
+test('invalid mapping inputs remain a no-op like the legacy path', () => {
+  assert.equal(executionOrderForSuggestedKeys(undefined, []), undefined)
+  assert.equal(executionOrderForSuggestedKeys([], []), undefined)
+  assert.equal(executionOrderForSuggestedKeys({}, 'not-an-array'), undefined)
+})

--- a/tests/vision-execution-order.test.js
+++ b/tests/vision-execution-order.test.js
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  currentVisionExecutionOrder,
+  withVisionExecutionOrder,
+} from '../lib/vision-execution-order.js'
+
+const pair = (provider, model, extra = {}) => ({ provider, model, ...extra })
+
+test('vision execution order exists only inside its async scope and carries only provider/model', async () => {
+  assert.equal(currentVisionExecutionOrder(), undefined)
+  const input = [pair('a', 'm1', { credential: 'must-not-leak' }), pair('b', 'm2', { score: 99 })]
+  const result = await withVisionExecutionOrder(input, async () => {
+    const current = currentVisionExecutionOrder()
+    assert.deepEqual(current, [pair('a', 'm1'), pair('b', 'm2')])
+    assert.equal(Object.isFrozen(current), true)
+    assert.equal(Object.isFrozen(current[0]), true)
+    await Promise.resolve()
+    assert.deepEqual(currentVisionExecutionOrder(), [pair('a', 'm1'), pair('b', 'm2')])
+    return 'ok'
+  })
+  assert.equal(result, 'ok')
+  assert.equal(currentVisionExecutionOrder(), undefined)
+})
+
+test('nested execution order restores the parent scope after the child completes', async () => {
+  await withVisionExecutionOrder([pair('outer', 'm')], async () => {
+    assert.equal(currentVisionExecutionOrder()[0].provider, 'outer')
+    await withVisionExecutionOrder([pair('inner', 'm')], async () => {
+      assert.equal(currentVisionExecutionOrder()[0].provider, 'inner')
+    })
+    assert.equal(currentVisionExecutionOrder()[0].provider, 'outer')
+  })
+  assert.equal(currentVisionExecutionOrder(), undefined)
+})
+
+test('parallel visual calls do not leak execution order across AsyncLocalStorage scopes', async () => {
+  let releaseA
+  let releaseB
+  const gateA = new Promise((resolve) => { releaseA = resolve })
+  const gateB = new Promise((resolve) => { releaseB = resolve })
+  let enteredA
+  let enteredB
+  const readyA = new Promise((resolve) => { enteredA = resolve })
+  const readyB = new Promise((resolve) => { enteredB = resolve })
+
+  const a = withVisionExecutionOrder([pair('provider-a', 'model-a')], async () => {
+    enteredA()
+    await gateA
+    return currentVisionExecutionOrder()[0]
+  })
+  const b = withVisionExecutionOrder([pair('provider-b', 'model-b')], async () => {
+    enteredB()
+    await gateB
+    return currentVisionExecutionOrder()[0]
+  })
+
+  await Promise.all([readyA, readyB])
+  releaseB()
+  const bResult = await b
+  assert.deepEqual(bResult, pair('provider-b', 'model-b'))
+  assert.equal(currentVisionExecutionOrder(), undefined)
+  releaseA()
+  const aResult = await a
+  assert.deepEqual(aResult, pair('provider-a', 'model-a'))
+  assert.equal(currentVisionExecutionOrder(), undefined)
+})
+
+test('execution order rejects malformed pairs before entering a scope', () => {
+  assert.throws(() => withVisionExecutionOrder({}, () => {}), /must be an array/)
+  assert.throws(() => withVisionExecutionOrder([pair('', 'model')], () => {}), /non-empty provider and model/)
+  assert.throws(() => withVisionExecutionOrder([pair('provider', '')], () => {}), /non-empty provider and model/)
+  assert.throws(() => withVisionExecutionOrder([], undefined), /requires a function/)
+  assert.equal(currentVisionExecutionOrder(), undefined)
+})

--- a/tests/vision-routing-evidence-parity.test.js
+++ b/tests/vision-routing-evidence-parity.test.js
@@ -1,0 +1,152 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  collectCapabilityShadowCandidates,
+  generatedCapabilityRoute as legacyGeneratedCapabilityRoute,
+} from '../lib/vision-capability-shadow.js'
+import {
+  collectVisionRoutingCandidates,
+  collectVisionRoutingEvidence,
+  generatedCapabilityRoute,
+} from '../lib/vision-routing-evidence.js'
+
+const OVH = {
+  name: 'ovh-free',
+  baseURL: 'https://example.test/v1',
+  model: 'qwen3-vl',
+  apiKeyEnv: '',
+}
+
+const PAID = {
+  name: 'paid-cloud',
+  baseURL: 'https://paid.example.test/v1',
+  model: 'vision-pro',
+  apiKeyEnv: 'PAID_KEY',
+}
+
+function coreFixture() {
+  return {
+    DEFAULT_HTTP_PROVIDERS: [OVH],
+    adapterAvailable: () => true,
+    decideVisionBackendCapability: () => ({ image: true, attemptable: true }),
+    localProvidersOf: () => [{
+      name: 'local-ollama',
+      baseURL: 'http://127.0.0.1:11434/v1',
+      model: 'qwen2.5vl',
+      apiKeyEnv: '',
+    }],
+    httpProvidersOf: () => [OVH, PAID],
+  }
+}
+
+function ctxFixture() {
+  return {
+    get() { return undefined },
+    llm: {
+      registration(provider) {
+        return { adapter: { constructor: { name: `Adapter_${provider}` } } }
+      },
+      async resolveModelInfo() {
+        return { inputModalities: ['text', 'image'] }
+      },
+    },
+  }
+}
+
+function storeFixture() {
+  return {
+    async get() {
+      return {
+        scores: { general: 0.75, ocr: 0.9 },
+        measuredAt: 1_700_000_000_000,
+        measuredAtByAxis: { general: 1_700_000_000_001, ocr: 1_700_000_000_002 },
+        benchmarkLatencyMs: 321,
+        benchmarkMedianLatencyMsByAxis: { general: 300, ocr: 340 },
+      }
+    },
+  }
+}
+
+function runtimeFixture() {
+  return {
+    get(key) {
+      return {
+        runtimeLatencyMsByAxis: { general: key.includes('local') ? 40 : 80 },
+        observedLatencyMsByAxis: { general: 75 },
+        sampleCountByAxis: { general: 4 },
+        observedAtByAxis: { general: 1_700_000_100_000 },
+        maxAgeMs: 60_000,
+        minSamples: 3,
+      }
+    },
+  }
+}
+
+const config = {
+  wrapperRoute: 'deepseek-vision',
+  chainRoute: 'vision-chain',
+  providers: [
+    { provider: 'custom', model: 'chosen', fallbacks: ['fallback'] },
+    { provider: 'vision-http', model: 'local-ollama/qwen2.5vl', fallbacks: [] },
+  ],
+  httpProviders: [PAID],
+}
+
+test('P1 evidence collector preserves legacy candidate order, keys, roles and evidence exactly', async () => {
+  const legacy = await collectCapabilityShadowCandidates(
+    ctxFixture(),
+    config,
+    coreFixture(),
+    storeFixture(),
+    runtimeFixture(),
+  )
+  const next = await collectVisionRoutingCandidates(
+    ctxFixture(),
+    config,
+    coreFixture(),
+    storeFixture(),
+    runtimeFixture(),
+  )
+
+  assert.deepEqual(next, legacy)
+  assert.deepEqual(next.map((candidate) => candidate.key), legacy.map((candidate) => candidate.key))
+  assert.deepEqual(next.map((candidate) => candidate.routeRole), legacy.map((candidate) => candidate.routeRole))
+  assert.deepEqual(next.map((candidate) => candidate.endpointFingerprint), legacy.map((candidate) => candidate.endpointFingerprint))
+})
+
+test('P1 evidence boundary returns facts only and contains health failures as uncertainty', async () => {
+  const seen = []
+  const evidence = await collectVisionRoutingEvidence({
+    ctx: ctxFixture(),
+    config,
+    core: coreFixture(),
+    store: storeFixture(),
+    runtimePerformanceStore: runtimeFixture(),
+    healthForCandidate(candidate) {
+      seen.push(candidate.key)
+      if (candidate.key === 'custom/fallback') throw new Error('health unavailable')
+      return { state: candidate.local ? 'local' : 'ready' }
+    },
+    healthContext: { source: 'parity-test' },
+  })
+
+  assert.ok(evidence.candidates.length > 0)
+  assert.deepEqual(Object.keys(evidence.measured), evidence.candidates.map((candidate) => candidate.key))
+  assert.deepEqual(seen, evidence.candidates.map((candidate) => candidate.key))
+  assert.equal(Object.hasOwn(evidence.health, 'custom/fallback'), false)
+  assert.equal(evidence.health['custom/chosen'].state, 'ready')
+  assert.equal(evidence.health['vision-http/local-ollama/qwen2.5vl'].state, 'local')
+  assert.deepEqual(Object.keys(evidence).sort(), ['candidates', 'health', 'measured'])
+})
+
+test('generated Router routes keep exact legacy filtering semantics', () => {
+  for (const [provider, cfg] of [
+    ['deepseek-vision', {}],
+    ['vision-chain', {}],
+    ['custom-vision', {}],
+    ['my-wrapper', { wrapperRoute: 'my-wrapper', chainRoute: 'my-chain' }],
+    ['my-chain', { wrapperRoute: 'my-wrapper', chainRoute: 'my-chain' }],
+  ]) {
+    assert.equal(generatedCapabilityRoute(provider, cfg), legacyGeneratedCapabilityRoute(provider, cfg))
+  }
+})


### PR DESCRIPTION
## Scope

Implements the first P1 convergence slice from the 2.x architecture plan using the required old-production/new-parity migration pattern. Production execution remains on the historical fake-settings path in this PR; the new boundaries are proven before taking authority.

### P1-A — evidence collector parity
- add `lib/vision-routing-evidence.js`
- isolate configured/local/fallback-only candidate discovery, endpoint identity, measured/runtime evidence, and health collection
- keep the existing `vision-capability-shadow.js` collector as production authority for this slice
- prove exact `deepEqual` parity for candidate order, keys, routeRole, endpoint fingerprints and attached evidence

### P1-B — scoped execution-order boundary
- add `lib/vision-execution-order.js`
- AsyncLocalStorage scope contains only detached, frozen `{ provider, model }` pairs
- no settings, credentials, authority, scores, evidence or Host services in the scope
- prove teardown, nested restoration, concurrent isolation and malformed-input behavior

### P1-C preparation — explicit order mapping parity
- add `lib/vision-execution-order-plan.js`
- convert planner keys directly to narrow provider/model execution order
- preserve configured routes omitted by evidence
- allow only already-enabled local backends to be synthesized from planner keys
- never synthesize arbitrary discovered adapters or unconfigured direct HTTP routes
- prove parity against `autoExecutionConfigFor()` for reorder/no-op/fallback/dedup/local/unconfigured cases

### CI
- add `P1 Routing Parity` on Node 22/24
- final head also passes full Node 22/24 CI, DSH Contract, native multimodal cold resume and Ubuntu/macOS/Windows host-sharp

## Explicit non-goals of this slice
- `routingPairs()` does not consume `VisionExecutionOrderContext` yet
- production still executes through the historical fake-settings path
- no fake-settings deletion
- no Auto scoring or authority change
- no `vision-capability-shadow` rename yet

## Next P1 slice
Wire the explicit order into core `routingPairs()` under dual-path parity, recheck live authority/settings before scoping it, and keep old fake-settings execution as production fallback until parity is complete. Only then switch production authority and delete the settings impersonation path.