### PR TITLE
refactor(session): switch core to explicit session runtime

### DIFF
--- a/index.js
+++ b/index.js
@@ -3060,7 +3060,7 @@ export function isOpenAIHttpBridgeTransport(transport) {
   }
 }
 
-export function apply(ctx, config = {}) {
+export function apply(ctx, config = {}, runtime = {}) {
   // Route sharp version diagnostics (issue #75) through the harness logger
   // instead of console.warn, so the warning lands in the server log.
   registerSharpWarningHook((message) => {
@@ -3074,7 +3074,8 @@ export function apply(ctx, config = {}) {
   // not to the plugin process. The compatibility facade is used only at
   // adapter boundaries that do not expose a Session; ambiguous attachment ids
   // deliberately miss instead of crossing conversations.
-  const visionState = createSessionVisionStateStore({
+  const sessionVisionRuntime = runtime?.sessionVision
+  const visionState = sessionVisionRuntime?.stateStore ?? createSessionVisionStateStore({
     maxSessions: 64,
     idleTtlMs: 60 * 60 * 1000,
     descriptionMaxEntries: 64,

--- a/lib/runtime-composition.js
+++ b/lib/runtime-composition.js
@@ -12,6 +12,7 @@ import { contextWithVisionExecutionPolicy } from './vision-execution-policy.js'
 import { contextWithVisionBackendRuntimePolicy } from './vision-backend-runtime-policy.js'
 import { contextWithNativeImageCoexistence } from './native-image-coexistence.js'
 import { installSessionVisionIndexBoundary } from './session-vision-index.js'
+import { createSessionVisionRuntime } from './session-vision-runtime.js'
 import { installLegacyCoreVisionPolicyBridge } from './legacy-core-vision-policy-bridge.js'
 import { installPiAiBridgeWireCompat } from './pi-ai-bridge-wire-compat.js'
 import { installLiveModelDiscovery } from './live-model-discovery.js'
@@ -57,6 +58,17 @@ import {
   installVisionSettingsWebBoundary,
   installVisionWebIntegration,
 } from './web/index.js'
+
+function liveVisionSettings(ctx, fallback) {
+  try {
+    const settings = ctx?.get?.('settings')
+    const current = settings?.get?.('vision-router')
+    if (current && typeof current === 'object' && !Array.isArray(current)) return current
+  } catch {
+    // Before Settings mounts, the normalized composition config is authoritative.
+  }
+  return fallback
+}
 
 export function applyVisionRuntimeComposition(ctx, config = {}, core) {
   // DSH's browser WebServer can intentionally bind 0.0.0.0 and carries no
@@ -137,16 +149,21 @@ export function applyVisionRuntimeComposition(ctx, config = {}, core) {
   const toolRuntimeCtx = installVisionToolRuntimeBoundary(attachmentCompatCtx, runtimeConfig)
   const nativeImageCompat = contextWithNativeImageCoexistence(toolRuntimeCtx, runtimeConfig)
 
-  // P2-C centralizes the durable attachment index and two model-surface repair
-  // cursors inside the same native-ownership ALS. Its decorated next() runs
-  // after downstream middleware settles but before the mature core resumes, so
-  // the old core scan blocks remain compatibility no-ops without changing Host
-  // persistence or resume semantics.
+  // C1 production owner: one explicit bounded store + one explicit index. The
+  // index reads the same live Host settings namespace but never discovers the
+  // store through a module-global current pointer and never monkey-patches its
+  // lookup API. Core receives this same narrow runtime through its optional
+  // internal runtime argument; direct legacy core callers keep the old fallback.
+  const sessionVisionRuntime = createSessionVisionRuntime({
+    core,
+    config: () => liveVisionSettings(nativeImageCompat.ctx, nativeImageCompat.config),
+    logger: logging.logger,
+  })
   const sessionIndexCtx = installSessionVisionIndexBoundary(
     nativeImageCompat.ctx,
     nativeImageCompat.config,
     core,
-    { logger: logging.logger },
+    { logger: logging.logger, index: sessionVisionRuntime.index },
   )
   const legacyCoreCompat = installLegacyCoreVisionPolicyBridge(
     sessionIndexCtx,
@@ -264,7 +281,11 @@ export function applyVisionRuntimeComposition(ctx, config = {}, core) {
   try {
     const result = withVisionCircuitBreakerObserver(
       breakerShadowHealth.capture,
-      () => core.apply(backendRuntimeCtx, legacyCoreCompat.config),
+      () => core.apply(
+        backendRuntimeCtx,
+        legacyCoreCompat.config,
+        { sessionVision: sessionVisionRuntime },
+      ),
     )
     legacyCoreCompat.finishSchemaBootstrap()
     installWrapperDirectoryAlias(attachmentCompatCtx, runtimeConfig, logging.logger)

--- a/tests/p3-entry-composition.test.js
+++ b/tests/p3-entry-composition.test.js
@@ -30,6 +30,7 @@ test('P3-F composition remains bounded and preserves the mature runtime sequence
     'installHostSettingsCompatibility(',
     'installVisionToolRuntimeBoundary(attachmentCompatCtx, runtimeConfig)',
     'contextWithNativeImageCoexistence(toolRuntimeCtx, runtimeConfig)',
+    'createSessionVisionRuntime({',
     'installSessionVisionIndexBoundary(',
     'installLegacyCoreVisionPolicyBridge(',
     'installVisionLimitDiagnostics(',
@@ -44,7 +45,7 @@ test('P3-F composition remains bounded and preserves the mature runtime sequence
     'contextWithVisionBackendRuntimePolicy(',
     'installCapabilityBenchmarkService(',
     'installTesseractExecFileCompat(backendRuntimeCtx)',
-    'core.apply(backendRuntimeCtx, legacyCoreCompat.config)',
+    '() => core.apply(',
   ]
 
   let previous = -1
@@ -54,6 +55,11 @@ test('P3-F composition remains bounded and preserves the mature runtime sequence
     previous = at
   }
 
+  assert.match(
+    source,
+    /\(\) => core\.apply\(\s*backendRuntimeCtx,\s*legacyCoreCompat\.config,\s*\{ sessionVision: sessionVisionRuntime \},?\s*\)/s,
+    'core must receive both the fully composed backend context and the explicit SessionVisionRuntime owner',
+  )
   assert.ok(
     source.split('\n').length < 400,
     'runtime composition must remain orchestration-sized rather than becoming a new monolith',

--- a/tests/qa-runtime-identity.test.js
+++ b/tests/qa-runtime-identity.test.js
@@ -99,6 +99,12 @@ test('P3 final composition keeps runtime order outside the thin public entry', a
   const nativeAt = source.indexOf(
     'const nativeImageCompat = contextWithNativeImageCoexistence(toolRuntimeCtx, runtimeConfig)',
   )
+  const sessionRuntimeAt = source.indexOf(
+    'const sessionVisionRuntime = createSessionVisionRuntime({',
+  )
+  const sessionIndexAt = source.indexOf(
+    'const sessionIndexCtx = installSessionVisionIndexBoundary(',
+  )
   const bridgeAt = source.indexOf(
     'const legacyCoreCompat = installLegacyCoreVisionPolicyBridge(',
   )
@@ -117,7 +123,7 @@ test('P3 final composition keeps runtime order outside the thin public entry', a
   const backendRuntimeAt = source.indexOf(
     'const backendRuntimeCtx = contextWithVisionBackendRuntimePolicy(performanceCtx, {',
   )
-  const coreApplyAt = source.indexOf('() => core.apply(backendRuntimeCtx, legacyCoreCompat.config)')
+  const coreApplyAt = source.indexOf('() => core.apply(')
   const finishAt = source.indexOf('legacyCoreCompat.finishSchemaBootstrap()', coreApplyAt)
 
   assert.ok(mutationAt >= 0)
@@ -129,7 +135,9 @@ test('P3 final composition keeps runtime order outside the thin public entry', a
   assert.ok(settingsAt > loggingAt)
   assert.ok(runtimeAt > settingsAt, 'runtime boundary must see rc7/rc8 host settings compatibility')
   assert.ok(nativeAt > runtimeAt, 'session image ownership must run inside live tool/cancellation policy')
-  assert.ok(bridgeAt > nativeAt, 'legacy core projection must consume the session-scoped ownership policy')
+  assert.ok(sessionRuntimeAt > nativeAt, 'explicit SessionVisionRuntime must consume the final session ownership context')
+  assert.ok(sessionIndexAt > sessionRuntimeAt, 'the session index boundary must receive the explicit runtime owner')
+  assert.ok(bridgeAt > sessionIndexAt, 'legacy core projection must consume the indexed session-scoped ownership policy')
   assert.ok(
     diagnosticsAt > bridgeAt,
     'limit diagnostics must observe only the final legacy-core policy view and may not become an execution policy itself',
@@ -145,6 +153,11 @@ test('P3 final composition keeps runtime order outside the thin public entry', a
     'preflight image-delivery policy must remain outermost so direct bridges bypass runtime speed sampling',
   )
   assert.ok(coreApplyAt > backendRuntimeAt, 'core must receive the fully composed backend runtime context')
+  assert.match(
+    source.slice(coreApplyAt),
+    /^\(\) => core\.apply\(\s*backendRuntimeCtx,\s*legacyCoreCompat\.config,\s*\{ sessionVision: sessionVisionRuntime \},?\s*\)/s,
+    'core must receive the same explicit SessionVisionRuntime owner as the session index boundary',
+  )
   assert.ok(finishAt > coreApplyAt, 'the temporary schema bootstrap projection ends immediately after core wiring')
 
   const afterAdapterContract = source.slice(adapterContractAt + 1)

--- a/tests/session-runtime-core-wiring.test.js
+++ b/tests/session-runtime-core-wiring.test.js
@@ -1,0 +1,38 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+
+async function source(path) {
+  return readFile(new URL(`../${path}`, import.meta.url), 'utf8')
+}
+
+test('runtime composition creates one explicit SessionVisionRuntime and gives the same owner to boundary and core', async () => {
+  const runtime = await source('lib/runtime-composition.js')
+
+  assert.match(runtime, /const sessionVisionRuntime = createSessionVisionRuntime\(/)
+  assert.match(
+    runtime,
+    /installSessionVisionIndexBoundary\([\s\S]*?index: sessionVisionRuntime\.index/,
+  )
+  assert.match(
+    runtime,
+    /core\.apply\([\s\S]*?\{ sessionVision: sessionVisionRuntime \}[\s\S]*?\)/,
+  )
+  assert.equal(
+    (runtime.match(/createSessionVisionRuntime\(/g) ?? []).length,
+    1,
+    'composition must create exactly one SessionVisionRuntime',
+  )
+})
+
+test('core accepts the optional internal runtime without breaking two-argument direct callers', async () => {
+  const core = await source('index.js')
+
+  assert.match(core, /export function apply\(ctx, config = \{\}, runtime = \{\}\) \{/)
+  assert.match(core, /const sessionVisionRuntime = runtime\?\.sessionVision/)
+  assert.match(
+    core,
+    /const visionState = sessionVisionRuntime\?\.stateStore \?\? createSessionVisionStateStore\(\{/,
+    'core must use the explicit composition-owned store when supplied and preserve the legacy fallback otherwise',
+  )
+})

--- a/tests/session-vision-state-integration.test.js
+++ b/tests/session-vision-state-integration.test.js
@@ -5,7 +5,12 @@ import test from 'node:test'
 const source = await readFile(new URL('../index.js', import.meta.url), 'utf8')
 
 test('runtime no longer owns cross-turn vision state in process-global raw Maps', () => {
-  assert.match(source, /const visionState = createSessionVisionStateStore\(/)
+  assert.match(source, /const sessionVisionRuntime = runtime\?\.sessionVision/)
+  assert.match(
+    source,
+    /const visionState = sessionVisionRuntime\?\.stateStore \?\? createSessionVisionStateStore\(/,
+    'explicit composition ownership must take precedence while preserving two-argument direct-call fallback',
+  )
   assert.doesNotMatch(source, /const imageMemory = new Map\(\)/)
   assert.doesNotMatch(source, /const sessionAttachmentsById = new Map\(\)/)
   assert.doesNotMatch(source, /const scannedSessionEventSeqs = new Map\(\)/)


### PR DESCRIPTION
## C1-B formal acceptance — COMPLETE / PASS

Final head: `00d7bbcbf3ec46437e3ad8ecdefcd8e95d55dc9e`
Base: `main@11ca4d1e4ba9edf333bdaff7cd16ca5f4cb9453f`

### Production switch

- [x] Public runtime composition creates exactly one explicit `SessionVisionRuntime { stateStore, index }`.
- [x] The same runtime owner is passed to `SessionVisionIndex` and to `core.apply(..., { sessionVision })`.
- [x] Core accepts an optional third internal runtime argument.
- [x] Production prefers `runtime.sessionVision.stateStore`.
- [x] Historical two-argument `core.apply(ctx, config)` keeps the bounded local-store fallback.
- [x] Exact core patch was only 3 insertions / 2 deletions.
- [x] Local focused suite passed 30/30.

### Structure-contract update

Two old source-order tests initially failed because they hard-coded the historical two-argument `core.apply(...)` call. They were updated without weakening lifecycle ordering. The final tests now explicitly require:

`native ownership -> explicit SessionVisionRuntime -> SessionIndex boundary -> legacy projection -> diagnostics/structured/runtime layers -> fully composed backend context -> core.apply`

and verify that `core.apply` receives the exact same `sessionVisionRuntime` owner as the SessionIndex boundary.

### Final-head CI

All workflows passed on `00d7bbcb...`:

- Architecture Closure: success
- P2 Data Boundary: success
- P3 Compatibility Convergence: success
- P1 Routing Parity: success
- DSH Contract: success
- Native multimodal cold resume: success
- Large image resource stress: success
- CI: success

Full CI includes:
- Node 22 `pnpm test`: success
- Node 24 `pnpm test`: success
- rc6 / rc7 / rc8: success
- Ubuntu / macOS / Windows host-sharp: success

DSH Contract minimum / legacy / current: all success.
Native cold-resume rc7/rc8 on Node22/24: all success.

### Scope discipline

This PR intentionally does **not** delete the old core event-log scan, target recovery, surface-repair code, module-global current-store bridge, or legacy Settings projection. Those remain as oracle/compatibility code until C1-C, after this switched production path has independently proven green.

### Verdict

**C1-B production switch: COMPLETE / PASS.**