### PR TITLE
refactor(session): establish explicit closure parity seams

### DIFF
--- a/.github/workflows/architecture-closure.yml
+++ b/.github/workflows/architecture-closure.yml
@@ -6,6 +6,7 @@ on:
       - 'entry.js'
       - 'index.js'
       - 'lib/runtime-composition.js'
+      - 'lib/core-vision-surface.js'
       - 'lib/session-vision-*.js'
       - 'lib/session-surface-policy.js'
       - 'lib/legacy-core-vision-policy-bridge.js'
@@ -16,6 +17,8 @@ on:
       - 'lib/vision-capability-shadow.js'
       - 'docs/architecture/**'
       - 'tests/architecture-contract-baseline.test.js'
+      - 'tests/core-vision-surface-parity.test.js'
+      - 'tests/session-vision-runtime-parity.test.js'
       - 'tests/vision-execution-order-core-wiring.test.js'
       - 'tests/session-vision-state-integration.test.js'
       - 'tests/session-surface-policy.test.js'
@@ -30,6 +33,7 @@ on:
       - 'entry.js'
       - 'index.js'
       - 'lib/runtime-composition.js'
+      - 'lib/core-vision-surface.js'
       - 'lib/session-vision-*.js'
       - 'lib/session-surface-policy.js'
       - 'lib/legacy-core-vision-policy-bridge.js'
@@ -40,6 +44,8 @@ on:
       - 'lib/vision-capability-shadow.js'
       - 'docs/architecture/**'
       - 'tests/architecture-contract-baseline.test.js'
+      - 'tests/core-vision-surface-parity.test.js'
+      - 'tests/session-vision-runtime-parity.test.js'
       - 'tests/vision-execution-order-core-wiring.test.js'
       - 'tests/session-vision-state-integration.test.js'
       - 'tests/session-surface-policy.test.js'
@@ -73,6 +79,8 @@ jobs:
         run: >-
           node --test
           tests/architecture-contract-baseline.test.js
+          tests/core-vision-surface-parity.test.js
+          tests/session-vision-runtime-parity.test.js
           tests/vision-execution-order-core-wiring.test.js
           tests/session-vision-state-integration.test.js
           tests/session-surface-policy.test.js

--- a/lib/core-vision-surface.js
+++ b/lib/core-vision-surface.js
@@ -1,0 +1,83 @@
+import {
+  currentSessionSurfacePolicy,
+  resolveSessionSurfacePolicy,
+} from './session-surface-policy.js'
+
+const CORE_SURFACE_KEYS = Object.freeze([
+  'tool',
+  'rewriteImages',
+  'instantDescribe',
+  'autoActivateOnImage',
+  'structuredVisionBootstrap',
+])
+
+function isObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function own(object, key) {
+  return Object.prototype.hasOwnProperty.call(object, key)
+}
+
+/**
+ * Explicit core-facing projection of the SessionSurfacePolicy.
+ *
+ * During C1-A this is a parity seam only: production still uses the legacy
+ * Settings/config bridge. The returned object carries only the five config
+ * values that the legacy bridge may override plus the already-resolved image
+ * ownership facts. It deliberately cannot masquerade as a Settings service or
+ * a full plugin config object.
+ *
+ * C1 switches core reads to this value only after old/new parity is proven.
+ */
+export function projectCoreVisionSurface(config = {}, sessionPolicy) {
+  const value = isObject(config) ? config : {}
+  const policy = sessionPolicy && typeof sessionPolicy === 'object'
+    ? sessionPolicy
+    : resolveSessionSurfacePolicy({ config: value })
+  const overrides = isObject(policy.legacyConfigOverrides)
+    ? policy.legacyConfigOverrides
+    : {}
+  const projected = {}
+
+  for (const key of CORE_SURFACE_KEYS) {
+    projected[key] = own(overrides, key) ? overrides[key] : value[key]
+  }
+
+  return Object.freeze({
+    ownership: policy.ownership,
+    preserveRawImages: policy.preserveRawImages === true,
+    rewriteCurrentImages: policy.rewriteCurrentImages === true,
+    values: Object.freeze(projected),
+  })
+}
+
+/** Resolve an explicit core surface from an explicit ownership-policy input. */
+export function resolveCoreVisionSurface({
+  visionPolicy,
+  config = {},
+  schemaBootstrapping = false,
+} = {}) {
+  const value = isObject(config) ? config : {}
+  return projectCoreVisionSurface(
+    value,
+    resolveSessionSurfacePolicy({
+      visionPolicy,
+      config: value,
+      schemaBootstrapping,
+    }),
+  )
+}
+
+/** Resolve the current turn-local surface without exposing a Settings facade. */
+export function currentCoreVisionSurface(config = {}, options = {}) {
+  const value = isObject(config) ? config : {}
+  return projectCoreVisionSurface(
+    value,
+    currentSessionSurfacePolicy(value, {
+      schemaBootstrapping: options?.schemaBootstrapping === true,
+    }),
+  )
+}
+
+export const CORE_VISION_SURFACE_KEYS = CORE_SURFACE_KEYS

--- a/lib/session-vision-index.js
+++ b/lib/session-vision-index.js
@@ -32,32 +32,44 @@ function boundedMessage(error) {
 }
 
 /**
- * P2 session data-plane index.
+ * Session visual data-plane index.
  *
  * SessionVisionStateStore remains the bounded storage owner. This object owns
- * the formerly scattered operations around it: incremental durable-log scan,
- * target-only recovery after bounded-cache eviction, tool-result image surface
- * repair, and expired structured guard-stop surface repair.
+ * incremental durable-log scan, target-only recovery after bounded-cache
+ * eviction, tool-result image surface repair and expired structured guard-stop
+ * surface repair.
  *
- * No new Session event type or persistence format is introduced. Surface
- * repair keeps using the Host's existing replacement event contract.
+ * `legacyLookupDelegation` exists only for the pre-Closure monolithic-core
+ * compatibility path. New explicit SessionVisionRuntime instances set it to
+ * false, so the index never replaces stateStore.lookupAttachment().
  */
 export function createSessionVisionIndex({
   stateStore = currentSessionVisionStateStore,
   core,
   config = {},
   logger,
+  legacyLookupDelegation = true,
 } = {}) {
   if (!core || typeof core !== 'object') throw new TypeError('session vision index requires core helpers')
-  const toolSurfaceScans = new WeakMap()
-  const guardSurfaceScans = new WeakMap()
   const adoptedStores = new WeakSet()
   const primitiveLookupByStore = new WeakMap()
+  const toolSurfaceScans = new WeakMap()
+  const guardSurfaceScans = new WeakMap()
+
+  const primitiveLookupFor = (store) => {
+    let primitive = primitiveLookupByStore.get(store)
+    if (primitive) return primitive
+    primitive = typeof store?.lookupAttachment === 'function'
+      ? store.lookupAttachment.bind(store)
+      : undefined
+    if (primitive) primitiveLookupByStore.set(store, primitive)
+    return primitive
+  }
 
   const storeNow = () => {
     const store = typeof stateStore === 'function' ? stateStore() : stateStore
     if (!store || typeof store !== 'object') return undefined
-    adoptStore(store)
+    if (legacyLookupDelegation === true) adoptStore(store)
     return store
   }
 
@@ -76,8 +88,8 @@ export function createSessionVisionIndex({
     const refs = typeof core.collectEventAttachmentRefs === 'function'
       ? core.collectEventAttachmentRefs(events.slice(last))
       : []
-    // Match the mature core ordering: advance the cursor even when no refs are
-    // found so irrelevant durable history is never rescanned indefinitely.
+    // Advance even when no refs are present so irrelevant durable history is
+    // never rescanned indefinitely.
     store.setScannedEventSeq(session, events.length)
     if (Array.isArray(refs) && refs.length > 0) store.recordAttachments(session, refs)
   }
@@ -115,15 +127,11 @@ export function createSessionVisionIndex({
   }
 
   function adoptStore(store) {
-    if (adoptedStores.has(store)) return store
-    const original = typeof store.lookupAttachment === 'function'
-      ? store.lookupAttachment.bind(store)
-      : undefined
+    if (legacyLookupDelegation !== true || adoptedStores.has(store)) return store
+    const original = primitiveLookupFor(store)
     if (original) {
-      primitiveLookupByStore.set(store, original)
-      // Compatibility delegation: the monolithic core still calls
-      // visionState.lookupAttachment(). Point that call at the new index so its
-      // old targeted-recovery block becomes a no-op on every successful lookup.
+      // Compatibility delegation for the pre-Closure monolithic core. The new
+      // explicit runtime never enters this branch.
       store.lookupAttachment = (session, id) => lookupWithStore(store, original, session, id)
     }
     adoptedStores.add(store)
@@ -133,12 +141,12 @@ export function createSessionVisionIndex({
   const lookupAttachment = (session, id) => {
     const store = storeNow()
     if (!store) return undefined
-    const primitive = primitiveLookupByStore.get(store)
-      ?? (typeof store.lookupAttachment === 'function' ? store.lookupAttachment.bind(store) : undefined)
+    const primitive = primitiveLookupFor(store)
     if (!primitive) return undefined
-    return adoptedStores.has(store)
-      ? store.lookupAttachment(session, id)
-      : lookupWithStore(store, primitive, session, id)
+    if (legacyLookupDelegation === true && adoptedStores.has(store)) {
+      return store.lookupAttachment(session, id)
+    }
+    return lookupWithStore(store, primitive, session, id)
   }
 
   const nextSurfaceSeqs = (scans, session) => {
@@ -185,8 +193,6 @@ export function createSessionVisionIndex({
         )
         repaired += 1
       } catch (error) {
-        // Preserve the mature fail-safe contract: a failed repair leaves the
-        // original event untouched and cannot make the session unreadable.
         logger?.warn?.(
           'vision-router: session tool-result surface repair failed seq=%s error=%s',
           plan.seq,
@@ -257,13 +263,12 @@ export function createSessionVisionIndex({
 
 /**
  * Intercept core's pre-step registration and decorate only its downstream
- * `next()` result. This preserves middleware ordering: downstream handlers run
- * first exactly as before; the centralized index executes after they settle but
- * before the mature core resumes and reaches its compatibility scan blocks.
+ * `next()` result. Passing `options.index` is the C1 explicit-runtime seam; the
+ * legacy path still constructs an index from the transitional current store.
  */
 export function installSessionVisionIndexBoundary(ctx, config, core, options = {}) {
   if (!isObject(ctx)) return ctx
-  const index = createSessionVisionIndex({
+  const index = options.index ?? createSessionVisionIndex({
     core,
     config: () => {
       try {

--- a/lib/session-vision-runtime.js
+++ b/lib/session-vision-runtime.js
@@ -1,0 +1,46 @@
+import { createSessionVisionIndex } from './session-vision-index.js'
+import { createSessionVisionStateStore } from './session-vision-state.js'
+
+export const DEFAULT_SESSION_VISION_STATE_OPTIONS = Object.freeze({
+  maxSessions: 64,
+  idleTtlMs: 60 * 60 * 1000,
+  descriptionMaxEntries: 64,
+  descriptionMaxChars: 256 * 1024,
+  attachmentMaxEntries: 256,
+})
+
+/**
+ * Narrow C1 ownership boundary for Session-local Vision Router state.
+ *
+ * This object intentionally owns only the bounded state store and its index.
+ * It is not a general runtime service locator. During C1-A production still
+ * uses the mature core construction path; parity tests prove this explicit
+ * runtime can replace the implicit current-store bridge before the switch.
+ */
+export function createSessionVisionRuntime({
+  core,
+  config = {},
+  logger,
+  stateStore,
+  stateOptions = {},
+} = {}) {
+  if (!core || typeof core !== 'object') {
+    throw new TypeError('session vision runtime requires core helpers')
+  }
+
+  const store = stateStore ?? createSessionVisionStateStore({
+    ...DEFAULT_SESSION_VISION_STATE_OPTIONS,
+    ...(stateOptions && typeof stateOptions === 'object' ? stateOptions : {}),
+  })
+  const index = createSessionVisionIndex({
+    stateStore: store,
+    core,
+    config,
+    logger,
+  })
+
+  return Object.freeze({
+    stateStore: store,
+    index,
+  })
+}

--- a/lib/session-vision-runtime.js
+++ b/lib/session-vision-runtime.js
@@ -16,6 +16,10 @@ export const DEFAULT_SESSION_VISION_STATE_OPTIONS = Object.freeze({
  * It is not a general runtime service locator. During C1-A production still
  * uses the mature core construction path; parity tests prove this explicit
  * runtime can replace the implicit current-store bridge before the switch.
+ *
+ * The explicit runtime never monkey-patches stateStore.lookupAttachment().
+ * Full durable recovery is requested through index.lookupAttachment(), making
+ * ownership visible at the call site before C1 deletes the legacy delegation.
  */
 export function createSessionVisionRuntime({
   core,
@@ -37,6 +41,7 @@ export function createSessionVisionRuntime({
     core,
     config,
     logger,
+    legacyLookupDelegation: false,
   })
 
   return Object.freeze({

--- a/tests/core-vision-surface-parity.test.js
+++ b/tests/core-vision-surface-parity.test.js
@@ -1,0 +1,129 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { resolveSessionSurfacePolicy } from '../lib/session-surface-policy.js'
+import {
+  CORE_VISION_SURFACE_KEYS,
+  resolveCoreVisionSurface,
+} from '../lib/core-vision-surface.js'
+
+const OWNERSHIPS = [
+  'native-image',
+  'vision-router-owned',
+  'text-only',
+  'unknown',
+]
+
+function policyFor(ownership) {
+  return {
+    ownership,
+    preserveRawImages:
+      ownership === 'native-image' ||
+      ownership === 'vision-router-owned' ||
+      ownership === 'unknown',
+    rewriteCurrentImages: ownership === 'text-only',
+    suppressGenericAutoMount: ownership === 'native-image',
+    allowStructuredBootstrap: ownership !== 'native-image',
+  }
+}
+
+function legacyProjectedValues(config, visionPolicy, schemaBootstrapping) {
+  const policy = resolveSessionSurfacePolicy({
+    visionPolicy,
+    config,
+    schemaBootstrapping,
+  })
+  const projected = { ...config, ...policy.legacyConfigOverrides }
+  return {
+    policy,
+    values: Object.fromEntries(
+      CORE_VISION_SURFACE_KEYS.map((key) => [key, projected[key]]),
+    ),
+  }
+}
+
+function boolConfigs() {
+  const keys = [
+    'tool',
+    'rewriteImages',
+    'instantDescribe',
+    'autoActivateOnImage',
+    'structuredVisionBootstrap',
+  ]
+  const rows = []
+  for (let mask = 0; mask < (1 << keys.length); mask++) {
+    rows.push(Object.fromEntries(
+      keys.map((key, index) => [key, Boolean(mask & (1 << index))]),
+    ))
+  }
+  return rows
+}
+
+test('explicit core surface is exactly equivalent to every legacy projection combination', () => {
+  let cases = 0
+  for (const ownership of OWNERSHIPS) {
+    const visionPolicy = policyFor(ownership)
+    for (const config of boolConfigs()) {
+      for (const schemaBootstrapping of [false, true]) {
+        const legacy = legacyProjectedValues(config, visionPolicy, schemaBootstrapping)
+        const explicit = resolveCoreVisionSurface({
+          visionPolicy,
+          config,
+          schemaBootstrapping,
+        })
+
+        assert.deepEqual(
+          explicit.values,
+          legacy.values,
+          `core surface drift for ${ownership} bootstrap=${schemaBootstrapping} config=${JSON.stringify(config)}`,
+        )
+        assert.equal(explicit.ownership, legacy.policy.ownership)
+        assert.equal(explicit.preserveRawImages, legacy.policy.preserveRawImages)
+        assert.equal(explicit.rewriteCurrentImages, legacy.policy.rewriteCurrentImages)
+        cases += 1
+      }
+    }
+  }
+  assert.equal(cases, 256)
+})
+
+test('absence of session ownership does not invent UNKNOWN or rewrite authority', () => {
+  const config = {
+    tool: true,
+    rewriteImages: true,
+    instantDescribe: true,
+    autoActivateOnImage: true,
+    structuredVisionBootstrap: true,
+  }
+  const legacy = legacyProjectedValues(config, undefined, false)
+  const explicit = resolveCoreVisionSurface({ config })
+
+  assert.equal(explicit.ownership, undefined)
+  assert.equal(explicit.preserveRawImages, false)
+  assert.equal(explicit.rewriteCurrentImages, false)
+  assert.deepEqual(explicit.values, legacy.values)
+})
+
+test('explicit surface cannot expose unrelated plugin configuration as a fake Settings object', () => {
+  const config = {
+    tool: true,
+    rewriteImages: true,
+    instantDescribe: true,
+    autoActivateOnImage: true,
+    structuredVisionBootstrap: true,
+    proxy: 'http://secret-proxy.example',
+    providers: [{ provider: 'paid-provider', model: 'secret-model' }],
+    allowRemoteSettings: true,
+  }
+  const explicit = resolveCoreVisionSurface({
+    visionPolicy: policyFor('native-image'),
+    config,
+  })
+
+  assert.deepEqual(Object.keys(explicit.values), [...CORE_VISION_SURFACE_KEYS])
+  assert.equal(Object.hasOwn(explicit.values, 'proxy'), false)
+  assert.equal(Object.hasOwn(explicit.values, 'providers'), false)
+  assert.equal(Object.hasOwn(explicit.values, 'allowRemoteSettings'), false)
+  assert.equal(Object.isFrozen(explicit), true)
+  assert.equal(Object.isFrozen(explicit.values), true)
+})

--- a/tests/session-vision-runtime-parity.test.js
+++ b/tests/session-vision-runtime-parity.test.js
@@ -49,6 +49,21 @@ test('explicit SessionVisionRuntime owns exactly one store and one index', () =>
   )
 })
 
+test('explicit runtime never monkey-patches the state-store lookup API', () => {
+  const store = createSessionVisionStateStore()
+  const originalLookup = store.lookupAttachment
+  const runtime = createSessionVisionRuntime({ core: coreStub(), stateStore: store })
+  const session = {
+    id: 'no-monkey-patch',
+    events: [{ type: 'user/message', data: { refs: [ref('durable')] } }],
+    surface: { nodes: [0] },
+  }
+
+  runtime.index.scanEventLog(session)
+  runtime.index.lookupAttachment(session, 'durable')
+  assert.equal(store.lookupAttachment, originalLookup)
+})
+
 test('explicit runtime index remains bound to its own store when legacy current-store pointer drifts', () => {
   const storeA = createSessionVisionStateStore()
   const runtime = createSessionVisionRuntime({ core: coreStub(), stateStore: storeA })

--- a/tests/session-vision-runtime-parity.test.js
+++ b/tests/session-vision-runtime-parity.test.js
@@ -1,0 +1,89 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  createSessionVisionRuntime,
+  DEFAULT_SESSION_VISION_STATE_OPTIONS,
+} from '../lib/session-vision-runtime.js'
+import {
+  createSessionVisionStateStore,
+  currentSessionVisionStateStore,
+} from '../lib/session-vision-state.js'
+
+function ref(id) {
+  return { attachmentId: id, name: `${id}.png`, mediaType: 'image/png' }
+}
+
+function coreStub() {
+  return {
+    collectEventAttachmentRefs(events) {
+      const out = []
+      for (const event of events ?? []) {
+        if (Array.isArray(event?.data?.refs)) out.push(...event.data.refs)
+      }
+      return out
+    },
+    rewriteImageBlocks(messages) {
+      const attachments = []
+      for (const message of messages ?? []) {
+        for (const block of message?.content ?? []) {
+          if (block?.type === 'image' && block.attachment) attachments.push(block.attachment)
+        }
+      }
+      return { messages, attachments }
+    },
+    planToolResultImageShadows() { return [] },
+    planGuardStopShadows() { return [] },
+  }
+}
+
+test('explicit SessionVisionRuntime owns exactly one store and one index', () => {
+  const runtime = createSessionVisionRuntime({ core: coreStub() })
+  assert.ok(runtime.stateStore)
+  assert.ok(runtime.index)
+  assert.equal(Object.isFrozen(runtime), true)
+  assert.deepEqual(
+    runtime.stateStore.options,
+    DEFAULT_SESSION_VISION_STATE_OPTIONS,
+    'closure runtime must preserve the mature core store bounds exactly',
+  )
+})
+
+test('explicit runtime index remains bound to its own store when legacy current-store pointer drifts', () => {
+  const storeA = createSessionVisionStateStore()
+  const runtime = createSessionVisionRuntime({ core: coreStub(), stateStore: storeA })
+  const session = {
+    id: 'session-a',
+    events: [{ type: 'user/message', data: { refs: [ref('owned-by-a')] } }],
+    surface: { nodes: [0] },
+  }
+
+  // Simulate the exact reason the transitional module-global bridge is unsafe:
+  // another store is constructed later in the same process.
+  const storeB = createSessionVisionStateStore()
+  assert.equal(currentSessionVisionStateStore(), storeB)
+
+  runtime.index.scanEventLog(session)
+  assert.equal(storeA.lookupAttachment(session, 'owned-by-a')?.attachmentId, 'owned-by-a')
+  assert.equal(storeB.lookupAttachment(session, 'owned-by-a'), undefined)
+})
+
+test('explicit runtime preserves bounded target-only durable recovery semantics', () => {
+  const runtime = createSessionVisionRuntime({
+    core: coreStub(),
+    stateOptions: { attachmentMaxEntries: 1 },
+  })
+  const session = {
+    id: 'bounded-recovery',
+    events: [
+      { type: 'user/message', data: { refs: [ref('old')] } },
+      { type: 'user/message', data: { refs: [ref('new')] } },
+    ],
+    surface: { nodes: [0, 1] },
+  }
+
+  runtime.index.scanEventLog(session)
+  assert.equal(runtime.stateStore.stateStats(session).attachments, 1)
+  assert.equal(runtime.index.lookupAttachment(session, 'old')?.attachmentId, 'old')
+  assert.equal(runtime.stateStore.stateStats(session).attachments, 1)
+})


### PR DESCRIPTION
## C1-A — Session/Core parity seam

First implementation slice after the C0 contract freeze. Production behavior is intentionally unchanged in this PR.

### Added

- `core-vision-surface.js`
  - explicit, immutable core-facing projection of SessionSurfacePolicy
  - carries only the five values the legacy bridge may override
  - cannot impersonate Settings or expose unrelated provider/proxy/authority configuration
- exhaustive old/new surface parity
  - 4 ownership classes × 32 config combinations × schema-bootstrap on/off = 256 exact comparisons
- `session-vision-runtime.js`
  - narrow `{ stateStore, index }` ownership object only
  - preserves the mature state-store bounds
  - explicitly binds SessionVisionIndex to its store
- runtime ownership parity tests
  - prove explicit index remains bound to its store even when the transitional module-global current-store pointer is changed by another store
  - preserve bounded target-only durable recovery
- Architecture Closure Node 22/24 gate now includes the C1 parity tests

### Deliberate non-goals

- production still uses the legacy Settings projection in this slice
- production core still constructs the mature Session store in this slice
- no currentStore deletion yet
- no store monkey-patch deletion yet
- no old core session scan/surface-repair deletion yet
- no index.js behavior change

### Migration rule

This PR exists so the legacy implementation remains a parity oracle. Only after this head is green do we switch production ownership in the next C1 slice; old code is deleted only after the switched path independently passes the same gates.