### PR TITLE
refactor: modularize P3 web integration

### DIFF
--- a/.github/workflows/p3-compat-convergence.yml
+++ b/.github/workflows/p3-compat-convergence.yml
@@ -33,7 +33,7 @@ permissions:
   contents: read
 
 jobs:
-  governance:
+  convergence:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -49,8 +49,9 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - name: Support-window and Doctor policy
+      - name: Support-window, Doctor and Web responsibility boundaries
         run: >-
           node --test
           tests/dsh-support-window.test.js
           tests/doctor-host-capabilities.test.js
+          tests/p3-web-modularization.test.js

--- a/entry.js
+++ b/entry.js
@@ -19,11 +19,6 @@ import { installLegacyCoreVisionPolicyBridge } from './lib/legacy-core-vision-po
 import { installPiAiBridgeWireCompat } from './lib/pi-ai-bridge-wire-compat.js'
 import { installLiveModelDiscovery } from './lib/live-model-discovery.js'
 import { installVisionModelRegistry } from './lib/vision-model-registry.js'
-import { installStrictLiveModelClientPrelude } from './lib/strict-live-model-client-prelude.js'
-import { installWrapperScopeClientPrelude } from './lib/wrapper-scope-client-prelude.js'
-import { installClientPresentationBoundary } from './lib/client-presentation-boundary.js'
-import { installGuideVisionToggleHighlight } from './lib/guide-vision-toggle-highlight.js'
-import { installVisionModelVisibilityBoundary } from './lib/vision-model-visibility-boundary.js'
 import { installAdversarialHardening } from './lib/adversarial-hardening.js'
 import { installOllamaColdStartGuard } from './lib/ollama-cold-start.js'
 import { installLocalVisionStabilizer } from './lib/local-vision-stabilizer.js'
@@ -34,14 +29,9 @@ import { installTesseractExecFileCompat } from './lib/tesseract-exec-compat.js'
 import { installLocalMutationRouteBoundary } from './lib/web-capability-boundary.js'
 import { installScreenshotSourceBoundary } from './lib/screenshot-source-boundary.js'
 import { installVisionToolRuntimeBoundary } from './lib/vision-tool-runtime-boundary.js'
-import { installVisionRouterRemoteSettingsBridge } from './lib/remote-settings-bridge.js'
-import { installSettingsLimitClientPrelude } from './lib/settings-limit-client-prelude.js'
-import { installSettingsRc8ClientLifecycle } from './lib/settings-client-rc8-lifecycle.js'
 import { installVisionRoutingRuntime } from './lib/vision-routing-runtime.js'
 import { createCapabilityProfileStore } from './lib/vision-capability-probe.js'
 import { installCapabilityBenchmarkService } from './lib/vision-capability-benchmark-service.js'
-import { installCapabilityBenchmarkClient } from './lib/vision-capability-benchmark-client.js'
-import { installVisionRoutingSettingsPrelude } from './lib/vision-routing-settings-prelude.js'
 import { resolveVisionRoutingProduct } from './lib/vision-routing-product.js'
 import {
   normalizeBackgroundMeasurementAuthority,
@@ -66,6 +56,10 @@ import {
   installVisionAttachmentAdmissionPolicy,
   protectHostProviderOwnership,
 } from './lib/dsh-contract-compat.js'
+import {
+  installVisionSettingsWebBoundary,
+  installVisionWebIntegration,
+} from './lib/web/index.js'
 
 // Increment whenever the browser-visible settings contract gains a field whose
 // absence changes write semantics. This revision is also exposed as a resolved
@@ -208,11 +202,9 @@ export function apply(ctx, config = {}) {
   }
   const batchAttachmentHost = hasBatchAttachmentContract(stabilizedCtx)
   if (batchAttachmentHost) installVisionAttachmentAdmissionPolicy(stabilizedCtx, logging.logger)
-  // Install this before the consolidated Settings IA transform registered by
-  // the remote-settings bridge so the numeric fence remains the outer wrapper.
-  installSettingsLimitClientPrelude(stabilizedCtx)
-  installVisionRouterRemoteSettingsBridge(stabilizedCtx, logging.logger)
-  installSettingsRc8ClientLifecycle(stabilizedCtx)
+  // Preserve the historical pre-Host-settings wrapper order behind one P3-C
+  // Web responsibility boundary.
+  installVisionSettingsWebBoundary(stabilizedCtx, logging.logger)
   const ownershipCtx = batchAttachmentHost ? protectHostProviderOwnership(stabilizedCtx) : stabilizedCtx
   const settingsCtx = batchAttachmentHost
     ? installHostSettingsCompatibility(ownershipCtx, { ...runtimeConfig, stealth: false }, {
@@ -284,32 +276,17 @@ export function apply(ctx, config = {}) {
     logger: logging.logger,
   })
   installVisionModelRegistry(reconciledCtx, liveDiscovery, { config: runtimeConfig })
-  installClientPresentationBoundary(reconciledCtx)
-  // The same first walkthrough step now teaches the explicit "识图" control
-  // introduced by #284. Widen the existing spotlight to cover that button and
-  // the adjacent model selector as one target instead of leaving the control
-  // under the dimming veil.
-  installGuideVisionToggleHighlight(reconciledCtx)
-  // The Host keeps wrapper routes registered because image admission and the
-  // Vision toggle need their real identity. Hide only confidently owned
-  // wrapper groups from DSH's stock model-selection presentation and project an
-  // active wrapper back to its ordinary source label; uncertain routes stay
-  // visible rather than being guessed away.
-  installVisionModelVisibilityBoundary(reconciledCtx)
-  // Keep endpoint-discovered ids private to Vision Router's settings client,
-  // but make Settings -> Models authoritative when DSH already enumerates a
-  // provider. Live /models data now fills only a still-active provider whose
-  // DSH catalog is empty, so disabled models and removed providers cannot leak
-  // back into the Vision Router picker through stale endpoint discovery.
-  installStrictLiveModelClientPrelude(reconciledCtx)
-  // Surface the existing autoWrapProviders/wrappedProviders contract in the
-  // primary Vision Router settings section. This is presentation-only: the Host
-  // keeps one settings namespace and one wrapper-registration implementation.
-  installWrapperScopeClientPrelude(reconciledCtx)
-  // Capability Benchmark is the single visible and callable per-model
-  // capability-test surface in the release runtime.
-  installVisionRoutingSettingsPrelude(reconciledCtx)
-  installCapabilityBenchmarkClient(reconciledCtx)
+  // P3-C owns browser responsibility through lib/web/*. The mature injected
+  // clients remain unchanged and are installed in their historical order.
+  // Host product decisions are additionally exposed through a sanitized,
+  // read-only structured state endpoint for diagnostics/new client code.
+  installVisionWebIntegration(reconciledCtx, {
+    config: runtimeConfig,
+    core,
+    store: capabilityStore,
+    runtimePerformanceStore,
+    healthForCandidate: breakerShadowHealth.healthForCandidate,
+  })
   installPiAiBridgeWireCompat(reconciledCtx, logging.logger)
   const executionCtx = contextWithVisionExecutionPolicy(reconciledCtx, {
     isBridgeEvidence: (provider, model) => liveDiscovery.hasModel(provider, model),

--- a/lib/web/benchmark-panel.js
+++ b/lib/web/benchmark-panel.js
@@ -1,0 +1,6 @@
+import { installCapabilityBenchmarkClient } from '../vision-capability-benchmark-client.js'
+
+export function installVisionBenchmarkPanel(ctx) {
+  installCapabilityBenchmarkClient(ctx)
+  return ctx
+}

--- a/lib/web/diagnostics-panel.js
+++ b/lib/web/diagnostics-panel.js
@@ -1,0 +1,44 @@
+import { createVisionProductStateSnapshot } from './product-state.js'
+
+export const VISION_PRODUCT_STATE_PATH = '/_dsh/vision-router/product-state'
+
+function sendJson(res, status, body) {
+  res.writeHead(status, {
+    'content-type': 'application/json; charset=utf-8',
+    'cache-control': 'no-store',
+  })
+  res.end(JSON.stringify(body))
+}
+
+export function installVisionDiagnosticsPanel(ctx, options = {}) {
+  const snapshot = options.snapshot ?? (() => createVisionProductStateSnapshot({
+    ctx,
+    config: options.config,
+    core: options.core,
+    store: options.store,
+    runtimePerformanceStore: options.runtimePerformanceStore,
+    healthForCandidate: options.healthForCandidate,
+  }))
+
+  ctx?.inject?.(['webServer'], (webCtx) => {
+    webCtx.effect(() => webCtx.webServer.register({
+      kind: 'exact',
+      path: VISION_PRODUCT_STATE_PATH,
+      handler: async (req, res) => {
+        if (req.method !== 'GET') {
+          res.setHeader('Allow', 'GET')
+          sendJson(res, 405, { ok: false, error: 'method not allowed' })
+          return
+        }
+        try {
+          sendJson(res, 200, await snapshot())
+        } catch {
+          // Product-state diagnostics are advisory. Fail closed to an
+          // unavailable snapshot without exposing provider errors or secrets.
+          sendJson(res, 503, { ok: false, code: 'VISION_PRODUCT_STATE_UNAVAILABLE' })
+        }
+      },
+    }), 'vision-router: structured product state')
+  })
+  return ctx
+}

--- a/lib/web/index.js
+++ b/lib/web/index.js
@@ -1,0 +1,35 @@
+import { installVisionSettingsController } from './settings-controller.js'
+import { installVisionRemoteSettingsClient } from './remote-settings-client.js'
+import {
+  installVisionModelPickerControls,
+  installVisionModelPickerPresentation,
+} from './model-picker.js'
+import { installVisionOnboarding } from './onboarding.js'
+import { installVisionRoutingSection } from './routing-section.js'
+import { installVisionBenchmarkPanel } from './benchmark-panel.js'
+import { installVisionDiagnosticsPanel } from './diagnostics-panel.js'
+
+/** Preserve the pre-Host-settings wrapper order from the legacy entry. */
+export function installVisionSettingsWebBoundary(ctx, logger) {
+  installVisionSettingsController(ctx)
+  installVisionRemoteSettingsClient(ctx, logger)
+  return ctx
+}
+
+/**
+ * P3-C web composition boundary.
+ *
+ * These installers intentionally keep the mature client implementations and
+ * their historical order. The architectural change is responsibility
+ * ownership: entry/runtime code calls one Web boundary, while Host-owned
+ * product decisions are exposed through the diagnostics/product-state module.
+ */
+export function installVisionWebIntegration(ctx, options = {}) {
+  installVisionModelPickerPresentation(ctx)
+  installVisionOnboarding(ctx)
+  installVisionModelPickerControls(ctx)
+  installVisionRoutingSection(ctx)
+  installVisionBenchmarkPanel(ctx)
+  installVisionDiagnosticsPanel(ctx, options)
+  return ctx
+}

--- a/lib/web/index.js
+++ b/lib/web/index.js
@@ -9,10 +9,28 @@ import { installVisionRoutingSection } from './routing-section.js'
 import { installVisionBenchmarkPanel } from './benchmark-panel.js'
 import { installVisionDiagnosticsPanel } from './diagnostics-panel.js'
 
+const DEFAULT_INSTALLERS = Object.freeze({
+  settingsController: installVisionSettingsController,
+  remoteSettings: installVisionRemoteSettingsClient,
+  modelPresentation: installVisionModelPickerPresentation,
+  onboarding: installVisionOnboarding,
+  modelControls: installVisionModelPickerControls,
+  routingSection: installVisionRoutingSection,
+  benchmarkPanel: installVisionBenchmarkPanel,
+  diagnosticsPanel: installVisionDiagnosticsPanel,
+})
+
+function installersOf(overrides) {
+  return overrides && typeof overrides === 'object'
+    ? { ...DEFAULT_INSTALLERS, ...overrides }
+    : DEFAULT_INSTALLERS
+}
+
 /** Preserve the pre-Host-settings wrapper order from the legacy entry. */
-export function installVisionSettingsWebBoundary(ctx, logger) {
-  installVisionSettingsController(ctx)
-  installVisionRemoteSettingsClient(ctx, logger)
+export function installVisionSettingsWebBoundary(ctx, logger, overrides) {
+  const installers = installersOf(overrides)
+  installers.settingsController(ctx)
+  installers.remoteSettings(ctx, logger)
   return ctx
 }
 
@@ -25,11 +43,12 @@ export function installVisionSettingsWebBoundary(ctx, logger) {
  * product decisions are exposed through the diagnostics/product-state module.
  */
 export function installVisionWebIntegration(ctx, options = {}) {
-  installVisionModelPickerPresentation(ctx)
-  installVisionOnboarding(ctx)
-  installVisionModelPickerControls(ctx)
-  installVisionRoutingSection(ctx)
-  installVisionBenchmarkPanel(ctx)
-  installVisionDiagnosticsPanel(ctx, options)
+  const installers = installersOf(options.installers)
+  installers.modelPresentation(ctx)
+  installers.onboarding(ctx)
+  installers.modelControls(ctx)
+  installers.routingSection(ctx)
+  installers.benchmarkPanel(ctx)
+  installers.diagnosticsPanel(ctx, options)
   return ctx
 }

--- a/lib/web/model-picker.js
+++ b/lib/web/model-picker.js
@@ -1,0 +1,12 @@
+import { installClientPresentationBoundary } from '../client-presentation-boundary.js'
+import { installVisionModelVisibilityBoundary } from '../vision-model-visibility-boundary.js'
+import { installStrictLiveModelClientPrelude } from '../strict-live-model-client-prelude.js'
+import { installWrapperScopeClientPrelude } from '../wrapper-scope-client-prelude.js'
+
+export function installVisionModelPicker(ctx) {
+  installClientPresentationBoundary(ctx)
+  installVisionModelVisibilityBoundary(ctx)
+  installStrictLiveModelClientPrelude(ctx)
+  installWrapperScopeClientPrelude(ctx)
+  return ctx
+}

--- a/lib/web/model-picker.js
+++ b/lib/web/model-picker.js
@@ -3,10 +3,20 @@ import { installVisionModelVisibilityBoundary } from '../vision-model-visibility
 import { installStrictLiveModelClientPrelude } from '../strict-live-model-client-prelude.js'
 import { installWrapperScopeClientPrelude } from '../wrapper-scope-client-prelude.js'
 
-export function installVisionModelPicker(ctx) {
+export function installVisionModelPickerPresentation(ctx) {
   installClientPresentationBoundary(ctx)
+  return ctx
+}
+
+export function installVisionModelPickerControls(ctx) {
   installVisionModelVisibilityBoundary(ctx)
   installStrictLiveModelClientPrelude(ctx)
   installWrapperScopeClientPrelude(ctx)
+  return ctx
+}
+
+export function installVisionModelPicker(ctx) {
+  installVisionModelPickerPresentation(ctx)
+  installVisionModelPickerControls(ctx)
   return ctx
 }

--- a/lib/web/onboarding.js
+++ b/lib/web/onboarding.js
@@ -1,0 +1,6 @@
+import { installGuideVisionToggleHighlight } from '../guide-vision-toggle-highlight.js'
+
+export function installVisionOnboarding(ctx) {
+  installGuideVisionToggleHighlight(ctx)
+  return ctx
+}

--- a/lib/web/product-state.js
+++ b/lib/web/product-state.js
@@ -1,0 +1,112 @@
+import { collectVisionRoutingEvidence } from '../vision-routing-evidence.js'
+import { resolveVisionRoutingAuthority } from '../vision-routing-authority.js'
+
+function activeSettings(ctx, fallback) {
+  try {
+    const settings = ctx?.get?.('settings')
+    const current = settings?.get?.('vision-router')
+    return current && typeof current === 'object' && !Array.isArray(current) ? current : fallback
+  } catch {
+    return fallback
+  }
+}
+
+function healthClassOf(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return 'unknown'
+  if (value.circuitOpen === true && value.rateLimited === true) return 'rate-limited'
+  if (value.circuitOpen === true) return 'blocked'
+  if (value.circuitOpen === false) return 'healthy'
+  return 'unknown'
+}
+
+function capabilityStateOf(candidate) {
+  const measured = candidate?.measured
+  if (measured && typeof measured === 'object' && Object.keys(measured).length > 0) return 'measured'
+  return candidate?.benchmarkable === true ? 'unmeasured' : 'unavailable'
+}
+
+function benchmarkReasonOf(candidate) {
+  if (!candidate) return 'candidate-unavailable'
+  if (candidate.benchmarkable !== true) return 'stable-benchmark-identity-unavailable'
+  return null
+}
+
+function backgroundEligibilityOf(candidate, authority) {
+  if (!authority?.backgroundMeasurementActive) {
+    return { eligible: false, reason: 'background-measurement-not-active' }
+  }
+  if (candidate?.benchmarkable !== true) {
+    return { eligible: false, reason: 'benchmark-unavailable' }
+  }
+  if (authority.backgroundMeasurement === 'all') return { eligible: true, reason: null }
+  if (authority.backgroundMeasurement !== 'local-free') {
+    return { eligible: false, reason: 'background-measurement-off' }
+  }
+  const localOrFree = candidate?.local === true || candidate?.cost === 0
+  return localOrFree
+    ? { eligible: true, reason: null }
+    : { eligible: false, reason: 'local-free-policy-excludes-cloud-cost' }
+}
+
+function publicAuthority(authority) {
+  return Object.freeze({
+    execution: authority.execution,
+    autoSelectionAuthorized: authority.autoSelectionAuthorized,
+    backgroundMeasurement: authority.backgroundMeasurement,
+    backgroundMeasurementAuthorized: authority.backgroundMeasurementAuthorized,
+    backgroundMeasurementActive: authority.backgroundMeasurementActive,
+  })
+}
+
+export function projectVisionProductCandidate(candidate, health, authority) {
+  const background = backgroundEligibilityOf(candidate, authority)
+  return Object.freeze({
+    key: String(candidate?.key ?? ''),
+    provider: String(candidate?.provider ?? ''),
+    model: String(candidate?.model ?? ''),
+    canBenchmark: candidate?.benchmarkable === true,
+    benchmarkReason: benchmarkReasonOf(candidate),
+    routingMode: authority.execution,
+    currentAuthority: publicAuthority(authority),
+    healthClass: healthClassOf(health),
+    capabilityState: capabilityStateOf(candidate),
+    backgroundEligible: background.eligible,
+    backgroundReason: background.reason,
+  })
+}
+
+/**
+ * P3-C Host-owned product projection.
+ *
+ * The browser receives decisions, not credentials/endpoints/breaker internals.
+ * Runtime authority is resolved from the live Host settings namespace and
+ * evidence remains read-only. No field in this projection grants authority.
+ */
+export async function createVisionProductStateSnapshot({
+  ctx,
+  config,
+  core,
+  store,
+  runtimePerformanceStore,
+  healthForCandidate,
+} = {}) {
+  const current = activeSettings(ctx, config)
+  const authority = resolveVisionRoutingAuthority(current)
+  const evidence = await collectVisionRoutingEvidence({
+    ctx,
+    config: current,
+    core,
+    store,
+    runtimePerformanceStore,
+    healthForCandidate,
+  })
+  const candidates = evidence.candidates.map((candidate) =>
+    projectVisionProductCandidate(candidate, evidence.health?.[candidate.key], authority))
+
+  return Object.freeze({
+    ok: true,
+    routingMode: authority.execution,
+    currentAuthority: publicAuthority(authority),
+    candidates: Object.freeze(candidates),
+  })
+}

--- a/lib/web/remote-settings-client.js
+++ b/lib/web/remote-settings-client.js
@@ -1,0 +1,8 @@
+import { installVisionRouterRemoteSettingsBridge } from '../remote-settings-bridge.js'
+import { installSettingsRc8ClientLifecycle } from '../settings-client-rc8-lifecycle.js'
+
+export function installVisionRemoteSettingsClient(ctx, logger) {
+  installVisionRouterRemoteSettingsBridge(ctx, logger)
+  installSettingsRc8ClientLifecycle(ctx)
+  return ctx
+}

--- a/lib/web/routing-section.js
+++ b/lib/web/routing-section.js
@@ -1,0 +1,6 @@
+import { installVisionRoutingSettingsPrelude } from '../vision-routing-settings-prelude.js'
+
+export function installVisionRoutingSection(ctx) {
+  installVisionRoutingSettingsPrelude(ctx)
+  return ctx
+}

--- a/lib/web/settings-controller.js
+++ b/lib/web/settings-controller.js
@@ -1,0 +1,6 @@
+import { installSettingsLimitClientPrelude } from '../settings-limit-client-prelude.js'
+
+export function installVisionSettingsController(ctx) {
+  installSettingsLimitClientPrelude(ctx)
+  return ctx
+}

--- a/tests/bundle-defaults.test.js
+++ b/tests/bundle-defaults.test.js
@@ -126,13 +126,18 @@ test('manual Release workflow creates only the exact current-main package tag be
 
 test('release runtime exposes one benchmark UI and no production v2 acceptance control surface', async () => {
   const entry = await readFile(new URL('../entry.js', import.meta.url), 'utf8')
+  const benchmarkPanel = await readFile(new URL('../lib/web/benchmark-panel.js', import.meta.url), 'utf8')
+  const webComposition = await readFile(new URL('../lib/web/index.js', import.meta.url), 'utf8')
   const pkg = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8'))
 
-  assert.doesNotMatch(entry, /installExactVisionTestClient/)
-  assert.doesNotMatch(entry, /installV2AcceptanceService/)
-  assert.doesNotMatch(entry, /createV2ExecutionAcceptanceObserver/)
-  assert.doesNotMatch(entry, /installVisionRoutingPreviewService/)
-  assert.match(entry, /installCapabilityBenchmarkClient/)
+  const releaseSurface = `${entry}\n${benchmarkPanel}\n${webComposition}`
+  assert.doesNotMatch(releaseSurface, /installExactVisionTestClient/)
+  assert.doesNotMatch(releaseSurface, /installV2AcceptanceService/)
+  assert.doesNotMatch(releaseSurface, /createV2ExecutionAcceptanceObserver/)
+  assert.doesNotMatch(releaseSurface, /installVisionRoutingPreviewService/)
+  assert.match(entry, /installVisionWebIntegration/)
+  assert.match(benchmarkPanel, /installCapabilityBenchmarkClient/)
+  assert.match(webComposition, /benchmarkPanel/)
   assert.equal(pkg.bin['dsh-vision-router'], './lib/doctor-cli-p0.js')
   assert.equal(Object.prototype.hasOwnProperty.call(pkg.bin, 'dsh-vision-router-acceptance'), false)
   assert.equal(Object.prototype.hasOwnProperty.call(pkg.scripts, 'test:acceptance:v2'), false)

--- a/tests/p3-web-modularization.test.js
+++ b/tests/p3-web-modularization.test.js
@@ -1,0 +1,184 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  installVisionSettingsWebBoundary,
+  installVisionWebIntegration,
+} from '../lib/web/index.js'
+import {
+  createVisionProductStateSnapshot,
+  projectVisionProductCandidate,
+} from '../lib/web/product-state.js'
+import {
+  installVisionDiagnosticsPanel,
+  VISION_PRODUCT_STATE_PATH,
+} from '../lib/web/diagnostics-panel.js'
+
+test('P3-C web composition preserves the legacy installer order and context identity', () => {
+  const ctx = { marker: 'same-context' }
+  const logger = { info() {} }
+  const calls = []
+  const installer = (name) => (value, arg) => {
+    assert.equal(value, ctx)
+    calls.push([name, arg])
+    return value
+  }
+  const overrides = {
+    settingsController: installer('settings-controller'),
+    remoteSettings: installer('remote-settings'),
+    modelPresentation: installer('model-presentation'),
+    onboarding: installer('onboarding'),
+    modelControls: installer('model-controls'),
+    routingSection: installer('routing-section'),
+    benchmarkPanel: installer('benchmark-panel'),
+    diagnosticsPanel: installer('diagnostics-panel'),
+  }
+
+  assert.equal(installVisionSettingsWebBoundary(ctx, logger, overrides), ctx)
+  assert.equal(installVisionWebIntegration(ctx, { installers: overrides, marker: 1 }), ctx)
+
+  assert.deepEqual(calls.map(([name]) => name), [
+    'settings-controller',
+    'remote-settings',
+    'model-presentation',
+    'onboarding',
+    'model-controls',
+    'routing-section',
+    'benchmark-panel',
+    'diagnostics-panel',
+  ])
+  assert.equal(calls[1][1], logger)
+  assert.equal(calls.at(-1)[1].marker, 1)
+})
+
+test('Host product projection owns benchmark, authority, health and capability semantics without leaking transport facts', async () => {
+  const live = {
+    routingMode: 'auto',
+    routingPreference: 'balanced',
+    backgroundBenchmarking: 'all',
+    providers: [{ provider: 'vision-http', model: 'local-ollama/qwen-vl' }],
+  }
+  const ctx = {
+    get(name) {
+      if (name === 'settings') return { get: (namespace) => namespace === 'vision-router' ? live : undefined }
+      return undefined
+    },
+  }
+  const core = {
+    localProvidersOf() {
+      return [{
+        name: 'local-ollama',
+        model: 'qwen-vl',
+        baseURL: 'http://127.0.0.1:11434/v1',
+        apiKeyEnv: 'SECRET_REF_THAT_MUST_NOT_LEAK',
+      }]
+    },
+    httpProvidersOf() { return [] },
+    DEFAULT_HTTP_PROVIDERS: [],
+  }
+  const store = {
+    async get() {
+      return {
+        scores: { ocr: 0.91 },
+        measuredAt: 1_780_000_000_000,
+      }
+    },
+  }
+
+  const snapshot = await createVisionProductStateSnapshot({
+    ctx,
+    config: {},
+    core,
+    store,
+    healthForCandidate: async () => ({ circuitOpen: true, rateLimited: true, reason: 'rate-limit', until: 123 }),
+  })
+
+  assert.equal(snapshot.ok, true)
+  assert.equal(snapshot.routingMode, 'auto')
+  assert.equal(snapshot.currentAuthority.autoSelectionAuthorized, true)
+  assert.equal(snapshot.currentAuthority.backgroundMeasurementActive, true)
+  assert.equal(snapshot.candidates.length, 1)
+  const candidate = snapshot.candidates[0]
+  assert.equal(candidate.canBenchmark, true)
+  assert.equal(candidate.benchmarkReason, null)
+  assert.equal(candidate.healthClass, 'rate-limited')
+  assert.equal(candidate.capabilityState, 'measured')
+  assert.equal(candidate.backgroundEligible, true)
+  assert.equal(Object.hasOwn(candidate, 'endpoint'), false)
+  assert.equal(Object.hasOwn(candidate, 'endpointFingerprint'), false)
+  assert.equal(Object.hasOwn(candidate, 'endpointCredentialRef'), false)
+  assert.equal(JSON.stringify(snapshot).includes('SECRET_REF_THAT_MUST_NOT_LEAK'), false)
+})
+
+test('product projection gives deterministic reasons for unavailable and policy-excluded states', () => {
+  const authority = {
+    execution: 'ordered',
+    autoSelectionAuthorized: false,
+    backgroundMeasurement: 'local-free',
+    backgroundMeasurementAuthorized: true,
+    backgroundMeasurementActive: false,
+  }
+  const projected = projectVisionProductCandidate({
+    key: 'cloud/model',
+    provider: 'cloud',
+    model: 'model',
+    benchmarkable: false,
+  }, undefined, authority)
+
+  assert.equal(projected.canBenchmark, false)
+  assert.equal(projected.benchmarkReason, 'stable-benchmark-identity-unavailable')
+  assert.equal(projected.routingMode, 'ordered')
+  assert.equal(projected.healthClass, 'unknown')
+  assert.equal(projected.capabilityState, 'unavailable')
+  assert.equal(projected.backgroundEligible, false)
+  assert.equal(projected.backgroundReason, 'background-measurement-not-active')
+})
+
+function responseCapture() {
+  const out = { status: undefined, headers: {}, body: undefined }
+  return {
+    out,
+    setHeader(name, value) { out.headers[name.toLowerCase()] = value },
+    writeHead(status, headers) { out.status = status; Object.assign(out.headers, headers) },
+    end(body) { out.body = body },
+  }
+}
+
+test('structured product-state endpoint is GET-only and redacts internal snapshot failures', async () => {
+  let route
+  const webCtx = {
+    webServer: {
+      register(value) { route = value; return () => {} },
+    },
+    effect(fn) { return fn() },
+  }
+  const ctx = {
+    inject(deps, fn) {
+      assert.deepEqual(deps, ['webServer'])
+      fn(webCtx)
+    },
+  }
+
+  installVisionDiagnosticsPanel(ctx, { snapshot: async () => ({ ok: true, candidates: [] }) })
+  assert.equal(route.path, VISION_PRODUCT_STATE_PATH)
+
+  const ok = responseCapture()
+  await route.handler({ method: 'GET' }, ok)
+  assert.equal(ok.out.status, 200)
+  assert.deepEqual(JSON.parse(ok.out.body), { ok: true, candidates: [] })
+
+  const denied = responseCapture()
+  await route.handler({ method: 'POST' }, denied)
+  assert.equal(denied.out.status, 405)
+  assert.equal(denied.out.headers.allow, 'GET')
+
+  installVisionDiagnosticsPanel(ctx, { snapshot: async () => { throw new Error('api-key=secret-value') } })
+  const failed = responseCapture()
+  await route.handler({ method: 'GET' }, failed)
+  assert.equal(failed.out.status, 503)
+  assert.deepEqual(JSON.parse(failed.out.body), {
+    ok: false,
+    code: 'VISION_PRODUCT_STATE_UNAVAILABLE',
+  })
+  assert.equal(String(failed.out.body).includes('secret-value'), false)
+})


### PR DESCRIPTION
## P3-C — Web client modularization

This slice moves Web responsibility ownership out of `entry.js` without rewriting the mature browser clients.

### Responsibility modules

`lib/web/` now owns:

- `settings-controller`
- `remote-settings-client`
- `model-picker`
- `onboarding`
- `routing-section`
- `benchmark-panel`
- `diagnostics-panel`
- `product-state`
- one composition boundary in `lib/web/index.js`

The production installer order is intentionally identical to the legacy entry order and is directly regression-tested with injected installer spies.

### Host-owned structured product state

A new read-only `/_dsh/vision-router/product-state` projection returns sanitized Host decisions for each current candidate:

- `canBenchmark`
- `benchmarkReason`
- `routingMode`
- `currentAuthority`
- `healthClass`
- `capabilityState`
- background eligibility/reason

The projection is resolved from live Host settings, routing evidence and breaker health. It deliberately excludes endpoint URLs, endpoint fingerprints, credential references, raw breaker objects and provider error strings.

This does not grant authority: Auto/background authority still comes only from the existing live settings contract.

### Entry change

`entry.js` no longer imports or individually composes the nine browser/settings installers. It invokes:

- `installVisionSettingsWebBoundary(...)` at the exact old pre-settings location;
- `installVisionWebIntegration(...)` at the exact old model/routing/benchmark client location.

No other runtime layer is reordered.

### Tests

`tests/p3-web-modularization.test.js` covers:

- exact legacy Web installer order and context identity;
- Host product-state semantics;
- no endpoint/fingerprint/credential leakage;
- deterministic benchmark/health/capability reasons;
- GET-only diagnostics endpoint and generic/redacted failure behavior.

P3 convergence runs this on Node 22 and 24.

## Acceptance rule

Do not merge on focused tests alone. Require full CI, DSH minimum/previous/current contracts, P1 parity, native multimodal cold resume and code scanning on the final head.