### PR TITLE
refactor: complete P3 entry composition cleanup

### DIFF
--- a/.github/workflows/p3-compat-convergence.yml
+++ b/.github/workflows/p3-compat-convergence.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     paths:
       - 'entry.js'
+      - 'README.md'
+      - 'README.zh.md'
       - 'lib/dsh-support-window.js'
       - 'lib/doctor-cli-p0.js'
       - 'lib/web/**'
@@ -18,6 +20,8 @@ on:
     branches: [main]
     paths:
       - 'entry.js'
+      - 'README.md'
+      - 'README.zh.md'
       - 'lib/dsh-support-window.js'
       - 'lib/doctor-cli-p0.js'
       - 'lib/web/**'
@@ -49,9 +53,10 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - name: Support-window, Doctor and Web responsibility boundaries
+      - name: Support-window, Doctor, Web and final composition boundaries
         run: >-
           node --test
           tests/dsh-support-window.test.js
           tests/doctor-host-capabilities.test.js
           tests/p3-web-modularization.test.js
+          tests/p3-entry-composition.test.js

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Any of these channels can join the vision chain as an `httpProviders` entry (key
 - **Original pixels, real answers.** The vision chain reads the image at original resolution (auto-downscaled only to protect latency/quota); the agent's question travels with the image, so answers are about *your* question, not a generic description.
 - **Automatic failover with classified errors.** Region blocks, ToS filtering, 402 quota, 429 rate limits, context overflow, network failures — the chain walks providers one by one and only reports after all of them failed, with actionable advice. A 429 immediately advances to the next backend and opens a Retry-After-aware cooldown instead of sleeping inside the request.
 - **Image memory.** Vision answers are cached by attachment content hash; later text turns substitute the recorded description (marked as untrusted evidence), so DeepSeek genuinely remembers earlier images without re-spending vision calls.
-- **A verifiable pixel loop.** Reference → `vision_html_screenshot` → `vision_pixel_diff` (ratio + red heatmap + worst-region ranking) → fix → repeat until the mismatch converges. UI restoration becomes measurable instead of eyeballed.
+- **A verifiable pixel loop.** Reference → `vision_html_screenshot` → `vision_pixel_diff` (ratio + worst 8×8-grid regions) → fix → repeat until the mismatch converges. UI restoration becomes measurable instead of eyeballed.
 - **Stable tool schema.** All fourteen deep tools are registered from session start by default, avoiding a mid-conversation tool-list expansion that can invalidate long-context KV/prefix caches. `progressiveTools: true` remains an advanced boot-time opt-in; only then does `vision_activate` mount the tools on demand. See [`docs/progressive-tools-cache.md`](docs/progressive-tools-cache.md).
 - **Selective proxy.** Only the configured vision provider hosts go through your local proxy; DeepSeek stays direct.
 
@@ -410,6 +410,7 @@ ollama pull qwen2.5vl
 ## Requirements
 
 - DeepSeek Harness Web profile. Normal installs can use `npx @deepseek-ai/dsh ...`; source checkouts use `pnpm dsh ...`. A bare `dsh ...` command only works when the CLI is already on your shell `PATH`.
+- **DSH Host support window:** DVR 2.0.x supports DSH `0.1.0-rc.6` (minimum), `0.1.0-rc.8` (previous train), and current `0.1.1-rc.2`. DVR 2.1.0 is the announced boundary that may raise the minimum to `0.1.0-rc.8`; a 2.0.x patch will not silently raise the Host floor. See [DSH Host support window](docs/architecture/dsh-support-window.md).
 - Node ≥ 22 (host side).
 - No API key for the default free chain; a credential reference (`apiKeyEnv`) only for paid `httpProviders`.
 - Chrome / Chromium / Edge is needed only for `vision_html_screenshot`; every other tool works without a browser.

--- a/README.zh.md
+++ b/README.zh.md
@@ -408,6 +408,7 @@ ollama pull qwen2.5vl
 ## 环境要求
 
 - DeepSeek Harness 的 Web profile。普通安装可用 `npx @deepseek-ai/dsh ...`；从源码仓库运行时用 `pnpm dsh ...`。只有 CLI 已经进入系统 `PATH` 时才能直接写 `dsh ...`。
+- **DSH Host 支持窗口：** DVR 2.0.x 支持 DSH `0.1.0-rc.6`（最低）、`0.1.0-rc.8`（上一支持线）以及当前 `0.1.1-rc.2`。DVR 2.1.0 是已公告、允许把最低 Host 提升到 `0.1.0-rc.8` 的边界；2.0.x 补丁版本不会静默提高最低 Host。详见 [DSH Host 支持窗口](docs/architecture/dsh-support-window.md)。
 - Node ≥ 22（宿主侧）。
 - 默认免费链路无需 API Key；付费 `httpProviders` 只需一个凭据引用（`apiKeyEnv`）。
 - 只有 `vision_html_screenshot` 需要 Chrome / Chromium / Edge；其余工具无浏览器也能用。

--- a/entry.js
+++ b/entry.js
@@ -1,65 +1,11 @@
 // Public plugin entrypoint.
 //
-// Keep the large implementation in index.js, but normalize the progressive
-// tools switch here before Cordis reads the exported Config. Issue #81 showed
-// that changing the tool schema mid-session can invalidate provider prefix/KV
-// caches for very long conversations, so progressive exposure is now an
-// explicit opt-in rather than the implicit fallback.
+// P3-F keeps this file as the public schema/export boundary. Runtime ownership
+// lives in lib/runtime-composition.js; the mature core remains in index.js.
 
 import z from '@deepseek-ai/schemastery'
 import * as core from './index.js'
-import { installVisionRouterFileLogging } from './lib/file-logger.js'
-import { contextWithDelegatedReplay } from './lib/replay-delegation.js'
-import { contextWithReplayEnvelopeV2Compat } from './lib/replay-envelope-v2-compat.js'
-import { contextWithVisionExecutionPolicy } from './lib/vision-execution-policy.js'
-import { contextWithVisionBackendRuntimePolicy } from './lib/vision-backend-runtime-policy.js'
-import { contextWithNativeImageCoexistence } from './lib/native-image-coexistence.js'
-import { installSessionVisionIndexBoundary } from './lib/session-vision-index.js'
-import { installLegacyCoreVisionPolicyBridge } from './lib/legacy-core-vision-policy-bridge.js'
-import { installPiAiBridgeWireCompat } from './lib/pi-ai-bridge-wire-compat.js'
-import { installLiveModelDiscovery } from './lib/live-model-discovery.js'
-import { installVisionModelRegistry } from './lib/vision-model-registry.js'
-import { installAdversarialHardening } from './lib/adversarial-hardening.js'
-import { installOllamaColdStartGuard } from './lib/ollama-cold-start.js'
-import { installLocalVisionStabilizer } from './lib/local-vision-stabilizer.js'
-import { installWrapperDirectoryAlias } from './lib/wrapper-directory.js'
-import { installAndroidAttachmentCompat } from './lib/android-attachment-compat.js'
-import { contextWithCoalescedAdapterUpdates } from './lib/adapter-update-coalescer.js'
-import { installTesseractExecFileCompat } from './lib/tesseract-exec-compat.js'
-import { installLocalMutationRouteBoundary } from './lib/web-capability-boundary.js'
-import { installScreenshotSourceBoundary } from './lib/screenshot-source-boundary.js'
-import { installVisionToolRuntimeBoundary } from './lib/vision-tool-runtime-boundary.js'
-import { installVisionRoutingRuntime } from './lib/vision-routing-runtime.js'
-import { createCapabilityProfileStore } from './lib/vision-capability-probe.js'
-import { installCapabilityBenchmarkService } from './lib/vision-capability-benchmark-service.js'
-import { resolveVisionRoutingProduct } from './lib/vision-routing-product.js'
-import {
-  normalizeBackgroundMeasurementAuthority,
-  resolveVisionRoutingAuthority,
-} from './lib/vision-routing-authority.js'
-import { withVisionCircuitBreakerObserver } from './lib/vision-breaker-observer.js'
-import { createVisionBreakerShadowHealth } from './lib/vision-breaker-shadow-health.js'
-import { installBackgroundCapabilityProfiling } from './lib/vision-background-benchmark.js'
-import {
-  contextWithVisionRuntimePerformance,
-  createVisionRuntimePerformanceStore,
-} from './lib/vision-runtime-performance.js'
-import {
-  installStructuredFlowHardening,
-  normalizeGuidanceOverrides,
-} from './lib/structured-flow-hardening.js'
-import { installVisionLimitDiagnostics } from './lib/vision-limit-diagnostics.js'
-import {
-  attachmentContextForContract,
-  hasBatchAttachmentContract,
-  installHostSettingsCompatibility,
-  installVisionAttachmentAdmissionPolicy,
-  protectHostProviderOwnership,
-} from './lib/dsh-contract-compat.js'
-import {
-  installVisionSettingsWebBoundary,
-  installVisionWebIntegration,
-} from './lib/web/index.js'
+import { applyVisionRuntimeComposition } from './lib/runtime-composition.js'
 
 // Increment whenever the browser-visible settings contract gains a field whose
 // absence changes write semantics. This revision is also exposed as a resolved
@@ -77,47 +23,32 @@ core.Config.set('progressiveTools', z.boolean().default(false))
 // one visual task (including fallbacks) shares 120s. The whole-turn visual
 // budget is an optional user safety cap rather than an Agent lifetime policy:
 // 0 means unlimited, which is the default for long-running autonomous turns.
-// The runtime policy below still reserves the final quarter of a multi-backend
-// task for fallback, so disabling the aggregate cap does not revive the
-// historical "120s per backend" stall that #117 removed.
 core.Config.set('visionTaskTimeoutMs', z.number().step(1000).min(1000).max(180000).default(120000))
 core.Config.set('visionTurnBudgetMs', z.number().step(1000).min(0).max(600000).default(0))
 
 // Both visible entry points — Settings > Vision Router and the legacy
 // Settings > Plugins compatibility card — edit the same Host-owned namespace.
-// Keep the depth enum and custom cap on this final public contract so either
-// entry serializes exactly the same shape on every supported Host generation.
 core.Config.set('visionDepth', z.union(['fast', 'standard', 'deep', 'custom']).default('standard'))
 core.Config.set('visionDepthMaxCalls', z.number().step(1).min(0).max(100).default(0))
 
-// Product semantics: users choose whether Vision Router may select a backend
-// automatically or must obey the configured order, plus a plain-language
-// routing preference. Ordered remains the safe default; Auto changes execution
+// Product semantics: ordered remains the safe default; Auto changes execution
 // only under explicit live routingMode:auto authority.
 core.Config.set('routingMode', z.union(['ordered', 'auto']).default('ordered'))
 core.Config.set(
   'routingPreference',
   z.union(['balanced', 'quality', 'speed', 'local']).default('balanced'),
 )
-// Background measurement is a separate user authority. Even local/free work
-// consumes resources, so absence never grants it: users explicitly choose
-// local-free or all when they want standing background measurement.
+// Background measurement is separate user authority; absence never grants it.
 core.Config.set(
   'backgroundBenchmarking',
   z.union(['local-free', 'all', 'off']).default('off'),
 )
 
-// Settings surfaces and Host persistence must agree on this field. Keep the
-// permission on the public entry contract as well as index.js so a packaged
-// build cannot expose the new client toggle while registering an older Host
-// schema that silently recovers from the rejected settings.mutate call. This
-// deliberately repeats the default: entry.js is the final schema authority
-// loaded by Cordis and therefore the right place to close client/Host drift.
+// Settings surfaces and Host persistence must agree on this field.
 core.Config.set('allowRemoteSettings', z.boolean().default(false))
 
 // Internal read-only-by-convention handshake. It is not rendered by Vision
-// Router's settings UI and is not in the remote mutable allow-list; its resolved
-// default lets diagnostics prove which schema the running Host actually loaded.
+// Router's settings UI and is not in the remote mutable allow-list.
 core.Config.set(
   'settingsContractRevision',
   z.number().step(1).min(1).max(SETTINGS_CONTRACT_REVISION).default(SETTINGS_CONTRACT_REVISION),
@@ -132,242 +63,16 @@ export {
   installVisionAttachmentAdmissionPolicy,
   protectHostProviderOwnership,
   // Transitional public aliases retained for callers/tests written during the
-  // rc.7 compatibility pass. Runtime code below no longer branches on names.
+  // rc.7 compatibility pass. Production runtime branches on feature seams.
   installRc7SettingsCompatibility,
   isRc7ContractRuntime,
   protectRc7ProviderOwnership,
 } from './lib/dsh-contract-compat.js'
 export const Config = core.Config
 
-// Defense in depth for direct/programmatic callers that invoke apply() without
-// first running the Cordis Config resolver: only an explicit true enables the
-// schema-changing progressive mode. The wrapped context changes logger plus a
-// private llm/tools view used only by Vision Router: wrapper -> delegate calls
-// preserve replay identity, while vision-tool network calls are constrained to
-// the exact backends the user selected in Vision Router.
+// Defense in depth for direct/programmatic callers is implemented by the same
+// production composition used by Cordis. This public entry intentionally owns
+// no runtime installer ordering beyond that single call.
 export function apply(ctx, config = {}) {
-  // DSH's browser WebServer can intentionally bind 0.0.0.0 and carries no
-  // authentication layer of its own. Same-origin headers are only a CSRF
-  // signal, so install a transport-level loopback fence before ANY plugin-owned
-  // route is registered. The wrapper patches only webServer.register and hands
-  // every injection callback the original child context identity unchanged.
-  const localMutationCtx = installLocalMutationRouteBoundary(ctx)
-  // Normalize DSH 0.1.1's prepareCall contract at the deepest private LLM
-  // boundary. Higher Vision Router layers can finish wrapping adapter.stream
-  // before this boundary captures the final Host-visible adapter, so prepareCall
-  // cannot bypass local/runtime/replay stream behavior.
-  const adapterContractCtx = contextWithCoalescedAdapterUpdates(localMutationCtx)
-  const logging = installVisionRouterFileLogging(adapterContractCtx)
-  const capabilityStore = createCapabilityProfileStore({ logger: logging.logger })
-  // Runtime speed is deliberately process-local and short-lived. It is not
-  // persisted beside capability evidence because network/provider performance
-  // is a dynamic runtime fact, not a model capability fact.
-  const runtimePerformanceStore = createVisionRuntimePerformanceStore()
-  const delegatedReplayCtx = contextWithDelegatedReplay(logging.ctx, {
-    wrapperRoute:
-      typeof config.wrapperRoute === 'string' && config.wrapperRoute !== ''
-        ? config.wrapperRoute
-        : 'deepseek-vision',
-    visionConfig: config,
-  })
-  const runtimeCtx = contextWithReplayEnvelopeV2Compat(delegatedReplayCtx)
-  const screenshotSourceCtx = installScreenshotSourceBoundary(runtimeCtx, core)
-  const { ctx: hardenedCtx, config: hardenedConfig } = installAdversarialHardening(
-    screenshotSourceCtx,
-    config,
-    core,
-  )
-  const ollamaColdStartCtx = installOllamaColdStartGuard(hardenedCtx, hardenedConfig, core)
-  const { ctx: stabilizedCtx, bootConfig } = installLocalVisionStabilizer(
-    ollamaColdStartCtx,
-    hardenedConfig,
-    core,
-  )
-  const routingProduct = resolveVisionRoutingProduct(bootConfig)
-  const runtimeConfig = {
-    ...bootConfig,
-    routingMode: routingProduct.mode,
-    routingPreference: routingProduct.preference,
-    backgroundBenchmarking: normalizeBackgroundMeasurementAuthority(bootConfig.backgroundBenchmarking),
-    progressiveTools: hardenedConfig.progressiveTools === true,
-    guidanceOverrides: normalizeGuidanceOverrides(bootConfig.guidanceOverrides ?? hardenedConfig.guidanceOverrides),
-    visionTaskTimeoutMs:
-      Number.isFinite(Number(bootConfig.visionTaskTimeoutMs))
-        ? Number(bootConfig.visionTaskTimeoutMs)
-        : 120000,
-    visionTurnBudgetMs:
-      Number.isFinite(Number(bootConfig.visionTurnBudgetMs))
-        ? Number(bootConfig.visionTurnBudgetMs)
-        : 0,
-  }
-  const batchAttachmentHost = hasBatchAttachmentContract(stabilizedCtx)
-  if (batchAttachmentHost) installVisionAttachmentAdmissionPolicy(stabilizedCtx, logging.logger)
-  // Preserve the historical pre-Host-settings wrapper order behind one P3-C
-  // Web responsibility boundary.
-  installVisionSettingsWebBoundary(stabilizedCtx, logging.logger)
-  const ownershipCtx = batchAttachmentHost ? protectHostProviderOwnership(stabilizedCtx) : stabilizedCtx
-  const settingsCtx = batchAttachmentHost
-    ? installHostSettingsCompatibility(ownershipCtx, { ...runtimeConfig, stealth: false }, {
-        namespace: 'vision-router',
-        Config: core.Config,
-      })
-    : ownershipCtx
-  const attachmentCompatCtx = attachmentContextForContract(settingsCtx, logging.logger, {
-    installAndroidAttachmentCompat,
-  })
-  const toolRuntimeCtx = installVisionToolRuntimeBoundary(attachmentCompatCtx, runtimeConfig)
-  const nativeImageCompat = contextWithNativeImageCoexistence(toolRuntimeCtx, runtimeConfig)
-  // P2-C centralizes the durable attachment index and two model-surface repair
-  // cursors inside the same native-ownership ALS. Its decorated next() runs
-  // after downstream middleware settles but before the mature core resumes, so
-  // the old core scan blocks become compatibility no-ops without changing Host
-  // persistence or resume semantics.
-  const sessionIndexCtx = installSessionVisionIndexBoundary(
-    nativeImageCompat.ctx,
-    nativeImageCompat.config,
-    core,
-    { logger: logging.logger },
-  )
-  // Feed the session-level image-ownership decision into the legacy core's
-  // wrapper/tool gates without reintroducing a global policy guess.
-  const legacyCoreCompat = installLegacyCoreVisionPolicyBridge(
-    sessionIndexCtx,
-    nativeImageCompat.config,
-    { rewriteHistoryImages: core.rewriteHistoryImages },
-  )
-  // Final structured-flow guard sits closest to core.apply so it sees the
-  // actual tool registrations and pre-step listener. It makes bootstrap
-  // one-shot, enforces fast/standard/deep/custom quotas, tracks mixed branches,
-  // rejects empty/non-evidence results, and applies the optional turn deadline
-  // only when the user explicitly configures one. The diagnostic observer sits
-  // immediately inside it so it can inspect the final budget result/guard while
-  // leaving #220/#295 wall-clock semantics untouched.
-  const limitDiagnosticCtx = installVisionLimitDiagnostics(
-    legacyCoreCompat.ctx,
-    legacyCoreCompat.config,
-    logging.logger,
-  )
-  const structuredCtx = installStructuredFlowHardening(limitDiagnosticCtx, legacyCoreCompat.config)
-  const backgroundProfiling = installBackgroundCapabilityProfiling(
-    structuredCtx,
-    runtimeConfig,
-    core,
-    capabilityStore,
-    { logger: logging.logger },
-  )
-  const breakerShadowHealth = createVisionBreakerShadowHealth(backgroundProfiling.ctx)
-  const routingRuntimeCtx = installVisionRoutingRuntime(
-    backgroundProfiling.ctx,
-    runtimeConfig,
-    core,
-    {
-      logger: logging.logger,
-      store: capabilityStore,
-      runtimePerformanceStore,
-      healthForCandidate: breakerShadowHealth.healthForCandidate,
-    },
-  )
-  // prepareCall normalization/reconciliation is already installed at the
-  // deepest private Host registration boundary above. Do not wrap it again
-  // here or a prepared adapter may capture a pre-wrapper stream.
-  const reconciledCtx = routingRuntimeCtx
-  const liveDiscovery = installLiveModelDiscovery(reconciledCtx, {
-    config: runtimeConfig,
-    logger: logging.logger,
-  })
-  installVisionModelRegistry(reconciledCtx, liveDiscovery, { config: runtimeConfig })
-  // P3-C owns browser responsibility through lib/web/*. The mature injected
-  // clients remain unchanged and are installed in their historical order.
-  // Host product decisions are additionally exposed through a sanitized,
-  // read-only structured state endpoint for diagnostics/new client code.
-  installVisionWebIntegration(reconciledCtx, {
-    config: runtimeConfig,
-    core,
-    store: capabilityStore,
-    runtimePerformanceStore,
-    healthForCandidate: breakerShadowHealth.healthForCandidate,
-  })
-  installPiAiBridgeWireCompat(reconciledCtx, logging.logger)
-  const executionCtx = contextWithVisionExecutionPolicy(reconciledCtx, {
-    isBridgeEvidence: (provider, model) => liveDiscovery.hasModel(provider, model),
-    evidenceSource: (provider, model) => liveDiscovery.evidenceSource?.(provider, model),
-    logger: logging.logger,
-  })
-  // Only real visual-tool adapter streams are timed, and only while live Auto
-  // authority permits future-routing observation. Benchmark/background calls
-  // have no visual-tool scope and cannot contaminate this store.
-  const performanceCtx = contextWithVisionRuntimePerformance(
-    executionCtx,
-    runtimePerformanceStore,
-    {
-      logger: logging.logger,
-      observationAllowed() {
-        try {
-          const settings = executionCtx?.get?.('settings')
-          const current = settings?.get?.('vision-router')
-          if (!current || typeof current !== 'object' || Array.isArray(current)) return false
-          return resolveVisionRoutingAuthority(current).ephemeralRuntimeObservation
-        } catch {
-          return false
-        }
-      },
-    },
-  )
-  // v1.7.7's outer policy covers cases where DSH would otherwise project image
-  // bytes to SHA text before an adapter gets the chance to reject them. Keeping
-  // it outside the runtime-performance observer means native adapter execution
-  // is still timed, while a preflight direct bridge bypasses runtime sampling
-  // and therefore stays incomparable for Balanced/Speed as designed.
-  const backendRuntimeCtx = contextWithVisionBackendRuntimePolicy(performanceCtx, {
-    config: runtimeConfig,
-    core,
-    evidenceSource: (provider, model) => liveDiscovery.evidenceSource?.(provider, model),
-    logger: logging.logger,
-  })
-  installCapabilityBenchmarkService(backendRuntimeCtx, runtimeConfig, core, {
-    logger: logging.logger,
-    store: capabilityStore,
-  })
-  installTesseractExecFileCompat(backendRuntimeCtx)
-
-  try {
-    const c = hardenedConfig && typeof hardenedConfig === 'object' ? hardenedConfig : {}
-    const local = c.localOllama && typeof c.localOllama === 'object' ? c.localOllama : {}
-    const lms = c.localLmStudio && typeof c.localLmStudio === 'object' ? c.localLmStudio : {}
-    logging.logger.info(
-      'vision-router: base config summary — contract=%s instantDescribe=%s localDescribeStyle=%s localOllama=%s localLmStudio=%s',
-      batchAttachmentHost ? 'batch-attachments' : 'single-attachment',
-      c.instantDescribe === true ? 'on' : 'off',
-      c.localDescribeStyle === 'structured' ? 'structured' : 'plain',
-      local.enabled === true ? 'on' : 'off',
-      lms.enabled === true ? 'on' : 'off',
-    )
-  } catch {
-    /* diagnostics must never break apply */
-  }
-  try {
-    const result = withVisionCircuitBreakerObserver(
-      breakerShadowHealth.capture,
-      () => core.apply(backendRuntimeCtx, legacyCoreCompat.config),
-    )
-    legacyCoreCompat.finishSchemaBootstrap()
-    installWrapperDirectoryAlias(attachmentCompatCtx, runtimeConfig, logging.logger)
-    if (result && typeof result.then === 'function') {
-      return result.catch((error) => {
-        logging.logger.error(
-          'vision-router: plugin apply failed: %s',
-          error && error.stack ? error.stack : error && error.message ? error.message : String(error),
-        )
-        throw error
-      })
-    }
-    return result
-  } catch (error) {
-    legacyCoreCompat.finishSchemaBootstrap()
-    logging.logger.error(
-      'vision-router: plugin apply failed: %s',
-      error && error.stack ? error.stack : error && error.message ? error.message : String(error),
-    )
-    throw error
-  }
+  return applyVisionRuntimeComposition(ctx, config, core)
 }

--- a/lib/runtime-composition.js
+++ b/lib/runtime-composition.js
@@ -1,0 +1,289 @@
+// Final P3 runtime composition boundary.
+//
+// This module owns orchestration only. It deliberately does not own product
+// settings, route scoring, provider transports, session persistence, or browser
+// implementation details. Keep the mature installers below in their historical
+// order so entry.js can remain the thin public schema/export boundary.
+
+import { installVisionRouterFileLogging } from './file-logger.js'
+import { contextWithDelegatedReplay } from './replay-delegation.js'
+import { contextWithReplayEnvelopeV2Compat } from './replay-envelope-v2-compat.js'
+import { contextWithVisionExecutionPolicy } from './vision-execution-policy.js'
+import { contextWithVisionBackendRuntimePolicy } from './vision-backend-runtime-policy.js'
+import { contextWithNativeImageCoexistence } from './native-image-coexistence.js'
+import { installSessionVisionIndexBoundary } from './session-vision-index.js'
+import { installLegacyCoreVisionPolicyBridge } from './legacy-core-vision-policy-bridge.js'
+import { installPiAiBridgeWireCompat } from './pi-ai-bridge-wire-compat.js'
+import { installLiveModelDiscovery } from './live-model-discovery.js'
+import { installVisionModelRegistry } from './vision-model-registry.js'
+import { installAdversarialHardening } from './adversarial-hardening.js'
+import { installOllamaColdStartGuard } from './ollama-cold-start.js'
+import { installLocalVisionStabilizer } from './local-vision-stabilizer.js'
+import { installWrapperDirectoryAlias } from './wrapper-directory.js'
+import { installAndroidAttachmentCompat } from './android-attachment-compat.js'
+import { contextWithCoalescedAdapterUpdates } from './adapter-update-coalescer.js'
+import { installTesseractExecFileCompat } from './tesseract-exec-compat.js'
+import { installLocalMutationRouteBoundary } from './web-capability-boundary.js'
+import { installScreenshotSourceBoundary } from './screenshot-source-boundary.js'
+import { installVisionToolRuntimeBoundary } from './vision-tool-runtime-boundary.js'
+import { installVisionRoutingRuntime } from './vision-routing-runtime.js'
+import { createCapabilityProfileStore } from './vision-capability-probe.js'
+import { installCapabilityBenchmarkService } from './vision-capability-benchmark-service.js'
+import { resolveVisionRoutingProduct } from './vision-routing-product.js'
+import {
+  normalizeBackgroundMeasurementAuthority,
+  resolveVisionRoutingAuthority,
+} from './vision-routing-authority.js'
+import { withVisionCircuitBreakerObserver } from './vision-breaker-observer.js'
+import { createVisionBreakerShadowHealth } from './vision-breaker-shadow-health.js'
+import { installBackgroundCapabilityProfiling } from './vision-background-benchmark.js'
+import {
+  contextWithVisionRuntimePerformance,
+  createVisionRuntimePerformanceStore,
+} from './vision-runtime-performance.js'
+import {
+  installStructuredFlowHardening,
+  normalizeGuidanceOverrides,
+} from './structured-flow-hardening.js'
+import { installVisionLimitDiagnostics } from './vision-limit-diagnostics.js'
+import {
+  attachmentContextForContract,
+  hasBatchAttachmentContract,
+  installHostSettingsCompatibility,
+  installVisionAttachmentAdmissionPolicy,
+  protectHostProviderOwnership,
+} from './dsh-contract-compat.js'
+import {
+  installVisionSettingsWebBoundary,
+  installVisionWebIntegration,
+} from './web/index.js'
+
+export function applyVisionRuntimeComposition(ctx, config = {}, core) {
+  // DSH's browser WebServer can intentionally bind 0.0.0.0 and carries no
+  // authentication layer of its own. Same-origin headers are only a CSRF
+  // signal, so install a transport-level loopback fence before ANY plugin-owned
+  // route is registered. The wrapper patches only webServer.register and hands
+  // every injection callback the original child context identity unchanged.
+  const localMutationCtx = installLocalMutationRouteBoundary(ctx)
+
+  // Normalize DSH 0.1.1's prepareCall contract at the deepest private LLM
+  // boundary. Higher Vision Router layers can finish wrapping adapter.stream
+  // before this boundary captures the final Host-visible adapter, so prepareCall
+  // cannot bypass local/runtime/replay stream behavior.
+  const adapterContractCtx = contextWithCoalescedAdapterUpdates(localMutationCtx)
+  const logging = installVisionRouterFileLogging(adapterContractCtx)
+  const capabilityStore = createCapabilityProfileStore({ logger: logging.logger })
+
+  // Runtime speed is deliberately process-local and short-lived. It is not
+  // persisted beside capability evidence because network/provider performance
+  // is a dynamic runtime fact, not a model capability fact.
+  const runtimePerformanceStore = createVisionRuntimePerformanceStore()
+  const delegatedReplayCtx = contextWithDelegatedReplay(logging.ctx, {
+    wrapperRoute:
+      typeof config.wrapperRoute === 'string' && config.wrapperRoute !== ''
+        ? config.wrapperRoute
+        : 'deepseek-vision',
+    visionConfig: config,
+  })
+  const runtimeCtx = contextWithReplayEnvelopeV2Compat(delegatedReplayCtx)
+  const screenshotSourceCtx = installScreenshotSourceBoundary(runtimeCtx, core)
+  const { ctx: hardenedCtx, config: hardenedConfig } = installAdversarialHardening(
+    screenshotSourceCtx,
+    config,
+    core,
+  )
+  const ollamaColdStartCtx = installOllamaColdStartGuard(hardenedCtx, hardenedConfig, core)
+  const { ctx: stabilizedCtx, bootConfig } = installLocalVisionStabilizer(
+    ollamaColdStartCtx,
+    hardenedConfig,
+    core,
+  )
+
+  const routingProduct = resolveVisionRoutingProduct(bootConfig)
+  const runtimeConfig = {
+    ...bootConfig,
+    routingMode: routingProduct.mode,
+    routingPreference: routingProduct.preference,
+    backgroundBenchmarking: normalizeBackgroundMeasurementAuthority(bootConfig.backgroundBenchmarking),
+    progressiveTools: hardenedConfig.progressiveTools === true,
+    guidanceOverrides: normalizeGuidanceOverrides(bootConfig.guidanceOverrides ?? hardenedConfig.guidanceOverrides),
+    visionTaskTimeoutMs:
+      Number.isFinite(Number(bootConfig.visionTaskTimeoutMs))
+        ? Number(bootConfig.visionTaskTimeoutMs)
+        : 120000,
+    visionTurnBudgetMs:
+      Number.isFinite(Number(bootConfig.visionTurnBudgetMs))
+        ? Number(bootConfig.visionTurnBudgetMs)
+        : 0,
+  }
+
+  const batchAttachmentHost = hasBatchAttachmentContract(stabilizedCtx)
+  if (batchAttachmentHost) installVisionAttachmentAdmissionPolicy(stabilizedCtx, logging.logger)
+
+  // P3-C keeps browser/settings ownership behind explicit Web boundaries while
+  // preserving the exact historical pre-settings/client install order.
+  installVisionSettingsWebBoundary(stabilizedCtx, logging.logger)
+  const ownershipCtx = batchAttachmentHost ? protectHostProviderOwnership(stabilizedCtx) : stabilizedCtx
+  const settingsCtx = batchAttachmentHost
+    ? installHostSettingsCompatibility(ownershipCtx, { ...runtimeConfig, stealth: false }, {
+        namespace: 'vision-router',
+        Config: core.Config,
+      })
+    : ownershipCtx
+  const attachmentCompatCtx = attachmentContextForContract(settingsCtx, logging.logger, {
+    installAndroidAttachmentCompat,
+  })
+
+  const toolRuntimeCtx = installVisionToolRuntimeBoundary(attachmentCompatCtx, runtimeConfig)
+  const nativeImageCompat = contextWithNativeImageCoexistence(toolRuntimeCtx, runtimeConfig)
+
+  // P2-C centralizes the durable attachment index and two model-surface repair
+  // cursors inside the same native-ownership ALS. Its decorated next() runs
+  // after downstream middleware settles but before the mature core resumes, so
+  // the old core scan blocks remain compatibility no-ops without changing Host
+  // persistence or resume semantics.
+  const sessionIndexCtx = installSessionVisionIndexBoundary(
+    nativeImageCompat.ctx,
+    nativeImageCompat.config,
+    core,
+    { logger: logging.logger },
+  )
+  const legacyCoreCompat = installLegacyCoreVisionPolicyBridge(
+    sessionIndexCtx,
+    nativeImageCompat.config,
+    { rewriteHistoryImages: core.rewriteHistoryImages },
+  )
+
+  // Final structured-flow guard sits closest to core.apply so it sees the
+  // actual tool registrations and pre-step listener. The diagnostic observer
+  // remains immediately inside it so existing timeout/budget semantics stay
+  // unchanged.
+  const limitDiagnosticCtx = installVisionLimitDiagnostics(
+    legacyCoreCompat.ctx,
+    legacyCoreCompat.config,
+    logging.logger,
+  )
+  const structuredCtx = installStructuredFlowHardening(limitDiagnosticCtx, legacyCoreCompat.config)
+  const backgroundProfiling = installBackgroundCapabilityProfiling(
+    structuredCtx,
+    runtimeConfig,
+    core,
+    capabilityStore,
+    { logger: logging.logger },
+  )
+  const breakerShadowHealth = createVisionBreakerShadowHealth(backgroundProfiling.ctx)
+  const routingRuntimeCtx = installVisionRoutingRuntime(
+    backgroundProfiling.ctx,
+    runtimeConfig,
+    core,
+    {
+      logger: logging.logger,
+      store: capabilityStore,
+      runtimePerformanceStore,
+      healthForCandidate: breakerShadowHealth.healthForCandidate,
+    },
+  )
+
+  // prepareCall normalization/reconciliation is already installed at the
+  // deepest private Host registration boundary above. Do not wrap it again or a
+  // prepared adapter may capture a pre-wrapper stream.
+  const reconciledCtx = routingRuntimeCtx
+  const liveDiscovery = installLiveModelDiscovery(reconciledCtx, {
+    config: runtimeConfig,
+    logger: logging.logger,
+  })
+  installVisionModelRegistry(reconciledCtx, liveDiscovery, { config: runtimeConfig })
+  installVisionWebIntegration(reconciledCtx, {
+    config: runtimeConfig,
+    core,
+    store: capabilityStore,
+    runtimePerformanceStore,
+    healthForCandidate: breakerShadowHealth.healthForCandidate,
+  })
+  installPiAiBridgeWireCompat(reconciledCtx, logging.logger)
+
+  const executionCtx = contextWithVisionExecutionPolicy(reconciledCtx, {
+    isBridgeEvidence: (provider, model) => liveDiscovery.hasModel(provider, model),
+    evidenceSource: (provider, model) => liveDiscovery.evidenceSource?.(provider, model),
+    logger: logging.logger,
+  })
+
+  // Only real visual-tool adapter streams are timed, and only while live Auto
+  // authority permits future-routing observation. Benchmark/background calls
+  // have no visual-tool scope and cannot contaminate this store.
+  const performanceCtx = contextWithVisionRuntimePerformance(
+    executionCtx,
+    runtimePerformanceStore,
+    {
+      logger: logging.logger,
+      observationAllowed() {
+        try {
+          const settings = executionCtx?.get?.('settings')
+          const current = settings?.get?.('vision-router')
+          if (!current || typeof current !== 'object' || Array.isArray(current)) return false
+          return resolveVisionRoutingAuthority(current).ephemeralRuntimeObservation
+        } catch {
+          return false
+        }
+      },
+    },
+  )
+
+  // The outer backend policy still covers Hosts that would otherwise project
+  // image bytes to SHA text before an adapter can reject them. Native adapter
+  // execution remains observable while direct bridge preflight stays outside
+  // runtime sampling, preserving Balanced/Speed incomparability semantics.
+  const backendRuntimeCtx = contextWithVisionBackendRuntimePolicy(performanceCtx, {
+    config: runtimeConfig,
+    core,
+    evidenceSource: (provider, model) => liveDiscovery.evidenceSource?.(provider, model),
+    logger: logging.logger,
+  })
+  installCapabilityBenchmarkService(backendRuntimeCtx, runtimeConfig, core, {
+    logger: logging.logger,
+    store: capabilityStore,
+  })
+  installTesseractExecFileCompat(backendRuntimeCtx)
+
+  try {
+    const c = hardenedConfig && typeof hardenedConfig === 'object' ? hardenedConfig : {}
+    const local = c.localOllama && typeof c.localOllama === 'object' ? c.localOllama : {}
+    const lms = c.localLmStudio && typeof c.localLmStudio === 'object' ? c.localLmStudio : {}
+    logging.logger.info(
+      'vision-router: base config summary — contract=%s instantDescribe=%s localDescribeStyle=%s localOllama=%s localLmStudio=%s',
+      batchAttachmentHost ? 'batch-attachments' : 'single-attachment',
+      c.instantDescribe === true ? 'on' : 'off',
+      c.localDescribeStyle === 'structured' ? 'structured' : 'plain',
+      local.enabled === true ? 'on' : 'off',
+      lms.enabled === true ? 'on' : 'off',
+    )
+  } catch {
+    /* diagnostics must never break apply */
+  }
+
+  try {
+    const result = withVisionCircuitBreakerObserver(
+      breakerShadowHealth.capture,
+      () => core.apply(backendRuntimeCtx, legacyCoreCompat.config),
+    )
+    legacyCoreCompat.finishSchemaBootstrap()
+    installWrapperDirectoryAlias(attachmentCompatCtx, runtimeConfig, logging.logger)
+    if (result && typeof result.then === 'function') {
+      return result.catch((error) => {
+        logging.logger.error(
+          'vision-router: plugin apply failed: %s',
+          error && error.stack ? error.stack : error && error.message ? error.message : String(error),
+        )
+        throw error
+      })
+    }
+    return result
+  } catch (error) {
+    legacyCoreCompat.finishSchemaBootstrap()
+    logging.logger.error(
+      'vision-router: plugin apply failed: %s',
+      error && error.stack ? error.stack : error && error.message ? error.message : String(error),
+    )
+    throw error
+  }
+}

--- a/tests/bundle-defaults.test.js
+++ b/tests/bundle-defaults.test.js
@@ -126,16 +126,18 @@ test('manual Release workflow creates only the exact current-main package tag be
 
 test('release runtime exposes one benchmark UI and no production v2 acceptance control surface', async () => {
   const entry = await readFile(new URL('../entry.js', import.meta.url), 'utf8')
+  const runtimeComposition = await readFile(new URL('../lib/runtime-composition.js', import.meta.url), 'utf8')
   const benchmarkPanel = await readFile(new URL('../lib/web/benchmark-panel.js', import.meta.url), 'utf8')
   const webComposition = await readFile(new URL('../lib/web/index.js', import.meta.url), 'utf8')
   const pkg = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8'))
 
-  const releaseSurface = `${entry}\n${benchmarkPanel}\n${webComposition}`
+  const releaseSurface = `${entry}\n${runtimeComposition}\n${benchmarkPanel}\n${webComposition}`
   assert.doesNotMatch(releaseSurface, /installExactVisionTestClient/)
   assert.doesNotMatch(releaseSurface, /installV2AcceptanceService/)
   assert.doesNotMatch(releaseSurface, /createV2ExecutionAcceptanceObserver/)
   assert.doesNotMatch(releaseSurface, /installVisionRoutingPreviewService/)
-  assert.match(entry, /installVisionWebIntegration/)
+  assert.match(entry, /applyVisionRuntimeComposition/)
+  assert.match(runtimeComposition, /installVisionWebIntegration/)
   assert.match(benchmarkPanel, /installCapabilityBenchmarkClient/)
   assert.match(webComposition, /benchmarkPanel/)
   assert.equal(pkg.bin['dsh-vision-router'], './lib/doctor-cli-p0.js')

--- a/tests/dsh-support-window.test.js
+++ b/tests/dsh-support-window.test.js
@@ -1,5 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
 
 import {
   DSH_SUPPORT_WINDOW,
@@ -49,4 +50,20 @@ test('support window text exposes current and announced floors without changing 
   assert.ok(lines.some((line) => line.includes('DVR 2.1.0 -> DSH 0.1.0-rc.8')))
   assert.ok(lines.some((line) => line.includes('HOST_BELOW_NEXT_FLOOR_CAPABILITIES')))
   assert.equal(Object.isFrozen(lines), true)
+})
+
+test('public READMEs state the current and announced Host floors', async () => {
+  const [english, chinese] = await Promise.all([
+    readFile(new URL('../README.md', import.meta.url), 'utf8'),
+    readFile(new URL('../README.zh.md', import.meta.url), 'utf8'),
+  ])
+
+  for (const source of [english, chinese]) {
+    assert.match(source, /2\.0\.x/)
+    assert.match(source, /0\.1\.0-rc\.6/)
+    assert.match(source, /0\.1\.0-rc\.8/)
+    assert.match(source, /0\.1\.1-rc\.2/)
+    assert.match(source, /2\.1\.0/)
+    assert.match(source, /docs\/architecture\/dsh-support-window\.md/)
+  }
 })

--- a/tests/p3-entry-composition.test.js
+++ b/tests/p3-entry-composition.test.js
@@ -1,0 +1,62 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+
+test('P3-F keeps entry as a thin schema/export boundary', async () => {
+  const entry = await readFile(new URL('../entry.js', import.meta.url), 'utf8')
+  const imports = entry.match(/^import\s.+$/gm) ?? []
+
+  assert.equal(imports.length, 3)
+  assert.match(entry, /import z from '@deepseek-ai\/schemastery'/)
+  assert.match(entry, /import \* as core from '.\/index\.js'/)
+  assert.match(entry, /import \{ applyVisionRuntimeComposition \} from '.\/lib\/runtime-composition\.js'/)
+  assert.match(entry, /export function apply\(ctx, config = \{\}\) \{\s*return applyVisionRuntimeComposition\(ctx, config, core\)\s*\}/s)
+  assert.doesNotMatch(
+    entry,
+    /installVisionRouterFileLogging|installVisionRoutingRuntime|installVisionWebIntegration|contextWithVisionRuntimePerformance|core\.apply\(/,
+  )
+  assert.ok(entry.split('\n').length < 120, 'public entry must not grow back into runtime composition')
+})
+
+test('P3-F composition remains bounded and preserves the mature runtime sequence', async () => {
+  const source = await readFile(new URL('../lib/runtime-composition.js', import.meta.url), 'utf8')
+  const ordered = [
+    'installLocalMutationRouteBoundary(ctx)',
+    'contextWithCoalescedAdapterUpdates(localMutationCtx)',
+    'installVisionRouterFileLogging(adapterContractCtx)',
+    'installAdversarialHardening(',
+    'installLocalVisionStabilizer(',
+    'installVisionSettingsWebBoundary(stabilizedCtx, logging.logger)',
+    'installHostSettingsCompatibility(',
+    'installVisionToolRuntimeBoundary(attachmentCompatCtx, runtimeConfig)',
+    'contextWithNativeImageCoexistence(toolRuntimeCtx, runtimeConfig)',
+    'installSessionVisionIndexBoundary(',
+    'installLegacyCoreVisionPolicyBridge(',
+    'installVisionLimitDiagnostics(',
+    'installStructuredFlowHardening(limitDiagnosticCtx, legacyCoreCompat.config)',
+    'installBackgroundCapabilityProfiling(',
+    'installVisionRoutingRuntime(',
+    'installLiveModelDiscovery(',
+    'installVisionModelRegistry(',
+    'installVisionWebIntegration(',
+    'contextWithVisionExecutionPolicy(',
+    'contextWithVisionRuntimePerformance(',
+    'contextWithVisionBackendRuntimePolicy(',
+    'installCapabilityBenchmarkService(',
+    'installTesseractExecFileCompat(backendRuntimeCtx)',
+    'core.apply(backendRuntimeCtx, legacyCoreCompat.config)',
+  ]
+
+  let previous = -1
+  for (const marker of ordered) {
+    const at = source.indexOf(marker)
+    assert.ok(at > previous, `${marker} must remain after the previous runtime boundary`)
+    previous = at
+  }
+
+  assert.ok(
+    source.split('\n').length < 400,
+    'runtime composition must remain orchestration-sized rather than becoming a new monolith',
+  )
+  assert.doesNotMatch(source, /Config\.set\(|rankVisionCandidates\(|callOpenAICompatible\(|imageMemorySet\(/)
+})

--- a/tests/qa-runtime-identity.test.js
+++ b/tests/qa-runtime-identity.test.js
@@ -79,8 +79,14 @@ test('vision_present registration accepts host originalDimensions without loosen
   )
 })
 
-test('entry keeps prepareCall, tool runtime, session policy bridge, diagnostics, structured hardening, runtime observation and backend runtime policy in final order', async () => {
-  const source = await readFile(new URL('../entry.js', import.meta.url), 'utf8')
+test('P3 final composition keeps runtime order outside the thin public entry', async () => {
+  const entry = await readFile(new URL('../entry.js', import.meta.url), 'utf8')
+  const source = await readFile(new URL('../lib/runtime-composition.js', import.meta.url), 'utf8')
+
+  assert.match(entry, /import \{ applyVisionRuntimeComposition \} from '.\/lib\/runtime-composition\.js'/)
+  assert.match(entry, /return applyVisionRuntimeComposition\(ctx, config, core\)/)
+  assert.doesNotMatch(entry, /installVisionRouterFileLogging|installVisionRoutingRuntime|installVisionWebIntegration/)
+
   const mutationAt = source.indexOf('const localMutationCtx = installLocalMutationRouteBoundary(ctx)')
   const adapterContractAt = source.indexOf(
     'const adapterContractCtx = contextWithCoalescedAdapterUpdates(localMutationCtx)',


### PR DESCRIPTION
## P3-F — Final entry composition cleanup

### Scope

This final architecture slice makes `entry.js` the thin public schema/export boundary and moves runtime orchestration into the bounded `lib/runtime-composition.js` module.

No routing algorithm, score, UI authority, provider transport, persistence format, authority rule or product default changes in this slice.

### Composition contract

`entry.js` now owns only:

- public Schemastery contract/defaults;
- public exports/compat aliases;
- thin `apply(ctx, config)` delegation.

`lib/runtime-composition.js` owns only installer ordering. The existing runtime sequence is preserved from loopback mutation fencing through Host compatibility, image/session boundaries, routing/model/Web integration, runtime observation, benchmark service and final `core.apply`.

Dedicated P3-F tests prevent the public entry from absorbing runtime installers again and bound the composition module so it cannot become a new monolith.

### Public support window

README.md and README.zh.md now explicitly publish the same P3-A Host contract already enforced by code/Doctor:

- DVR 2.0.x minimum: DSH `0.1.0-rc.6`;
- previous supported train: `0.1.0-rc.8`;
- current validated Host: `0.1.1-rc.2`;
- DVR 2.1.0 is the announced boundary that may raise the minimum to `0.1.0-rc.8`;
- no 2.0.x patch silently raises the Host floor.

`tests/dsh-support-window.test.js` now locks both public READMEs to this policy.

### Product / authority / lifetime

Behavior remains identical:

- ordered/Auto routing semantics unchanged;
- background measurement remains separately authorized;
- native multimodal coexistence unchanged;
- rc6/rc8/current Host behavior unchanged;
- local/direct/native provider fallback unchanged;
- Settings and remote-settings authority unchanged;
- no persistent data migration;
- no new background work;
- caller abort, plugin disposal and live authority revoke ownership stay in their existing modules.

### Security / resource

No credential, endpoint, loopback, path, raw response, image-memory, artifact, queue or timeout policy changes. No code-mutating GitHub Action was added.

### Final validation — head `9af8871ffd43f753db0da050a7b8d00a29544caf`

All required functional gates are completed successfully:

- CI `33148921589` — success
  - Node 22 — success
  - Node 24 — success
  - Ubuntu host-sharp — success
  - macOS host-sharp — success
  - Windows host-sharp — success
  - DSH rc6 / rc7 / rc8 compatibility jobs — success
- DSH Contract `33148921534` — success
  - minimum-contract — success
  - legacy-contract — success
  - current-contract — success
- P1 Routing Parity `33148921539` — success
- P2 Data Boundary `33148921676` — success
- P3 Compatibility Convergence `33148921538` — success
- Native multimodal cold resume `33148921546` — success on rc7/rc8 × Node22/24
- Large image resource stress `33148921554` — success
- Formal CodeQL check `98776221056` — success: **No new alerts in code changed by this pull request**, 0 annotations

A separate dynamic `github-advanced-security` AI-agent check continues to fail independently with one workflow annotation, as on earlier P3 slices. It produced no CodeQL alert; the formal GitHub Advanced Security CodeQL gate above is green and is the security result used for acceptance.

### Adversarial review

No P3-F authority, concurrency, lifetime, cancellation, persistence, security or resource blocker found. The composition move preserves the mature installer sequence, and the new structural tests make accidental ownership drift fail CI.

## Verdict

**P3-F READY.** This is the final P3 implementation slice.