### PR TITLE
refactor: define P1 reorder-only core semantics

### DIFF
--- a/.github/workflows/p1-routing-parity.yml
+++ b/.github/workflows/p1-routing-parity.yml
@@ -29,4 +29,4 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: Evidence collector parity and execution-order isolation
-        run: node --test tests/vision-routing-evidence-parity.test.js tests/vision-execution-order.test.js tests/vision-execution-order-plan-parity.test.js
+        run: node --test tests/vision-routing-evidence-parity.test.js tests/vision-execution-order.test.js tests/vision-execution-order-plan-parity.test.js tests/vision-execution-order-apply.test.js

--- a/lib/vision-execution-order-apply.js
+++ b/lib/vision-execution-order-apply.js
@@ -1,0 +1,61 @@
+function pairIdentity(pair) {
+  const provider = typeof pair?.provider === 'string' ? pair.provider.trim() : ''
+  const model = typeof pair?.model === 'string' ? pair.model.trim() : ''
+  return provider !== '' && model !== '' ? `${provider}\u0000${model}` : undefined
+}
+
+/**
+ * Apply an explicit P1 execution order to a base pair list without changing
+ * the base set of executable routes.
+ *
+ * This is intentionally a stable reorder, not replacement:
+ * - a scoped pair not present in `basePairs` is ignored (cannot invent a route);
+ * - every base pair omitted by the planner is appended in its original order
+ *   (cannot delete configured/local/discovered fallback);
+ * - duplicate base/scoped identities collapse to the first base occurrence;
+ * - no scoped order means byte-for-shape legacy behavior: a detached copy of
+ *   the base list in the same order.
+ *
+ * The caller remains responsible for constructing `basePairs` with its normal
+ * adapter/HTTP/local availability rules. This helper owns ordering only.
+ */
+export function applyVisionExecutionOrder(basePairs, scopedOrder) {
+  const base = Array.isArray(basePairs)
+    ? basePairs.filter((pair) => pairIdentity(pair) !== undefined)
+    : []
+  const baseById = new Map()
+  for (const pair of base) {
+    const id = pairIdentity(pair)
+    if (!baseById.has(id)) baseById.set(id, pair)
+  }
+
+  if (!Array.isArray(scopedOrder) || scopedOrder.length === 0) {
+    return [...baseById.values()]
+  }
+
+  const out = []
+  const seen = new Set()
+  const addBasePair = (pair) => {
+    const id = pairIdentity(pair)
+    if (id === undefined || seen.has(id)) return
+    seen.add(id)
+    out.push(pair)
+  }
+
+  for (const requested of scopedOrder) {
+    const id = pairIdentity(requested)
+    if (id === undefined) continue
+    const pair = baseById.get(id)
+    if (pair !== undefined) addBasePair(pair)
+  }
+  for (const pair of baseById.values()) addBasePair(pair)
+  return out
+}
+
+export function sameVisionPairOrder(left, right) {
+  if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length) return false
+  for (let index = 0; index < left.length; index += 1) {
+    if (pairIdentity(left[index]) !== pairIdentity(right[index])) return false
+  }
+  return true
+}

--- a/tests/vision-execution-order-apply.test.js
+++ b/tests/vision-execution-order-apply.test.js
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  applyVisionExecutionOrder,
+  sameVisionPairOrder,
+} from '../lib/vision-execution-order-apply.js'
+
+const pair = (provider, model, extra = {}) => ({ provider, model, ...extra })
+
+test('no scope preserves the base pair order and first-occurrence dedupe', () => {
+  const base = [pair('a', '1'), pair('b', '2'), pair('a', '1', { duplicate: true })]
+  assert.deepEqual(applyVisionExecutionOrder(base, undefined), [pair('a', '1'), pair('b', '2')])
+})
+
+test('scoped order reorders only routes already present in the base set', () => {
+  const base = [pair('a', '1'), pair('local', 'vl'), pair('b', '2'), pair('fallback', '3')]
+  const scoped = [
+    pair('local', 'vl'),
+    pair('not-configured', 'invented'),
+    pair('b', '2'),
+    pair('a', '1'),
+  ]
+  assert.deepEqual(applyVisionExecutionOrder(base, scoped), [
+    pair('local', 'vl'),
+    pair('b', '2'),
+    pair('a', '1'),
+    pair('fallback', '3'),
+  ])
+})
+
+test('planner omission never deletes configured/local/discovered fallbacks', () => {
+  const base = [
+    pair('configured-a', '1'),
+    pair('vision-http', 'local-ollama/qwen-vl'),
+    pair('configured-b', '2'),
+    pair('auto-discovered', 'vision-fallback'),
+  ]
+  const scoped = [pair('configured-b', '2'), pair('configured-a', '1')]
+  assert.deepEqual(applyVisionExecutionOrder(base, scoped), [
+    pair('configured-b', '2'),
+    pair('configured-a', '1'),
+    pair('vision-http', 'local-ollama/qwen-vl'),
+    pair('auto-discovered', 'vision-fallback'),
+  ])
+})
+
+test('disabled local route requested by a stale scope cannot be reintroduced', () => {
+  const base = [pair('configured', 'm')]
+  const scoped = [pair('vision-http', 'local-ollama/disabled'), pair('configured', 'm')]
+  assert.deepEqual(applyVisionExecutionOrder(base, scoped), [pair('configured', 'm')])
+})
+
+test('blocked or unavailable base filtering remains caller-owned and cannot be widened by scope', () => {
+  const baseAfterCoreAvailability = [pair('healthy', 'm1'), pair('fallback', 'm2')]
+  const scoped = [pair('blocked', 'm0'), pair('fallback', 'm2'), pair('healthy', 'm1')]
+  assert.deepEqual(applyVisionExecutionOrder(baseAfterCoreAvailability, scoped), [
+    pair('fallback', 'm2'),
+    pair('healthy', 'm1'),
+  ])
+})
+
+test('sameVisionPairOrder compares only provider/model identity', () => {
+  assert.equal(
+    sameVisionPairOrder([pair('a', '1', { score: 1 })], [pair('a', '1', { score: 999 })]),
+    true,
+  )
+  assert.equal(sameVisionPairOrder([pair('a', '1')], [pair('b', '1')]), false)
+  assert.equal(sameVisionPairOrder([pair('a', '1')], [pair('a', '1'), pair('b', '2')]), false)
+})


### PR DESCRIPTION
## P1-C — core ordering contract before production wiring

This slice freezes the semantics the direct `VisionExecutionOrderContext` consumer must use before touching the large core routing closure.

### New stable reorder primitive
`lib/vision-execution-order-apply.js` applies a scoped order to the pair set the core has already determined is executable.

Invariants:
- scope can only reorder a route already present in the core base set
- stale/unconfigured/disabled scoped routes are ignored
- configured/local/discovered fallbacks omitted by the planner remain appended in original order
- no scope preserves legacy base order
- duplicate identities collapse deterministically

This matters because the real tool chain contains more than configured candidates: it retains local and conservative discovered fallbacks after the planner-visible set. Replacing the whole array with the scoped plan would silently delete those fallbacks; stable reordering preserves the released behavior.

### Tests / CI
- add `tests/vision-execution-order-apply.test.js`
- extend `P1 Routing Parity` on Node 22/24
- cover reorder-only, no invention, no deletion, stale local route, caller-owned availability filtering and pair-order identity

### Production behavior
No production path changes in this slice. The historical fake-settings execution remains authoritative until the two core call sites consume this primitive under dual-path parity.