### PR TITLE
refactor: finish P2 runtime boundaries

### DIFF
--- a/.github/workflows/p2-data-boundary.yml
+++ b/.github/workflows/p2-data-boundary.yml
@@ -25,6 +25,7 @@ on:
       - 'tests/vision-artifact-store.test.js'
       - 'tests/artifact-path-security.test.js'
       - 'tests/resource-retention-lifecycle.test.js'
+      - 'tests/p2-exit-gate.test.js'
       - 'tests/qa-cancellation-publication.test.js'
       - 'tests/session-surface-policy.test.js'
       - 'tests/session-vision-state.test.js'
@@ -64,6 +65,7 @@ on:
       - 'tests/vision-artifact-store.test.js'
       - 'tests/artifact-path-security.test.js'
       - 'tests/resource-retention-lifecycle.test.js'
+      - 'tests/p2-exit-gate.test.js'
       - 'tests/qa-cancellation-publication.test.js'
       - 'tests/session-surface-policy.test.js'
       - 'tests/session-vision-state.test.js'
@@ -99,12 +101,13 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - name: Artifact facade parity and lifecycle safety
+      - name: Artifact facade parity, lifecycle safety and P2 exit stress
         run: >-
           node --test
           tests/vision-artifact-store.test.js
           tests/artifact-path-security.test.js
           tests/resource-retention-lifecycle.test.js
+          tests/p2-exit-gate.test.js
           tests/qa-cancellation-publication.test.js
 
   session-surface:

--- a/.github/workflows/p2-data-boundary.yml
+++ b/.github/workflows/p2-data-boundary.yml
@@ -15,9 +15,13 @@ on:
       - 'lib/legacy-core-vision-policy-bridge.js'
       - 'lib/structured-flow-hardening.js'
       - 'lib/vision-provider-transport.js'
+      - 'lib/legacy-global-proxy-boundary.js'
       - 'lib/http-compat.js'
       - 'lib/catalog-corrections.js'
       - 'lib/public-entry.js'
+      - 'lib/vision-background-benchmark.js'
+      - 'docs/architecture/compat-inventory.md'
+      - 'docs/architecture/p2-jobs-feasibility.md'
       - 'tests/vision-artifact-store.test.js'
       - 'tests/artifact-path-security.test.js'
       - 'tests/resource-retention-lifecycle.test.js'
@@ -30,7 +34,10 @@ on:
       - 'tests/issue-276-session-image-ownership.test.js'
       - 'tests/issue-289-native-nonintervention.test.js'
       - 'tests/vision-provider-transport.test.js'
+      - 'tests/legacy-global-proxy-boundary.test.js'
       - 'tests/http-compat.test.js'
+      - 'tests/vision-background-benchmark.test.js'
+      - 'tests/vision-background-lifecycle.test.js'
       - '.github/workflows/p2-data-boundary.yml'
   push:
     branches: [main]
@@ -47,9 +54,13 @@ on:
       - 'lib/legacy-core-vision-policy-bridge.js'
       - 'lib/structured-flow-hardening.js'
       - 'lib/vision-provider-transport.js'
+      - 'lib/legacy-global-proxy-boundary.js'
       - 'lib/http-compat.js'
       - 'lib/catalog-corrections.js'
       - 'lib/public-entry.js'
+      - 'lib/vision-background-benchmark.js'
+      - 'docs/architecture/compat-inventory.md'
+      - 'docs/architecture/p2-jobs-feasibility.md'
       - 'tests/vision-artifact-store.test.js'
       - 'tests/artifact-path-security.test.js'
       - 'tests/resource-retention-lifecycle.test.js'
@@ -62,7 +73,10 @@ on:
       - 'tests/issue-276-session-image-ownership.test.js'
       - 'tests/issue-289-native-nonintervention.test.js'
       - 'tests/vision-provider-transport.test.js'
+      - 'tests/legacy-global-proxy-boundary.test.js'
       - 'tests/http-compat.test.js'
+      - 'tests/vision-background-benchmark.test.js'
+      - 'tests/vision-background-lifecycle.test.js'
       - '.github/workflows/p2-data-boundary.yml'
 
 permissions:
@@ -136,8 +150,31 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - name: Router-owned provider HTTP is independent of the global fetch patch
+      - name: Router-owned provider HTTP and legacy proxy narrowing
         run: >-
           node --test
           tests/vision-provider-transport.test.js
+          tests/legacy-global-proxy-boundary.test.js
           tests/http-compat.test.js
+
+  jobs-feasibility:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [22, 24]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86
+        with:
+          version: 11.20.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: ${{ matrix.node }}
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Current scheduler authority, preemption and lifecycle evidence
+        run: >-
+          node --test
+          tests/vision-background-benchmark.test.js
+          tests/vision-background-lifecycle.test.js

--- a/docs/architecture/compat-inventory.md
+++ b/docs/architecture/compat-inventory.md
@@ -65,6 +65,15 @@ P0 records why each major compatibility seam exists and the condition that permi
 - **Removal condition:** upstream endpoint behavior becomes generic-compatible for a rule and regression evidence confirms the preset is no longer needed.
 - **Tests:** `http-compat`, provider HTTP regression tests.
 
+## `lib/legacy-global-proxy-boundary.js`
+
+- **Reason:** retain the process-global proxy patch only for Host-owned/raw-fetch visual providers that still lack a provider-scoped proxy seam. Router-owned `vision-http` and direct protocol-correction traffic already uses `VisionProviderTransport` with an explicit dispatcher.
+- **Host gap:** the supported Host window does not yet guarantee one provider-scoped/shared HTTP proxy seam that third-party Host-owned adapters can consume without a process-global fetch wrapper.
+- **First needed for:** legacy/custom Host-owned visual provider compatibility when users configure Vision Router proxy routing.
+- **Feature detection:** live visual-chain ownership. Router-owned routes bypass the legacy patch; any unknown/Host-owned provider conservatively keeps it available. This is capability/ownership detection, not a Host-version persona.
+- **Removal condition:** **the minimum supported DSH provides a provider-scoped/shared HTTP proxy seam** that covers the remaining Host-owned/raw-fetch provider compatibility requirement.
+- **Tests:** `legacy-global-proxy-boundary`, `vision-provider-transport`, `adversarial-hardening`, P2 Data Boundary Node 22/24.
+
 ## `lib/tesseract-exec-compat.js`
 
 - **Reason:** isolate runtime/Node process-exec differences around the local OCR binary.

--- a/docs/architecture/p2-jobs-feasibility.md
+++ b/docs/architecture/p2-jobs-feasibility.md
@@ -1,0 +1,94 @@
+# P2-F — `ctx.jobs` Feasibility Spike
+
+Status: **NO-GO: retain current scheduler**
+
+Reviewed against:
+
+- DeepSeek Harness `main` at `cd5ef8148158c3a752a658978873241fdf8e2bbc` (`dsh@0.1.2-alpha.1` release merge, 2026-08-27).
+- Official Jobs subsystem contract: `docs/subsystems/jobs.md` at the same commit.
+- Vision Router `createBackgroundCapabilityProfiler()` and its current regression suites.
+
+This is a feasibility result, not a rejection of `ctx.jobs` as a Host feature. Jobs is the correct generic long-running-work registry when its ownership model matches the producer. The question here is narrower: **would replacing Vision Router's background capability scheduler with `ctx.jobs` reduce custom lifecycle code without weakening routing authority, priority, or restart semantics?** The answer is no on the current Host contract.
+
+## Host contract observed
+
+The current DSH Jobs contract provides:
+
+- atomic registration and lifecycle state;
+- optional exact `Agent` ownership with session-fenced access;
+- unowned jobs when no owner is supplied;
+- cancellation, bounded wait, output/status reads and completion listeners;
+- owner disposal and service disposal cancellation/await semantics;
+- an attached-controller admission fence: `start()` refuses work when no attached job controller serves the selected owner;
+- one registry across process compositions, with visibility/delivery determined by the registering context and owner.
+
+It does **not** define a producer-independent priority scheduler. In particular, the Jobs contract has no native concept of:
+
+```text
+foreground visual work
+  > manual capability benchmark
+  > unattended background benchmark
+```
+
+Nor does it know Vision Router's live measurement authority, endpoint identity/fingerprint, local-free eligibility, topology revision, or publish fence.
+
+## Ten required checks
+
+| # | Requirement | Current scheduler | `ctx.jobs` as replacement | Result |
+|---|---|---|---|---|
+| 1 | profile-wide job ownership | Profiler is installed once on the plugin composition/capability store and is not session-owned. | An **unowned** Job can be profile/process-visible, but an owned Job is tied to an exact Agent and requires a serving controller. Choosing unowned preserves profile scope but gains no useful owner lifecycle over the current profiler. | **No migration benefit** |
+| 2 | Web settings page close must not stop work | Background profiler lives in the plugin fiber; the Web route is only a status/control projection. Closing the page does not own the profiler. | Possible only if the Job registration/controller is kept outside the page/client scope. This adds composition/controller placement constraints rather than removing them. | **Current is simpler** |
+| 3 | plugin dispose immediately terminates work | `installBackgroundCapabilityProfiling()` registers an effect disposer that unregisters listeners and calls `profiler.stop()`, which aborts current work. | Jobs service/owner disposal can cancel and await compliant producers. | **Jobs capable, no decisive gain** |
+| 4 | `all → off` immediately aborts | Policy polling and `settingsChanged()` revoke authorization and abort the active controller; yielded work does not receive provider backoff. | Jobs can carry a `cancel()` hook, but it does not observe Vision Router settings or infer authority revoke. We would retain the same settings watcher/policy logic to call it. | **No lifecycle reduction** |
+| 5 | `all → local-free` narrows correctly | `workStillAuthorized()` re-evaluates live authority and candidate eligibility; paid work aborts while eligible local work may continue. | Jobs has no backend/authority semantics. The same Vision Router eligibility code must remain outside the registry. | **No lifecycle reduction** |
+| 6 | manual Benchmark preempts background | `manualStart()` increments a lease, aborts current background work, and blocks new background ticks until all manual work releases. | Jobs has no cross-kind priority/preemption contract. We would have to rebuild the same arbitration above Jobs. | **FAIL as replacement** |
+| 7 | foreground visual work has highest priority | `foregroundStart()` immediately aborts background work and resets the idle window; foreground tool wrappers bracket activity. | Jobs has no producer-independent priority/preemption contract. | **FAIL as replacement** |
+| 8 | headless behavior | Scheduler depends on settings/core/store/timers, not on a browser page or Agent owner. | An unowned Job can be headless, but an owned Job adds owner/controller admission requirements. Using unowned Jobs again removes the principal ownership benefit. | **Current is simpler / fewer assumptions** |
+| 9 | process restart semantics | Work itself is intentionally not resumed. On restart the scheduler reconstructs from persisted measured evidence, image verdicts and bounded background-stop records, then chooses fresh work. | Current JobRegistry is a process-local lifecycle registry; the documented contract does not provide durable replay/resume of producer work. We would still need Vision Router's persisted evidence/stop semantics. | **No migration benefit** |
+| 10 | background stop/evidence publish fencing | Before `store.put`, `assertBackgroundPublishable()` rechecks live authority, current candidate existence, benchmarkability, endpoint fingerprint and current background eligibility. Persistent stops are separately bounded and credential-aware. | Jobs settlement records generic lifecycle state; it does not validate model identity, fingerprint, routing authority, or evidence publication. The full fence must remain. | **FAIL as simplification** |
+
+## GO criteria evaluation
+
+The implementation plan allows migration only if Jobs satisfies all of these architecture outcomes.
+
+| GO criterion | Evaluation |
+|---|---|
+| Reduce custom lifecycle code | **FAIL.** Priority, settings/topology invalidation, eligibility and publish fencing all remain; Jobs adds registration/controller placement. |
+| Do not weaken authority revoke | Achievable only by retaining the current revoke logic around Jobs; therefore no simplification. |
+| Preserve priority | **FAIL natively.** Current DSH Jobs has no foreground/manual/background priority contract. |
+| Preserve Web-close continuation | Achievable only with careful unowned/profile-scoped registration, which adds scope assumptions. |
+| Do not add session-owner assumptions | **FAIL for owned Jobs;** unowned Jobs avoid the assumption but also discard the ownership benefit. |
+
+## Decision
+
+```text
+NO-GO: retain current scheduler
+```
+
+This is a successful P2-F outcome under the implementation plan.
+
+The current `createBackgroundCapabilityProfiler()` remains production authority for unattended benchmark scheduling. `ctx.jobs` should be reconsidered only if a future Host contract adds a generic priority/resource scheduler or a profile-scoped owner/controller seam that demonstrably eliminates Vision Router's custom arbitration rather than wrapping it.
+
+## Evidence / regression coverage
+
+Current repository tests already exercise the semantics that a migration would have to preserve:
+
+- `tests/vision-background-benchmark.test.js`
+  - foreground abort/preemption;
+  - manual benchmark lease/preemption;
+  - `all → off` revoke;
+  - `all → local-free` narrowing;
+  - topology-change abort;
+  - local-free eligibility.
+- `tests/vision-background-lifecycle.test.js`
+  - bounded persistent-stop lifetime;
+  - credential-rotation release;
+  - failure-lifetime separation.
+- `lib/vision-background-benchmark.js`
+  - plugin effect disposal;
+  - headless timer ownership;
+  - pre-publish live authority / candidate / fingerprint fence.
+
+Official DSH reference used for the spike:
+
+- `https://github.com/deepseek-ai/deepseek-harness/blob/cd5ef8148158c3a752a658978873241fdf8e2bbc/docs/subsystems/jobs.md`

--- a/lib/legacy-global-proxy-boundary.js
+++ b/lib/legacy-global-proxy-boundary.js
@@ -1,0 +1,126 @@
+// P2-E: keep the process-global fetch patch only as a compatibility fallback
+// for Host-owned/raw-fetch visual providers. Router-owned provider HTTP already
+// uses VisionProviderTransport and therefore never needs this seam.
+
+const moduleFetch =
+  typeof globalThis.fetch === 'function'
+    ? globalThis.fetch.bind(globalThis)
+    : undefined
+
+export const LEGACY_GLOBAL_PROXY_REMOVAL_CONDITION =
+  'Remove when the minimum supported DSH provides a provider-scoped/shared HTTP proxy seam.'
+
+function validPair(provider, model) {
+  return typeof provider === 'string' && provider !== '' && typeof model === 'string' && model !== ''
+}
+
+function configuredPairs(config = {}) {
+  const pairs = []
+  if (Array.isArray(config.providers)) {
+    for (const entry of config.providers) {
+      if (!validPair(entry?.provider, entry?.model)) continue
+      pairs.push({ provider: entry.provider, model: entry.model })
+      for (const fallback of entry.fallbacks ?? []) {
+        if (typeof fallback === 'string' && fallback !== '') {
+          pairs.push({ provider: entry.provider, model: fallback })
+        }
+      }
+    }
+  }
+  if (pairs.length === 0 && validPair(config.provider, config.model)) {
+    pairs.push({ provider: config.provider, model: config.model })
+    for (const fallback of config.fallbacks ?? []) {
+      if (typeof fallback === 'string' && fallback !== '') {
+        pairs.push({ provider: config.provider, model: fallback })
+      }
+    }
+  }
+  if (pairs.length === 0) pairs.push({ provider: 'vision-http', model: 'ovh/Qwen3.5-397B-A17B' })
+  return pairs
+}
+
+function routerOwnedProvider(provider, config = {}) {
+  if (provider === 'vision-http') return true
+  const wrapper = typeof config.wrapperRoute === 'string' && config.wrapperRoute !== ''
+    ? config.wrapperRoute
+    : 'deepseek-vision'
+  const chain = typeof config.chainRoute === 'string' && config.chainRoute !== ''
+    ? config.chainRoute
+    : 'vision-chain'
+  if (provider === wrapper || provider === chain) return true
+  // Hidden native takeover route is registered by this plugin and does not
+  // require the Host/raw-fetch compatibility patch.
+  if (provider === 'deepseek-official-native') return true
+  return false
+}
+
+/**
+ * True only when the configured visual chain still contains a provider whose
+ * network transport is owned by the Host/another adapter. This is deliberately
+ * conservative: any unknown provider keeps the compatibility seam available.
+ */
+export function legacyGlobalProxyRequired(config = {}) {
+  return configuredPairs(config).some(
+    (pair) => !routerOwnedProvider(pair.provider, config),
+  )
+}
+
+function liveConfig(ctx, fallback) {
+  try {
+    const settings = ctx?.get?.('settings')
+    const value = settings?.get?.('vision-router')
+    if (value && typeof value === 'object' && !Array.isArray(value)) return value
+  } catch {
+    // Composition config remains authoritative until Settings is available.
+  }
+  return fallback
+}
+
+/**
+ * Install after core.apply has installed its lifecycle-safe legacy proxy patch.
+ *
+ * The outer gate bypasses that process-global patch entirely whenever the live
+ * visual chain is Router-owned. If a Host-owned provider is configured, calls
+ * fall through to the legacy patched fetch exactly as before. No request URL,
+ * header or body is rewritten here; this boundary only decides whether the old
+ * compatibility seam is allowed to participate.
+ */
+export function installLegacyGlobalProxyBoundary(ctx, config = {}, options = {}) {
+  const originalFetch = typeof options.originalFetch === 'function'
+    ? options.originalFetch
+    : moduleFetch
+  const legacyFetch = typeof globalThis.fetch === 'function'
+    ? globalThis.fetch
+    : undefined
+  if (typeof originalFetch !== 'function' || typeof legacyFetch !== 'function') return () => {}
+
+  let active = true
+  const gatedFetch = (...args) => {
+    if (!active) return originalFetch(...args)
+    const current = liveConfig(ctx, config)
+    return legacyGlobalProxyRequired(current)
+      ? legacyFetch(...args)
+      : originalFetch(...args)
+  }
+
+  globalThis.fetch = gatedFetch
+
+  let disposed = false
+  const dispose = () => {
+    if (disposed) return
+    disposed = true
+    active = false
+    // Preserve a later plugin wrapper if one was installed above us. A retained
+    // reference to gatedFetch becomes an inert delegator to the original Host
+    // fetch, so Vision Router cannot resurface after disposal.
+    if (globalThis.fetch === gatedFetch) globalThis.fetch = legacyFetch
+  }
+
+  if (typeof ctx?.effect === 'function') {
+    ctx.effect(
+      () => dispose,
+      'vision-router: legacy global proxy compatibility gate',
+    )
+  }
+  return dispose
+}

--- a/lib/legacy-global-proxy-boundary.js
+++ b/lib/legacy-global-proxy-boundary.js
@@ -110,10 +110,11 @@ export function installLegacyGlobalProxyBoundary(ctx, config = {}, options = {})
     if (disposed) return
     disposed = true
     active = false
-    // Preserve a later plugin wrapper if one was installed above us. A retained
-    // reference to gatedFetch becomes an inert delegator to the original Host
-    // fetch, so Vision Router cannot resurface after disposal.
-    if (globalThis.fetch === gatedFetch) globalThis.fetch = legacyFetch
+    // Preserve a later plugin wrapper if one was installed above us. If we are
+    // still outermost, restore the original Host fetch directly instead of the
+    // inner legacy guard: this remains correct regardless of effect-disposal
+    // order and cannot leave an inert Vision Router closure as process state.
+    if (globalThis.fetch === gatedFetch) globalThis.fetch = originalFetch
   }
 
   if (typeof ctx?.effect === 'function') {

--- a/lib/public-entry.js
+++ b/lib/public-entry.js
@@ -5,6 +5,7 @@ import {
   createVisionProviderTransport,
   installVisionProviderTransport,
 } from './vision-provider-transport.js'
+import { installLegacyGlobalProxyBoundary } from './legacy-global-proxy-boundary.js'
 
 export * from '../entry.js'
 
@@ -23,11 +24,11 @@ function liveVisionConfig(ctx, fallback) {
  * Public package entry: keep the mature entry.js implementation intact and
  * place the #284 hardening at its outermost registration/browser boundary.
  *
- * P2 also installs the Router-owned provider transport here, before base.apply
- * can install the legacy process-wide proxy fetch patch. The transport module
- * captured the original fetch at module load and reads live Vision Router
- * settings on every request, so direct visual-provider HTTP can use an explicit
- * dispatcher without depending on global fetch mutation.
+ * P2 installs the Router-owned provider transport before base.apply can install
+ * the legacy process-wide proxy fetch patch. After base.apply has installed the
+ * old lifecycle-safe seam, P2-E adds a compatibility gate above it: Router-only
+ * visual chains bypass the global patch completely; only a configured
+ * Host-owned/raw-fetch visual provider keeps the legacy seam active.
  */
 export function apply(ctx, config = {}) {
   const hardening = createVisionToggleRootHardening(ctx, config)
@@ -43,6 +44,7 @@ export function apply(ctx, config = {}) {
       'vision-router: provider transport',
     )
     const result = base.apply(runtimeCtx, hardening.config)
+    installLegacyGlobalProxyBoundary(runtimeCtx, hardening.config)
     hardening.installClientBoundary()
     return result
   } catch (error) {

--- a/tests/legacy-global-proxy-boundary.test.js
+++ b/tests/legacy-global-proxy-boundary.test.js
@@ -1,0 +1,178 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  LEGACY_GLOBAL_PROXY_REMOVAL_CONDITION,
+  installLegacyGlobalProxyBoundary,
+  legacyGlobalProxyRequired,
+} from '../lib/legacy-global-proxy-boundary.js'
+
+function response(source) {
+  return Promise.resolve({ ok: true, source })
+}
+
+test('default and Router-owned visual chains do not require the legacy global proxy seam', () => {
+  assert.equal(legacyGlobalProxyRequired({}), false)
+  assert.equal(
+    legacyGlobalProxyRequired({
+      providers: [
+        { provider: 'vision-http', model: 'ovh/Qwen3.5-397B-A17B', fallbacks: ['local-ollama/qwen2.5vl'] },
+      ],
+    }),
+    false,
+  )
+  assert.equal(
+    legacyGlobalProxyRequired({
+      providers: [{ provider: 'vision-chain', model: 'vision-chain', fallbacks: [] }],
+    }),
+    false,
+  )
+  assert.equal(
+    legacyGlobalProxyRequired({
+      wrapperRoute: 'custom-wrapper',
+      providers: [{ provider: 'custom-wrapper', model: 'deepseek-v4-pro', fallbacks: [] }],
+    }),
+    false,
+  )
+})
+
+test('unknown or mixed Host-owned providers conservatively retain the compatibility seam', () => {
+  assert.equal(
+    legacyGlobalProxyRequired({
+      providers: [{ provider: 'custom-host-provider', model: 'vl-model', fallbacks: [] }],
+    }),
+    true,
+  )
+  assert.equal(
+    legacyGlobalProxyRequired({
+      providers: [
+        { provider: 'vision-http', model: 'ovh/Qwen3.5-397B-A17B', fallbacks: [] },
+        { provider: 'custom-host-provider', model: 'vl-model', fallbacks: [] },
+      ],
+    }),
+    true,
+  )
+})
+
+test('live settings switch the global compatibility seam on and off without restart', async () => {
+  const saved = globalThis.fetch
+  let originalCalls = 0
+  let legacyCalls = 0
+  const originalFetch = async () => {
+    originalCalls += 1
+    return response('original')
+  }
+  const legacyFetch = async () => {
+    legacyCalls += 1
+    return response('legacy')
+  }
+  let config = {
+    providers: [{ provider: 'vision-http', model: 'ovh/Qwen3.5-397B-A17B', fallbacks: [] }],
+  }
+  const effects = []
+  const ctx = {
+    get(name) {
+      if (name === 'settings') return { get: () => config }
+      return undefined
+    },
+    effect(factory) {
+      effects.push(factory())
+    },
+  }
+
+  try {
+    globalThis.fetch = legacyFetch
+    installLegacyGlobalProxyBoundary(ctx, config, { originalFetch })
+
+    await globalThis.fetch('https://maintenance.example.test')
+    assert.equal(originalCalls, 1)
+    assert.equal(legacyCalls, 0, 'Router-only chain must bypass the process-global compatibility patch')
+
+    config = {
+      providers: [{ provider: 'custom-host-provider', model: 'vl-model', fallbacks: [] }],
+    }
+    await globalThis.fetch('https://provider.example.test')
+    assert.equal(legacyCalls, 1, 'Host-owned provider must keep the legacy compatibility seam available')
+
+    config = {
+      providers: [{ provider: 'vision-http', model: 'ovh/Qwen3.5-397B-A17B', fallbacks: [] }],
+    }
+    await globalThis.fetch('https://provider.example.test')
+    assert.equal(originalCalls, 2, 'returning to Router-owned transport must narrow the seam immediately')
+  } finally {
+    for (const dispose of effects.reverse()) dispose?.()
+    globalThis.fetch = saved
+  }
+})
+
+test('outermost cleanup restores original fetch and retained gate cannot resurface', async () => {
+  const saved = globalThis.fetch
+  let originalCalls = 0
+  let legacyCalls = 0
+  const originalFetch = async () => {
+    originalCalls += 1
+    return response('original')
+  }
+  const legacyFetch = async () => {
+    legacyCalls += 1
+    return response('legacy')
+  }
+  let cleanup
+  const ctx = {
+    get() {
+      return { get: () => ({ providers: [{ provider: 'custom-host-provider', model: 'vl', fallbacks: [] }] }) }
+    },
+    effect(factory) {
+      cleanup = factory()
+    },
+  }
+
+  try {
+    globalThis.fetch = legacyFetch
+    const dispose = installLegacyGlobalProxyBoundary(ctx, {}, { originalFetch })
+    const retainedGate = globalThis.fetch
+    await retainedGate('https://provider.example.test')
+    assert.equal(legacyCalls, 1)
+
+    dispose()
+    assert.equal(globalThis.fetch, originalFetch)
+    await retainedGate('https://provider.example.test')
+    assert.equal(originalCalls, 1, 'retained gate must become an inert delegator after unload')
+    assert.equal(legacyCalls, 1)
+
+    cleanup?.()
+    dispose()
+    assert.equal(globalThis.fetch, originalFetch, 'cleanup must be idempotent')
+  } finally {
+    globalThis.fetch = saved
+  }
+})
+
+test('cleanup preserves a later plugin wrapper', async () => {
+  const saved = globalThis.fetch
+  const originalFetch = async () => response('original')
+  const legacyFetch = async () => response('legacy')
+  try {
+    globalThis.fetch = legacyFetch
+    const dispose = installLegacyGlobalProxyBoundary(
+      { get() { return undefined } },
+      {},
+      { originalFetch },
+    )
+    const gate = globalThis.fetch
+    const later = (...args) => gate(...args)
+    globalThis.fetch = later
+
+    dispose()
+    assert.equal(globalThis.fetch, later)
+    const result = await later('https://maintenance.example.test')
+    assert.equal((await result).source, 'original')
+  } finally {
+    globalThis.fetch = saved
+  }
+})
+
+test('removal condition is explicit and tied to the minimum Host proxy seam', () => {
+  assert.match(LEGACY_GLOBAL_PROXY_REMOVAL_CONDITION, /minimum supported DSH/i)
+  assert.match(LEGACY_GLOBAL_PROXY_REMOVAL_CONDITION, /provider-scoped\/shared HTTP proxy seam/i)
+})

--- a/tests/p2-exit-gate.test.js
+++ b/tests/p2-exit-gate.test.js
@@ -1,0 +1,148 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { access, mkdir, mkdtemp, readFile, rm, utimes, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import { cleanupArtifactRuns, retainArtifactRun } from '../lib/artifact-retention.js'
+import { ARTIFACT_RUNS_DIR } from '../lib/artifact-io.js'
+
+async function exists(target) {
+  try {
+    await access(target)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function withTempDir(prefix, fn) {
+  const root = await mkdtemp(path.join(tmpdir(), prefix))
+  try {
+    return await fn(root)
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+}
+
+test('P2 Exit Gate: .runs cleanup remains complete with many unknown root entries', async () => {
+  await withTempDir('dvr-p2-exit-unknown-', async (root) => {
+    const runsRoot = path.join(root, ARTIFACT_RUNS_DIR)
+    await mkdir(runsRoot)
+
+    // Deliberately place far more unknown/user entries than managed runs in the
+    // same root. Discovery must examine them without treating them as owned or
+    // allowing them to hide expired managed runs behind directory order.
+    const unknownCount = 256
+    for (let index = 0; index < unknownCount; index++) {
+      if (index % 2 === 0) {
+        await writeFile(path.join(runsRoot, `user-note-${index}.txt`), `keep-${index}`)
+      } else {
+        const dir = path.join(runsRoot, `user-folder-${index}`)
+        await mkdir(dir)
+        await writeFile(path.join(dir, 'keep.txt'), `keep-${index}`)
+      }
+    }
+
+    const oldA = path.join(runsRoot, '.vision-run-old-a')
+    const oldB = path.join(runsRoot, '.vision-run-old-b')
+    await mkdir(oldA)
+    await mkdir(oldB)
+    await writeFile(path.join(oldA, 'a.bin'), 'a')
+    await writeFile(path.join(oldB, 'b.bin'), 'b')
+    await utimes(oldA, 1, 1)
+    await utimes(oldB, 1, 1)
+
+    const result = await cleanupArtifactRuns(runsRoot, {
+      now: 10_000,
+      ttlMs: 1_000,
+      maxRuns: 512,
+      maxBytes: 1024 * 1024,
+      maxDiscoveryEntries: 1_024,
+      maxScanEntries: 1_024,
+      maxScanMs: 60_000,
+      includeScanDiagnostics: true,
+    })
+
+    assert.equal(result.scan.discoveryComplete, true)
+    assert.equal(result.scanned, 2, 'only managed run directories count as owned runs')
+    assert.equal(result.removed, 2, 'all expired managed runs must be found despite unknown-entry noise')
+    assert.equal(await exists(oldA), false)
+    assert.equal(await exists(oldB), false)
+
+    for (let index = 0; index < unknownCount; index++) {
+      if (index % 2 === 0) {
+        assert.equal(
+          await readFile(path.join(runsRoot, `user-note-${index}.txt`), 'utf8'),
+          `keep-${index}`,
+        )
+      } else {
+        assert.equal(
+          await readFile(path.join(runsRoot, `user-folder-${index}`, 'keep.txt'), 'utf8'),
+          `keep-${index}`,
+        )
+      }
+    }
+  })
+})
+
+test('P2 Exit Gate: an active run is never removed by TTL, maxRuns or maxBytes pressure', async () => {
+  await withTempDir('dvr-p2-exit-active-', async (root) => {
+    const activeName = '.vision-run-active'
+    const staleName = '.vision-run-stale'
+    const active = path.join(root, activeName)
+    const stale = path.join(root, staleName)
+    await mkdir(active)
+    await mkdir(stale)
+    await writeFile(path.join(active, 'large.bin'), Buffer.alloc(64))
+    await writeFile(path.join(stale, 'small.bin'), Buffer.alloc(8))
+    await utimes(active, 1, 1)
+    await utimes(stale, 1, 1)
+
+    const release = retainArtifactRun(activeName)
+    try {
+      const result = await cleanupArtifactRuns(root, {
+        now: 10_000,
+        ttlMs: 1_000,
+        maxRuns: 1,
+        maxBytes: 1,
+        maxDiscoveryEntries: 64,
+        maxScanEntries: 64,
+        maxScanMs: 60_000,
+        includeScanDiagnostics: true,
+      })
+      assert.equal(await exists(active), true)
+      assert.equal(await exists(stale), false)
+      assert.equal(result.removed, 1)
+    } finally {
+      release()
+    }
+  })
+})
+
+test('P2 Exit Gate: legacy direct managed artifacts can age out while the new .runs namespace is preserved', async () => {
+  await withTempDir('dvr-p2-exit-legacy-', async (root) => {
+    const legacy = path.join(root, '.vision-run-legacy')
+    const runsRoot = path.join(root, ARTIFACT_RUNS_DIR)
+    await mkdir(legacy)
+    await mkdir(runsRoot)
+    await writeFile(path.join(legacy, 'legacy.bin'), 'old')
+    await writeFile(path.join(runsRoot, 'user-marker.txt'), 'keep')
+    await utimes(legacy, 1, 1)
+
+    const result = await cleanupArtifactRuns(root, {
+      now: 10_000,
+      ttlMs: 1_000,
+      maxRuns: 512,
+      maxBytes: 1024 * 1024,
+      maxDiscoveryEntries: 64,
+      maxScanEntries: 64,
+      maxScanMs: 60_000,
+      includeScanDiagnostics: true,
+    })
+
+    assert.equal(result.removed, 1)
+    assert.equal(await exists(legacy), false)
+    assert.equal(await readFile(path.join(runsRoot, 'user-marker.txt'), 'utf8'), 'keep')
+  })
+})


### PR DESCRIPTION
## P2-E / P2-F — FORMAL ACCEPTANCE / PASS

Final head: `f26f29b35572437b4c2749825138468f9a96a38c`
Base: `main@40973f9841e43428d9afd96f8b16b0835caf36c7`

### P2-E — COMPLETE / PASS

`legacy-global-proxy-boundary.js` lowers the remaining process-global fetch seam to compatibility-only authority:

- default / Router-owned visual chains bypass the legacy global patch completely;
- `vision-http` and its local/direct HTTP models use `VisionProviderTransport` and do not depend on the process-global patch;
- wrapper/chain synthetic routes and the hidden native takeover route do not require the old seam;
- any unknown / Host-owned visual provider conservatively keeps legacy compatibility available;
- live settings changes narrow/restore the seam without restart;
- disposal restores original Host fetch when outermost, preserves later plugin wrappers, and makes retained gate references inert;
- no request body/header/URL semantics are rewritten by the gate.

Normative removal condition is recorded in `docs/architecture/compat-inventory.md` and the boundary constant:

> Remove when the minimum supported DSH provides a provider-scoped/shared HTTP proxy seam.

### P2-F — COMPLETE / PASS via NO-GO

Written decision: **`NO-GO: retain current scheduler`**.

The 10-item feasibility matrix in `docs/architecture/p2-jobs-feasibility.md` was rechecked against DeepSeek Harness current main `cd5ef8148158c3a752a658978873241fdf8e2bbc` (`dsh@0.1.2-alpha.1`) and its generated Jobs contract.

`ctx.jobs` supplies generic registration/access/cancel/wait/owner+service lifecycle, but not Vision Router's foreground > manual > background priority, live authority narrowing, topology abort, backend fingerprint identity or pre-publish evidence fence. Owned Jobs also add Agent/controller admission assumptions; unowned Jobs avoid them but provide no lifecycle simplification. A migration would therefore wrap rather than replace the existing scheduler logic and fails the implementation-plan GO criteria.

This NO-GO is an explicitly valid successful P2-F outcome under the implementation plan.

## P2 Exit Gate — COMPLETE / PASS

1. **`.runs` under many unknown root entries still fully cleans up — PASS**
   - Added `tests/p2-exit-gate.test.js` with 256 unknown user entries surrounding expired managed runs.
   - Requires complete discovery, removes every expired managed run, and verifies every unknown entry remains untouched.
   - P2 artifact-boundary Node 22 and 24: success.

2. **Active run is never incorrectly deleted — PASS**
   - Exit-gate test applies TTL + maxRuns + maxBytes pressure simultaneously while `retainArtifactRun()` protects the active run.
   - Active run survives; stale inactive run is removed.
   - Existing artifact facade/resource lifecycle tests remain green.

3. **Legacy artifacts can gradually age out — PASS**
   - Exit-gate test proves a legacy direct `.vision-run-*` artifact ages out while the new `.runs` namespace remains untouched.
   - Existing compatibility retention test remains green.

4. **Session resume regressions all pass — PASS**
   - P2 session-surface Node 22/24: success.
   - `Native multimodal cold resume` run `33144129654`: success.
   - SessionVisionIndex, state/integration, #276 ownership and #289 native nonintervention gates all remain green.

5. **Router-owned provider HTTP no longer depends on the global patch — PASS**
   - P2 provider-transport Node 22/24: success.
   - Tests prove Router-owned OpenAI/Anthropic traffic uses `VisionProviderTransport` even with a poisoned legacy/caller fetch.
   - New gate proves Router-only chains bypass the legacy process-global seam and live Host-owned chains can still opt into it conservatively.

6. **Jobs spike has written GO/NO-GO conclusion — PASS**
   - `docs/architecture/p2-jobs-feasibility.md` records the full ten-check matrix and final `NO-GO: retain current scheduler`.
   - P2 jobs-feasibility Node 22/24 reruns current scheduler authority, preemption and lifecycle regressions successfully.

## Final CI evidence on final head

- `P2 Data Boundary` run `33144129658`: **success**
  - artifact-boundary Node 22/24: success
  - session-surface Node 22/24: success
  - provider-transport Node 22/24: success
  - jobs-feasibility Node 22/24: success
- `P1 Routing Parity` run `33144129664`: **success**
- `DSH Contract` run `33144129653`: **success**
- `Native multimodal cold resume` run `33144129654`: **success**
- `CI` run `33144129673`: **success**
  - `test (22)`: success
  - `test (24)`: success
  - DSH rc.6/rc.7/rc.8: success
  - Ubuntu/macOS/Windows host-sharp: success

## Verdict

**P2-E: COMPLETE / PASS**

**P2-F: COMPLETE / PASS (`NO-GO: retain current scheduler`)**

**P2 Exit Gate: COMPLETE / PASS**

After merge, P2 may be marked **GO** once the merged main commit's triggered gates remain green.