### PR TITLE
refactor(artifacts): isolate temporary runs namespace

### DIFF
--- a/lib/artifact-io.js
+++ b/lib/artifact-io.js
@@ -11,6 +11,7 @@ import {
 } from './artifact-retention.js'
 
 export const DEFAULT_ARTIFACTS_DIR = '.dsh-vision-router/artifacts'
+export const ARTIFACT_RUNS_DIR = '.runs'
 
 function isPathInside(root, candidate) {
   const relative = path.relative(root, candidate)
@@ -91,9 +92,12 @@ async function safeLstat(target, lstatImpl) {
 }
 
 /**
- * Hardened artifact target primitive. This module is intentionally below the
- * P2 data-plane facade so compatibility shims and the facade share one security
- * implementation without creating a circular dependency.
+ * Hardened artifact target primitive below VisionArtifactStore.
+ *
+ * P2-B gives managed tool-run artifacts their own `.runs/` namespace. The
+ * namespace is treated as infrastructure, not user-controlled path data: an
+ * existing symlink is rejected even when it points somewhere else inside the
+ * workspace. Artifacts outside a managed run keep their original root layout.
  */
 export async function resolveArtifactTarget(workspace, artifactsDir, relativePath, deps = {}) {
   const realpathImpl = deps.realpath ?? realpath
@@ -107,12 +111,28 @@ export async function resolveArtifactTarget(workspace, artifactsDir, relativePat
   const runId = currentArtifactRunId()
   const requestedTarget = normalizeRelativeArtifactPath(relativePath)
   const relativeTarget = runId
-    ? normalizeRelativeArtifactPath(path.join(runId, requestedTarget))
+    ? normalizeRelativeArtifactPath(path.join(ARTIFACT_RUNS_DIR, runId, requestedTarget))
     : requestedTarget
   const lexicalBase = path.resolve(workspaceReal, relativeBase)
   if (!isPathInside(workspaceReal, lexicalBase)) {
     throw new Error('vision-router: artifactsDir must stay inside the session workspace')
   }
+
+  const lexicalRunsBase = runId ? path.resolve(lexicalBase, ARTIFACT_RUNS_DIR) : undefined
+  if (lexicalRunsBase && !isPathInside(lexicalBase, lexicalRunsBase)) {
+    throw new Error('vision-router: managed artifact runs must stay inside the artifacts directory')
+  }
+  if (lexicalRunsBase) {
+    const before = await safeLstat(lexicalRunsBase, lstatImpl)
+    throwIfVisionAborted()
+    if (before?.isSymbolicLink?.()) {
+      throw new Error('vision-router: managed artifact runs directory must not be a symlink')
+    }
+    if (before !== undefined && !before.isDirectory?.()) {
+      throw new Error('vision-router: managed artifact runs path must be a directory')
+    }
+  }
+
   const lexicalTarget = path.resolve(lexicalBase, relativeTarget)
   if (!isPathInside(lexicalBase, lexicalTarget)) {
     throw new Error('vision-router: artifact target must stay inside the artifacts directory')
@@ -134,18 +154,30 @@ export async function resolveArtifactTarget(workspace, artifactsDir, relativePat
     throw new Error('vision-router: artifact parent escapes the session workspace through a symlink')
   }
 
+  let runsBaseReal
+  if (lexicalRunsBase) {
+    const after = await safeLstat(lexicalRunsBase, lstatImpl)
+    throwIfVisionAborted()
+    if (!after?.isDirectory?.() || after.isSymbolicLink?.()) {
+      throw new Error('vision-router: managed artifact runs directory must be a real directory')
+    }
+    runsBaseReal = await realpathImpl(lexicalRunsBase)
+    throwIfVisionAborted()
+    if (!isPathInside(artifactsBaseReal, runsBaseReal)) {
+      throw new Error('vision-router: managed artifact runs directory escapes the artifacts directory')
+    }
+  }
+
   const target = path.join(parentReal, path.basename(lexicalTarget))
   const existing = await safeLstat(target, lstatImpl)
   throwIfVisionAborted()
   if (existing?.isDirectory?.()) {
     throw new Error('vision-router: artifact target is a directory')
   }
-  return { target, parentReal, artifactsBaseReal, existing, runId }
+  return { target, parentReal, artifactsBaseReal, runsBaseReal, existing, runId }
 }
 
-/**
- * Hardened atomic publication primitive used by VisionArtifactStore.
- */
+/** Hardened atomic publication primitive used by VisionArtifactStore. */
 export async function writeArtifactFile(workspace, artifactsDir, relativePath, data, deps = {}) {
   const writeFileImpl = deps.writeFile ?? writeFile
   const renameImpl = deps.rename ?? rename
@@ -171,6 +203,12 @@ export async function writeArtifactFile(workspace, artifactsDir, relativePath, d
     await renameImpl(temp, resolved.target)
     published = true
     if (resolved.runId) {
+      // New managed runs live under `.runs`, so retention scans that directory
+      // directly. Also schedule the old artifact root so pre-P2-B direct
+      // `.vision-run-*` directories continue to age out safely.
+      if (resolved.runsBaseReal) {
+        scheduleArtifactRetention(resolved.runsBaseReal, { protectRunId: resolved.runId })
+      }
       scheduleArtifactRetention(resolved.artifactsBaseReal, { protectRunId: resolved.runId })
     }
     return resolved.target

--- a/lib/vision-artifact-store.js
+++ b/lib/vision-artifact-store.js
@@ -21,12 +21,10 @@ function callDeps(base, options) {
 /**
  * P2 artifact data-plane facade and production ownership boundary.
  *
- * P2-A is intentionally behavior-preserving: this facade owns no new layout,
- * metadata or cleanup policy. It delegates to the hardened artifact IO and
- * retention primitives so paths, filenames, return values, symlink handling,
- * atomic publication, cancellation and run retention remain compatible with
- * the pre-facade runtime. The legacy artifact-boundary module now delegates
- * back into this facade, so old callers and new callers share this one path.
+ * Managed tool-run artifacts are isolated by the hardened IO layer under
+ * `<artifactsDir>/.runs/<runId>/...`. Calls made without a managed run keep the
+ * historical `<artifactsDir>/<relativePath>` layout, so persistent/user-facing
+ * artifacts do not move merely because the Store exists.
  *
  * `workspace` and `artifactsDir` may be functions so callers can retain the
  * current live-settings/session semantics instead of capturing stale values.
@@ -61,9 +59,9 @@ export function createVisionArtifactStore({ workspace, artifactsDir, deps = {} }
 
     publish,
 
-    // P2-A deliberately keeps temporary publication on the existing layout.
-    // P2-B may redirect managed run outputs into `.runs/`; doing so here would
-    // violate the required first-stage path/filename/return-value parity.
+    // Temporary-vs-persistent placement is authority/lifetime driven: the
+    // ambient managed artifactRunId decides whether hardened IO uses `.runs`.
+    // Keeping this method as an alias avoids inventing a second placement path.
     publishTemporary(relativePath, data, options = {}) {
       return publish(relativePath, data, options)
     },

--- a/tests/vision-artifact-store.test.js
+++ b/tests/vision-artifact-store.test.js
@@ -8,11 +8,15 @@ import {
   rm,
   symlink,
   utimes,
+  writeFile,
 } from 'node:fs/promises'
 import path from 'node:path'
 import { tmpdir } from 'node:os'
 import { writeArtifactFile as compatibilityWriteArtifactFile } from '../lib/artifact-boundary.js'
-import { writeArtifactFile as primitiveWriteArtifactFile } from '../lib/artifact-io.js'
+import {
+  ARTIFACT_RUNS_DIR,
+  writeArtifactFile as primitiveWriteArtifactFile,
+} from '../lib/artifact-io.js'
 import { cleanupArtifactRuns } from '../lib/artifact-retention.js'
 import { createVisionArtifactStore } from '../lib/vision-artifact-store.js'
 import { runWithVisionTurnBudget } from '../lib/turn-budget-context.js'
@@ -30,17 +34,17 @@ function relativeToWorkspace(workspace, target) {
   return path.relative(workspace, target).split(path.sep).join('/')
 }
 
-test('VisionArtifactStore publish preserves the hardened writer path, bytes and return contract', async () => {
+test('VisionArtifactStore publish preserves the hardened writer path, bytes and return contract outside a managed run', async () => {
   await withTempDir('dvr-artifact-store-', async (root) => {
-    const legacyWorkspace = path.join(root, 'legacy')
+    const primitiveWorkspace = path.join(root, 'primitive')
     const facadeWorkspace = path.join(root, 'facade')
-    await mkdir(legacyWorkspace)
+    await mkdir(primitiveWorkspace)
     await mkdir(facadeWorkspace)
 
     const data = Buffer.from('p2-artifact-parity')
     const relativePath = 'nested/output.txt'
-    const legacy = await primitiveWriteArtifactFile(
-      legacyWorkspace,
+    const primitive = await primitiveWriteArtifactFile(
+      primitiveWorkspace,
       '.dsh-vision-router/artifacts',
       relativePath,
       data,
@@ -52,11 +56,14 @@ test('VisionArtifactStore publish preserves the hardened writer path, bytes and 
     const next = await store.publish(relativePath, data)
 
     assert.equal(
-      relativeToWorkspace(legacyWorkspace, legacy),
+      relativeToWorkspace(primitiveWorkspace, primitive),
       relativeToWorkspace(facadeWorkspace, next),
     )
     assert.deepEqual(await readFile(next), data)
-    assert.deepEqual(await readFile(legacy), data)
+    await assert.rejects(
+      () => lstat(path.join(facadeWorkspace, '.dsh-vision-router/artifacts', ARTIFACT_RUNS_DIR)),
+      { code: 'ENOENT' },
+    )
   })
 })
 
@@ -113,20 +120,41 @@ test('VisionArtifactStore reads live workspace/artifactsDir values instead of ca
   })
 })
 
-test('publishTemporary keeps the current managed-run layout exactly unchanged during P2-A', async () => {
+test('managed run publication is isolated under the .runs namespace', async () => {
   await withTempDir('dvr-artifact-temp-', async (root) => {
     const runId = '.vision-run-p2-parity'
-    const store = createVisionArtifactStore({
-      workspace: root,
-      artifactsDir: 'artifacts',
-    })
+    const store = createVisionArtifactStore({ workspace: root, artifactsDir: 'artifacts' })
     const target = await runWithVisionTurnBudget(
       { artifactRunId: runId },
       () => store.publishTemporary('preview.png', Buffer.from('png')),
     )
 
-    assert.equal(relativeToWorkspace(root, target), `artifacts/${runId}/preview.png`)
+    assert.equal(
+      relativeToWorkspace(root, target),
+      `artifacts/${ARTIFACT_RUNS_DIR}/${runId}/preview.png`,
+    )
     assert.deepEqual(await readFile(target), Buffer.from('png'))
+    await assert.rejects(() => lstat(path.join(root, 'artifacts', runId)), { code: 'ENOENT' })
+  })
+})
+
+test('managed .runs namespace rejects symlink ownership even when the link stays inside the workspace', async () => {
+  await withTempDir('dvr-artifact-runs-link-', async (root) => {
+    const artifacts = path.join(root, 'artifacts')
+    const redirected = path.join(root, 'redirected-runs')
+    await mkdir(artifacts)
+    await mkdir(redirected)
+    await symlink(redirected, path.join(artifacts, ARTIFACT_RUNS_DIR), 'dir')
+
+    const store = createVisionArtifactStore({ workspace: root, artifactsDir: 'artifacts' })
+    await assert.rejects(
+      () => runWithVisionTurnBudget(
+        { artifactRunId: '.vision-run-p2-symlink' },
+        () => store.publishTemporary('escape.png', Buffer.from('nope')),
+      ),
+      /managed artifact runs directory must not be a symlink/,
+    )
+    await assert.rejects(() => lstat(path.join(redirected, '.vision-run-p2-symlink')), { code: 'ENOENT' })
   })
 })
 
@@ -153,18 +181,55 @@ test('facade resolve/publish retain the existing traversal and symlink safety po
   })
 })
 
-test('facade run ownership protects an active run until release', async () => {
+test('new .runs retention deletes only managed run directories and preserves unknown entries', async () => {
+  await withTempDir('dvr-artifact-runs-retention-', async (root) => {
+    const runsRoot = path.join(root, ARTIFACT_RUNS_DIR)
+    const oldRun = path.join(runsRoot, '.vision-run-old')
+    const unknownDir = path.join(runsRoot, 'user-folder')
+    await mkdir(oldRun, { recursive: true })
+    await mkdir(unknownDir)
+    await writeFile(path.join(runsRoot, 'user-note.txt'), 'keep')
+    const old = new Date(Date.now() - 60_000)
+    await utimes(oldRun, old, old)
+
+    const result = await cleanupArtifactRuns(runsRoot, { ttlMs: 1, now: Date.now() })
+    assert.equal(result.removed, 1)
+    await assert.rejects(() => lstat(oldRun), { code: 'ENOENT' })
+    assert.equal((await lstat(unknownDir)).isDirectory(), true)
+    assert.equal(await readFile(path.join(runsRoot, 'user-note.txt'), 'utf8'), 'keep')
+  })
+})
+
+test('legacy direct managed runs still age out without touching the new .runs namespace', async () => {
+  await withTempDir('dvr-artifact-legacy-retention-', async (root) => {
+    const legacyRun = path.join(root, '.vision-run-legacy')
+    const runsRoot = path.join(root, ARTIFACT_RUNS_DIR)
+    await mkdir(legacyRun)
+    await mkdir(runsRoot)
+    await writeFile(path.join(runsRoot, 'marker.txt'), 'keep')
+    const old = new Date(Date.now() - 60_000)
+    await utimes(legacyRun, old, old)
+
+    const result = await cleanupArtifactRuns(root, { ttlMs: 1, now: Date.now() })
+    assert.equal(result.removed, 1)
+    await assert.rejects(() => lstat(legacyRun), { code: 'ENOENT' })
+    assert.equal(await readFile(path.join(runsRoot, 'marker.txt'), 'utf8'), 'keep')
+  })
+})
+
+test('facade run ownership protects an active run inside .runs until release', async () => {
   await withTempDir('dvr-artifact-retain-', async (root) => {
     const runId = '.vision-run-p2-active'
-    const target = path.join(root, runId)
-    await mkdir(target)
+    const runsRoot = path.join(root, ARTIFACT_RUNS_DIR)
+    const target = path.join(runsRoot, runId)
+    await mkdir(target, { recursive: true })
     const old = new Date(Date.now() - 60_000)
     await utimes(target, old, old)
 
-    const store = createVisionArtifactStore({ workspace: root, artifactsDir: '.' })
+    const store = createVisionArtifactStore({ workspace: root, artifactsDir: 'artifacts' })
     const release = store.retainRun(runId)
     try {
-      const protectedCleanup = await cleanupArtifactRuns(root, {
+      const protectedCleanup = await cleanupArtifactRuns(runsRoot, {
         ttlMs: 1,
         now: Date.now(),
       })
@@ -174,7 +239,7 @@ test('facade run ownership protects an active run until release', async () => {
       release()
     }
 
-    const afterRelease = await cleanupArtifactRuns(root, {
+    const afterRelease = await cleanupArtifactRuns(runsRoot, {
       ttlMs: 1,
       now: Date.now(),
     })


### PR DESCRIPTION
## P2-B formal acceptance — COMPLETE / PASS

Final head: `6a02362679de1944ca6b1763903f070656a5360d`
Base: `main@7965b1359243c9fff49868943c3709fa15c401bb`

### Completed migration

- [x] Managed vision-tool run artifacts now live under `<artifactsDir>/.runs/<runId>/...`.
- [x] Artifacts outside a managed run keep the historical `<artifactsDir>/<relativePath>` layout.
- [x] `.runs` is treated as Router-owned infrastructure and must be a real directory.
- [x] `.runs` symlink takeover is rejected even when the link target remains inside the workspace.
- [x] Existing traversal, canonicalization, atomic publication and cancellation rules remain intact.
- [x] New run retention scans `<artifactsDir>/.runs` directly using the existing bounded direct-child cleanup implementation.
- [x] Legacy `<artifactsDir>/.vision-run-*` cleanup remains scheduled so pre-P2-B runs age out safely.
- [x] Unknown files/directories under `.runs` remain outside destructive cleanup policy.
- [x] Active-run retain/release protection works in the new namespace.

### Final Exit Gate evidence

All checks passed on the final head:

- P2 Data Boundary run `33098971529`: success (Node 22 + Node 24)
- P1 Routing Parity run `33098971588`: success
- CI run `33098971513`: success
  - `test (22)`: success
  - `test (24)`: success
  - DSH contract rc.6 / rc.7 / rc.8: success
  - host-sharp Ubuntu / macOS / Windows: success
- DSH Contract run `33098971935`: success
- Native multimodal cold resume run `33098971586`: success

### Diff safety

Final PR contains exactly three files:

- `lib/artifact-io.js`
- `lib/vision-artifact-store.js`
- `tests/vision-artifact-store.test.js`

No large runtime file and no retention algorithm implementation was rewritten.

### Formal verdict

**P2-B COMPLETE / PASS.**

The temporary managed-run namespace migration is safe to merge. Persistent/root artifacts remain unchanged, legacy runs remain cleanable, and all final compatibility/security gates are green.