### PR TITLE
refactor(artifacts): introduce managed artifact store

### DIFF
--- a/.github/workflows/p2-data-boundary.yml
+++ b/.github/workflows/p2-data-boundary.yml
@@ -1,0 +1,54 @@
+name: P2 Data Boundary
+
+on:
+  pull_request:
+    paths:
+      - 'lib/artifact-*.js'
+      - 'lib/vision-artifact-store.js'
+      - 'lib/vision-tool-runtime-boundary.js'
+      - 'lib/adversarial-hardening.js'
+      - 'tests/vision-artifact-store.test.js'
+      - 'tests/artifact-path-security.test.js'
+      - 'tests/resource-retention-lifecycle.test.js'
+      - 'tests/qa-cancellation-publication.test.js'
+      - '.github/workflows/p2-data-boundary.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'lib/artifact-*.js'
+      - 'lib/vision-artifact-store.js'
+      - 'lib/vision-tool-runtime-boundary.js'
+      - 'lib/adversarial-hardening.js'
+      - 'tests/vision-artifact-store.test.js'
+      - 'tests/artifact-path-security.test.js'
+      - 'tests/resource-retention-lifecycle.test.js'
+      - 'tests/qa-cancellation-publication.test.js'
+      - '.github/workflows/p2-data-boundary.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  artifact-boundary:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [22, 24]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86
+        with:
+          version: 11.20.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: ${{ matrix.node }}
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Artifact facade parity and lifecycle safety
+        run: >-
+          node --test
+          tests/vision-artifact-store.test.js
+          tests/artifact-path-security.test.js
+          tests/resource-retention-lifecycle.test.js
+          tests/qa-cancellation-publication.test.js

--- a/lib/artifact-boundary.js
+++ b/lib/artifact-boundary.js
@@ -1,184 +1,25 @@
-import { randomUUID } from 'node:crypto'
-import { lstat, mkdir, realpath, rename, unlink, writeFile } from 'node:fs/promises'
-import path from 'node:path'
-import {
-  currentVisionTurnBudget,
-  currentVisionTurnBudgetSignal,
-} from './turn-budget-context.js'
-import {
-  isManagedArtifactRunName,
-  scheduleArtifactRetention,
-} from './artifact-retention.js'
+import { createVisionArtifactStore } from './vision-artifact-store.js'
 
-export const DEFAULT_ARTIFACTS_DIR = '.dsh-vision-router/artifacts'
+export {
+  DEFAULT_ARTIFACTS_DIR,
+  normalizeArtifactsDir,
+} from './artifact-io.js'
 
-function isPathInside(root, candidate) {
-  const relative = path.relative(root, candidate)
-  return relative === '' || (relative !== '..' && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative))
-}
-
-function isMissing(error) {
-  return error && (error.code === 'ENOENT' || error.code === 'ENOTDIR')
-}
-
-function artifactAbortError() {
-  const error = new Error('vision-router: artifact publication aborted')
-  error.name = 'AbortError'
-  error.code = 'ABORT_ERR'
-  return error
-}
-
-function throwIfVisionAborted() {
-  if (currentVisionTurnBudgetSignal()?.aborted) throw artifactAbortError()
-}
-
-function currentArtifactRunId() {
-  const value = currentVisionTurnBudget()?.artifactRunId
-  return isManagedArtifactRunName(value) ? value : undefined
-}
-
-export function normalizeArtifactsDir(value) {
-  if (typeof value !== 'string' || value.trim() === '') return DEFAULT_ARTIFACTS_DIR
-  const raw = value.trim()
-  if (path.isAbsolute(raw) || path.win32.isAbsolute(raw)) return DEFAULT_ARTIFACTS_DIR
-  const parts = raw.split(/[\\/]+/)
-  if (parts.some((part) => part === '..')) return DEFAULT_ARTIFACTS_DIR
-  const normalized = path.normalize(raw)
-  if (normalized === '' || normalized === '.' || normalized === path.sep) return DEFAULT_ARTIFACTS_DIR
-  return normalized
-}
-
-function normalizeRelativeArtifactPath(value) {
-  if (typeof value !== 'string' || value.trim() === '') {
-    throw new Error('vision-router: artifact path must be a non-empty relative path')
-  }
-  const raw = value.trim()
-  if (path.isAbsolute(raw) || path.win32.isAbsolute(raw)) {
-    throw new Error('vision-router: artifact path must stay inside the artifacts directory')
-  }
-  const parts = raw.split(/[\\/]+/)
-  if (parts.some((part) => part === '..')) {
-    throw new Error('vision-router: artifact path must stay inside the artifacts directory')
-  }
-  const normalized = path.normalize(raw)
-  if (normalized === '' || normalized === '.' || normalized === path.sep) {
-    throw new Error('vision-router: artifact path must name a file')
-  }
-  return normalized
-}
-
-async function realpathNearestExisting(candidate, realpathImpl) {
-  let current = candidate
-  while (true) {
-    try {
-      return await realpathImpl(current)
-    } catch (error) {
-      if (!isMissing(error)) throw error
-      const parent = path.dirname(current)
-      if (parent === current) throw error
-      current = parent
-    }
-  }
-}
-
-async function safeLstat(target, lstatImpl) {
-  try {
-    return await lstatImpl(target)
-  } catch (error) {
-    if (isMissing(error)) return undefined
-    throw error
-  }
+/**
+ * Compatibility boundary retained for existing production callers during P2.
+ * Resolution authority now flows through VisionArtifactStore while the public
+ * function signature and return value remain unchanged.
+ */
+export function resolveArtifactTarget(workspace, artifactsDir, relativePath, deps = {}) {
+  return createVisionArtifactStore({ workspace, artifactsDir, deps }).resolve(relativePath)
 }
 
 /**
- * Resolve an artifact target without treating lexical workspace containment as
- * authority. Existing ancestors are canonicalized before mkdir runs, then the
- * completed parent and artifact root are canonicalized again.
+ * Compatibility writer retained while callers migrate to VisionArtifactStore.
+ * The store delegates to the exact hardened IO primitive that previously lived
+ * here, so path layout, atomic publication, cancellation and retention semantics
+ * remain unchanged.
  */
-export async function resolveArtifactTarget(workspace, artifactsDir, relativePath, deps = {}) {
-  const realpathImpl = deps.realpath ?? realpath
-  const mkdirImpl = deps.mkdir ?? mkdir
-  const lstatImpl = deps.lstat ?? lstat
-
-  throwIfVisionAborted()
-  const workspaceReal = await realpathImpl(path.resolve(String(workspace ?? '')))
-  throwIfVisionAborted()
-  const relativeBase = normalizeArtifactsDir(artifactsDir)
-  const runId = currentArtifactRunId()
-  const requestedTarget = normalizeRelativeArtifactPath(relativePath)
-  const relativeTarget = runId
-    ? normalizeRelativeArtifactPath(path.join(runId, requestedTarget))
-    : requestedTarget
-  const lexicalBase = path.resolve(workspaceReal, relativeBase)
-  if (!isPathInside(workspaceReal, lexicalBase)) {
-    throw new Error('vision-router: artifactsDir must stay inside the session workspace')
-  }
-  const lexicalTarget = path.resolve(lexicalBase, relativeTarget)
-  if (!isPathInside(lexicalBase, lexicalTarget)) {
-    throw new Error('vision-router: artifact target must stay inside the artifacts directory')
-  }
-
-  const lexicalParent = path.dirname(lexicalTarget)
-  const existingAncestorReal = await realpathNearestExisting(lexicalParent, realpathImpl)
-  throwIfVisionAborted()
-  if (!isPathInside(workspaceReal, existingAncestorReal)) {
-    throw new Error('vision-router: artifact parent escapes the session workspace through a symlink')
-  }
-
-  await mkdirImpl(lexicalParent, { recursive: true })
-  throwIfVisionAborted()
-  const parentReal = await realpathImpl(lexicalParent)
-  const artifactsBaseReal = await realpathImpl(lexicalBase)
-  throwIfVisionAborted()
-  if (!isPathInside(workspaceReal, parentReal) || !isPathInside(workspaceReal, artifactsBaseReal)) {
-    throw new Error('vision-router: artifact parent escapes the session workspace through a symlink')
-  }
-
-  const target = path.join(parentReal, path.basename(lexicalTarget))
-  const existing = await safeLstat(target, lstatImpl)
-  throwIfVisionAborted()
-  if (existing?.isDirectory?.()) {
-    throw new Error('vision-router: artifact target is a directory')
-  }
-  return { target, parentReal, artifactsBaseReal, existing, runId }
-}
-
-/**
- * Publish artifact bytes without ever opening the final target for writing.
- * A temp file is written in the canonical parent and renamed over the target;
- * an existing symlink is unlinked as a directory entry rather than followed.
- */
-export async function writeArtifactFile(workspace, artifactsDir, relativePath, data, deps = {}) {
-  const writeFileImpl = deps.writeFile ?? writeFile
-  const renameImpl = deps.rename ?? rename
-  const unlinkImpl = deps.unlink ?? unlink
-  const resolved = await resolveArtifactTarget(workspace, artifactsDir, relativePath, deps)
-  const temp = path.join(
-    resolved.parentReal,
-    `.dsh-vision-router-${process.pid}-${randomUUID()}.tmp`,
-  )
-  let published = false
-  try {
-    throwIfVisionAborted()
-    await writeFileImpl(temp, data, { mode: 0o600 })
-    throwIfVisionAborted()
-    if (resolved.existing !== undefined) {
-      try {
-        await unlinkImpl(resolved.target)
-      } catch (error) {
-        if (!isMissing(error)) throw error
-      }
-      throwIfVisionAborted()
-    }
-    await renameImpl(temp, resolved.target)
-    published = true
-    if (resolved.runId) {
-      scheduleArtifactRetention(resolved.artifactsBaseReal, { protectRunId: resolved.runId })
-    }
-    return resolved.target
-  } finally {
-    if (!published) {
-      try { await unlinkImpl(temp) } catch { /* best effort */ }
-    }
-  }
+export function writeArtifactFile(workspace, artifactsDir, relativePath, data, deps = {}) {
+  return createVisionArtifactStore({ workspace, artifactsDir, deps }).publish(relativePath, data)
 }

--- a/lib/artifact-io.js
+++ b/lib/artifact-io.js
@@ -1,0 +1,182 @@
+import { randomUUID } from 'node:crypto'
+import { lstat, mkdir, realpath, rename, unlink, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import {
+  currentVisionTurnBudget,
+  currentVisionTurnBudgetSignal,
+} from './turn-budget-context.js'
+import {
+  isManagedArtifactRunName,
+  scheduleArtifactRetention,
+} from './artifact-retention.js'
+
+export const DEFAULT_ARTIFACTS_DIR = '.dsh-vision-router/artifacts'
+
+function isPathInside(root, candidate) {
+  const relative = path.relative(root, candidate)
+  return relative === '' || (relative !== '..' && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative))
+}
+
+function isMissing(error) {
+  return error && (error.code === 'ENOENT' || error.code === 'ENOTDIR')
+}
+
+function artifactAbortError() {
+  const error = new Error('vision-router: artifact publication aborted')
+  error.name = 'AbortError'
+  error.code = 'ABORT_ERR'
+  return error
+}
+
+function throwIfVisionAborted() {
+  if (currentVisionTurnBudgetSignal()?.aborted) throw artifactAbortError()
+}
+
+function currentArtifactRunId() {
+  const value = currentVisionTurnBudget()?.artifactRunId
+  return isManagedArtifactRunName(value) ? value : undefined
+}
+
+export function normalizeArtifactsDir(value) {
+  if (typeof value !== 'string' || value.trim() === '') return DEFAULT_ARTIFACTS_DIR
+  const raw = value.trim()
+  if (path.isAbsolute(raw) || path.win32.isAbsolute(raw)) return DEFAULT_ARTIFACTS_DIR
+  const parts = raw.split(/[\\/]+/)
+  if (parts.some((part) => part === '..')) return DEFAULT_ARTIFACTS_DIR
+  const normalized = path.normalize(raw)
+  if (normalized === '' || normalized === '.' || normalized === path.sep) return DEFAULT_ARTIFACTS_DIR
+  return normalized
+}
+
+function normalizeRelativeArtifactPath(value) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error('vision-router: artifact path must be a non-empty relative path')
+  }
+  const raw = value.trim()
+  if (path.isAbsolute(raw) || path.win32.isAbsolute(raw)) {
+    throw new Error('vision-router: artifact path must stay inside the artifacts directory')
+  }
+  const parts = raw.split(/[\\/]+/)
+  if (parts.some((part) => part === '..')) {
+    throw new Error('vision-router: artifact path must stay inside the artifacts directory')
+  }
+  const normalized = path.normalize(raw)
+  if (normalized === '' || normalized === '.' || normalized === path.sep) {
+    throw new Error('vision-router: artifact path must name a file')
+  }
+  return normalized
+}
+
+async function realpathNearestExisting(candidate, realpathImpl) {
+  let current = candidate
+  while (true) {
+    try {
+      return await realpathImpl(current)
+    } catch (error) {
+      if (!isMissing(error)) throw error
+      const parent = path.dirname(current)
+      if (parent === current) throw error
+      current = parent
+    }
+  }
+}
+
+async function safeLstat(target, lstatImpl) {
+  try {
+    return await lstatImpl(target)
+  } catch (error) {
+    if (isMissing(error)) return undefined
+    throw error
+  }
+}
+
+/**
+ * Hardened artifact target primitive. This module is intentionally below the
+ * P2 data-plane facade so compatibility shims and the facade share one security
+ * implementation without creating a circular dependency.
+ */
+export async function resolveArtifactTarget(workspace, artifactsDir, relativePath, deps = {}) {
+  const realpathImpl = deps.realpath ?? realpath
+  const mkdirImpl = deps.mkdir ?? mkdir
+  const lstatImpl = deps.lstat ?? lstat
+
+  throwIfVisionAborted()
+  const workspaceReal = await realpathImpl(path.resolve(String(workspace ?? '')))
+  throwIfVisionAborted()
+  const relativeBase = normalizeArtifactsDir(artifactsDir)
+  const runId = currentArtifactRunId()
+  const requestedTarget = normalizeRelativeArtifactPath(relativePath)
+  const relativeTarget = runId
+    ? normalizeRelativeArtifactPath(path.join(runId, requestedTarget))
+    : requestedTarget
+  const lexicalBase = path.resolve(workspaceReal, relativeBase)
+  if (!isPathInside(workspaceReal, lexicalBase)) {
+    throw new Error('vision-router: artifactsDir must stay inside the session workspace')
+  }
+  const lexicalTarget = path.resolve(lexicalBase, relativeTarget)
+  if (!isPathInside(lexicalBase, lexicalTarget)) {
+    throw new Error('vision-router: artifact target must stay inside the artifacts directory')
+  }
+
+  const lexicalParent = path.dirname(lexicalTarget)
+  const existingAncestorReal = await realpathNearestExisting(lexicalParent, realpathImpl)
+  throwIfVisionAborted()
+  if (!isPathInside(workspaceReal, existingAncestorReal)) {
+    throw new Error('vision-router: artifact parent escapes the session workspace through a symlink')
+  }
+
+  await mkdirImpl(lexicalParent, { recursive: true })
+  throwIfVisionAborted()
+  const parentReal = await realpathImpl(lexicalParent)
+  const artifactsBaseReal = await realpathImpl(lexicalBase)
+  throwIfVisionAborted()
+  if (!isPathInside(workspaceReal, parentReal) || !isPathInside(workspaceReal, artifactsBaseReal)) {
+    throw new Error('vision-router: artifact parent escapes the session workspace through a symlink')
+  }
+
+  const target = path.join(parentReal, path.basename(lexicalTarget))
+  const existing = await safeLstat(target, lstatImpl)
+  throwIfVisionAborted()
+  if (existing?.isDirectory?.()) {
+    throw new Error('vision-router: artifact target is a directory')
+  }
+  return { target, parentReal, artifactsBaseReal, existing, runId }
+}
+
+/**
+ * Hardened atomic publication primitive used by VisionArtifactStore.
+ */
+export async function writeArtifactFile(workspace, artifactsDir, relativePath, data, deps = {}) {
+  const writeFileImpl = deps.writeFile ?? writeFile
+  const renameImpl = deps.rename ?? rename
+  const unlinkImpl = deps.unlink ?? unlink
+  const resolved = await resolveArtifactTarget(workspace, artifactsDir, relativePath, deps)
+  const temp = path.join(
+    resolved.parentReal,
+    `.dsh-vision-router-${process.pid}-${randomUUID()}.tmp`,
+  )
+  let published = false
+  try {
+    throwIfVisionAborted()
+    await writeFileImpl(temp, data, { mode: 0o600 })
+    throwIfVisionAborted()
+    if (resolved.existing !== undefined) {
+      try {
+        await unlinkImpl(resolved.target)
+      } catch (error) {
+        if (!isMissing(error)) throw error
+      }
+      throwIfVisionAborted()
+    }
+    await renameImpl(temp, resolved.target)
+    published = true
+    if (resolved.runId) {
+      scheduleArtifactRetention(resolved.artifactsBaseReal, { protectRunId: resolved.runId })
+    }
+    return resolved.target
+  } finally {
+    if (!published) {
+      try { await unlinkImpl(temp) } catch { /* best effort */ }
+    }
+  }
+}

--- a/lib/vision-artifact-store.js
+++ b/lib/vision-artifact-store.js
@@ -19,13 +19,14 @@ function callDeps(base, options) {
 }
 
 /**
- * P2 artifact data-plane facade.
+ * P2 artifact data-plane facade and production ownership boundary.
  *
  * P2-A is intentionally behavior-preserving: this facade owns no new layout,
- * metadata or cleanup policy. It delegates to the already-hardened artifact
- * IO/retention primitives so paths, filenames, return values, symlink handling,
+ * metadata or cleanup policy. It delegates to the hardened artifact IO and
+ * retention primitives so paths, filenames, return values, symlink handling,
  * atomic publication, cancellation and run retention remain compatible with
- * the pre-facade runtime.
+ * the pre-facade runtime. The legacy artifact-boundary module now delegates
+ * back into this facade, so old callers and new callers share this one path.
  *
  * `workspace` and `artifactsDir` may be functions so callers can retain the
  * current live-settings/session semantics instead of capturing stale values.

--- a/lib/vision-artifact-store.js
+++ b/lib/vision-artifact-store.js
@@ -1,7 +1,7 @@
 import {
   resolveArtifactTarget,
   writeArtifactFile,
-} from './artifact-boundary.js'
+} from './artifact-io.js'
 import {
   retainArtifactRun,
   scheduleArtifactRetention,
@@ -23,9 +23,9 @@ function callDeps(base, options) {
  *
  * P2-A is intentionally behavior-preserving: this facade owns no new layout,
  * metadata or cleanup policy. It delegates to the already-hardened artifact
- * boundary/retention implementation so paths, filenames, return values,
- * symlink handling, atomic publication, cancellation and run retention remain
- * byte-for-byte compatible with the pre-facade runtime.
+ * IO/retention primitives so paths, filenames, return values, symlink handling,
+ * atomic publication, cancellation and run retention remain compatible with
+ * the pre-facade runtime.
  *
  * `workspace` and `artifactsDir` may be functions so callers can retain the
  * current live-settings/session semantics instead of capturing stale values.

--- a/lib/vision-artifact-store.js
+++ b/lib/vision-artifact-store.js
@@ -1,0 +1,78 @@
+import {
+  resolveArtifactTarget,
+  writeArtifactFile,
+} from './artifact-boundary.js'
+import {
+  retainArtifactRun,
+  scheduleArtifactRetention,
+} from './artifact-retention.js'
+
+function live(value) {
+  return typeof value === 'function' ? value() : value
+}
+
+function callDeps(base, options) {
+  const extra = options && typeof options === 'object' ? options.deps : undefined
+  return extra && typeof extra === 'object'
+    ? { ...base, ...extra }
+    : base
+}
+
+/**
+ * P2 artifact data-plane facade.
+ *
+ * P2-A is intentionally behavior-preserving: this facade owns no new layout,
+ * metadata or cleanup policy. It delegates to the already-hardened artifact
+ * boundary/retention implementation so paths, filenames, return values,
+ * symlink handling, atomic publication, cancellation and run retention remain
+ * byte-for-byte compatible with the pre-facade runtime.
+ *
+ * `workspace` and `artifactsDir` may be functions so callers can retain the
+ * current live-settings/session semantics instead of capturing stale values.
+ */
+export function createVisionArtifactStore({ workspace, artifactsDir, deps = {} } = {}) {
+  const location = () => ({
+    workspace: live(workspace),
+    artifactsDir: live(artifactsDir),
+  })
+
+  const publish = (relativePath, data, options = {}) => {
+    const current = location()
+    return writeArtifactFile(
+      current.workspace,
+      current.artifactsDir,
+      relativePath,
+      data,
+      callDeps(deps, options),
+    )
+  }
+
+  return Object.freeze({
+    resolve(relativePath, options = {}) {
+      const current = location()
+      return resolveArtifactTarget(
+        current.workspace,
+        current.artifactsDir,
+        relativePath,
+        callDeps(deps, options),
+      )
+    },
+
+    publish,
+
+    // P2-A deliberately keeps temporary publication on the existing layout.
+    // P2-B may redirect managed run outputs into `.runs/`; doing so here would
+    // violate the required first-stage path/filename/return-value parity.
+    publishTemporary(relativePath, data, options = {}) {
+      return publish(relativePath, data, options)
+    },
+
+    retainRun(runId) {
+      return retainArtifactRun(runId)
+    },
+
+    scheduleRetention(root, options = {}) {
+      return scheduleArtifactRetention(root, options)
+    },
+  })
+}

--- a/tests/vision-artifact-store.test.js
+++ b/tests/vision-artifact-store.test.js
@@ -127,7 +127,6 @@ test('facade run ownership protects an active run until release', async () => {
     const runId = '.vision-run-p2-active'
     const target = path.join(root, runId)
     await mkdir(target)
-    await readFile(new URL('data:text/plain,')).catch(() => undefined)
     const old = new Date(Date.now() - 60_000)
     await utimes(target, old, old)
 

--- a/tests/vision-artifact-store.test.js
+++ b/tests/vision-artifact-store.test.js
@@ -11,7 +11,8 @@ import {
 } from 'node:fs/promises'
 import path from 'node:path'
 import { tmpdir } from 'node:os'
-import { writeArtifactFile } from '../lib/artifact-boundary.js'
+import { writeArtifactFile as compatibilityWriteArtifactFile } from '../lib/artifact-boundary.js'
+import { writeArtifactFile as primitiveWriteArtifactFile } from '../lib/artifact-io.js'
 import { cleanupArtifactRuns } from '../lib/artifact-retention.js'
 import { createVisionArtifactStore } from '../lib/vision-artifact-store.js'
 import { runWithVisionTurnBudget } from '../lib/turn-budget-context.js'
@@ -38,7 +39,7 @@ test('VisionArtifactStore publish preserves the hardened writer path, bytes and 
 
     const data = Buffer.from('p2-artifact-parity')
     const relativePath = 'nested/output.txt'
-    const legacy = await writeArtifactFile(
+    const legacy = await primitiveWriteArtifactFile(
       legacyWorkspace,
       '.dsh-vision-router/artifacts',
       relativePath,
@@ -56,6 +57,36 @@ test('VisionArtifactStore publish preserves the hardened writer path, bytes and 
     )
     assert.deepEqual(await readFile(next), data)
     assert.deepEqual(await readFile(legacy), data)
+  })
+})
+
+test('legacy artifact boundary remains behavior-compatible after becoming a store shim', async () => {
+  await withTempDir('dvr-artifact-shim-', async (root) => {
+    const primitiveWorkspace = path.join(root, 'primitive')
+    const shimWorkspace = path.join(root, 'shim')
+    await mkdir(primitiveWorkspace)
+    await mkdir(shimWorkspace)
+
+    const data = Buffer.from('compatibility-shim')
+    const relativePath = 'nested/compat.txt'
+    const primitive = await primitiveWriteArtifactFile(
+      primitiveWorkspace,
+      'artifacts',
+      relativePath,
+      data,
+    )
+    const shim = await compatibilityWriteArtifactFile(
+      shimWorkspace,
+      'artifacts',
+      relativePath,
+      data,
+    )
+
+    assert.equal(
+      relativeToWorkspace(primitiveWorkspace, primitive),
+      relativeToWorkspace(shimWorkspace, shim),
+    )
+    assert.deepEqual(await readFile(shim), data)
   })
 })
 

--- a/tests/vision-artifact-store.test.js
+++ b/tests/vision-artifact-store.test.js
@@ -1,0 +1,154 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  symlink,
+  utimes,
+} from 'node:fs/promises'
+import path from 'node:path'
+import { tmpdir } from 'node:os'
+import { writeArtifactFile } from '../lib/artifact-boundary.js'
+import { cleanupArtifactRuns } from '../lib/artifact-retention.js'
+import { createVisionArtifactStore } from '../lib/vision-artifact-store.js'
+import { runWithVisionTurnBudget } from '../lib/turn-budget-context.js'
+
+async function withTempDir(prefix, fn) {
+  const root = await mkdtemp(path.join(tmpdir(), prefix))
+  try {
+    return await fn(root)
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+}
+
+function relativeToWorkspace(workspace, target) {
+  return path.relative(workspace, target).split(path.sep).join('/')
+}
+
+test('VisionArtifactStore publish preserves the hardened writer path, bytes and return contract', async () => {
+  await withTempDir('dvr-artifact-store-', async (root) => {
+    const legacyWorkspace = path.join(root, 'legacy')
+    const facadeWorkspace = path.join(root, 'facade')
+    await mkdir(legacyWorkspace)
+    await mkdir(facadeWorkspace)
+
+    const data = Buffer.from('p2-artifact-parity')
+    const relativePath = 'nested/output.txt'
+    const legacy = await writeArtifactFile(
+      legacyWorkspace,
+      '.dsh-vision-router/artifacts',
+      relativePath,
+      data,
+    )
+    const store = createVisionArtifactStore({
+      workspace: facadeWorkspace,
+      artifactsDir: '.dsh-vision-router/artifacts',
+    })
+    const next = await store.publish(relativePath, data)
+
+    assert.equal(
+      relativeToWorkspace(legacyWorkspace, legacy),
+      relativeToWorkspace(facadeWorkspace, next),
+    )
+    assert.deepEqual(await readFile(next), data)
+    assert.deepEqual(await readFile(legacy), data)
+  })
+})
+
+test('VisionArtifactStore reads live workspace/artifactsDir values instead of capturing stale settings', async () => {
+  await withTempDir('dvr-artifact-live-', async (root) => {
+    const first = path.join(root, 'first')
+    const second = path.join(root, 'second')
+    await mkdir(first)
+    await mkdir(second)
+    let workspace = first
+    let artifactsDir = 'artifacts-a'
+    const store = createVisionArtifactStore({
+      workspace: () => workspace,
+      artifactsDir: () => artifactsDir,
+    })
+
+    const a = await store.publish('a.txt', 'a')
+    workspace = second
+    artifactsDir = 'artifacts-b'
+    const b = await store.publish('b.txt', 'b')
+
+    assert.equal(relativeToWorkspace(first, a), 'artifacts-a/a.txt')
+    assert.equal(relativeToWorkspace(second, b), 'artifacts-b/b.txt')
+  })
+})
+
+test('publishTemporary keeps the current managed-run layout exactly unchanged during P2-A', async () => {
+  await withTempDir('dvr-artifact-temp-', async (root) => {
+    const runId = '.vision-run-p2-parity'
+    const store = createVisionArtifactStore({
+      workspace: root,
+      artifactsDir: 'artifacts',
+    })
+    const target = await runWithVisionTurnBudget(
+      { artifactRunId: runId },
+      () => store.publishTemporary('preview.png', Buffer.from('png')),
+    )
+
+    assert.equal(relativeToWorkspace(root, target), `artifacts/${runId}/preview.png`)
+    assert.deepEqual(await readFile(target), Buffer.from('png'))
+  })
+})
+
+test('facade resolve/publish retain the existing traversal and symlink safety policy', async () => {
+  await withTempDir('dvr-artifact-security-', async (root) => {
+    const outside = path.join(root, 'outside')
+    const workspace = path.join(root, 'workspace')
+    await mkdir(outside)
+    await mkdir(workspace)
+    const store = createVisionArtifactStore({ workspace, artifactsDir: 'artifacts' })
+
+    await assert.rejects(
+      () => store.resolve('../escape.txt'),
+      /artifact path must stay inside|artifact target must stay inside/,
+    )
+
+    const artifacts = path.join(workspace, 'artifacts')
+    await mkdir(artifacts)
+    await symlink(outside, path.join(artifacts, 'linked'))
+    await assert.rejects(
+      () => store.publish('linked/escape.txt', 'nope'),
+      /escapes the session workspace through a symlink/,
+    )
+  })
+})
+
+test('facade run ownership protects an active run until release', async () => {
+  await withTempDir('dvr-artifact-retain-', async (root) => {
+    const runId = '.vision-run-p2-active'
+    const target = path.join(root, runId)
+    await mkdir(target)
+    await readFile(new URL('data:text/plain,')).catch(() => undefined)
+    const old = new Date(Date.now() - 60_000)
+    await utimes(target, old, old)
+
+    const store = createVisionArtifactStore({ workspace: root, artifactsDir: '.' })
+    const release = store.retainRun(runId)
+    try {
+      const protectedCleanup = await cleanupArtifactRuns(root, {
+        ttlMs: 1,
+        now: Date.now(),
+      })
+      assert.equal(protectedCleanup.removed, 0)
+      assert.equal((await lstat(target)).isDirectory(), true)
+    } finally {
+      release()
+    }
+
+    const afterRelease = await cleanupArtifactRuns(root, {
+      ttlMs: 1,
+      now: Date.now(),
+    })
+    assert.equal(afterRelease.removed, 1)
+    await assert.rejects(() => lstat(target), { code: 'ENOENT' })
+  })
+})


### PR DESCRIPTION
## P2-A formal acceptance — COMPLETE / PASS

Final head: `ccf3c7bd9a5c8424601dda5b88c4c6b84efb8868`
Base: `main@92cdfd0d0401b530d24d6d9cfd33c1eb970caed2`

### Completed architecture convergence

- [x] Added `VisionArtifactStore` as the production artifact data-plane facade.
- [x] Facade surface: `publish`, `publishTemporary`, `resolve`, `retainRun`, `scheduleRetention`.
- [x] Existing hardened IO moved intact into `artifact-io.js` below the facade.
- [x] Legacy `artifact-boundary.js` is now a compatibility shim that delegates through `VisionArtifactStore`.
- [x] Existing production callers therefore flow through the Store without requiring risky edits to large runtime files.
- [x] No artifact root, filename, returned path, `.vision-run-*` layout or persistence format changes in P2-A.
- [x] Atomic temp-write/rename, symlink/traversal rejection, cancellation checks and retention behavior remain on the same hardened primitive.
- [x] Workspace/artifactsDir may be live functions so the Store does not capture stale session/settings locations.
- [x] Active-run retain/release remains tool-lifetime scoped.

### Final Exit Gate evidence

All checks passed on the final head:

- P2 Data Boundary run `33098300840`: success (Node 22 + Node 24)
- P1 Routing Parity run `33098300950`: success
- CI run `33098300940`: success
  - `test (22)`: success
  - `test (24)`: success
  - DSH contract rc.6 / rc.7 / rc.8: success
  - host-sharp Ubuntu / macOS / Windows: success
- DSH Contract run `33098300897`: success
- Native multimodal cold resume run `33098300882`: success

### Diff safety

Final PR contains only the expected five files:

- `.github/workflows/p2-data-boundary.yml`
- `lib/artifact-boundary.js`
- `lib/artifact-io.js`
- `lib/vision-artifact-store.js`
- `tests/vision-artifact-store.test.js`

No large runtime file was rewritten.

### Formal verdict

**P2-A COMPLETE / PASS.**

The artifact data plane is now centralized behind `VisionArtifactStore` with behavior parity proven. P2-B may begin after merge and is the first stage allowed to introduce the managed `.runs/` namespace for temporary run artifacts only.