### PR TITLE
refactor(session): remove Settings impersonation from pre-step compatibility

### DIFF
--- a/.github/workflows/architecture-closure.yml
+++ b/.github/workflows/architecture-closure.yml
@@ -18,6 +18,7 @@ on:
       - 'docs/architecture/**'
       - 'tests/architecture-contract-baseline.test.js'
       - 'tests/core-vision-surface-parity.test.js'
+      - 'tests/settings-impersonation-closure.test.js'
       - 'tests/session-runtime-core-wiring.test.js'
       - 'tests/session-vision-runtime-parity.test.js'
       - 'tests/vision-execution-order-core-wiring.test.js'
@@ -46,6 +47,7 @@ on:
       - 'docs/architecture/**'
       - 'tests/architecture-contract-baseline.test.js'
       - 'tests/core-vision-surface-parity.test.js'
+      - 'tests/settings-impersonation-closure.test.js'
       - 'tests/session-runtime-core-wiring.test.js'
       - 'tests/session-vision-runtime-parity.test.js'
       - 'tests/vision-execution-order-core-wiring.test.js'
@@ -82,6 +84,7 @@ jobs:
           node --test
           tests/architecture-contract-baseline.test.js
           tests/core-vision-surface-parity.test.js
+          tests/settings-impersonation-closure.test.js
           tests/session-runtime-core-wiring.test.js
           tests/session-vision-runtime-parity.test.js
           tests/vision-execution-order-core-wiring.test.js

--- a/lib/legacy-core-vision-policy-bridge.js
+++ b/lib/legacy-core-vision-policy-bridge.js
@@ -5,121 +5,6 @@ function isObject(value) {
   return value !== null && typeof value === 'object'
 }
 
-function projectedConfig(value, state) {
-  if (!isObject(value) || Array.isArray(value)) return value
-  const policy = currentSessionSurfacePolicy(value, {
-    schemaBootstrapping: state.schemaBootstrapping,
-  })
-  const overrides = policy.legacyConfigOverrides
-  return Object.keys(overrides).length > 0 ? { ...value, ...overrides } : value
-}
-
-function configView(config, state) {
-  if (!isObject(config)) return config
-  // Do not use the caller's config as the Proxy target. DSH or a test Host may
-  // freeze parsed config objects; projecting tool/rewrite values through a
-  // frozen target would violate Proxy invariants for non-configurable,
-  // non-writable properties. An empty extensible facade keeps projection
-  // virtual while writes/deletes still forward to the original object.
-  return new Proxy({}, {
-    get(_target, property) {
-      const projected = projectedConfig(config, state)
-      const value = Reflect.get(projected, property, projected)
-      return typeof value === 'function' ? value.bind(projected) : value
-    },
-    has(_target, property) {
-      return property in projectedConfig(config, state)
-    },
-    ownKeys() {
-      return Reflect.ownKeys(projectedConfig(config, state))
-    },
-    getOwnPropertyDescriptor(_target, property) {
-      const projected = projectedConfig(config, state)
-      const descriptor = Object.getOwnPropertyDescriptor(projected, property)
-      return descriptor === undefined
-        ? undefined
-        : { ...descriptor, configurable: true }
-    },
-    getPrototypeOf() {
-      return Reflect.getPrototypeOf(config)
-    },
-    set(_target, property, value) {
-      return Reflect.set(config, property, value, config)
-    },
-    deleteProperty(_target, property) {
-      return Reflect.deleteProperty(config, property)
-    },
-  })
-}
-
-function scopeView(scope, state) {
-  if (!isObject(scope)) return scope
-  return new Proxy(scope, {
-    get(target, property) {
-      if (property === 'get') {
-        const get = Reflect.get(target, property, target)
-        if (typeof get !== 'function') return get
-        return (...args) => projectedConfig(get.apply(target, args), state)
-      }
-      if (property === 'watch') {
-        const watch = Reflect.get(target, property, target)
-        if (typeof watch !== 'function') return watch
-        return (callback, ...rest) =>
-          watch.call(
-            target,
-            (...args) => {
-              if (typeof callback !== 'function') return undefined
-              if (args.length === 0) return callback()
-              const [value, ...tail] = args
-              return callback(projectedConfig(value, state), ...tail)
-            },
-            ...rest,
-          )
-      }
-      const value = Reflect.get(target, property, target)
-      return typeof value === 'function' ? value.bind(target) : value
-    },
-  })
-}
-
-function settingsView(settings, state) {
-  if (!isObject(settings)) return settings
-  return new Proxy(settings, {
-    get(target, property) {
-      if (property === 'get') {
-        const get = Reflect.get(target, property, target)
-        if (typeof get !== 'function') return get
-        return (namespace, ...args) => {
-          const value = get.call(target, namespace, ...args)
-          return namespace === 'vision-router' ? projectedConfig(value, state) : value
-        }
-      }
-      if (property === 'register') {
-        const register = Reflect.get(target, property, target)
-        if (typeof register !== 'function') return register
-        return (namespace, ...args) => {
-          const scope = register.call(target, namespace, ...args)
-          return namespace === 'vision-router' ? scopeView(scope, state) : scope
-        }
-      }
-      const value = Reflect.get(target, property, target)
-      return typeof value === 'function' ? value.bind(target) : value
-    },
-  })
-}
-
-function childContextView(child, state) {
-  if (!isObject(child)) return child
-  const settings = settingsView(child.settings, state)
-  return new Proxy(child, {
-    get(target, property) {
-      if (property === 'settings') return settings
-      const value = Reflect.get(target, property, target)
-      return typeof value === 'function' ? value.bind(target) : value
-    },
-  })
-}
-
 function collectAttachmentIds(messages) {
   const ids = []
   const seen = new Set()
@@ -146,10 +31,8 @@ function collectAttachmentIds(messages) {
   return ids.reverse()
 }
 
-function appendVisionRouterAttachmentHint(payload, decision, config, state) {
-  const policy = currentSessionSurfacePolicy(config, {
-    schemaBootstrapping: state.schemaBootstrapping,
-  })
+function appendVisionRouterAttachmentHint(payload, decision, config) {
+  const policy = currentSessionSurfacePolicy(config)
   if (decision?.kind === 'reject' || policy.ownership !== 'vision-router-owned') {
     return decision
   }
@@ -188,10 +71,8 @@ function appendVisionRouterAttachmentHint(payload, decision, config, state) {
     : { kind: 'continue', messages }
 }
 
-function rewriteTextOnlyDecision(payload, decision, rewriteHistoryImages, config, state) {
-  const policy = currentSessionSurfacePolicy(config, {
-    schemaBootstrapping: state.schemaBootstrapping,
-  })
+function rewriteTextOnlyDecision(payload, decision, rewriteHistoryImages, config) {
+  const policy = currentSessionSurfacePolicy(config)
   if (
     decision?.kind === 'reject' ||
     policy.rewriteCurrentImages !== true ||
@@ -219,70 +100,25 @@ function rewriteTextOnlyDecision(payload, decision, rewriteHistoryImages, config
 }
 
 /**
- * Adapt the centralized session surface policy to the legacy monolithic core.
+ * Preserve the two remaining pre-step compatibility behaviors without
+ * impersonating Settings/config for Core.
  *
  * Ownership classification remains native-image-coexistence's responsibility.
- * This bridge consumes only the immutable session-surface snapshot: it projects
- * legacy config reads while one pre-step is active, reuses the exact
- * SessionMemoryView for text-only rewriting, and surfaces current attachment
- * ids only for a Vision Router-owned route. No cross-session lookup, route
- * selection or tool-execution authority is introduced here.
+ * Core consumes its five policy-derived switches through CoreVisionSurface.
+ * This boundary only reuses the exact SessionMemoryView for a text-only image
+ * rewrite and surfaces current durable attachment ids for a Vision Router-owned
+ * route. Every other context service, Settings object, injected child and config
+ * value passes through unchanged.
  */
 export function installLegacyCoreVisionPolicyBridge(
   ctx,
   config = {},
   { rewriteHistoryImages } = {},
 ) {
-  if (!isObject(ctx)) {
-    return {
-      ctx,
-      config,
-      finishSchemaBootstrap() {},
-    }
-  }
-
-  const state = { schemaBootstrapping: true }
-  const projectedBootConfig = configView(config, state)
-  const settingsCache = new WeakMap()
-
-  const wrapSettings = (settings) => {
-    if (!isObject(settings)) return settings
-    const cached = settingsCache.get(settings)
-    if (cached) return cached
-    const wrapped = settingsView(settings, state)
-    settingsCache.set(settings, wrapped)
-    return wrapped
-  }
+  if (!isObject(ctx)) return { ctx, config }
 
   const wrappedCtx = new Proxy(ctx, {
     get(target, property) {
-      if (property === 'get') {
-        const get = Reflect.get(target, property, target)
-        if (typeof get !== 'function') return get
-        return (name, ...args) => {
-          const value = get.call(target, name, ...args)
-          return name === 'settings' ? wrapSettings(value) : value
-        }
-      }
-      if (property === 'inject') {
-        const inject = Reflect.get(target, property, target)
-        if (typeof inject !== 'function') return inject
-        return (dependencies, callback, ...rest) => {
-          if (
-            !Array.isArray(dependencies) ||
-            !dependencies.includes('settings') ||
-            typeof callback !== 'function'
-          ) {
-            return inject.call(target, dependencies, callback, ...rest)
-          }
-          return inject.call(
-            target,
-            dependencies,
-            (child) => callback(childContextView(child, state)),
-            ...rest,
-          )
-        }
-      }
       if (property === 'on') {
         const on = Reflect.get(target, property, target)
         if (typeof on !== 'function') return on
@@ -297,9 +133,8 @@ export function installLegacyCoreVisionPolicyBridge(
               decision,
               rewriteHistoryImages,
               config,
-              state,
             )
-            return appendVisionRouterAttachmentHint(payload, rewritten, config, state)
+            return appendVisionRouterAttachmentHint(payload, rewritten, config)
           }, ...rest)
         }
       }
@@ -310,9 +145,6 @@ export function installLegacyCoreVisionPolicyBridge(
 
   return {
     ctx: wrappedCtx,
-    config: projectedBootConfig,
-    finishSchemaBootstrap() {
-      state.schemaBootstrapping = false
-    },
+    config,
   }
 }

--- a/lib/runtime-composition.js
+++ b/lib/runtime-composition.js
@@ -169,6 +169,9 @@ export function applyVisionRuntimeComposition(ctx, config = {}, core) {
     core,
     { logger: logging.logger, index: sessionVisionRuntime.index },
   )
+  // C1-E keeps only the real pre-step compatibility behaviors here. Session
+  // policy is no longer projected through fake Settings/config views; Core's
+  // policy-derived switches come exclusively from CoreVisionSurfaceRuntime.
   const legacyCoreCompat = installLegacyCoreVisionPolicyBridge(
     sessionIndexCtx,
     nativeImageCompat.config,
@@ -295,7 +298,6 @@ export function applyVisionRuntimeComposition(ctx, config = {}, core) {
       ),
     )
     coreVisionSurfaceRuntime.finishSchemaBootstrap()
-    legacyCoreCompat.finishSchemaBootstrap()
     installWrapperDirectoryAlias(attachmentCompatCtx, runtimeConfig, logging.logger)
     if (result && typeof result.then === 'function') {
       return result.catch((error) => {
@@ -309,7 +311,6 @@ export function applyVisionRuntimeComposition(ctx, config = {}, core) {
     return result
   } catch (error) {
     coreVisionSurfaceRuntime.finishSchemaBootstrap()
-    legacyCoreCompat.finishSchemaBootstrap()
     logging.logger.error(
       'vision-router: plugin apply failed: %s',
       error && error.stack ? error.stack : error && error.message ? error.message : String(error),

--- a/tests/issue-276-entry-policy-bridge.test.js
+++ b/tests/issue-276-entry-policy-bridge.test.js
@@ -149,9 +149,6 @@ async function runCoreLikePreStep(harness, bridge, provider, messages, observe) 
 
 test('text-only session uses the canonical core writer even when a global wrapper exists', async () => {
   const harness = bridgeHarness({ inputModalities: ['text'] })
-  // This registration is intentionally outside Vision Router's private context:
-  // it reproduces the old global wrapperRegistered condition without granting
-  // ownership of the currently selected Host route.
   harness.ctx.llm.registerAdapter(['deepseek-vision'], { stream() {} })
   const { bridge } = composeBridge(harness)
   const messages = [imageMessage('sha256:text-route')]
@@ -165,6 +162,7 @@ test('text-only session uses the canonical core writer even when a global wrappe
       const policy = currentSessionVisionPolicy()
       assert.equal(policy.ownership, IMAGE_OWNERSHIP.TEXT_ONLY)
       assert.equal(policy.rewriteCurrentImages, true)
+      assert.equal(bridge.config, harness.persisted)
       assert.equal(bridge.config.rewriteImages, true)
     },
   )
@@ -214,7 +212,8 @@ test('Vision Router-owned adapter keeps raw image blocks at the adapter boundary
     const policy = currentSessionVisionPolicy()
     assert.equal(policy.ownership, IMAGE_OWNERSHIP.VISION_ROUTER)
     assert.equal(policy.preserveRawImages, true)
-    assert.equal(bridge.config.rewriteImages, false)
+    assert.equal(bridge.config, harness.persisted)
+    assert.equal(bridge.config.rewriteImages, true)
   })
 
   assert.equal(result.messages[0].content[0].content[0].type, 'image')
@@ -231,10 +230,14 @@ test('native session preserves pixels, suppresses automatic orchestration, and k
   const result = await runCoreLikePreStep(harness, bridge, 'deepseek-official', messages, () => {
     const policy = currentSessionVisionPolicy()
     assert.equal(policy.ownership, IMAGE_OWNERSHIP.NATIVE)
-    assert.equal(bridge.config.rewriteImages, false)
-    assert.equal(bridge.config.instantDescribe, false)
-    assert.equal(bridge.config.autoActivateOnImage, false)
-    assert.equal(bridge.config.structuredVisionBootstrap, false)
+    assert.equal(policy.preserveRawImages, true)
+    assert.equal(policy.suppressGenericAutoMount, true)
+    assert.equal(policy.allowStructuredBootstrap, false)
+    assert.equal(bridge.config, harness.persisted)
+    assert.equal(bridge.config.rewriteImages, true)
+    assert.equal(bridge.config.instantDescribe, true)
+    assert.equal(bridge.config.autoActivateOnImage, true)
+    assert.equal(bridge.config.structuredVisionBootstrap, true)
     assert.equal(bridge.config.tool, true)
   })
 
@@ -250,22 +253,26 @@ test('UNKNOWN capability preserves the existing Host image contract instead of f
     const policy = currentSessionVisionPolicy()
     assert.equal(policy.ownership, IMAGE_OWNERSHIP.UNKNOWN)
     assert.equal(policy.preserveRawImages, true)
-    assert.equal(bridge.config.rewriteImages, false)
+    assert.equal(bridge.config, harness.persisted)
+    assert.equal(bridge.config.rewriteImages, true)
   })
 
   assert.equal(result.messages[0].content[0].content[0].type, 'image')
 })
 
-test('tool=false is projected only while legacy core builds schema; execution follows the live setting', async () => {
+test('tool=false stays real through the pre-step bridge while execution follows live settings', async () => {
   const harness = bridgeHarness({ config: { tool: false } })
   const { bridge } = composeBridge(harness, { toolRuntime: true })
 
-  let projectedScope
+  let liveScope
   bridge.ctx.inject(['settings'], (child) => {
-    projectedScope = child.settings.register('vision-router')
+    liveScope = child.settings.register('vision-router')
   })
-  assert.equal(bridge.config.tool, true)
-  assert.equal(projectedScope.get().tool, true)
+  assert.equal(bridge.config, harness.persisted)
+  assert.equal(bridge.config.tool, false)
+  assert.equal(liveScope.get(), harness.persisted)
+  assert.equal(liveScope.get().tool, false)
+  assert.equal(Object.hasOwn(bridge, 'finishSchemaBootstrap'), false)
 
   let calls = 0
   bridge.ctx.tools.register({
@@ -278,9 +285,6 @@ test('tool=false is projected only while legacy core builds schema; execution fo
   const registered = harness.tools.get('vision_describe')
   assert.ok(registered)
 
-  bridge.finishSchemaBootstrap()
-  assert.equal(bridge.config.tool, false)
-  assert.equal(projectedScope.get().tool, false)
   await assert.rejects(() => registered.execute({}, {}), /vision tools are disabled/)
   assert.equal(calls, 0)
 

--- a/tests/issue-276-policy-hardening.test.js
+++ b/tests/issue-276-policy-hardening.test.js
@@ -22,27 +22,39 @@ function imageMessage() {
   }
 }
 
-test('legacy boot projection tolerates frozen config without mutating its source', () => {
+test('pre-step compatibility keeps frozen config exact instead of projecting internal policy', () => {
   const frozen = Object.freeze({
     tool: false,
     rewriteImages: true,
     instantDescribe: true,
     autoActivateOnImage: true,
   })
+  const settings = { marker: 'real-settings' }
+  const child = { settings }
+  const ctx = {
+    get(name) {
+      return name === 'settings' ? settings : undefined
+    },
+    inject(_dependencies, callback) {
+      return callback(child)
+    },
+    on() {
+      return () => {}
+    },
+  }
   const bridge = installLegacyCoreVisionPolicyBridge(
-    {},
+    ctx,
     frozen,
     { rewriteHistoryImages },
   )
 
-  assert.equal(bridge.config.tool, true)
-  assert.equal(frozen.tool, false)
-  assert.equal(Object.keys(bridge.config).includes('tool'), true)
-  assert.equal({ ...bridge.config }.tool, true)
-
-  bridge.finishSchemaBootstrap()
+  assert.equal(bridge.config, frozen)
   assert.equal(bridge.config.tool, false)
-  assert.equal(frozen.tool, false)
+  assert.equal(bridge.ctx.get('settings'), settings)
+  let injected
+  bridge.ctx.inject(['settings'], (value) => { injected = value })
+  assert.equal(injected, child)
+  assert.equal(Object.hasOwn(bridge, 'finishSchemaBootstrap'), false)
 })
 
 test('text-only image policy preserves reject decisions by exact identity', async () => {

--- a/tests/issue-289-native-nonintervention.test.js
+++ b/tests/issue-289-native-nonintervention.test.js
@@ -1,6 +1,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
+import { currentCoreVisionSurface } from '../lib/core-vision-surface.js'
 import {
   IMAGE_OWNERSHIP,
   contextWithNativeImageCoexistence,
@@ -113,17 +114,20 @@ test('Host-native image models make structured bootstrap optional, not tools una
   assert.equal(text.allowStructuredBootstrap, true)
 })
 
-test('legacy core sees 1+x disabled only during a native turn while tool access stays enabled', async () => {
+test('explicit CoreVisionSurface suppresses native 1+x without mutating Settings/config', async () => {
   const harness = boot()
   const native = contextWithNativeImageCoexistence(harness.ctx, harness.persisted)
   const legacy = installLegacyCoreVisionPolicyBridge(native.ctx, native.config)
   let observed
 
   legacy.ctx.on('agent/pre-step', async (payload, next) => {
+    const surface = currentCoreVisionSurface(legacy.config)
     observed = {
       ownership: currentSessionVisionPolicy()?.ownership,
-      structuredVisionBootstrap: legacy.config.structuredVisionBootstrap,
-      tool: legacy.config.tool,
+      surfaceStructuredBootstrap: surface.structuredBootstrap,
+      surfaceToolAvailable: surface.toolAvailable,
+      persistedStructuredBootstrap: legacy.config.structuredVisionBootstrap,
+      persistedTool: legacy.config.tool,
     }
     return next()
   })
@@ -136,8 +140,10 @@ test('legacy core sees 1+x disabled only during a native turn while tool access 
   )
   assert.deepEqual(observed, {
     ownership: IMAGE_OWNERSHIP.NATIVE,
-    structuredVisionBootstrap: false,
-    tool: true,
+    surfaceStructuredBootstrap: false,
+    surfaceToolAvailable: true,
+    persistedStructuredBootstrap: true,
+    persistedTool: true,
   })
 
   await handler(
@@ -146,8 +152,10 @@ test('legacy core sees 1+x disabled only during a native turn while tool access 
   )
   assert.deepEqual(observed, {
     ownership: IMAGE_OWNERSHIP.TEXT_ONLY,
-    structuredVisionBootstrap: true,
-    tool: true,
+    surfaceStructuredBootstrap: true,
+    surfaceToolAvailable: true,
+    persistedStructuredBootstrap: true,
+    persistedTool: true,
   })
 })
 

--- a/tests/qa-runtime-identity.test.js
+++ b/tests/qa-runtime-identity.test.js
@@ -127,7 +127,7 @@ test('P3 final composition keeps runtime order outside the thin public entry', a
     'const backendRuntimeCtx = contextWithVisionBackendRuntimePolicy(performanceCtx, {',
   )
   const coreApplyAt = source.indexOf('() => core.apply(')
-  const finishAt = source.indexOf('legacyCoreCompat.finishSchemaBootstrap()', coreApplyAt)
+  const finishAt = source.indexOf('coreVisionSurfaceRuntime.finishSchemaBootstrap()', coreApplyAt)
 
   assert.ok(mutationAt >= 0)
   assert.ok(
@@ -147,10 +147,13 @@ test('P3 final composition keeps runtime order outside the thin public entry', a
     'explicit SessionVisionRuntime must remain alongside the CoreVisionSurface owner',
   )
   assert.ok(sessionIndexAt > sessionRuntimeAt, 'the session index boundary must receive the explicit runtime owner')
-  assert.ok(bridgeAt > sessionIndexAt, 'legacy core projection must consume the indexed session-scoped ownership policy')
+  assert.ok(
+    bridgeAt > sessionIndexAt,
+    'the retained pre-step compatibility boundary must consume the indexed session-scoped ownership policy',
+  )
   assert.ok(
     diagnosticsAt > bridgeAt,
-    'limit diagnostics must observe only the final legacy-core policy view and may not become an execution policy itself',
+    'limit diagnostics must observe the final pre-step compatibility view and may not become an execution policy itself',
   )
   assert.ok(
     structuredAt > diagnosticsAt,
@@ -168,7 +171,12 @@ test('P3 final composition keeps runtime order outside the thin public entry', a
     /^\(\) => core\.apply\(\s*backendRuntimeCtx,\s*legacyCoreCompat\.config,\s*\{[\s\S]*?sessionVision:\s*sessionVisionRuntime,[\s\S]*?coreVisionSurface:\s*coreVisionSurfaceRuntime,[\s\S]*?\},?\s*\)/,
     'core must receive the same explicit SessionVisionRuntime and CoreVisionSurfaceRuntime owners as composition',
   )
-  assert.ok(finishAt > coreApplyAt, 'the temporary schema bootstrap projection ends immediately after core wiring')
+  assert.ok(finishAt > coreApplyAt, 'CoreVisionSurface alone owns the temporary schema-bootstrap lifecycle')
+  assert.equal(
+    source.includes('legacyCoreCompat.finishSchemaBootstrap()'),
+    false,
+    'the pre-step compatibility boundary must not regain schema-bootstrap authority',
+  )
 
   const afterAdapterContract = source.slice(adapterContractAt + 1)
   assert.equal(

--- a/tests/settings-impersonation-closure.test.js
+++ b/tests/settings-impersonation-closure.test.js
@@ -1,0 +1,57 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+
+import { installLegacyCoreVisionPolicyBridge } from '../lib/legacy-core-vision-policy-bridge.js'
+
+test('legacy pre-step compatibility cannot impersonate Settings, scopes, injected children or config', async () => {
+  const source = await readFile(
+    new URL('../lib/legacy-core-vision-policy-bridge.js', import.meta.url),
+    'utf8',
+  )
+
+  for (const forbidden of [
+    'projectedConfig',
+    'configView',
+    'scopeView',
+    'settingsView',
+    'childContextView',
+    'settingsCache',
+    'finishSchemaBootstrap',
+  ]) {
+    assert.equal(source.includes(forbidden), false, `${forbidden} must not return to the legacy bridge`)
+  }
+  assert.doesNotMatch(source, /property === ['"]get['"]/, 'bridge must not intercept ctx.get/settings')
+  assert.doesNotMatch(source, /property === ['"]inject['"]/, 'bridge must not intercept injected Settings children')
+  assert.match(source, /property === ['"]on['"]/, 'the retained compatibility seam is pre-step only')
+})
+
+test('legacy pre-step compatibility preserves real config and Settings identities', () => {
+  const config = Object.freeze({
+    tool: false,
+    rewriteImages: true,
+    structuredVisionBootstrap: true,
+  })
+  const settings = Object.freeze({ marker: 'settings-service' })
+  const child = Object.freeze({ settings })
+  const ctx = {
+    get(name) {
+      return name === 'settings' ? settings : undefined
+    },
+    inject(_dependencies, callback) {
+      return callback(child)
+    },
+    on() {
+      return () => {}
+    },
+  }
+
+  const bridge = installLegacyCoreVisionPolicyBridge(ctx, config)
+  assert.equal(bridge.config, config)
+  assert.equal(bridge.ctx.get('settings'), settings)
+
+  let injected
+  bridge.ctx.inject(['settings'], (value) => { injected = value })
+  assert.equal(injected, child)
+  assert.equal(Object.hasOwn(bridge, 'finishSchemaBootstrap'), false)
+})


### PR DESCRIPTION
## Scope

Architecture Closure C1-E: delete the remaining Session policy → fake Settings/config projection after the explicit CoreVisionSurface production switch.

This PR removes from `lib/legacy-core-vision-policy-bridge.js`:

- config projection / config Proxy
- Settings Proxy
- settings scope Proxy
- injected child-context Settings Proxy
- `ctx.get('settings')` interception
- `ctx.inject(['settings'])` interception
- the bridge-owned schema-bootstrap lifecycle

The retained boundary is intentionally narrow: it wraps only `agent/pre-step` to preserve the two real compatibility behaviors that are not Settings impersonation:

- text-only history image rewrite using the exact session memory
- Vision Router-owned durable attachment-id hint injection

## Product behavior

Must remain unchanged:

- text-only sessions receive the existing image-history rewrite
- Vision Router-owned routes keep raw pixels and receive exact durable attachment ids
- Host-native multimodal routes remain non-destructive and do not get Router hints
- UNKNOWN capability remains non-destructive
- explicit Vision Router tools remain usable on native routes
- live tool settings continue to gate execution without schema churn

## Authority

No authority expands. This PR removes an indirect authority path: Session policy can no longer masquerade as Settings/config. The five policy-derived Core decisions remain owned by the explicit `CoreVisionSurfaceRuntime` merged in C1-D.

## Lifetime

The bridge no longer owns any schema-bootstrap state. The only temporary bootstrap lifetime is `CoreVisionSurfaceRuntime.finishSchemaBootstrap()`.

## Host compatibility

No supported Host compatibility seam is deleted. `installHostSettingsCompatibility` and other rc6/rc8/current Host feature-detected bridges are untouched. Only the internal fake-Settings projection is removed.

## Concurrency / cancellation

No ALS, session-store, adapter-registration, task, timer, cancellation, or background-work lifetime changes. Native ownership ALS remains authoritative; the retained pre-step wrapper continues to consume it read-only.

## Security

No credential, remote-settings, loopback, path, proxy, or provider-response exposure changes. Removing Settings impersonation narrows the internal privilege surface.

## Resource

No image, cache, artifact, response-size, queue, timer, or job policy changes.

## Regression gate

Adds `tests/settings-impersonation-closure.test.js` to Architecture Closure Node 22/24. The gate forbids the legacy bridge from regaining config/Settings/scope/child-context projection or `ctx.get`/`ctx.inject` interception while explicitly allowing the retained pre-step compatibility seam.

## Rollback

No persistent data format changes. Reverting this PR restores the compatibility projection without migrating or rewriting session/settings data.

C1 must not advance to C2 until this PR is merged and merged-main required/closure gates are green.