### PR TITLE
refactor(core): switch to explicit CoreVisionSurface

### DIFF
--- a/index.js
+++ b/index.js
@@ -3070,6 +3070,17 @@ export function apply(ctx, config = {}, runtime = {}) {
   // Live configuration: composition entry at boot, then the resolved settings
   // section once the settings service mounts (installSettingsSection below).
   let current = () => config
+  const coreVisionSurfaceRuntime = runtime?.coreVisionSurface
+  const coreVisionFlag = (name, fallback) => {
+    if (
+      coreVisionSurfaceRuntime &&
+      typeof coreVisionSurfaceRuntime.current === 'function'
+    ) {
+      const surface = coreVisionSurfaceRuntime.current()
+      if (surface && typeof surface[name] === 'boolean') return surface[name]
+    }
+    return fallback()
+  }
   const pairs = () => providersOf(current())
   // #208: cross-turn visual knowledge belongs to a bounded session owner,
   // not to the plugin process. The compatibility facade is used only at
@@ -3138,8 +3149,20 @@ export function apply(ctx, config = {}, runtime = {}) {
         text && typeof text.model === 'string' && text.model !== '' ? text.model : 'deepseek-v4-pro',
     }
   }
-  const toolEnabled = () => current().tool !== false
-  const structuredBootstrapEnabled = () => current().structuredVisionBootstrap === true
+  const toolEnabled = () =>
+    coreVisionFlag('toolAvailable', () => current().tool !== false)
+  const structuredBootstrapEnabled = () =>
+    coreVisionFlag(
+      'structuredBootstrap',
+      () => current().structuredVisionBootstrap === true,
+    )
+  const instantDescribeEnabled = () =>
+    coreVisionFlag('instantDescribe', () => current().instantDescribe === true)
+  const autoActivateOnImageEnabled = () =>
+    coreVisionFlag(
+      'autoActivateOnImage',
+      () => current().autoActivateOnImage !== false,
+    )
   const visionDepth = () => (current().visionDepth === 'fast' || current().visionDepth === 'deep' ? current().visionDepth : 'standard')
   // 档位提示（注入 bootstrapReminder / followupReminder）：
   // - bootstrapReminder（bootstrap 执行前，visual_kind 未知）：只给档位句
@@ -3155,7 +3178,8 @@ export function apply(ctx, config = {}, runtime = {}) {
   // Per-session turn gate: pass 1 is the actual universal structured visual call.
   // The gate opens only after vision_bootstrap has completed that visual request.
   const structuredBootstrapTurnState = new WeakMap()
-  const rewriteEnabled = () => current().rewriteImages !== false
+  const rewriteEnabled = () =>
+    coreVisionFlag('rewriteEnabled', () => current().rewriteImages !== false)
   const downscaleEnabled = () => current().downscale !== false
   const downscaleMaxPixels = () => {
     const value = current().downscaleMaxPixels
@@ -3180,7 +3204,7 @@ export function apply(ctx, config = {}, runtime = {}) {
   // The main 1+x structured bootstrap owns the first visual pass.
   // Never stack instantDescribe in front of it (that would silently become 2+x).
   const instantLocalProvider = () =>
-    current().instantDescribe === true && !structuredBootstrapEnabled()
+    instantDescribeEnabled() && !structuredBootstrapEnabled()
       ? localProvidersOf(current())
       : undefined
   const instantLocalStyle = () =>
@@ -4775,7 +4799,7 @@ export function apply(ctx, config = {}, runtime = {}) {
       if (hasImage) {
         ctx.logger.info(
           'vision-router: image turn — instantDescribe=%s localBackends=%s',
-          current().instantDescribe === true ? 'on' : 'off',
+          instantDescribeEnabled() ? 'on' : 'off',
           localProvidersOf(current())
             .map((p) => p.name)
             .join(',') || 'none',
@@ -4887,7 +4911,7 @@ export function apply(ctx, config = {}, runtime = {}) {
       // 都先尝试本地识别并把结果写入 imageMemory：后续 rewriteHistoryImages
       // / wrapper 改写时缓存命中，模型第一轮即"看懂"。失败（无本地后端 /
       // 连接失败 / 超时）静默回退原有标记，绝不阻塞图片轮。
-      if (rewriteEnabled() && !routingEnabled() && current().instantDescribe === true) {
+      if (rewriteEnabled() && !routingEnabled() && instantDescribeEnabled()) {
         const localProviders = instantLocalProvider()
         if (localProviders !== undefined && localProviders.length > 0) {
           try {
@@ -4914,7 +4938,7 @@ export function apply(ctx, config = {}, runtime = {}) {
       }
       // Auto-mount the deep vision tools on image turns: the model can use
       // them from its very first step without the user asking for them.
-      if (toolEnabled() && current().autoActivateOnImage !== false) {
+      if (toolEnabled() && autoActivateOnImageEnabled()) {
         const outcome = activateDeepTools()
         if (!autoMountNotified && outcome.includes('已挂载')) {
           autoMountNotified = true

--- a/lib/core-vision-surface.js
+++ b/lib/core-vision-surface.js
@@ -19,16 +19,23 @@ function own(object, key) {
   return Object.prototype.hasOwnProperty.call(object, key)
 }
 
+function coreFlags(values) {
+  return {
+    toolAvailable: values.tool !== false,
+    rewriteEnabled: values.rewriteImages !== false,
+    instantDescribe: values.instantDescribe === true,
+    autoActivateOnImage: values.autoActivateOnImage !== false,
+    structuredBootstrap: values.structuredVisionBootstrap === true,
+  }
+}
+
 /**
  * Explicit core-facing projection of the SessionSurfacePolicy.
  *
- * During C1-A this is a parity seam only: production still uses the legacy
- * Settings/config bridge. The returned object carries only the five config
- * values that the legacy bridge may override plus the already-resolved image
- * ownership facts. It deliberately cannot masquerade as a Settings service or
- * a full plugin config object.
- *
- * C1 switches core reads to this value only after old/new parity is proven.
+ * The returned object carries only the five config values that the historical
+ * Settings/config projection could override plus explicit booleans consumed by
+ * Core and the already-resolved image ownership facts. It deliberately cannot
+ * masquerade as a Settings service or a full plugin config object.
  */
 export function projectCoreVisionSurface(config = {}, sessionPolicy) {
   const value = isObject(config) ? config : {}
@@ -48,6 +55,7 @@ export function projectCoreVisionSurface(config = {}, sessionPolicy) {
     ownership: policy.ownership,
     preserveRawImages: policy.preserveRawImages === true,
     rewriteCurrentImages: policy.rewriteCurrentImages === true,
+    ...coreFlags(projected),
     values: Object.freeze(projected),
   })
 }
@@ -78,6 +86,39 @@ export function currentCoreVisionSurface(config = {}, options = {}) {
       schemaBootstrapping: options?.schemaBootstrapping === true,
     }),
   )
+}
+
+/**
+ * One explicit production seam for Core's five policy-derived switches.
+ *
+ * The config source stays live, but schema bootstrap is an internal lifecycle
+ * bit rather than a fake Settings/config value. Direct Core callers can keep
+ * their two-argument compatibility path; composition passes this runtime as
+ * the authoritative production surface.
+ */
+export function createCoreVisionSurfaceRuntime({ config = {} } = {}) {
+  let schemaBootstrapping = true
+
+  const current = () => {
+    let source = config
+    if (typeof config === 'function') {
+      try {
+        source = config()
+      } catch {
+        source = {}
+      }
+    }
+    return currentCoreVisionSurface(isObject(source) ? source : {}, {
+      schemaBootstrapping,
+    })
+  }
+
+  return Object.freeze({
+    current,
+    finishSchemaBootstrap() {
+      schemaBootstrapping = false
+    },
+  })
 }
 
 export const CORE_VISION_SURFACE_KEYS = CORE_SURFACE_KEYS

--- a/lib/runtime-composition.js
+++ b/lib/runtime-composition.js
@@ -11,6 +11,7 @@ import { contextWithReplayEnvelopeV2Compat } from './replay-envelope-v2-compat.j
 import { contextWithVisionExecutionPolicy } from './vision-execution-policy.js'
 import { contextWithVisionBackendRuntimePolicy } from './vision-backend-runtime-policy.js'
 import { contextWithNativeImageCoexistence } from './native-image-coexistence.js'
+import { createCoreVisionSurfaceRuntime } from './core-vision-surface.js'
 import { installSessionVisionIndexBoundary } from './session-vision-index.js'
 import { createSessionVisionRuntime } from './session-vision-runtime.js'
 import { installLegacyCoreVisionPolicyBridge } from './legacy-core-vision-policy-bridge.js'
@@ -148,6 +149,9 @@ export function applyVisionRuntimeComposition(ctx, config = {}, core) {
 
   const toolRuntimeCtx = installVisionToolRuntimeBoundary(attachmentCompatCtx, runtimeConfig)
   const nativeImageCompat = contextWithNativeImageCoexistence(toolRuntimeCtx, runtimeConfig)
+  const coreVisionSurfaceRuntime = createCoreVisionSurfaceRuntime({
+    config: () => liveVisionSettings(nativeImageCompat.ctx, nativeImageCompat.config),
+  })
 
   // C1 production owner: one explicit bounded store + one explicit index. The
   // index reads the same live Host settings namespace but never discovers the
@@ -284,9 +288,13 @@ export function applyVisionRuntimeComposition(ctx, config = {}, core) {
       () => core.apply(
         backendRuntimeCtx,
         legacyCoreCompat.config,
-        { sessionVision: sessionVisionRuntime },
+        {
+          sessionVision: sessionVisionRuntime,
+          coreVisionSurface: coreVisionSurfaceRuntime,
+        },
       ),
     )
+    coreVisionSurfaceRuntime.finishSchemaBootstrap()
     legacyCoreCompat.finishSchemaBootstrap()
     installWrapperDirectoryAlias(attachmentCompatCtx, runtimeConfig, logging.logger)
     if (result && typeof result.then === 'function') {
@@ -300,6 +308,7 @@ export function applyVisionRuntimeComposition(ctx, config = {}, core) {
     }
     return result
   } catch (error) {
+    coreVisionSurfaceRuntime.finishSchemaBootstrap()
     legacyCoreCompat.finishSchemaBootstrap()
     logging.logger.error(
       'vision-router: plugin apply failed: %s',

--- a/tests/core-vision-surface-parity.test.js
+++ b/tests/core-vision-surface-parity.test.js
@@ -1,9 +1,11 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
 
 import { resolveSessionSurfacePolicy } from '../lib/session-surface-policy.js'
 import {
   CORE_VISION_SURFACE_KEYS,
+  createCoreVisionSurfaceRuntime,
   resolveCoreVisionSurface,
 } from '../lib/core-vision-surface.js'
 
@@ -80,6 +82,11 @@ test('explicit core surface is exactly equivalent to every legacy projection com
         assert.equal(explicit.ownership, legacy.policy.ownership)
         assert.equal(explicit.preserveRawImages, legacy.policy.preserveRawImages)
         assert.equal(explicit.rewriteCurrentImages, legacy.policy.rewriteCurrentImages)
+        assert.equal(explicit.toolAvailable, legacy.values.tool !== false)
+        assert.equal(explicit.rewriteEnabled, legacy.values.rewriteImages !== false)
+        assert.equal(explicit.instantDescribe, legacy.values.instantDescribe === true)
+        assert.equal(explicit.autoActivateOnImage, legacy.values.autoActivateOnImage !== false)
+        assert.equal(explicit.structuredBootstrap, legacy.values.structuredVisionBootstrap === true)
         cases += 1
       }
     }
@@ -126,4 +133,52 @@ test('explicit surface cannot expose unrelated plugin configuration as a fake Se
   assert.equal(Object.hasOwn(explicit.values, 'allowRemoteSettings'), false)
   assert.equal(Object.isFrozen(explicit), true)
   assert.equal(Object.isFrozen(explicit.values), true)
+})
+
+test('CoreVisionSurface runtime keeps schema bootstrap explicit and reads live config', () => {
+  const live = {
+    tool: false,
+    rewriteImages: true,
+    instantDescribe: false,
+    autoActivateOnImage: true,
+    structuredVisionBootstrap: false,
+  }
+  const runtime = createCoreVisionSurfaceRuntime({ config: () => live })
+
+  assert.equal(runtime.current().toolAvailable, true)
+  assert.equal(runtime.current().rewriteEnabled, true)
+
+  runtime.finishSchemaBootstrap()
+  assert.equal(runtime.current().toolAvailable, false)
+
+  live.tool = true
+  live.instantDescribe = true
+  live.autoActivateOnImage = false
+  live.structuredVisionBootstrap = true
+  const current = runtime.current()
+  assert.equal(current.toolAvailable, true)
+  assert.equal(current.instantDescribe, true)
+  assert.equal(current.autoActivateOnImage, false)
+  assert.equal(current.structuredBootstrap, true)
+})
+
+test('production composition passes one explicit CoreVisionSurface runtime into Core', async () => {
+  const composition = await readFile(new URL('../lib/runtime-composition.js', import.meta.url), 'utf8')
+  const core = await readFile(new URL('../index.js', import.meta.url), 'utf8')
+
+  assert.match(composition, /import \{ createCoreVisionSurfaceRuntime \} from '.\/core-vision-surface\.js'/)
+  assert.match(composition, /const coreVisionSurfaceRuntime = createCoreVisionSurfaceRuntime\(/)
+  assert.match(composition, /coreVisionSurface: coreVisionSurfaceRuntime/)
+  assert.match(composition, /coreVisionSurfaceRuntime\.finishSchemaBootstrap\(\)/)
+
+  assert.match(core, /const coreVisionSurfaceRuntime = runtime\?\.coreVisionSurface/)
+  assert.match(core, /coreVisionFlag\('toolAvailable'/)
+  assert.match(core, /coreVisionFlag\('rewriteEnabled'/)
+  assert.match(core, /coreVisionFlag\('instantDescribe'/)
+  assert.match(core, /coreVisionFlag\('autoActivateOnImage'/)
+  assert.match(core, /coreVisionFlag\('structuredBootstrap'/)
+
+  assert.doesNotMatch(core, /const toolEnabled = \(\) => current\(\)\.tool !== false/)
+  assert.doesNotMatch(core, /const rewriteEnabled = \(\) => current\(\)\.rewriteImages !== false/)
+  assert.doesNotMatch(core, /const structuredBootstrapEnabled = \(\) => current\(\)\.structuredVisionBootstrap === true/)
 })

--- a/tests/core-vision-surface-parity.test.js
+++ b/tests/core-vision-surface-parity.test.js
@@ -172,11 +172,11 @@ test('production composition passes one explicit CoreVisionSurface runtime into 
   assert.match(composition, /coreVisionSurfaceRuntime\.finishSchemaBootstrap\(\)/)
 
   assert.match(core, /const coreVisionSurfaceRuntime = runtime\?\.coreVisionSurface/)
-  assert.match(core, /coreVisionFlag\('toolAvailable'/)
-  assert.match(core, /coreVisionFlag\('rewriteEnabled'/)
-  assert.match(core, /coreVisionFlag\('instantDescribe'/)
-  assert.match(core, /coreVisionFlag\('autoActivateOnImage'/)
-  assert.match(core, /coreVisionFlag\('structuredBootstrap'/)
+  assert.match(core, /coreVisionFlag\(\s*'toolAvailable'/)
+  assert.match(core, /coreVisionFlag\(\s*'rewriteEnabled'/)
+  assert.match(core, /coreVisionFlag\(\s*'instantDescribe'/)
+  assert.match(core, /coreVisionFlag\(\s*'autoActivateOnImage'/)
+  assert.match(core, /coreVisionFlag\(\s*'structuredBootstrap'/)
 
   assert.doesNotMatch(core, /const toolEnabled = \(\) => current\(\)\.tool !== false/)
   assert.doesNotMatch(core, /const rewriteEnabled = \(\) => current\(\)\.rewriteImages !== false/)

--- a/tests/p3-entry-composition.test.js
+++ b/tests/p3-entry-composition.test.js
@@ -30,6 +30,7 @@ test('P3-F composition remains bounded and preserves the mature runtime sequence
     'installHostSettingsCompatibility(',
     'installVisionToolRuntimeBoundary(attachmentCompatCtx, runtimeConfig)',
     'contextWithNativeImageCoexistence(toolRuntimeCtx, runtimeConfig)',
+    'createCoreVisionSurfaceRuntime({',
     'createSessionVisionRuntime({',
     'installSessionVisionIndexBoundary(',
     'installLegacyCoreVisionPolicyBridge(',
@@ -57,8 +58,8 @@ test('P3-F composition remains bounded and preserves the mature runtime sequence
 
   assert.match(
     source,
-    /\(\) => core\.apply\(\s*backendRuntimeCtx,\s*legacyCoreCompat\.config,\s*\{ sessionVision: sessionVisionRuntime \},?\s*\)/s,
-    'core must receive both the fully composed backend context and the explicit SessionVisionRuntime owner',
+    /\(\) => core\.apply\(\s*backendRuntimeCtx,\s*legacyCoreCompat\.config,\s*\{[\s\S]*?sessionVision:\s*sessionVisionRuntime,[\s\S]*?coreVisionSurface:\s*coreVisionSurfaceRuntime,[\s\S]*?\},?\s*\)/,
+    'core must receive the fully composed backend context plus explicit SessionVisionRuntime and CoreVisionSurface owners',
   )
   assert.ok(
     source.split('\n').length < 400,

--- a/tests/qa-runtime-identity.test.js
+++ b/tests/qa-runtime-identity.test.js
@@ -99,6 +99,9 @@ test('P3 final composition keeps runtime order outside the thin public entry', a
   const nativeAt = source.indexOf(
     'const nativeImageCompat = contextWithNativeImageCoexistence(toolRuntimeCtx, runtimeConfig)',
   )
+  const coreSurfaceRuntimeAt = source.indexOf(
+    'const coreVisionSurfaceRuntime = createCoreVisionSurfaceRuntime({',
+  )
   const sessionRuntimeAt = source.indexOf(
     'const sessionVisionRuntime = createSessionVisionRuntime({',
   )
@@ -135,7 +138,14 @@ test('P3 final composition keeps runtime order outside the thin public entry', a
   assert.ok(settingsAt > loggingAt)
   assert.ok(runtimeAt > settingsAt, 'runtime boundary must see rc7/rc8 host settings compatibility')
   assert.ok(nativeAt > runtimeAt, 'session image ownership must run inside live tool/cancellation policy')
-  assert.ok(sessionRuntimeAt > nativeAt, 'explicit SessionVisionRuntime must consume the final session ownership context')
+  assert.ok(
+    coreSurfaceRuntimeAt > nativeAt,
+    'explicit CoreVisionSurfaceRuntime must consume the final session ownership context',
+  )
+  assert.ok(
+    sessionRuntimeAt > coreSurfaceRuntimeAt,
+    'explicit SessionVisionRuntime must remain alongside the CoreVisionSurface owner',
+  )
   assert.ok(sessionIndexAt > sessionRuntimeAt, 'the session index boundary must receive the explicit runtime owner')
   assert.ok(bridgeAt > sessionIndexAt, 'legacy core projection must consume the indexed session-scoped ownership policy')
   assert.ok(
@@ -155,8 +165,8 @@ test('P3 final composition keeps runtime order outside the thin public entry', a
   assert.ok(coreApplyAt > backendRuntimeAt, 'core must receive the fully composed backend runtime context')
   assert.match(
     source.slice(coreApplyAt),
-    /^\(\) => core\.apply\(\s*backendRuntimeCtx,\s*legacyCoreCompat\.config,\s*\{ sessionVision: sessionVisionRuntime \},?\s*\)/s,
-    'core must receive the same explicit SessionVisionRuntime owner as the session index boundary',
+    /^\(\) => core\.apply\(\s*backendRuntimeCtx,\s*legacyCoreCompat\.config,\s*\{[\s\S]*?sessionVision:\s*sessionVisionRuntime,[\s\S]*?coreVisionSurface:\s*coreVisionSurfaceRuntime,[\s\S]*?\},?\s*\)/,
+    'core must receive the same explicit SessionVisionRuntime and CoreVisionSurfaceRuntime owners as composition',
   )
   assert.ok(finishAt > coreApplyAt, 'the temporary schema bootstrap projection ends immediately after core wiring')
 

--- a/tests/session-runtime-core-wiring.test.js
+++ b/tests/session-runtime-core-wiring.test.js
@@ -16,7 +16,7 @@ test('runtime composition creates one explicit SessionVisionRuntime and gives th
   )
   assert.match(
     runtime,
-    /core\.apply\([\s\S]*?\{ sessionVision: sessionVisionRuntime \}[\s\S]*?\)/,
+    /core\.apply\([\s\S]*?sessionVision:\s*sessionVisionRuntime[\s\S]*?\)/,
   )
   assert.equal(
     (runtime.match(/createSessionVisionRuntime\(/g) ?? []).length,


### PR DESCRIPTION
## Scope

Architecture Closure C1-D: CoreVisionSurface production switch.

This PR is deliberately limited to replacing the five Session-policy-derived Core reads that were supplied through the legacy Settings/config projection:

- tool availability
- image rewrite enablement
- instant describe enablement
- generic auto-activation on image
- structured bootstrap enablement

It does not change routing/provider selection, VisionExecutionOrder, tool protocol/schema, ArtifactStore, proxy behavior, benchmark scheduling, or external Settings contracts.

## Completed switch

Base main: `4f57abcffd0ca6234f7cc20eb0addd9ce08a4e21` (C1-C merged and merged-main gates green).

Production now creates one explicit `CoreVisionSurfaceRuntime` beside the explicit `SessionVisionRuntime` and passes both narrow owners into Core. Core consumes the five policy-derived booleans through that surface while all unrelated live product settings continue through the existing config path.

The 256 legacy-projection combinations remain the parity oracle and now verify all five explicit derived flags. Structural gates also verify runtime ordering and owner identity across composition, Session indexing, and Core.

The giant `index.js` switch was applied only through a SHA-anchored local worktree patch with unique-match assertions. Its final diff is surgical: 31 additions / 7 deletions, limited to the explicit surface runtime binding and the five Core policy read points.

Local validation of the production switch passed:

- focused C1-D/session ownership set: 39/39
- core: 206/206
- session: 57/57
- contract: 84/84

A pair of stale structure-only tests and the P3/QA runtime identity gates were updated to accept the new composed runtime object while strengthening their assertions to require both the exact `SessionVisionRuntime` and `CoreVisionSurfaceRuntime` owners.

## Next phase

C1-E Settings impersonation deletion remains explicitly out of scope for this PR. The legacy Settings/config projection stays present only as the remaining compatibility layer and parity oracle until this C1-D switch is merged and merged-main is revalidated.