### PR TITLE
refactor(session): centralize vision surface policy

### DIFF
--- a/.github/workflows/p2-data-boundary.yml
+++ b/.github/workflows/p2-data-boundary.yml
@@ -7,10 +7,21 @@ on:
       - 'lib/vision-artifact-store.js'
       - 'lib/vision-tool-runtime-boundary.js'
       - 'lib/adversarial-hardening.js'
+      - 'lib/session-surface-policy.js'
+      - 'lib/session-vision-state.js'
+      - 'lib/native-image-coexistence.js'
+      - 'lib/legacy-core-vision-policy-bridge.js'
+      - 'lib/structured-flow-hardening.js'
       - 'tests/vision-artifact-store.test.js'
       - 'tests/artifact-path-security.test.js'
       - 'tests/resource-retention-lifecycle.test.js'
       - 'tests/qa-cancellation-publication.test.js'
+      - 'tests/session-surface-policy.test.js'
+      - 'tests/session-vision-state.test.js'
+      - 'tests/session-vision-state-integration.test.js'
+      - 'tests/issue-276-entry-policy-bridge.test.js'
+      - 'tests/issue-276-session-image-ownership.test.js'
+      - 'tests/issue-289-native-nonintervention.test.js'
       - '.github/workflows/p2-data-boundary.yml'
   push:
     branches: [main]
@@ -19,10 +30,21 @@ on:
       - 'lib/vision-artifact-store.js'
       - 'lib/vision-tool-runtime-boundary.js'
       - 'lib/adversarial-hardening.js'
+      - 'lib/session-surface-policy.js'
+      - 'lib/session-vision-state.js'
+      - 'lib/native-image-coexistence.js'
+      - 'lib/legacy-core-vision-policy-bridge.js'
+      - 'lib/structured-flow-hardening.js'
       - 'tests/vision-artifact-store.test.js'
       - 'tests/artifact-path-security.test.js'
       - 'tests/resource-retention-lifecycle.test.js'
       - 'tests/qa-cancellation-publication.test.js'
+      - 'tests/session-surface-policy.test.js'
+      - 'tests/session-vision-state.test.js'
+      - 'tests/session-vision-state-integration.test.js'
+      - 'tests/issue-276-entry-policy-bridge.test.js'
+      - 'tests/issue-276-session-image-ownership.test.js'
+      - 'tests/issue-289-native-nonintervention.test.js'
       - '.github/workflows/p2-data-boundary.yml'
 
 permissions:
@@ -52,3 +74,29 @@ jobs:
           tests/artifact-path-security.test.js
           tests/resource-retention-lifecycle.test.js
           tests/qa-cancellation-publication.test.js
+
+  session-surface:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [22, 24]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86
+        with:
+          version: 11.20.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: ${{ matrix.node }}
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Session surface, ownership and legacy bridge parity
+        run: >-
+          node --test
+          tests/session-surface-policy.test.js
+          tests/session-vision-state.test.js
+          tests/session-vision-state-integration.test.js
+          tests/issue-276-entry-policy-bridge.test.js
+          tests/issue-276-session-image-ownership.test.js
+          tests/issue-289-native-nonintervention.test.js

--- a/lib/legacy-core-vision-policy-bridge.js
+++ b/lib/legacy-core-vision-policy-bridge.js
@@ -1,7 +1,4 @@
-import {
-  IMAGE_OWNERSHIP,
-  currentSessionVisionPolicy,
-} from './native-image-coexistence.js'
+import { currentSessionSurfacePolicy } from './session-surface-policy.js'
 import { knownSessionVisionMemory } from './session-vision-state.js'
 
 function isObject(value) {
@@ -10,50 +7,11 @@ function isObject(value) {
 
 function projectedConfig(value, state) {
   if (!isObject(value) || Array.isArray(value)) return value
-  const policy = currentSessionVisionPolicy()
-  let changed = false
-  const overrides = {}
-
-  // index.js still constructs the vision-tool definitions behind a boot-time
-  // `if (toolEnabled())`. Keep that legacy construction gate open only while
-  // apply() is wiring the schema. The runtime boundary observes the unprojected
-  // Settings service and remains authoritative for live execution permission.
-  if (state.schemaBootstrapping && value.tool === false) {
-    overrides.tool = true
-    changed = true
-  }
-
-  // Session ownership is stronger evidence than index.js's historical global
-  // wrapperRegistered flag. A native, Vision-Router-owned, or metadata-unknown
-  // route must not have raw pixels destructively rewritten by the legacy core.
-  if (policy?.preserveRawImages === true && value.rewriteImages !== false) {
-    overrides.rewriteImages = false
-    changed = true
-  }
-
-  // Native multimodal routes already see the pixels. Avoid hidden automatic
-  // caption/tool orchestration while preserving the Vision Router tool surface:
-  // a native model may still choose vision_ocr / vision_describe / etc. itself,
-  // and those explicit calls continue through the normal runtime guards.
-  if (policy?.ownership === IMAGE_OWNERSHIP.NATIVE) {
-    if (value.instantDescribe !== false) {
-      overrides.instantDescribe = false
-      changed = true
-    }
-    if (value.autoActivateOnImage !== false) {
-      overrides.autoActivateOnImage = false
-      changed = true
-    }
-  }
-  if (
-    policy?.allowStructuredBootstrap === false &&
-    value.structuredVisionBootstrap !== false
-  ) {
-    overrides.structuredVisionBootstrap = false
-    changed = true
-  }
-
-  return changed ? { ...value, ...overrides } : value
+  const policy = currentSessionSurfacePolicy(value, {
+    schemaBootstrapping: state.schemaBootstrapping,
+  })
+  const overrides = policy.legacyConfigOverrides
+  return Object.keys(overrides).length > 0 ? { ...value, ...overrides } : value
 }
 
 function configView(config, state) {
@@ -188,9 +146,11 @@ function collectAttachmentIds(messages) {
   return ids.reverse()
 }
 
-function appendVisionRouterAttachmentHint(payload, decision) {
-  const policy = currentSessionVisionPolicy()
-  if (decision?.kind === 'reject' || policy?.ownership !== IMAGE_OWNERSHIP.VISION_ROUTER) {
+function appendVisionRouterAttachmentHint(payload, decision, config, state) {
+  const policy = currentSessionSurfacePolicy(config, {
+    schemaBootstrapping: state.schemaBootstrapping,
+  })
+  if (decision?.kind === 'reject' || policy.ownership !== 'vision-router-owned') {
     return decision
   }
 
@@ -228,11 +188,13 @@ function appendVisionRouterAttachmentHint(payload, decision) {
     : { kind: 'continue', messages }
 }
 
-function rewriteTextOnlyDecision(payload, decision, rewriteHistoryImages) {
-  const policy = currentSessionVisionPolicy()
+function rewriteTextOnlyDecision(payload, decision, rewriteHistoryImages, config, state) {
+  const policy = currentSessionSurfacePolicy(config, {
+    schemaBootstrapping: state.schemaBootstrapping,
+  })
   if (
     decision?.kind === 'reject' ||
-    policy?.rewriteCurrentImages !== true ||
+    policy.rewriteCurrentImages !== true ||
     typeof rewriteHistoryImages !== 'function'
   ) {
     return decision
@@ -257,15 +219,14 @@ function rewriteTextOnlyDecision(payload, decision, rewriteHistoryImages) {
 }
 
 /**
- * Adapt the session-scoped ownership policy to the legacy monolithic core.
+ * Adapt the centralized session surface policy to the legacy monolithic core.
  *
- * The policy layer remains read-only. This bridge only projects legacy config
- * reads while one pre-step is active and post-processes an explicitly text-only
- * decision through index.js's exported rewriteHistoryImages implementation and
- * the exact SessionMemoryView registered by core for that pre-step. Vision
- * Router-owned image turns also receive an exact attachment-id hint so a
- * multimodal delegate can call the same session-fenced precision tools without
- * inventing a durable id. No cross-session attachment lookup is introduced.
+ * Ownership classification remains native-image-coexistence's responsibility.
+ * This bridge consumes only the immutable session-surface snapshot: it projects
+ * legacy config reads while one pre-step is active, reuses the exact
+ * SessionMemoryView for text-only rewriting, and surfaces current attachment
+ * ids only for a Vision Router-owned route. No cross-session lookup, route
+ * selection or tool-execution authority is introduced here.
  */
 export function installLegacyCoreVisionPolicyBridge(
   ctx,
@@ -331,8 +292,14 @@ export function installLegacyCoreVisionPolicyBridge(
           }
           return on.call(target, event, async function legacyCoreVisionPolicyPreStep(payload, next) {
             const decision = await handler.call(this, payload, next)
-            const rewritten = rewriteTextOnlyDecision(payload, decision, rewriteHistoryImages)
-            return appendVisionRouterAttachmentHint(payload, rewritten)
+            const rewritten = rewriteTextOnlyDecision(
+              payload,
+              decision,
+              rewriteHistoryImages,
+              config,
+              state,
+            )
+            return appendVisionRouterAttachmentHint(payload, rewritten, config, state)
           }, ...rest)
         }
       }

--- a/lib/session-surface-policy.js
+++ b/lib/session-surface-policy.js
@@ -1,0 +1,97 @@
+import { currentSessionVisionPolicy } from './native-image-coexistence.js'
+
+const OWNERSHIP = Object.freeze({
+  PLUGIN_OWNED: 'vision-router-owned',
+  NATIVE: 'native-image',
+  TEXT_ONLY: 'text-only',
+  UNKNOWN: 'unknown',
+})
+
+const KNOWN_OWNERSHIP = new Set(Object.values(OWNERSHIP))
+
+function isObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function normalizedOwnership(policy) {
+  if (!isObject(policy)) return undefined
+  return KNOWN_OWNERSHIP.has(policy.ownership) ? policy.ownership : OWNERSHIP.UNKNOWN
+}
+
+/**
+ * Resolve one immutable, read-only snapshot of the Vision Router capability
+ * surface for the current session.
+ *
+ * This layer does not classify model capability and does not grant authority.
+ * `visionPolicy` is evidence produced by native-image-coexistence; this module
+ * only projects that already-authoritative ownership decision onto the legacy
+ * configuration/surface questions that used to be answered in several places.
+ */
+export function resolveSessionSurfacePolicy({
+  visionPolicy,
+  config = {},
+  schemaBootstrapping = false,
+} = {}) {
+  const source = isObject(visionPolicy) ? visionPolicy : undefined
+  const value = isObject(config) ? config : {}
+  const ownership = normalizedOwnership(source)
+  const native = ownership === OWNERSHIP.NATIVE
+  const pluginOwned = ownership === OWNERSHIP.PLUGIN_OWNED
+  const textOnly = ownership === OWNERSHIP.TEXT_ONLY
+
+  // No active session policy means no session-specific rewrite/preservation
+  // authority. This distinction is important: absence is not the same as an
+  // explicit UNKNOWN capability snapshot, whose contract is non-destructive.
+  const preserveRawImages = source?.preserveRawImages === true
+  const rewriteCurrentImages = source?.rewriteCurrentImages === true
+  const allowStructuredBootstrap = source?.allowStructuredBootstrap !== false
+  const allowGenericAutoMount = source?.suppressGenericAutoMount !== true
+
+  const surface = Object.freeze({
+    preserveRawImages,
+    rewriteCurrentImages,
+    visionTools: value.tool !== false,
+    structuredBootstrap:
+      value.structuredVisionBootstrap === true && allowStructuredBootstrap,
+    genericAutoMount:
+      value.autoActivateOnImage !== false && allowGenericAutoMount,
+    instantDescribe:
+      value.instantDescribe !== false && !native,
+  })
+
+  const overrides = {}
+  if (schemaBootstrapping === true && value.tool === false) overrides.tool = true
+  if (preserveRawImages && value.rewriteImages !== false) overrides.rewriteImages = false
+  if (native && value.instantDescribe !== false) overrides.instantDescribe = false
+  if (native && value.autoActivateOnImage !== false) overrides.autoActivateOnImage = false
+  if (!allowStructuredBootstrap && value.structuredVisionBootstrap !== false) {
+    overrides.structuredVisionBootstrap = false
+  }
+
+  return Object.freeze({
+    ownership,
+    participates:
+      source !== undefined && (
+        pluginOwned ||
+        textOnly ||
+        surface.visionTools ||
+        surface.structuredBootstrap ||
+        surface.genericAutoMount
+      ),
+    preserveRawImages,
+    rewriteCurrentImages,
+    allowStructuredBootstrap,
+    allowGenericAutoMount,
+    surface,
+    legacyConfigOverrides: Object.freeze(overrides),
+  })
+}
+
+/** Read the turn-local ownership snapshot and resolve its capability surface. */
+export function currentSessionSurfacePolicy(config = {}, options = {}) {
+  return resolveSessionSurfacePolicy({
+    visionPolicy: currentSessionVisionPolicy(),
+    config,
+    schemaBootstrapping: options?.schemaBootstrapping === true,
+  })
+}

--- a/tests/session-surface-policy.test.js
+++ b/tests/session-surface-policy.test.js
@@ -1,0 +1,163 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { resolveSessionSurfacePolicy } from '../lib/session-surface-policy.js'
+
+function config(overrides = {}) {
+  return {
+    tool: true,
+    rewriteImages: true,
+    instantDescribe: true,
+    autoActivateOnImage: true,
+    structuredVisionBootstrap: true,
+    routing: false,
+    ...overrides,
+  }
+}
+
+function visionPolicy(ownership, overrides = {}) {
+  const native = ownership === 'native-image'
+  const pluginOwned = ownership === 'vision-router-owned'
+  const textOnly = ownership === 'text-only'
+  return {
+    ownership,
+    preserveRawImages: native || pluginOwned || ownership === 'unknown',
+    rewriteCurrentImages: textOnly,
+    suppressGenericAutoMount: native,
+    allowStructuredBootstrap: !native,
+    ...overrides,
+  }
+}
+
+test('native session preserves pixels, suppresses automatic orchestration, but keeps explicit tools available', () => {
+  const policy = resolveSessionSurfacePolicy({
+    visionPolicy: visionPolicy('native-image'),
+    config: config(),
+  })
+
+  assert.equal(policy.ownership, 'native-image')
+  assert.equal(policy.preserveRawImages, true)
+  assert.equal(policy.rewriteCurrentImages, false)
+  assert.equal(policy.allowStructuredBootstrap, false)
+  assert.equal(policy.allowGenericAutoMount, false)
+  assert.deepEqual(policy.surface, {
+    preserveRawImages: true,
+    rewriteCurrentImages: false,
+    visionTools: true,
+    structuredBootstrap: false,
+    genericAutoMount: false,
+    instantDescribe: false,
+  })
+  assert.deepEqual(policy.legacyConfigOverrides, {
+    rewriteImages: false,
+    instantDescribe: false,
+    autoActivateOnImage: false,
+    structuredVisionBootstrap: false,
+  })
+})
+
+test('Vision Router-owned session preserves pixels while retaining Router orchestration surface', () => {
+  const policy = resolveSessionSurfacePolicy({
+    visionPolicy: visionPolicy('vision-router-owned'),
+    config: config(),
+  })
+
+  assert.equal(policy.ownership, 'vision-router-owned')
+  assert.equal(policy.participates, true)
+  assert.deepEqual(policy.surface, {
+    preserveRawImages: true,
+    rewriteCurrentImages: false,
+    visionTools: true,
+    structuredBootstrap: true,
+    genericAutoMount: true,
+    instantDescribe: true,
+  })
+  assert.deepEqual(policy.legacyConfigOverrides, { rewriteImages: false })
+})
+
+test('text-only session keeps the current rewrite bridge and optional orchestration surface', () => {
+  const policy = resolveSessionSurfacePolicy({
+    visionPolicy: visionPolicy('text-only'),
+    config: config(),
+  })
+
+  assert.equal(policy.ownership, 'text-only')
+  assert.equal(policy.preserveRawImages, false)
+  assert.equal(policy.rewriteCurrentImages, true)
+  assert.equal(policy.surface.rewriteCurrentImages, true)
+  assert.equal(policy.surface.structuredBootstrap, true)
+  assert.equal(policy.surface.genericAutoMount, true)
+  assert.deepEqual(policy.legacyConfigOverrides, {})
+})
+
+test('explicit UNKNOWN session remains non-destructive without being misclassified as text-only', () => {
+  const policy = resolveSessionSurfacePolicy({
+    visionPolicy: visionPolicy('unknown'),
+    config: config(),
+  })
+
+  assert.equal(policy.ownership, 'unknown')
+  assert.equal(policy.preserveRawImages, true)
+  assert.equal(policy.rewriteCurrentImages, false)
+  assert.equal(policy.surface.visionTools, true)
+  assert.equal(policy.surface.structuredBootstrap, true)
+  assert.deepEqual(policy.legacyConfigOverrides, { rewriteImages: false })
+})
+
+test('absence of a session policy never invents UNKNOWN non-intervention authority', () => {
+  const policy = resolveSessionSurfacePolicy({
+    config: config(),
+  })
+
+  assert.equal(policy.ownership, undefined)
+  assert.equal(policy.participates, false)
+  assert.equal(policy.preserveRawImages, false)
+  assert.equal(policy.rewriteCurrentImages, false)
+  assert.deepEqual(policy.legacyConfigOverrides, {})
+})
+
+test('schema bootstrap may expose definitions without granting live tool execution', () => {
+  const policy = resolveSessionSurfacePolicy({
+    visionPolicy: visionPolicy('native-image'),
+    config: config({ tool: false }),
+    schemaBootstrapping: true,
+  })
+
+  assert.equal(policy.surface.visionTools, false)
+  assert.equal(policy.legacyConfigOverrides.tool, true)
+  assert.equal(policy.legacyConfigOverrides.structuredVisionBootstrap, false)
+})
+
+test('explicit user-off settings remain off and are never expanded by the surface policy', () => {
+  const policy = resolveSessionSurfacePolicy({
+    visionPolicy: visionPolicy('text-only', { rewriteCurrentImages: false }),
+    config: config({
+      tool: false,
+      rewriteImages: false,
+      instantDescribe: false,
+      autoActivateOnImage: false,
+      structuredVisionBootstrap: false,
+    }),
+  })
+
+  assert.deepEqual(policy.surface, {
+    preserveRawImages: false,
+    rewriteCurrentImages: false,
+    visionTools: false,
+    structuredBootstrap: false,
+    genericAutoMount: false,
+    instantDescribe: false,
+  })
+  assert.deepEqual(policy.legacyConfigOverrides, {})
+})
+
+test('surface snapshots and nested capability objects are immutable', () => {
+  const policy = resolveSessionSurfacePolicy({
+    visionPolicy: visionPolicy('native-image'),
+    config: config(),
+  })
+
+  assert.equal(Object.isFrozen(policy), true)
+  assert.equal(Object.isFrozen(policy.surface), true)
+  assert.equal(Object.isFrozen(policy.legacyConfigOverrides), true)
+})


### PR DESCRIPTION
## P2-C (surface half) formal acceptance — COMPLETE / PASS

Final head: `8ac7fc6fb17ef6587c991c7cfeb0a612d8af1b7d`
Base: `main@3ee59f40500e14ef422e309ccbff513617955c98`

### Completed in this PR

- [x] Added immutable `session-surface-policy` snapshot.
- [x] Centralized native / Vision Router-owned / text-only / unknown surface projection.
- [x] Native multimodal keeps explicit Vision Router tools available while automatic orchestration remains suppressed.
- [x] Explicit UNKNOWN remains non-destructive.
- [x] Absence of a session policy does not invent UNKNOWN authority.
- [x] Legacy core bridge now consumes the centralized surface snapshot instead of separately interpreting ownership classes.
- [x] No route selection, ownership evidence, tool authority, timeout/budget, ALS or SessionVisionStateStore semantics changed.

### Final CI evidence

All workflows passed on final head:

- `P2 Data Boundary` run `33099931983`: success
  - session-surface Node 22: success
  - session-surface Node 24: success
  - artifact-boundary Node 22: success
  - artifact-boundary Node 24: success
- `P1 Routing Parity` run `33099931998`: success
- `CI` run `33099932039`: success
- `DSH Contract` run `33099932024`: success
- `Native multimodal cold resume` run `33099932055`: success

### Important scope note

This closes only the **surface-policy half** of implementation-plan P2-C. The plan also requires centralizing event-log incremental scan, targeted attachment recovery, tool-result image surface repair and guard-stop surface repair into `session-vision-index.js` / the policy boundary. That work remains a separate P2-C follow-up and must be completed before P2 itself can pass its Exit Gate.

### Verdict

**P2-C surface half: COMPLETE / PASS.**

Do not mark overall P2-C or P2 complete until the indexing/surface-repair follow-up, P2-D transport, P2-E global-patch narrowing, and P2-F jobs spike are finished.