### PR TITLE
refactor(session): centralize vision session index

### DIFF
--- a/.github/workflows/p2-data-boundary.yml
+++ b/.github/workflows/p2-data-boundary.yml
@@ -3,12 +3,14 @@ name: P2 Data Boundary
 on:
   pull_request:
     paths:
+      - 'entry.js'
       - 'lib/artifact-*.js'
       - 'lib/vision-artifact-store.js'
       - 'lib/vision-tool-runtime-boundary.js'
       - 'lib/adversarial-hardening.js'
       - 'lib/session-surface-policy.js'
       - 'lib/session-vision-state.js'
+      - 'lib/session-vision-index.js'
       - 'lib/native-image-coexistence.js'
       - 'lib/legacy-core-vision-policy-bridge.js'
       - 'lib/structured-flow-hardening.js'
@@ -19,6 +21,7 @@ on:
       - 'tests/session-surface-policy.test.js'
       - 'tests/session-vision-state.test.js'
       - 'tests/session-vision-state-integration.test.js'
+      - 'tests/session-vision-index.test.js'
       - 'tests/issue-276-entry-policy-bridge.test.js'
       - 'tests/issue-276-session-image-ownership.test.js'
       - 'tests/issue-289-native-nonintervention.test.js'
@@ -26,12 +29,14 @@ on:
   push:
     branches: [main]
     paths:
+      - 'entry.js'
       - 'lib/artifact-*.js'
       - 'lib/vision-artifact-store.js'
       - 'lib/vision-tool-runtime-boundary.js'
       - 'lib/adversarial-hardening.js'
       - 'lib/session-surface-policy.js'
       - 'lib/session-vision-state.js'
+      - 'lib/session-vision-index.js'
       - 'lib/native-image-coexistence.js'
       - 'lib/legacy-core-vision-policy-bridge.js'
       - 'lib/structured-flow-hardening.js'
@@ -42,6 +47,7 @@ on:
       - 'tests/session-surface-policy.test.js'
       - 'tests/session-vision-state.test.js'
       - 'tests/session-vision-state-integration.test.js'
+      - 'tests/session-vision-index.test.js'
       - 'tests/issue-276-entry-policy-bridge.test.js'
       - 'tests/issue-276-session-image-ownership.test.js'
       - 'tests/issue-289-native-nonintervention.test.js'
@@ -91,12 +97,13 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - name: Session surface, ownership and legacy bridge parity
+      - name: Session surface, index, resume and ownership parity
         run: >-
           node --test
           tests/session-surface-policy.test.js
           tests/session-vision-state.test.js
           tests/session-vision-state-integration.test.js
+          tests/session-vision-index.test.js
           tests/issue-276-entry-policy-bridge.test.js
           tests/issue-276-session-image-ownership.test.js
           tests/issue-289-native-nonintervention.test.js

--- a/entry.js
+++ b/entry.js
@@ -14,6 +14,7 @@ import { contextWithReplayEnvelopeV2Compat } from './lib/replay-envelope-v2-comp
 import { contextWithVisionExecutionPolicy } from './lib/vision-execution-policy.js'
 import { contextWithVisionBackendRuntimePolicy } from './lib/vision-backend-runtime-policy.js'
 import { contextWithNativeImageCoexistence } from './lib/native-image-coexistence.js'
+import { installSessionVisionIndexBoundary } from './lib/session-vision-index.js'
 import { installLegacyCoreVisionPolicyBridge } from './lib/legacy-core-vision-policy-bridge.js'
 import { installPiAiBridgeWireCompat } from './lib/pi-ai-bridge-wire-compat.js'
 import { installLiveModelDiscovery } from './lib/live-model-discovery.js'
@@ -224,10 +225,21 @@ export function apply(ctx, config = {}) {
   })
   const toolRuntimeCtx = installVisionToolRuntimeBoundary(attachmentCompatCtx, runtimeConfig)
   const nativeImageCompat = contextWithNativeImageCoexistence(toolRuntimeCtx, runtimeConfig)
+  // P2-C centralizes the durable attachment index and two model-surface repair
+  // cursors inside the same native-ownership ALS. Its decorated next() runs
+  // after downstream middleware settles but before the mature core resumes, so
+  // the old core scan blocks become compatibility no-ops without changing Host
+  // persistence or resume semantics.
+  const sessionIndexCtx = installSessionVisionIndexBoundary(
+    nativeImageCompat.ctx,
+    nativeImageCompat.config,
+    core,
+    { logger: logging.logger },
+  )
   // Feed the session-level image-ownership decision into the legacy core's
   // wrapper/tool gates without reintroducing a global policy guess.
   const legacyCoreCompat = installLegacyCoreVisionPolicyBridge(
-    nativeImageCompat.ctx,
+    sessionIndexCtx,
     nativeImageCompat.config,
     { rewriteHistoryImages: core.rewriteHistoryImages },
   )

--- a/lib/session-vision-index.js
+++ b/lib/session-vision-index.js
@@ -1,0 +1,308 @@
+import { currentSessionSurfacePolicy } from './session-surface-policy.js'
+import { currentSessionVisionStateStore } from './session-vision-state.js'
+
+function isObject(value) {
+  return value !== null && typeof value === 'object'
+}
+
+function sessionEvents(session) {
+  try {
+    return Array.isArray(session?.events) ? session.events : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function surfaceNodes(session) {
+  try {
+    return Array.isArray(session?.surface?.nodes) ? session.surface.nodes : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function messagesFrom(payload, decision) {
+  if (Array.isArray(decision?.messages)) return decision.messages
+  return Array.isArray(payload?.messages) ? payload.messages : []
+}
+
+function boundedMessage(error) {
+  const text = error?.message ?? error
+  return String(text ?? '').slice(0, 400)
+}
+
+/**
+ * P2 session data-plane index.
+ *
+ * SessionVisionStateStore remains the bounded storage owner. This object owns
+ * the formerly scattered operations around it: incremental durable-log scan,
+ * target-only recovery after bounded-cache eviction, tool-result image surface
+ * repair, and expired structured guard-stop surface repair.
+ *
+ * No new Session event type or persistence format is introduced. Surface
+ * repair keeps using the Host's existing replacement event contract.
+ */
+export function createSessionVisionIndex({
+  stateStore = currentSessionVisionStateStore,
+  core,
+  config = {},
+  logger,
+} = {}) {
+  if (!core || typeof core !== 'object') throw new TypeError('session vision index requires core helpers')
+  const toolSurfaceScans = new WeakMap()
+  const guardSurfaceScans = new WeakMap()
+  const adoptedStores = new WeakSet()
+  const primitiveLookupByStore = new WeakMap()
+
+  const storeNow = () => {
+    const store = typeof stateStore === 'function' ? stateStore() : stateStore
+    if (!store || typeof store !== 'object') return undefined
+    adoptStore(store)
+    return store
+  }
+
+  const recordAttachments = (session, refs) => {
+    const store = storeNow()
+    if (!store || !session || !Array.isArray(refs) || refs.length === 0) return
+    store.recordAttachments(session, refs)
+  }
+
+  const scanEventLogWithStore = (store, session) => {
+    if (!store || !session) return
+    const events = sessionEvents(session)
+    if (!events || events.length === 0) return
+    const last = store.getScannedEventSeq(session)
+    if (last >= events.length) return
+    const refs = typeof core.collectEventAttachmentRefs === 'function'
+      ? core.collectEventAttachmentRefs(events.slice(last))
+      : []
+    // Match the mature core ordering: advance the cursor even when no refs are
+    // found so irrelevant durable history is never rescanned indefinitely.
+    store.setScannedEventSeq(session, events.length)
+    if (Array.isArray(refs) && refs.length > 0) store.recordAttachments(session, refs)
+  }
+
+  const scanEventLog = (session) => {
+    const store = storeNow()
+    if (store) scanEventLogWithStore(store, session)
+  }
+
+  const lookupWithStore = (store, primitiveLookup, session, id) => {
+    let hit = primitiveLookup(session, id)
+    if (hit !== undefined) return hit
+    if (session === undefined) return undefined
+
+    scanEventLogWithStore(store, session)
+    hit = primitiveLookup(session, id)
+    if (hit !== undefined) return hit
+
+    // Bounded cache eviction is a performance event, never a correctness
+    // event. Recover only the requested durable ref instead of rebuilding an
+    // unbounded attachment index.
+    const events = sessionEvents(session)
+    if (!events || events.length === 0 || typeof core.collectEventAttachmentRefs !== 'function') {
+      return undefined
+    }
+    const wanted = String(id)
+    const recovered = core.collectEventAttachmentRefs(events).find(
+      (ref) => ref && String(ref.attachmentId ?? ref.id) === wanted,
+    )
+    if (recovered !== undefined) {
+      store.recordAttachments(session, [recovered])
+      return recovered
+    }
+    return undefined
+  }
+
+  function adoptStore(store) {
+    if (adoptedStores.has(store)) return store
+    const original = typeof store.lookupAttachment === 'function'
+      ? store.lookupAttachment.bind(store)
+      : undefined
+    if (original) {
+      primitiveLookupByStore.set(store, original)
+      // Compatibility delegation: the monolithic core still calls
+      // visionState.lookupAttachment(). Point that call at the new index so its
+      // old targeted-recovery block becomes a no-op on every successful lookup.
+      store.lookupAttachment = (session, id) => lookupWithStore(store, original, session, id)
+    }
+    adoptedStores.add(store)
+    return store
+  }
+
+  const lookupAttachment = (session, id) => {
+    const store = storeNow()
+    if (!store) return undefined
+    const primitive = primitiveLookupByStore.get(store)
+      ?? (typeof store.lookupAttachment === 'function' ? store.lookupAttachment.bind(store) : undefined)
+    if (!primitive) return undefined
+    return adoptedStores.has(store)
+      ? store.lookupAttachment(session, id)
+      : lookupWithStore(store, primitive, session, id)
+  }
+
+  const nextSurfaceSeqs = (scans, session) => {
+    if (!session) return []
+    const nodes = surfaceNodes(session)
+    if (!nodes || nodes.length === 0) return []
+    let scan = scans.get(session)
+    if (!scan) {
+      scan = { count: 0 }
+      scans.set(session, scan)
+    }
+    // Compaction/resume may shrink/rebuild the surface. Reset the incremental
+    // cursor rather than assuming old indices still refer to the new surface.
+    if (scan.count > nodes.length) scan.count = 0
+    const fresh = nodes.slice(scan.count)
+    scan.count = nodes.length
+    return fresh
+  }
+
+  const keepToolResultImages = () => {
+    const policy = currentSessionSurfacePolicy(
+      typeof config === 'function' ? config() : config,
+    )
+    return policy.ownership === 'native-image' || policy.ownership === 'vision-router-owned'
+  }
+
+  const repairToolResultSurface = async (session) => {
+    const events = sessionEvents(session)
+    if (!events || typeof session?.append !== 'function') return 0
+    const seqs = nextSurfaceSeqs(toolSurfaceScans, session)
+    if (seqs.length === 0 || typeof core.planToolResultImageShadows !== 'function') return 0
+    const preserve = keepToolResultImages()
+    const plans = core.planToolResultImageShadows(events, seqs, () => !preserve)
+    let repaired = 0
+    for (const plan of plans) {
+      try {
+        await session.append(
+          'tool/result',
+          { ...plan.event.data, message: plan.message },
+          {
+            surfaceOp: { op: 'replace', start: plan.seq, end: plan.seq },
+            sourceEventSeqs: [plan.seq],
+          },
+        )
+        repaired += 1
+      } catch (error) {
+        // Preserve the mature fail-safe contract: a failed repair leaves the
+        // original event untouched and cannot make the session unreadable.
+        logger?.warn?.(
+          'vision-router: session tool-result surface repair failed seq=%s error=%s',
+          plan.seq,
+          boundedMessage(error),
+        )
+      }
+    }
+    return repaired
+  }
+
+  const repairGuardStopSurface = async (session) => {
+    const events = sessionEvents(session)
+    if (!events || typeof session?.append !== 'function') return 0
+    const seqs = nextSurfaceSeqs(guardSurfaceScans, session)
+    if (seqs.length === 0 || typeof core.planGuardStopShadows !== 'function') return 0
+    const plans = core.planGuardStopShadows(events, seqs)
+    let repaired = 0
+    for (const plan of plans) {
+      try {
+        await session.append(
+          'user/message',
+          plan.data,
+          {
+            surfaceOp: { op: 'replace', start: plan.seq, end: plan.seq },
+            sourceEventSeqs: [plan.seq],
+          },
+        )
+        repaired += 1
+      } catch (error) {
+        logger?.warn?.(
+          'vision-router: session guard-stop surface repair failed seq=%s error=%s',
+          plan.seq,
+          boundedMessage(error),
+        )
+      }
+    }
+    return repaired
+  }
+
+  const prepareDecision = async (payload, decision) => {
+    const session = payload?.agent?.session
+    if (!session) return decision
+    const store = storeNow()
+    if (!store) return decision
+
+    const messages = messagesFrom(payload, decision)
+    if (typeof core.rewriteImageBlocks === 'function') {
+      const found = core.rewriteImageBlocks(messages)
+      if (Array.isArray(found?.attachments) && found.attachments.length > 0) {
+        store.recordAttachments(session, found.attachments)
+      }
+    }
+    scanEventLogWithStore(store, session)
+    await repairToolResultSurface(session)
+    await repairGuardStopSurface(session)
+    return decision
+  }
+
+  return Object.freeze({
+    recordAttachments,
+    scanEventLog,
+    lookupAttachment,
+    repairToolResultSurface,
+    repairGuardStopSurface,
+    prepareDecision,
+  })
+}
+
+/**
+ * Intercept core's pre-step registration and decorate only its downstream
+ * `next()` result. This preserves middleware ordering: downstream handlers run
+ * first exactly as before; the centralized index executes after they settle but
+ * before the mature core resumes and reaches its compatibility scan blocks.
+ */
+export function installSessionVisionIndexBoundary(ctx, config, core, options = {}) {
+  if (!isObject(ctx)) return ctx
+  const index = createSessionVisionIndex({
+    core,
+    config: () => {
+      try {
+        const settings = ctx?.get?.('settings')
+        const live = settings?.get?.('vision-router')
+        if (live && typeof live === 'object' && !Array.isArray(live)) return live
+      } catch {}
+      return config
+    },
+    logger: options.logger,
+  })
+
+  return new Proxy(ctx, {
+    get(target, property) {
+      if (property === 'on') {
+        const on = Reflect.get(target, property, target)
+        if (typeof on !== 'function') return on
+        return (event, handler, ...rest) => {
+          if (event !== 'agent/pre-step' || typeof handler !== 'function') {
+            return on.call(target, event, handler, ...rest)
+          }
+          return on.call(
+            target,
+            event,
+            async function sessionVisionIndexedPreStep(payload, next) {
+              const indexedNext = typeof next === 'function'
+                ? async (...args) => {
+                    const decision = await next(...args)
+                    return index.prepareDecision(payload, decision)
+                  }
+                : next
+              return handler.call(this, payload, indexedNext)
+            },
+            ...rest,
+          )
+        }
+      }
+      const value = Reflect.get(target, property, target)
+      return typeof value === 'function' ? value.bind(target) : value
+    },
+  })
+}

--- a/lib/session-vision-state.js
+++ b/lib/session-vision-state.js
@@ -12,12 +12,24 @@ const DEFAULTS = Object.freeze({
 // Weak keys prevent a finished Session from being retained by this seam.
 const knownSessionMemoryViews = new WeakMap()
 
+// Transitional P2 bridge for the entry-layer SessionVisionIndex. The mature
+// core still constructs the one process/profile SessionVisionStateStore itself;
+// until P3 deletes that monolithic construction seam, the entry boundary needs
+// a read-only way to reach the same store instead of creating a second index.
+// Production creates one store per plugin composition. Tests that construct an
+// isolated store intentionally make that store current for their process.
+let currentStore
+
 function isSessionKey(value) {
   return value !== null && (typeof value === 'object' || typeof value === 'function')
 }
 
 export function knownSessionVisionMemory(session) {
   return isSessionKey(session) ? knownSessionMemoryViews.get(session) : undefined
+}
+
+export function currentSessionVisionStateStore() {
+  return currentStore
 }
 
 class WeightedLruMap {
@@ -413,5 +425,6 @@ export function createSessionVisionStateStore(config = {}) {
   }
 
   store.descriptionFacade = new DescriptionFacade(store)
+  currentStore = store
   return store
 }

--- a/tests/session-vision-index.test.js
+++ b/tests/session-vision-index.test.js
@@ -1,0 +1,212 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  createSessionVisionStateStore,
+  currentSessionVisionStateStore,
+} from '../lib/session-vision-state.js'
+import {
+  createSessionVisionIndex,
+  installSessionVisionIndexBoundary,
+} from '../lib/session-vision-index.js'
+
+function ref(id) {
+  return { attachmentId: id, name: `${id}.png`, mediaType: 'image/png' }
+}
+
+function collectEventAttachmentRefs(events) {
+  const out = []
+  for (const event of events ?? []) {
+    const refs = event?.data?.refs
+    if (Array.isArray(refs)) out.push(...refs)
+  }
+  return out
+}
+
+function coreStub() {
+  return {
+    collectEventAttachmentRefs,
+    rewriteImageBlocks(messages) {
+      const attachments = []
+      for (const message of messages ?? []) {
+        for (const block of message?.content ?? []) {
+          if (block?.type === 'image' && block.attachment) attachments.push(block.attachment)
+        }
+      }
+      return { messages, attachments }
+    },
+    planToolResultImageShadows(events, seqs, shouldStrip) {
+      const plans = []
+      for (const seq of seqs ?? []) {
+        const event = events?.[seq]
+        if (event?.type !== 'tool/result' || shouldStrip(seq, event) !== true) continue
+        if (event?.data?.message?.hasImage !== true) continue
+        plans.push({
+          seq,
+          event,
+          message: Object.freeze({ ...event.data.message, hasImage: false, sanitized: true }),
+        })
+      }
+      return plans
+    },
+    planGuardStopShadows(events, seqs) {
+      const plans = []
+      for (const seq of seqs ?? []) {
+        const event = events?.[seq]
+        if (event?.type !== 'user/message' || event?.data?.guardStop !== true) continue
+        plans.push({
+          seq,
+          event,
+          data: Object.freeze({ ...event.data, guardStop: false, expired: true }),
+        })
+      }
+      return plans
+    },
+  }
+}
+
+function sessionWith(events = [], nodes = events.map((_, index) => index)) {
+  return {
+    id: `session-${Math.random()}`,
+    events: [...events],
+    surface: { nodes: [...nodes] },
+    appended: [],
+    async append(type, data, options) {
+      const seq = this.events.length
+      this.events.push({ type, data })
+      this.appended.push({ type, data, options })
+      if (options?.surfaceOp?.op === 'replace') {
+        const at = this.surface.nodes.indexOf(options.surfaceOp.start)
+        if (at >= 0) this.surface.nodes[at] = seq
+      } else {
+        this.surface.nodes.push(seq)
+      }
+      return seq
+    },
+  }
+}
+
+test('state store constructed by mature core is discoverable by the P2 session index boundary', () => {
+  const store = createSessionVisionStateStore()
+  assert.equal(currentSessionVisionStateStore(), store)
+})
+
+test('incremental durable-log scan advances cursor and records only new attachment refs', () => {
+  const store = createSessionVisionStateStore({ attachmentMaxEntries: 8 })
+  const session = sessionWith([
+    { type: 'user/message', data: { refs: [ref('a')] } },
+  ])
+  const index = createSessionVisionIndex({ stateStore: store, core: coreStub() })
+
+  index.scanEventLog(session)
+  assert.equal(store.getScannedEventSeq(session), 1)
+  assert.equal(store.lookupAttachment(session, 'a')?.attachmentId, 'a')
+
+  session.events.push({ type: 'user/message', data: { refs: [ref('b')] } })
+  index.scanEventLog(session)
+  assert.equal(store.getScannedEventSeq(session), 2)
+  assert.equal(store.lookupAttachment(session, 'b')?.attachmentId, 'b')
+})
+
+test('bounded attachment eviction triggers target-only durable recovery through the same store lookup API', () => {
+  const store = createSessionVisionStateStore({ attachmentMaxEntries: 1 })
+  const session = sessionWith([
+    { type: 'user/message', data: { refs: [ref('old')] } },
+    { type: 'user/message', data: { refs: [ref('new')] } },
+  ])
+  const index = createSessionVisionIndex({ stateStore: store, core: coreStub() })
+
+  index.scanEventLog(session)
+  assert.equal(store.stateStats(session).attachments, 1)
+  // createSessionVisionIndex adopts the mature store's compatibility lookup;
+  // core callers therefore hit the centralized targeted recovery first.
+  assert.equal(store.lookupAttachment(session, 'old')?.attachmentId, 'old')
+  assert.equal(store.stateStats(session).attachments, 1)
+})
+
+test('tool-result surface repair is incremental and persists only Host replacement events', async () => {
+  const store = createSessionVisionStateStore()
+  const session = sessionWith([
+    { type: 'tool/result', data: { message: { hasImage: true, text: 'tool result' } } },
+  ])
+  const index = createSessionVisionIndex({ stateStore: store, core: coreStub() })
+
+  assert.equal(await index.repairToolResultSurface(session), 1)
+  assert.equal(session.appended.length, 1)
+  assert.equal(session.appended[0].type, 'tool/result')
+  assert.equal(session.appended[0].data.message.sanitized, true)
+  assert.deepEqual(session.appended[0].options, {
+    surfaceOp: { op: 'replace', start: 0, end: 0 },
+    sourceEventSeqs: [0],
+  })
+
+  assert.equal(await index.repairToolResultSurface(session), 0)
+  assert.equal(session.appended.length, 1, 'already-scanned surface nodes must not be rewritten twice')
+})
+
+test('guard-stop repair is incremental and preserves the existing user/message replacement contract', async () => {
+  const store = createSessionVisionStateStore()
+  const session = sessionWith([
+    { type: 'user/message', data: { id: 'vision-router-structured-guard-stop-1', guardStop: true } },
+  ])
+  const index = createSessionVisionIndex({ stateStore: store, core: coreStub() })
+
+  assert.equal(await index.repairGuardStopSurface(session), 1)
+  assert.equal(session.appended[0].type, 'user/message')
+  assert.equal(session.appended[0].data.expired, true)
+  assert.deepEqual(session.appended[0].options.sourceEventSeqs, [0])
+  assert.equal(await index.repairGuardStopSurface(session), 0)
+})
+
+test('surface cursor resets safely when compaction/replay shrinks the node list', async () => {
+  const store = createSessionVisionStateStore()
+  const session = sessionWith([
+    { type: 'tool/result', data: { message: { hasImage: false } } },
+    { type: 'tool/result', data: { message: { hasImage: false } } },
+  ])
+  const index = createSessionVisionIndex({ stateStore: store, core: coreStub() })
+  await index.repairToolResultSurface(session)
+
+  session.events.push({ type: 'tool/result', data: { message: { hasImage: true } } })
+  session.surface.nodes = [2]
+  assert.equal(await index.repairToolResultSurface(session), 1)
+})
+
+test('pre-step boundary prepares downstream decision before mature core resumes', async () => {
+  const store = createSessionVisionStateStore()
+  const handlers = new Map()
+  const ctx = {
+    on(event, handler) {
+      handlers.set(event, handler)
+      return () => handlers.delete(event)
+    },
+    get() {
+      return undefined
+    },
+  }
+  const wrapped = installSessionVisionIndexBoundary(ctx, {}, coreStub())
+
+  let observedCursor = 0
+  wrapped.on('agent/pre-step', async (payload, next) => {
+    const decision = await next()
+    observedCursor = store.getScannedEventSeq(payload.agent.session)
+    return decision
+  })
+
+  const session = sessionWith([
+    { type: 'user/message', data: { refs: [ref('durable')] } },
+  ])
+  const payload = {
+    agent: { session },
+    messages: [{ role: 'user', content: [{ type: 'image', attachment: ref('current') }] }],
+  }
+  const decision = { kind: 'continue', messages: payload.messages }
+  const registered = handlers.get('agent/pre-step')
+  assert.ok(registered)
+  const result = await registered(payload, async () => decision)
+
+  assert.equal(result, decision)
+  assert.equal(observedCursor, 1)
+  assert.equal(store.lookupAttachment(session, 'durable')?.attachmentId, 'durable')
+  assert.equal(store.lookupAttachment(session, 'current')?.attachmentId, 'current')
+})


### PR DESCRIPTION
## P2-C follow-up — SessionVisionIndex — FORMAL ACCEPTANCE / PASS

Final head: `aee5314ee91db553d847e7398fe021a2d107f2e9`
Base includes merged P2-D: `main@5eb0fb784d45ad1ade5eb7c9be2112f38dfc1c3f`

### Completed responsibilities

`session-vision-index.js` now centralizes the remaining P2-C data-plane responsibilities:

- incremental durable Session event-log attachment scan
- target-only attachment recovery after bounded-cache eviction
- tool-result image surface repair
- expired structured guard-stop surface repair

`SessionVisionStateStore` remains the bounded storage owner. The compatibility lookup used by the mature core delegates targeted recovery to the centralized index, so the old core block no longer acts as a second authority.

### Persistence / resume invariants accepted

- no new Session event type
- no new durable index format
- existing `tool/result` and `user/message` replacement events unchanged
- existing `surfaceOp: replace` / `sourceEventSeqs` contract unchanged
- compaction/replay shrink only resets the in-memory surface cursor
- cache eviction remains a performance event, never a correctness failure
- no cross-session lookup
- native image ownership policy remains authoritative for surface preservation

### Integration

The entry boundary is installed inside native image-ownership policy and before the mature core resumes from its pre-step `next()` call. This preserves middleware ordering while moving the data-plane authority into the centralized index.

The branch was synchronized with merged P2-D before final acceptance. The P2 workflow conflict was resolved as a union: both SessionVisionIndex and VisionProviderTransport Node 22/24 gates are present.

### Final CI evidence

All workflow families passed on final head:

- `P2 Data Boundary` run `33143509174`: success
- `P1 Routing Parity` run `33143509204`: success
- `CI` run `33143509160`: success
- `DSH Contract` run `33143509315`: success
- `Native multimodal cold resume` run `33143509287`: success
- `Large image resource stress` run `33143509254`: success

### Verdict

**P2-C: COMPLETE / PASS.**

Both the surface-policy half (#319) and indexing/surface-repair half (#321) are now accepted. Overall P2 still requires P2-E, P2-F and the final Exit Gate.