### PR TITLE
refactor(session): retire implicit Session store ownership

### DIFF
--- a/.github/workflows/architecture-closure.yml
+++ b/.github/workflows/architecture-closure.yml
@@ -18,6 +18,7 @@ on:
       - 'docs/architecture/**'
       - 'tests/architecture-contract-baseline.test.js'
       - 'tests/core-vision-surface-parity.test.js'
+      - 'tests/session-runtime-core-wiring.test.js'
       - 'tests/session-vision-runtime-parity.test.js'
       - 'tests/vision-execution-order-core-wiring.test.js'
       - 'tests/session-vision-state-integration.test.js'
@@ -45,6 +46,7 @@ on:
       - 'docs/architecture/**'
       - 'tests/architecture-contract-baseline.test.js'
       - 'tests/core-vision-surface-parity.test.js'
+      - 'tests/session-runtime-core-wiring.test.js'
       - 'tests/session-vision-runtime-parity.test.js'
       - 'tests/vision-execution-order-core-wiring.test.js'
       - 'tests/session-vision-state-integration.test.js'
@@ -80,6 +82,7 @@ jobs:
           node --test
           tests/architecture-contract-baseline.test.js
           tests/core-vision-surface-parity.test.js
+          tests/session-runtime-core-wiring.test.js
           tests/session-vision-runtime-parity.test.js
           tests/vision-execution-order-core-wiring.test.js
           tests/session-vision-state-integration.test.js

--- a/index.js
+++ b/index.js
@@ -73,6 +73,7 @@ import {
   scaleBox,
   scaledDimensions,
 } from './lib/image-resource-governor.js'
+import { createSessionVisionIndex } from './lib/session-vision-index.js'
 import { createSessionVisionStateStore } from './lib/session-vision-state.js'
 import {
   ERROR_RESPONSE_MAX_BYTES,
@@ -3082,6 +3083,17 @@ export function apply(ctx, config = {}, runtime = {}) {
     descriptionMaxChars: 256 * 1024,
     attachmentMaxEntries: 256,
   })
+  const sessionVisionIndex = sessionVisionRuntime?.index ?? createSessionVisionIndex({
+    stateStore: visionState,
+    core: {
+      collectEventAttachmentRefs,
+      rewriteImageBlocks,
+      planToolResultImageShadows,
+      planGuardStopShadows,
+    },
+    config: () => current(),
+    logger: ctx.logger,
+  })
   const imageMemory = visionState.descriptionFacade
   // #208 follow-up complete: session-visible paths use scoped memory; only
   // session-less adapter boundaries use the ambiguity-safe facade.
@@ -4730,284 +4742,16 @@ export function apply(ctx, config = {}, runtime = {}) {
     }, 'vision-router: proxy fetch')
   }
 
-  const recordUploadedAttachments = (session, attachments) => {
-    visionState.recordAttachments(session, attachments)
-  }
-
-  /**
-   * Index image attachments recorded anywhere in the session event log, not
-   * just in the inbox-claim message stream `agent/pre-step` hands us
-   * (issue #72). Host-produced images (the built-in `read_image` tool's
-   * re-uploads, persisted as `tool/result` events) never enter that stream,
-   * so the harness-announced attachment id stayed unresolvable even though
-   * the UI showed the image and the bytes are durably stored. `session.events`
-   * is the complete append-only log (seeded from storage on resume), so
-   * scanning it — incrementally, per session id — finds every ref with full
-   * metadata for a later `attachments.readImage(ref)`.
-   */
-  const scanSessionEventLog = (session) => {
-    if (!session) return
-    let events
-    try {
-      events = session.events
-    } catch {
-      return // not a host Session (or the getter is unavailable): nothing to scan
-    }
-    if (!Array.isArray(events) || events.length === 0) return
-    const last = visionState.getScannedEventSeq(session)
-    if (last >= events.length) return
-    const refs = collectEventAttachmentRefs(events.slice(last))
-    visionState.setScannedEventSeq(session, events.length)
-    if (refs.length > 0) recordUploadedAttachments(session, refs)
-  }
-
-  const lookupAttachment = (session, id) => {
-    let hit = visionState.lookupAttachment(session, id)
-    if (hit !== undefined) return hit
-    // Cache eviction is a performance event, never a correctness event. First
-    // consume any newly appended log entries; if the requested ref was older
-    // than the bounded working set, perform a target-only recovery from the
-    // durable session log instead of rebuilding an unbounded index.
-    if (session !== undefined) {
-      scanSessionEventLog(session)
-      hit = visionState.lookupAttachment(session, id)
-      if (hit !== undefined) return hit
-      let events
-      try {
-        events = session.events
-      } catch {
-        events = undefined
-      }
-      if (Array.isArray(events) && events.length > 0) {
-        const wanted = String(id)
-        const recovered = collectEventAttachmentRefs(events).find(
-          (ref) => ref && String(ref.attachmentId) === wanted,
-        )
-        if (recovered !== undefined) {
-          visionState.recordAttachments(session, [recovered])
-          return recovered
-        }
-      }
-    }
-    return undefined
-  }
-
-  // ── issue #74: shadow-sanitize tool-result image blocks on the surface ────
-  //
-  // A tool result that renders an image block (vision_present, or the host
-  // read_image on image-capable routes) is persisted as a durable
-  // `tool/result` event and then flows into EVERY later request through
-  // `Session.deriveMessages()`. A text-only adapter (DeepSeek native, pi-ai
-  // text routes) rejects nested images with UNSUPPORTED_CONTENT and the
-  // session is locked forever. The pre-step inbox sanitizer cannot see these
-  // historical events, so the surface itself is rewritten instead: each
-  // offending event is shadowed by a sanitized replacement event
-  // (`surfaceOp: {op:'replace'}`, the same mechanism the host compaction
-  // pruner uses). The Web UI transcript renders append-origin events, so the
-  // user still sees the image; only the model-visible surface is sanitized.
-  // The decision is route-aware: an image-capable route legitimately consumes
-  // read_image's result image, mirroring the host's own gate
-  // (`assertImageCapableRoute` in dsh-tool-fs).
-
-  // session -> { count: nodes examined, done: Set<seqs already decided> }
-  const sessionSurfaceScans = new WeakMap()
-
-  const sessionRouteHandlesImages = async (session) => {
-    let provider
-    let model
-    try {
-      const header = typeof session.requestHeader === 'function' ? session.requestHeader() : undefined
-      provider = header && header.config ? header.config.provider : undefined
-      model = header && header.config ? header.config.model : undefined
-    } catch {
-      return false
-    }
-    if (typeof provider !== 'string' || provider === '' || typeof model !== 'string' || model === '') {
-      return false
-    }
-    // Plugin-owned routes handle image blocks at their stream boundary: the
-    // wrapper and the provider twins rewrite them into markers/descriptions,
-    // the stealth adapter does the same, and the vision-chain route serves
-    // image-capable models.
-    if (provider === wrapperRoute() || provider === chainRoute() || provider.endsWith('-vision')) {
-      return true
-    }
-    if (stealthActive && provider === 'deepseek-official') return true
-    // Routing mode reverse-routes text-only turns back to the text provider;
-    // when neither the wrapper nor the stealth adapter is there to rewrite
-    // images, the reverse target is the bare text adapter, which rejects
-    // tool-result images. Sanitize so text turns stay usable.
-    if (routingEnabled() && reverseRoutingEnabled() && !wrapperRegistered && !stealthActive) {
-      return false
-    }
-    // Same probe the host uses to gate read_image: only routes whose models
-    // declare image input may keep tool-result images.
-    try {
-      const info = await ctx.llm.resolveModelInfo(provider, model)
-      return Array.isArray(info && info.inputModalities) && info.inputModalities.includes('image')
-    } catch {
-      return false // unknown route: fail safe and sanitize
-    }
-  }
-
-  const sanitizeSessionToolResults = async (session) => {
-    if (!session) return
-    let events
-    let nodes
-    try {
-      events = session.events
-      nodes = session.surface && session.surface.nodes
-    } catch {
-      return // not a host Session: nothing to sanitize
-    }
-    if (!Array.isArray(events) || !Array.isArray(nodes) || nodes.length === 0) return
-    let scan = sessionSurfaceScans.get(session)
-    if (!scan) {
-      scan = { count: 0, done: new Set() }
-      sessionSurfaceScans.set(session, scan)
-    }
-    // Compaction replaces the surface wholesale; a shrunk node list means the
-    // positional cursor is stale, so restart from the head. Kept decisions are
-    // memoized in `done`, so a restart is a cheap no-op for examined events.
-    if (nodes.length < scan.count) {
-      scan.count = 0
-      scan.done = new Set()
-    }
-    if (nodes.length === scan.count) return
-    let routeHandlesImages
-    const newSeqs = nodes.slice(scan.count)
-    for (const seq of newSeqs) {
-      const event = events[seq]
-      if (!event || event.type !== 'tool/result' || scan.done.has(seq)) continue
-      const message = event.data && event.data.message
-      if (!message || !Array.isArray(message.content) || !blocksHaveImage(message.content)) {
-        scan.done.add(seq)
-        continue
-      }
-      if (routeHandlesImages === undefined) {
-        routeHandlesImages = await sessionRouteHandlesImages(session)
-      }
-      if (routeHandlesImages) {
-        // Image-capable route: keep the image (read_image's result is the
-        // model's view of the file). The wrapper/twin/stealth routes rewrite
-        // it at stream time anyway.
-        scan.done.add(seq)
-        continue
-      }
-      const sanitized = sanitizeToolResultMessage(message)
-      if (sanitized === message) {
-        scan.done.add(seq)
-        continue
-      }
-      try {
-        session.append(
-          'tool/result',
-          { ...event.data, message: sanitized },
-          {
-            surfaceOp: { op: 'replace', start: seq, end: seq },
-            sourceEventSeqs: [seq],
-          },
-        )
-        scan.done.add(seq)
-        ctx.logger?.info(
-          'vision-router: sanitized a tool-result image block out of the model surface (event seq %s)',
-          seq,
-        )
-      } catch (error) {
-        // A failed shadow leaves the original event on the surface: the
-        // session stays usable (today's behavior) instead of crashing the
-        // pre-step.
-        ctx.logger?.warn(
-          'vision-router: could not sanitize tool-result image at event seq %s (%s)',
-          seq,
-          error && error.message ? error.message : String(error),
-        )
-      }
-    }
-    scan.count += newSeqs.length
-  }
-
-  /**
-   * Shadow-sanitize persisted guard-stop messages off the model surface.
-   *
-   * Guard-stop orders (turn-budget / depth-quota exhausted) were injected as
-   * `user/message` events and persisted into session history. `agent/pre-step`
-   * only sees the inbox claim — never the historical surface — so a pre-step
-   * rewrite cannot catch them before `Session.deriveMessages()` feeds history
-   * to the adapter. A persisted guard-stop is then replayed on EVERY later
-   * turn as a standing "never call vision tools again" order, even though the
-   * per-turn budget/depth quota resets every turn: the first image in a
-   * session is recognized, but every later image answers "本轮视觉总时间预算
-   * 已耗尽…" without calling any vision tool.
-   *
-   * This uses the same harness surface-shadow mechanism as the tool-result
-   * image sanitizer above: replace the surface node with an inert note via
-   * `surfaceOp: {op:'replace'}` + `sourceEventSeqs`, so the human transcript
-   * keeps the original while every later `deriveMessages()` projection sees
-   * the replacement. Durable, replayable, survives session resume.
-   */
-  const guardStopSurfaceScans = new WeakMap()
-  const sanitizeSessionGuardStops = async (session) => {
-    if (!session) return
-    let events
-    let nodes
-    try {
-      events = session.events
-      nodes = session.surface && session.surface.nodes
-    } catch {
-      return // not a host Session: nothing to sanitize
-    }
-    if (!Array.isArray(events) || !Array.isArray(nodes) || nodes.length === 0) return
-    let scan = guardStopSurfaceScans.get(session)
-    if (!scan) {
-      scan = { count: 0, done: new Set() }
-      guardStopSurfaceScans.set(session, scan)
-    }
-    // Compaction replaces the surface wholesale; a shrunk node list means the
-    // positional cursor is stale, so restart from the head (same as the
-    // tool-result sanitizer above).
-    if (nodes.length < scan.count) {
-      scan.count = 0
-      scan.done = new Set()
-    }
-    if (nodes.length === scan.count) return
-    const newSeqs = nodes.slice(scan.count)
-    const plans = planGuardStopShadows(events, newSeqs)
-    for (const plan of plans) {
-      if (scan.done.has(plan.seq)) continue
-      scan.done.add(plan.seq)
-      try {
-        session.append(
-          'user/message',
-          plan.data,
-          {
-            surfaceOp: { op: 'replace', start: plan.seq, end: plan.seq },
-            sourceEventSeqs: [plan.seq],
-          },
-        )
-        ctx.logger?.info(
-          'vision-router: shadowed a persisted guard-stop message off the model surface (event seq %s)',
-          plan.seq,
-        )
-      } catch (error) {
-        // A failed shadow leaves the original event on the surface: the
-        // session stays usable (today's behavior) instead of crashing the
-        // pre-step.
-        ctx.logger?.warn(
-          'vision-router: could not shadow guard-stop at event seq %s (%s)',
-          plan.seq,
-          error && error.message ? error.message : String(error),
-        )
-      }
-    }
-    scan.count += newSeqs.length
-  }
+  const lookupAttachment = (session, id) => sessionVisionIndex.lookupAttachment(session, id)
 
   // session -> { turn, startIndex, hasImage, routed, failures, lastError }
   const turnState = new WeakMap()
 
   ctx.on('agent/pre-step', async (payload, next) => {
-    const decision = await next()
+    let decision = await next()
+    if (sessionVisionRuntime?.index === undefined) {
+      decision = await sessionVisionIndex.prepareDecision(payload, decision)
+    }
     if (decision && decision.kind === 'reject') return decision
     const session = payload.agent && payload.agent.session
     if (!session) return decision
@@ -5038,40 +4782,13 @@ export function apply(ctx, config = {}, runtime = {}) {
         )
       }
     }
-    // Record every raw image reference before nested tool-result images are
-    // sanitized. This preserves attachment lookup for a later vision_describe.
-    const rawImageRefs = rewriteImageBlocks(rawMessages)
-    recordUploadedAttachments(session, rawImageRefs.attachments)
-    // Also index image attachments that live only in the session event log
-    // (read_image re-uploads never cross the inbox-claim message stream).
-    // Incremental: scans only new events (issue #72).
-    scanSessionEventLog(session)
     // Hard invariant: tool-produced image blocks never reach a model request.
-    // Two layers: (1) sanitize tool-result images in the inbox claim, and
-    // (2) shadow-sanitize historical tool/result events on the session
-    // surface (issue #74) — the only lever that can rewrite durable history.
+    // SessionVisionIndex owns durable-log indexing and historical surface
+    // repair; Core retains only the current inbox sanitizer.
     const sanitizedToolResults = sanitizeToolResultImages(rawMessages)
     const messages = sanitizedToolResults.messages
     const hasImage = messages.some((message) => blocksHaveImage(message && message.content))
-    try {
-      await sanitizeSessionToolResults(session)
-    } catch (error) {
-      ctx.logger?.warn(
-        'vision-router: session-surface sanitization failed (%s)',
-        error && error.message ? error.message : String(error),
-      )
-    }
-    // Guard-stop leftovers are persisted user messages, so they can only be
-    // removed from the model surface through the same shadow mechanism as
-    // tool-result images (issue #74-style surface rewrite).
-    try {
-      await sanitizeSessionGuardStops(session)
-    } catch (error) {
-      ctx.logger?.warn(
-        'vision-router: guard-stop surface sanitization failed (%s)',
-        error && error.message ? error.message : String(error),
-      )
-    }
+
     // Register the turn state BEFORE the image-turn branches below: those
     // branches return early (auto-mount reminder, history rewrite), and the
     // agent/request hook must still see the state, otherwise an image turn is

--- a/lib/session-vision-index.js
+++ b/lib/session-vision-index.js
@@ -1,5 +1,5 @@
 import { currentSessionSurfacePolicy } from './session-surface-policy.js'
-import { currentSessionVisionStateStore } from './session-vision-state.js'
+import { createSessionVisionStateStore } from './session-vision-state.js'
 
 function isObject(value) {
   return value !== null && typeof value === 'object'
@@ -39,48 +39,38 @@ function boundedMessage(error) {
  * eviction, tool-result image surface repair and expired structured guard-stop
  * surface repair.
  *
- * `legacyLookupDelegation` exists only for the pre-Closure monolithic-core
- * compatibility path. New explicit SessionVisionRuntime instances set it to
- * false, so the index never replaces stateStore.lookupAttachment().
+ * The index never replaces stateStore.lookupAttachment(). Durable recovery is
+ * requested explicitly through index.lookupAttachment(), so storage and
+ * recovery ownership remain visible at the call site.
  */
 export function createSessionVisionIndex({
-  stateStore = currentSessionVisionStateStore,
+  stateStore,
   core,
   config = {},
   logger,
-  legacyLookupDelegation = true,
 } = {}) {
   if (!core || typeof core !== 'object') throw new TypeError('session vision index requires core helpers')
-  const adoptedStores = new WeakSet()
-  const primitiveLookupByStore = new WeakMap()
+
+  // Direct/test callers get an isolated bounded store rather than discovering
+  // a module-global "current" owner. Production passes the composition-owned
+  // SessionVisionRuntime store explicitly.
+  const store = stateStore ?? createSessionVisionStateStore()
+  if (!store || typeof store !== 'object') {
+    throw new TypeError('session vision index requires a state store')
+  }
+  const primitiveLookup = typeof store.lookupAttachment === 'function'
+    ? store.lookupAttachment.bind(store)
+    : undefined
   const toolSurfaceScans = new WeakMap()
   const guardSurfaceScans = new WeakMap()
 
-  const primitiveLookupFor = (store) => {
-    let primitive = primitiveLookupByStore.get(store)
-    if (primitive) return primitive
-    primitive = typeof store?.lookupAttachment === 'function'
-      ? store.lookupAttachment.bind(store)
-      : undefined
-    if (primitive) primitiveLookupByStore.set(store, primitive)
-    return primitive
-  }
-
-  const storeNow = () => {
-    const store = typeof stateStore === 'function' ? stateStore() : stateStore
-    if (!store || typeof store !== 'object') return undefined
-    if (legacyLookupDelegation === true) adoptStore(store)
-    return store
-  }
-
   const recordAttachments = (session, refs) => {
-    const store = storeNow()
-    if (!store || !session || !Array.isArray(refs) || refs.length === 0) return
+    if (!session || !Array.isArray(refs) || refs.length === 0) return
     store.recordAttachments(session, refs)
   }
 
-  const scanEventLogWithStore = (store, session) => {
-    if (!store || !session) return
+  const scanEventLog = (session) => {
+    if (!session) return
     const events = sessionEvents(session)
     if (!events || events.length === 0) return
     const last = store.getScannedEventSeq(session)
@@ -94,17 +84,13 @@ export function createSessionVisionIndex({
     if (Array.isArray(refs) && refs.length > 0) store.recordAttachments(session, refs)
   }
 
-  const scanEventLog = (session) => {
-    const store = storeNow()
-    if (store) scanEventLogWithStore(store, session)
-  }
-
-  const lookupWithStore = (store, primitiveLookup, session, id) => {
+  const lookupAttachment = (session, id) => {
+    if (!primitiveLookup) return undefined
     let hit = primitiveLookup(session, id)
     if (hit !== undefined) return hit
     if (session === undefined) return undefined
 
-    scanEventLogWithStore(store, session)
+    scanEventLog(session)
     hit = primitiveLookup(session, id)
     if (hit !== undefined) return hit
 
@@ -124,29 +110,6 @@ export function createSessionVisionIndex({
       return recovered
     }
     return undefined
-  }
-
-  function adoptStore(store) {
-    if (legacyLookupDelegation !== true || adoptedStores.has(store)) return store
-    const original = primitiveLookupFor(store)
-    if (original) {
-      // Compatibility delegation for the pre-Closure monolithic core. The new
-      // explicit runtime never enters this branch.
-      store.lookupAttachment = (session, id) => lookupWithStore(store, original, session, id)
-    }
-    adoptedStores.add(store)
-    return store
-  }
-
-  const lookupAttachment = (session, id) => {
-    const store = storeNow()
-    if (!store) return undefined
-    const primitive = primitiveLookupFor(store)
-    if (!primitive) return undefined
-    if (legacyLookupDelegation === true && adoptedStores.has(store)) {
-      return store.lookupAttachment(session, id)
-    }
-    return lookupWithStore(store, primitive, session, id)
   }
 
   const nextSurfaceSeqs = (scans, session) => {
@@ -235,8 +198,6 @@ export function createSessionVisionIndex({
   const prepareDecision = async (payload, decision) => {
     const session = payload?.agent?.session
     if (!session) return decision
-    const store = storeNow()
-    if (!store) return decision
 
     const messages = messagesFrom(payload, decision)
     if (typeof core.rewriteImageBlocks === 'function') {
@@ -245,7 +206,7 @@ export function createSessionVisionIndex({
         store.recordAttachments(session, found.attachments)
       }
     }
-    scanEventLogWithStore(store, session)
+    scanEventLog(session)
     await repairToolResultSurface(session)
     await repairGuardStopSurface(session)
     return decision
@@ -263,12 +224,13 @@ export function createSessionVisionIndex({
 
 /**
  * Intercept core's pre-step registration and decorate only its downstream
- * `next()` result. Passing `options.index` is the C1 explicit-runtime seam; the
- * legacy path still constructs an index from the transitional current store.
+ * `next()` result. Production passes `options.index`; direct/test callers get
+ * an isolated index/store unless they explicitly provide `options.stateStore`.
  */
 export function installSessionVisionIndexBoundary(ctx, config, core, options = {}) {
   if (!isObject(ctx)) return ctx
   const index = options.index ?? createSessionVisionIndex({
+    stateStore: options.stateStore,
     core,
     config: () => {
       try {

--- a/lib/session-vision-runtime.js
+++ b/lib/session-vision-runtime.js
@@ -13,13 +13,11 @@ export const DEFAULT_SESSION_VISION_STATE_OPTIONS = Object.freeze({
  * Narrow C1 ownership boundary for Session-local Vision Router state.
  *
  * This object intentionally owns only the bounded state store and its index.
- * It is not a general runtime service locator. During C1-A production still
- * uses the mature core construction path; parity tests prove this explicit
- * runtime can replace the implicit current-store bridge before the switch.
+ * It is not a general runtime service locator. Production composition creates
+ * one instance and gives the same owner to the Session boundary and Core.
  *
- * The explicit runtime never monkey-patches stateStore.lookupAttachment().
- * Full durable recovery is requested through index.lookupAttachment(), making
- * ownership visible at the call site before C1 deletes the legacy delegation.
+ * Durable recovery is requested through index.lookupAttachment(); the index
+ * never monkey-patches stateStore.lookupAttachment().
  */
 export function createSessionVisionRuntime({
   core,
@@ -41,7 +39,6 @@ export function createSessionVisionRuntime({
     core,
     config,
     logger,
-    legacyLookupDelegation: false,
   })
 
   return Object.freeze({

--- a/lib/session-vision-state.js
+++ b/lib/session-vision-state.js
@@ -12,24 +12,12 @@ const DEFAULTS = Object.freeze({
 // Weak keys prevent a finished Session from being retained by this seam.
 const knownSessionMemoryViews = new WeakMap()
 
-// Transitional P2 bridge for the entry-layer SessionVisionIndex. The mature
-// core still constructs the one process/profile SessionVisionStateStore itself;
-// until P3 deletes that monolithic construction seam, the entry boundary needs
-// a read-only way to reach the same store instead of creating a second index.
-// Production creates one store per plugin composition. Tests that construct an
-// isolated store intentionally make that store current for their process.
-let currentStore
-
 function isSessionKey(value) {
   return value !== null && (typeof value === 'object' || typeof value === 'function')
 }
 
 export function knownSessionVisionMemory(session) {
   return isSessionKey(session) ? knownSessionMemoryViews.get(session) : undefined
-}
-
-export function currentSessionVisionStateStore() {
-  return currentStore
 }
 
 class WeightedLruMap {
@@ -425,6 +413,5 @@ export function createSessionVisionStateStore(config = {}) {
   }
 
   store.descriptionFacade = new DescriptionFacade(store)
-  currentStore = store
   return store
 }

--- a/tests/session-runtime-core-wiring.test.js
+++ b/tests/session-runtime-core-wiring.test.js
@@ -31,7 +31,7 @@ test('session state and index expose no hidden current owner or lookup monkey-pa
 
   assert.doesNotMatch(state, /currentSessionVisionStateStore|\blet currentStore\b/)
   assert.doesNotMatch(index, /currentSessionVisionStateStore|legacyLookupDelegation|adoptStore/)
-  assert.doesNotMatch(index, /store\.lookupAttachment\s*=/)
+  assert.doesNotMatch(index, /store\.lookupAttachment\s*=(?!=)/)
   assert.match(index, /stateStore \?\? createSessionVisionStateStore\(\)/)
 })
 

--- a/tests/session-runtime-core-wiring.test.js
+++ b/tests/session-runtime-core-wiring.test.js
@@ -25,6 +25,16 @@ test('runtime composition creates one explicit SessionVisionRuntime and gives th
   )
 })
 
+test('session state and index expose no hidden current owner or lookup monkey-patch seam', async () => {
+  const state = await source('lib/session-vision-state.js')
+  const index = await source('lib/session-vision-index.js')
+
+  assert.doesNotMatch(state, /currentSessionVisionStateStore|\blet currentStore\b/)
+  assert.doesNotMatch(index, /currentSessionVisionStateStore|legacyLookupDelegation|adoptStore/)
+  assert.doesNotMatch(index, /store\.lookupAttachment\s*=/)
+  assert.match(index, /stateStore \?\? createSessionVisionStateStore\(\)/)
+})
+
 test('core accepts the optional internal runtime without breaking two-argument direct callers', async () => {
   const core = await source('index.js')
 

--- a/tests/session-runtime-core-wiring.test.js
+++ b/tests/session-runtime-core-wiring.test.js
@@ -35,6 +35,25 @@ test('session state and index expose no hidden current owner or lookup monkey-pa
   assert.match(index, /stateStore \?\? createSessionVisionStateStore\(\)/)
 })
 
+test('core delegates Session indexing, recovery and surface repair to SessionVisionIndex only', async () => {
+  const core = await source('index.js')
+
+  assert.match(core, /import \{ createSessionVisionIndex \} from '.\/lib\/session-vision-index\.js'/)
+  assert.match(
+    core,
+    /const sessionVisionIndex = sessionVisionRuntime\?\.index \?\? createSessionVisionIndex\(/,
+  )
+  assert.match(
+    core,
+    /const lookupAttachment = \(session, id\) => sessionVisionIndex\.lookupAttachment\(session, id\)/,
+  )
+  assert.doesNotMatch(core, /const scanSessionEventLog\s*=/)
+  assert.doesNotMatch(core, /const sanitizeSessionToolResults\s*=/)
+  assert.doesNotMatch(core, /const sanitizeSessionGuardStops\s*=/)
+  assert.doesNotMatch(core, /const sessionSurfaceScans\s*=/)
+  assert.doesNotMatch(core, /const guardStopSurfaceScans\s*=/)
+})
+
 test('core accepts the optional internal runtime without breaking two-argument direct callers', async () => {
   const core = await source('index.js')
 
@@ -44,5 +63,10 @@ test('core accepts the optional internal runtime without breaking two-argument d
     core,
     /const visionState = sessionVisionRuntime\?\.stateStore \?\? createSessionVisionStateStore\(\{/,
     'core must use the explicit composition-owned store when supplied and preserve the legacy fallback otherwise',
+  )
+  assert.match(
+    core,
+    /if \(sessionVisionRuntime\?\.index === undefined\) \{\s*decision = await sessionVisionIndex\.prepareDecision\(payload, decision\)\s*\}/,
+    'two-argument direct callers must keep the same Session behavior through the local index fallback',
   )
 })

--- a/tests/session-vision-index.test.js
+++ b/tests/session-vision-index.test.js
@@ -1,10 +1,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
-import {
-  createSessionVisionStateStore,
-  currentSessionVisionStateStore,
-} from '../lib/session-vision-state.js'
+import { createSessionVisionStateStore } from '../lib/session-vision-state.js'
 import {
   createSessionVisionIndex,
   installSessionVisionIndexBoundary,
@@ -86,9 +83,13 @@ function sessionWith(events = [], nodes = events.map((_, index) => index)) {
   }
 }
 
-test('state store constructed by mature core is discoverable by the P2 session index boundary', () => {
-  const store = createSessionVisionStateStore()
-  assert.equal(currentSessionVisionStateStore(), store)
+test('state-store factories are independent and expose no implicit current owner', () => {
+  const first = createSessionVisionStateStore()
+  const second = createSessionVisionStateStore()
+  const session = { id: 'factory-isolation' }
+  first.recordAttachments(session, [ref('first-only')])
+  assert.equal(first.lookupAttachment(session, 'first-only')?.attachmentId, 'first-only')
+  assert.equal(second.lookupAttachment(session, 'first-only'), undefined)
 })
 
 test('incremental durable-log scan advances cursor and records only new attachment refs', () => {
@@ -108,8 +109,9 @@ test('incremental durable-log scan advances cursor and records only new attachme
   assert.equal(store.lookupAttachment(session, 'b')?.attachmentId, 'b')
 })
 
-test('bounded attachment eviction triggers target-only durable recovery through the same store lookup API', () => {
+test('bounded attachment eviction recovers only through SessionVisionIndex without patching the store API', () => {
   const store = createSessionVisionStateStore({ attachmentMaxEntries: 1 })
+  const originalLookup = store.lookupAttachment
   const session = sessionWith([
     { type: 'user/message', data: { refs: [ref('old')] } },
     { type: 'user/message', data: { refs: [ref('new')] } },
@@ -118,9 +120,9 @@ test('bounded attachment eviction triggers target-only durable recovery through 
 
   index.scanEventLog(session)
   assert.equal(store.stateStats(session).attachments, 1)
-  // createSessionVisionIndex adopts the mature store's compatibility lookup;
-  // core callers therefore hit the centralized targeted recovery first.
-  assert.equal(store.lookupAttachment(session, 'old')?.attachmentId, 'old')
+  assert.equal(store.lookupAttachment(session, 'old'), undefined)
+  assert.equal(index.lookupAttachment(session, 'old')?.attachmentId, 'old')
+  assert.equal(store.lookupAttachment, originalLookup)
   assert.equal(store.stateStats(session).attachments, 1)
 })
 
@@ -174,6 +176,7 @@ test('surface cursor resets safely when compaction/replay shrinks the node list'
 
 test('pre-step boundary prepares downstream decision before mature core resumes', async () => {
   const store = createSessionVisionStateStore()
+  const index = createSessionVisionIndex({ stateStore: store, core: coreStub() })
   const handlers = new Map()
   const ctx = {
     on(event, handler) {
@@ -184,7 +187,7 @@ test('pre-step boundary prepares downstream decision before mature core resumes'
       return undefined
     },
   }
-  const wrapped = installSessionVisionIndexBoundary(ctx, {}, coreStub())
+  const wrapped = installSessionVisionIndexBoundary(ctx, {}, coreStub(), { index })
 
   let observedCursor = 0
   wrapped.on('agent/pre-step', async (payload, next) => {

--- a/tests/session-vision-runtime-parity.test.js
+++ b/tests/session-vision-runtime-parity.test.js
@@ -5,10 +5,7 @@ import {
   createSessionVisionRuntime,
   DEFAULT_SESSION_VISION_STATE_OPTIONS,
 } from '../lib/session-vision-runtime.js'
-import {
-  createSessionVisionStateStore,
-  currentSessionVisionStateStore,
-} from '../lib/session-vision-state.js'
+import { createSessionVisionStateStore } from '../lib/session-vision-state.js'
 
 function ref(id) {
   return { attachmentId: id, name: `${id}.png`, mediaType: 'image/png' }
@@ -64,7 +61,7 @@ test('explicit runtime never monkey-patches the state-store lookup API', () => {
   assert.equal(store.lookupAttachment, originalLookup)
 })
 
-test('explicit runtime index remains bound to its own store when legacy current-store pointer drifts', () => {
+test('explicit runtime remains bound to its own store when another store is constructed later', () => {
   const storeA = createSessionVisionStateStore()
   const runtime = createSessionVisionRuntime({ core: coreStub(), stateStore: storeA })
   const session = {
@@ -73,11 +70,7 @@ test('explicit runtime index remains bound to its own store when legacy current-
     surface: { nodes: [0] },
   }
 
-  // Simulate the exact reason the transitional module-global bridge is unsafe:
-  // another store is constructed later in the same process.
   const storeB = createSessionVisionStateStore()
-  assert.equal(currentSessionVisionStateStore(), storeB)
-
   runtime.index.scanEventLog(session)
   assert.equal(storeA.lookupAttachment(session, 'owned-by-a')?.attachmentId, 'owned-by-a')
   assert.equal(storeB.lookupAttachment(session, 'owned-by-a'), undefined)

--- a/tests/session-vision-state-integration.test.js
+++ b/tests/session-vision-state-integration.test.js
@@ -3,6 +3,10 @@ import { readFile } from 'node:fs/promises'
 import test from 'node:test'
 
 const source = await readFile(new URL('../index.js', import.meta.url), 'utf8')
+const sessionIndexSource = await readFile(
+  new URL('../lib/session-vision-index.js', import.meta.url),
+  'utf8',
+)
 
 test('runtime no longer owns cross-turn vision state in process-global raw Maps', () => {
   assert.match(source, /const sessionVisionRuntime = runtime\?\.sessionVision/)
@@ -26,9 +30,9 @@ test('session-visible paths use the bound memory view instead of the global comp
 })
 
 test('attachment cache miss performs target-only durable log recovery', () => {
-  assert.match(source, /collectEventAttachmentRefs\(events\)\.find\(/)
-  assert.match(source, /String\(ref\.attachmentId\) === wanted/)
-  assert.match(source, /visionState\.recordAttachments\(session, \[recovered\]\)/)
+  assert.match(sessionIndexSource, /core\.collectEventAttachmentRefs\(events\)\.find\(/)
+  assert.match(sessionIndexSource, /String\(ref\.attachmentId \?\? ref\.id\) === wanted/)
+  assert.match(sessionIndexSource, /store\.recordAttachments\(session, \[recovered\]\)/)
 })
 
 test('high-resolution upload admission remains separate from execution budgets', async () => {


### PR DESCRIPTION
## Scope

Post-P3 Architecture Closure C1-C.

This branch completes the Session unique-owner deletion:

- removes module-global `currentStore` / `currentSessionVisionStateStore()`;
- makes `createSessionVisionStateStore()` a pure factory;
- removes SessionVisionIndex store adoption / `lookupAttachment` monkey-patching;
- keeps explicit `SessionVisionRuntime { stateStore, index }` as the production owner;
- makes `SessionVisionIndex` the sole production owner of durable-log indexing, target-only attachment recovery, tool-result surface repair, and guard-stop surface repair;
- removes the duplicate owner algorithms from `index.js` while preserving a two-argument direct-core fallback through a local `SessionVisionIndex`;
- moves durable-log recovery characterization to the actual owner;
- adds Session owner wiring to the Node 22/24 Architecture Closure gate.

## Validation

Current head: `67c7ec6cea8d09c8a825072814015ad0e2d2b46b`.

Local SHA-anchored monolith validation:

- focused Session owner set: 29/29 pass
- `npm run test:session`: 57/57 pass
- `npm run test:core`: 206/206 pass
- `index.js` final patch: 20 insertions / 303 deletions

Remote PR workflows at the current head:

- Architecture Closure — success
- CI — success
- DSH Contract — success
- P1 Routing Parity — success
- P2 Data Boundary — success
- Native multimodal cold resume — success
- Large image resource stress — success
- CodeQL — success, no new alerts in changed code

All 33 current check-runs are complete; no failure or in-progress check remains.

## Safety discipline

`index.js` was changed only through the SHA-anchored local worktree patch with unique-match assertions, `git diff --check`, human diff inspection and focused/full regression tests. No connector whole-file replacement and no code-writing GitHub Action was used.

## Contract discipline

No Config/Settings/tool/schema/route/session durable event/artifact/proxy/support-window contract is intentionally changed. C2 Presentation Convergence remains out of scope until all of C1 is complete.