### PR TITLE
refactor(transport): isolate vision provider HTTP

### DIFF
--- a/.github/workflows/p2-data-boundary.yml
+++ b/.github/workflows/p2-data-boundary.yml
@@ -12,6 +12,10 @@ on:
       - 'lib/native-image-coexistence.js'
       - 'lib/legacy-core-vision-policy-bridge.js'
       - 'lib/structured-flow-hardening.js'
+      - 'lib/vision-provider-transport.js'
+      - 'lib/http-compat.js'
+      - 'lib/catalog-corrections.js'
+      - 'lib/public-entry.js'
       - 'tests/vision-artifact-store.test.js'
       - 'tests/artifact-path-security.test.js'
       - 'tests/resource-retention-lifecycle.test.js'
@@ -22,6 +26,8 @@ on:
       - 'tests/issue-276-entry-policy-bridge.test.js'
       - 'tests/issue-276-session-image-ownership.test.js'
       - 'tests/issue-289-native-nonintervention.test.js'
+      - 'tests/vision-provider-transport.test.js'
+      - 'tests/http-compat.test.js'
       - '.github/workflows/p2-data-boundary.yml'
   push:
     branches: [main]
@@ -35,6 +41,10 @@ on:
       - 'lib/native-image-coexistence.js'
       - 'lib/legacy-core-vision-policy-bridge.js'
       - 'lib/structured-flow-hardening.js'
+      - 'lib/vision-provider-transport.js'
+      - 'lib/http-compat.js'
+      - 'lib/catalog-corrections.js'
+      - 'lib/public-entry.js'
       - 'tests/vision-artifact-store.test.js'
       - 'tests/artifact-path-security.test.js'
       - 'tests/resource-retention-lifecycle.test.js'
@@ -45,6 +55,8 @@ on:
       - 'tests/issue-276-entry-policy-bridge.test.js'
       - 'tests/issue-276-session-image-ownership.test.js'
       - 'tests/issue-289-native-nonintervention.test.js'
+      - 'tests/vision-provider-transport.test.js'
+      - 'tests/http-compat.test.js'
       - '.github/workflows/p2-data-boundary.yml'
 
 permissions:
@@ -100,3 +112,25 @@ jobs:
           tests/issue-276-entry-policy-bridge.test.js
           tests/issue-276-session-image-ownership.test.js
           tests/issue-289-native-nonintervention.test.js
+
+  provider-transport:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [22, 24]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86
+        with:
+          version: 11.20.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: ${{ matrix.node }}
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Router-owned provider HTTP is independent of the global fetch patch
+        run: >-
+          node --test
+          tests/vision-provider-transport.test.js
+          tests/http-compat.test.js

--- a/lib/catalog-corrections.js
+++ b/lib/catalog-corrections.js
@@ -15,6 +15,7 @@ import {
   readResponseTextBounded,
 } from './http-body-limit.js'
 import { stripTrailingSlashes } from './string-normalization.js'
+import { currentVisionProviderTransport } from './vision-provider-transport.js'
 
 export const CATALOG_ROUTING_CORRECTIONS = [
   {
@@ -254,7 +255,11 @@ export async function callAnthropicCompatible(provider, messages, options = {}) 
   const url = `${stripTrailingSlashes(provider.baseURL)}/v1/messages`
   let response
   try {
-    response = await fetch(url, {
+    const transport = currentVisionProviderTransport()
+    const requestFetch = transport
+      ? (input, init) => transport.fetch(input, init, { providerName: provider.name, allowProxy: true })
+      : fetch
+    response = await requestFetch(url, {
       method: 'POST',
       headers,
       body: JSON.stringify(system === undefined ? body : { ...body, system }),

--- a/lib/http-compat.js
+++ b/lib/http-compat.js
@@ -1,3 +1,5 @@
+import { currentVisionProviderTransport } from './vision-provider-transport.js'
+
 const GLM_4V_FLASH = /^glm-4v-flash(?:$|[-_.])/i
 export const DEFAULT_HTTP_ERROR_DETAIL_MAX_BYTES = 64 * 1024
 
@@ -262,6 +264,11 @@ function nextCompatibilityBody(body, detail) {
 /**
  * Fetch wrapper for vision-router's own OpenAI-compatible requests only.
  *
+ * When the P2 provider transport is installed, every active Router-owned call
+ * goes through that facade. The `fetchImpl` parameter remains as a compatibility
+ * fallback for direct/unit callers, so the behavior outside the public plugin
+ * composition is unchanged.
+ *
  * Layer 1: generic request shape (works for unknown/new models).
  * Layer 2: known model-family presets.
  * Layer 3: bounded, evidence-driven retries when the server reports an output
@@ -270,18 +277,27 @@ function nextCompatibilityBody(body, detail) {
  * sequentially without creating an unbounded retry loop.
  */
 export async function fetchWithOpenAICompatibility(fetchImpl, input, init, context = {}) {
-  if (typeof fetchImpl !== 'function' || context.active !== true) {
-    return fetchImpl(input, init)
+  if (typeof fetchImpl !== 'function') throw new TypeError('fetch implementation is required')
+  const transport = context.active === true ? currentVisionProviderTransport() : undefined
+  const requestFetch = transport
+    ? (nextInput, nextInit) => transport.fetch(nextInput, nextInit, {
+        providerName: context.providerName,
+        allowProxy: context.allowProxy !== false,
+      })
+    : fetchImpl
+
+  if (context.active !== true) {
+    return requestFetch(input, init)
   }
   if (!isCompatibleChatCompletionRequest(input, init)) {
-    return fetchImpl(input, init)
+    return requestFetch(input, init)
   }
 
   let parsed
   try {
     parsed = JSON.parse(init.body)
   } catch {
-    return fetchImpl(input, init)
+    return requestFetch(input, init)
   }
 
   const url = typeof input === 'string' || input instanceof URL ? input : input?.url
@@ -291,7 +307,7 @@ export async function fetchWithOpenAICompatibility(fetchImpl, input, init, conte
     prompt: context.prompt,
   })
   let requestBody = prepared.body
-  let response = await fetchImpl(input, { ...init, body: JSON.stringify(requestBody) })
+  let response = await requestFetch(input, { ...init, body: JSON.stringify(requestBody) })
 
   for (let correction = 0; correction < 2; correction++) {
     if (response.ok || (response.status !== 400 && response.status !== 422)) return response
@@ -308,7 +324,7 @@ export async function fetchWithOpenAICompatibility(fetchImpl, input, init, conte
     }
 
     requestBody = retryBody
-    response = await fetchImpl(input, { ...init, body: JSON.stringify(requestBody) })
+    response = await requestFetch(input, { ...init, body: JSON.stringify(requestBody) })
   }
 
   return response

--- a/lib/public-entry.js
+++ b/lib/public-entry.js
@@ -1,17 +1,52 @@
 import * as base from '../entry.js'
 import { createVisionToggleRootHardening } from './vision-toggle-root-hardening.js'
 import { contextWithVisionRoutingTopologyRefresh } from './vision-routing-topology-refresh.js'
+import {
+  createVisionProviderTransport,
+  installVisionProviderTransport,
+} from './vision-provider-transport.js'
 
 export * from '../entry.js'
+
+function liveVisionConfig(ctx, fallback) {
+  try {
+    const settings = ctx?.get?.('settings')
+    const value = settings?.get?.('vision-router')
+    if (value && typeof value === 'object' && !Array.isArray(value)) return value
+  } catch {
+    // Before Settings mounts, composition config is the authoritative fallback.
+  }
+  return fallback
+}
 
 /**
  * Public package entry: keep the mature entry.js implementation intact and
  * place the #284 hardening at its outermost registration/browser boundary.
+ *
+ * P2 also installs the Router-owned provider transport here, before base.apply
+ * can install the legacy process-wide proxy fetch patch. The transport module
+ * captured the original fetch at module load and reads live Vision Router
+ * settings on every request, so direct visual-provider HTTP can use an explicit
+ * dispatcher without depending on global fetch mutation.
  */
 export function apply(ctx, config = {}) {
   const hardening = createVisionToggleRootHardening(ctx, config)
   const runtimeCtx = contextWithVisionRoutingTopologyRefresh(hardening.ctx)
-  const result = base.apply(runtimeCtx, hardening.config)
-  hardening.installClientBoundary()
-  return result
+  const transport = createVisionProviderTransport({
+    ctx: hardening.ctx,
+    config: () => liveVisionConfig(hardening.ctx, config),
+  })
+  const releaseTransport = installVisionProviderTransport(transport)
+  try {
+    runtimeCtx?.effect?.(
+      () => releaseTransport,
+      'vision-router: provider transport',
+    )
+    const result = base.apply(runtimeCtx, hardening.config)
+    hardening.installClientBoundary()
+    return result
+  } catch (error) {
+    releaseTransport()
+    throw error
+  }
 }

--- a/lib/vision-provider-transport.js
+++ b/lib/vision-provider-transport.js
@@ -1,0 +1,196 @@
+import {
+  ERROR_RESPONSE_MAX_BYTES,
+  MODEL_RESPONSE_MAX_BYTES,
+  readResponseJsonBounded,
+  readResponseTextBounded,
+} from './http-body-limit.js'
+
+const DEFAULT_PROXY_HOSTS = Object.freeze([
+  'api.openrouter.ai',
+  'openrouter.ai',
+  'api.openai.com',
+  'api.anthropic.com',
+  'api.groq.com',
+  'api.mistral.ai',
+  'api.together.xyz',
+  'generativelanguage.googleapis.com',
+  'api.x.ai',
+])
+
+// Capture before core.apply installs the legacy process-wide fetch patch. The
+// P2 transport uses this original function explicitly, so Router-owned provider
+// calls are no longer coupled to globalThis.fetch mutation.
+const moduleFetch =
+  typeof globalThis.fetch === 'function'
+    ? globalThis.fetch.bind(globalThis)
+    : undefined
+
+const installed = []
+
+function live(value) {
+  return typeof value === 'function' ? value() : value
+}
+
+function asObject(value) {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value : {}
+}
+
+function asUrl(input) {
+  try {
+    return input instanceof URL ? input : new URL(typeof input === 'string' ? input : input?.url)
+  } catch {
+    return undefined
+  }
+}
+
+function hostMatchesAny(hostname, hosts) {
+  return (hosts ?? []).some(
+    (host) => hostname === host || hostname.endsWith(`.${host}`),
+  )
+}
+
+function proxySettings(config) {
+  const value = asObject(live(config))
+  const proxy = typeof value.proxy === 'string' && value.proxy.trim() !== ''
+    ? value.proxy.trim()
+    : undefined
+  const proxyHosts = Array.isArray(value.proxyHosts)
+    ? value.proxyHosts.filter((host) => typeof host === 'string' && host.trim() !== '').map((host) => host.trim())
+    : [...DEFAULT_PROXY_HOSTS]
+  return { proxy, proxyHosts }
+}
+
+function credentialService(ctx) {
+  try {
+    return ctx?.get?.('credentials')
+  } catch {
+    return undefined
+  }
+}
+
+function envCredential(ref) {
+  if (typeof process === 'undefined' || !process.env) return undefined
+  const value = process.env[ref]
+  return typeof value === 'string' && value !== '' ? value : undefined
+}
+
+/**
+ * Router-owned provider transport.
+ *
+ * It owns only direct visual-provider HTTP mechanics: the original fetch
+ * implementation, provider-scoped proxy dispatch, credential lookup helpers,
+ * bounded response readers and cancellation propagation. It intentionally does
+ * not cover update checks, GitHub/npm maintenance traffic or Host-owned LLM
+ * adapter requests.
+ */
+export function createVisionProviderTransport({
+  ctx,
+  config = {},
+  fetchImpl = moduleFetch,
+  importUndici = () => import('undici'),
+} = {}) {
+  if (typeof fetchImpl !== 'function') {
+    throw new TypeError('vision provider transport requires fetch')
+  }
+
+  let cachedProxyUrl
+  let cachedDispatcherPromise
+  const dispatcherFor = (proxyUrl) => {
+    if (cachedProxyUrl === proxyUrl && cachedDispatcherPromise) return cachedDispatcherPromise
+    cachedProxyUrl = proxyUrl
+    cachedDispatcherPromise = Promise.resolve(importUndici()).then(({ ProxyAgent }) => {
+      if (typeof ProxyAgent !== 'function') {
+        throw new Error('vision provider transport: undici ProxyAgent is unavailable')
+      }
+      return new ProxyAgent(proxyUrl)
+    }).catch((error) => {
+      if (cachedProxyUrl === proxyUrl) {
+        cachedProxyUrl = undefined
+        cachedDispatcherPromise = undefined
+      }
+      throw error
+    })
+    return cachedDispatcherPromise
+  }
+
+  const fetchProvider = async (input, init = {}, context = {}) => {
+    const url = asUrl(input)
+    const { proxy, proxyHosts } = proxySettings(config)
+    if (!url || !proxy || context.allowProxy === false || !hostMatchesAny(url.hostname, proxyHosts)) {
+      return fetchImpl(input, init)
+    }
+    const dispatcher = await dispatcherFor(proxy)
+    return fetchImpl(input, { ...init, dispatcher })
+  }
+
+  return Object.freeze({
+    fetch: fetchProvider,
+
+    async resolveCredential(ref) {
+      const name = typeof ref === 'string' ? ref.trim() : ''
+      if (!name) return undefined
+      const credentials = credentialService(ctx)
+      if (credentials && typeof credentials.resolve === 'function') {
+        try {
+          const hit = await credentials.resolve(name)
+          if (hit && typeof hit.value === 'string' && hit.value !== '') return hit.value
+        } catch {
+          // Environment remains the compatibility fallback.
+        }
+      }
+      return envCredential(name)
+    },
+
+    readErrorText(response, options = {}) {
+      return readResponseTextBounded(
+        response,
+        options.maxBytes ?? ERROR_RESPONSE_MAX_BYTES,
+        { label: options.label ?? 'vision provider error response' },
+      )
+    },
+
+    readModelJson(response, options = {}) {
+      return readResponseJsonBounded(
+        response,
+        options.maxBytes ?? MODEL_RESPONSE_MAX_BYTES,
+        { label: options.label ?? 'vision provider response' },
+      )
+    },
+
+    proxyDecision(input) {
+      const url = asUrl(input)
+      const { proxy, proxyHosts } = proxySettings(config)
+      return Object.freeze({
+        proxied: Boolean(url && proxy && hostMatchesAny(url.hostname, proxyHosts)),
+        proxy,
+        hostname: url?.hostname,
+      })
+    },
+  })
+}
+
+/**
+ * Transitional process/profile registration used while the monolithic core
+ * still calls `fetchWithOpenAICompatibility(fetch, ...)` without an injected
+ * transport parameter. This registry affects only Router-owned compatibility
+ * calls; it never patches global fetch. P3 can delete it once every caller
+ * accepts the transport explicitly.
+ */
+export function installVisionProviderTransport(transport) {
+  if (!transport || typeof transport.fetch !== 'function') {
+    throw new TypeError('invalid vision provider transport')
+  }
+  const token = Object.freeze({ transport })
+  installed.push(token)
+  let active = true
+  return () => {
+    if (!active) return
+    active = false
+    const index = installed.indexOf(token)
+    if (index >= 0) installed.splice(index, 1)
+  }
+}
+
+export function currentVisionProviderTransport() {
+  return installed[installed.length - 1]?.transport
+}

--- a/tests/vision-provider-transport.test.js
+++ b/tests/vision-provider-transport.test.js
@@ -1,0 +1,182 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+
+import {
+  createVisionProviderTransport,
+  currentVisionProviderTransport,
+  installVisionProviderTransport,
+} from '../lib/vision-provider-transport.js'
+import { fetchWithOpenAICompatibility } from '../lib/http-compat.js'
+import { callAnthropicCompatible } from '../lib/catalog-corrections.js'
+
+function okOpenAI(text = 'ok') {
+  return new Response(JSON.stringify({ choices: [{ message: { content: text } }] }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+function okAnthropic(text = 'ok') {
+  return new Response(JSON.stringify({ content: [{ type: 'text', text }] }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+function requestInit(body = {}) {
+  return {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      model: 'vision-model',
+      messages: [{ role: 'user', content: [{ type: 'text', text: 'see' }] }],
+      max_tokens: 64,
+      ...body,
+    }),
+  }
+}
+
+test('Router-owned OpenAI compatibility bypasses the caller/global fetch once transport is installed', async () => {
+  const calls = []
+  const original = async (input, init) => {
+    calls.push({ source: 'original', input, init })
+    return okOpenAI('transport')
+  }
+  const patched = async () => {
+    throw new Error('legacy global fetch patch must not own Router provider HTTP')
+  }
+  const transport = createVisionProviderTransport({ fetchImpl: original })
+  const release = installVisionProviderTransport(transport)
+  try {
+    const response = await fetchWithOpenAICompatibility(
+      patched,
+      'https://vision.example/v1/chat/completions',
+      requestInit(),
+      { active: true, providerName: 'example' },
+    )
+    assert.equal(response.ok, true)
+    assert.equal(calls.length, 1)
+    assert.equal(calls[0].source, 'original')
+  } finally {
+    release()
+  }
+  assert.equal(currentVisionProviderTransport(), undefined)
+})
+
+test('provider-scoped proxy uses an explicit dispatcher only for configured hosts', async () => {
+  const calls = []
+  class FakeProxyAgent {
+    constructor(url) {
+      this.url = url
+    }
+  }
+  let config = {
+    proxy: 'http://127.0.0.1:7890',
+    proxyHosts: ['api.example.com'],
+  }
+  const transport = createVisionProviderTransport({
+    config: () => config,
+    fetchImpl: async (input, init) => {
+      calls.push({ input: String(input), init })
+      return okOpenAI()
+    },
+    importUndici: async () => ({ ProxyAgent: FakeProxyAgent }),
+  })
+
+  await transport.fetch('https://api.example.com/v1/chat/completions', requestInit())
+  await transport.fetch('https://maintenance.example/v1/chat/completions', requestInit())
+
+  assert.equal(calls.length, 2)
+  assert.ok(calls[0].init.dispatcher instanceof FakeProxyAgent)
+  assert.equal(calls[0].init.dispatcher.url, 'http://127.0.0.1:7890')
+  assert.equal(calls[1].init.dispatcher, undefined)
+
+  config = { ...config, proxy: '' }
+  await transport.fetch('https://api.example.com/v1/chat/completions', requestInit())
+  assert.equal(calls[2].init.dispatcher, undefined, 'live proxy disable must take effect without restart')
+})
+
+test('active=false compatibility traffic is not claimed by the Router provider transport', async () => {
+  let transportCalls = 0
+  let callerCalls = 0
+  const transport = createVisionProviderTransport({
+    fetchImpl: async () => {
+      transportCalls += 1
+      return okOpenAI()
+    },
+  })
+  const release = installVisionProviderTransport(transport)
+  try {
+    await fetchWithOpenAICompatibility(
+      async () => {
+        callerCalls += 1
+        return okOpenAI()
+      },
+      'https://registry.example/chat/completions',
+      requestInit(),
+      { active: false },
+    )
+  } finally {
+    release()
+  }
+  assert.equal(transportCalls, 0)
+  assert.equal(callerCalls, 1)
+})
+
+test('Anthropic correction/local transport also bypasses ambient global fetch', async () => {
+  const calls = []
+  const transport = createVisionProviderTransport({
+    fetchImpl: async (input, init) => {
+      calls.push({ input: String(input), init })
+      return okAnthropic('anthropic-transport')
+    },
+  })
+  const release = installVisionProviderTransport(transport)
+  try {
+    const output = await callAnthropicCompatible(
+      { name: 'corrected', baseURL: 'https://api.example', model: 'vision', apiKeyEnv: '' },
+      [{ role: 'user', content: [{ type: 'text', text: 'look' }] }],
+      { allowKeyless: true },
+    )
+    assert.equal(output, 'anthropic-transport')
+    assert.equal(calls.length, 1)
+    assert.equal(calls[0].input, 'https://api.example/v1/messages')
+  } finally {
+    release()
+  }
+})
+
+test('transport credential resolver prefers Host credentials and falls back to environment', async () => {
+  const previous = process.env.DVR_TEST_PROVIDER_KEY
+  process.env.DVR_TEST_PROVIDER_KEY = 'env-secret'
+  try {
+    const transport = createVisionProviderTransport({
+      ctx: {
+        get(name) {
+          if (name !== 'credentials') return undefined
+          return {
+            async resolve(ref) {
+              return ref === 'HOST_KEY' ? { value: 'host-secret' } : undefined
+            },
+          }
+        },
+      },
+      fetchImpl: async () => okOpenAI(),
+    })
+    assert.equal(await transport.resolveCredential('HOST_KEY'), 'host-secret')
+    assert.equal(await transport.resolveCredential('DVR_TEST_PROVIDER_KEY'), 'env-secret')
+  } finally {
+    if (previous === undefined) delete process.env.DVR_TEST_PROVIDER_KEY
+    else process.env.DVR_TEST_PROVIDER_KEY = previous
+  }
+})
+
+test('public entry installs the provider transport before legacy core apply', async () => {
+  const source = await readFile(new URL('../lib/public-entry.js', import.meta.url), 'utf8')
+  const installAt = source.indexOf('installVisionProviderTransport(transport)')
+  const applyAt = source.indexOf('base.apply(runtimeCtx, hardening.config)')
+  assert.ok(installAt >= 0)
+  assert.ok(applyAt > installAt)
+  assert.match(source, /config:\s*\(\) => liveVisionConfig/)
+})


### PR DESCRIPTION
## P2-D — VisionProviderTransport — FORMAL ACCEPTANCE / PASS

Final head: `51674f923dd77931d9218b701b20abde9e435f69`
Base: `main@f473911c48fee2c75efae6853f7cd4ed5cf08647`

### Accepted scope

Router-owned visual-provider HTTP is now isolated behind `VisionProviderTransport`:

- OpenAI-compatible `vision-http` provider requests use the facade.
- Anthropic correction/local visual-provider requests use the same facade.
- Proxy routing is provider-scoped with an explicit Undici dispatcher.
- Live Vision Router proxy settings are read per request.
- Credential lookup helper and bounded response readers live at the transport boundary.
- Existing caller AbortSignal/deadline propagation remains intact.

### Non-owned traffic remains outside

- npm registry update checks
- GitHub release checks
- ordinary maintenance HTTP
- Host-owned LLM adapter requests

### Global-fetch independence proven

The public package entry installs the transport before legacy core apply. Router-owned provider requests therefore use the captured original fetch and no longer depend on the process-wide fetch patch for their proxy behavior.

### Final CI evidence

All workflow families passed on the final head:

- `P2 Data Boundary` run `33101702213`: success — includes provider-transport Node 22/24 gates
- `P1 Routing Parity` run `33101702287`: success
- `CI` run `33101702274`: success
- `DSH Contract` run `33101702896`: success
- `Native multimodal cold resume` run `33101702337`: success

Dedicated transport tests prove:
- poisoned/legacy caller fetch cannot capture Router-owned OpenAI HTTP
- Anthropic correction/local HTTP uses the facade
- proxy dispatcher is limited to configured provider hosts
- proxy disable is live without restart
- inactive/maintenance compatibility traffic is not claimed
- credential seam preserves Host-first/environment-fallback behavior
- public entry installs transport before legacy core apply
- existing `http-compat` regression tests remain green

### Verdict

**P2-D: COMPLETE / PASS.**

P2-E remains responsible for narrowing the remaining legacy process-wide fetch patch to only flows that still require it and documenting its final deletion condition.