### PR TITLE
refactor(web): add Host-owned presentation DTO parity seam

### DIFF
--- a/.github/workflows/architecture-closure.yml
+++ b/.github/workflows/architecture-closure.yml
@@ -15,10 +15,15 @@ on:
       - 'lib/catalog-corrections.js'
       - 'lib/web/**'
       - 'lib/vision-capability-shadow.js'
+      - 'lib/vision-capability-benchmark-service.js'
+      - 'lib/vision-capability-benchmark-client.js'
+      - 'lib/vision-capability-benchmark-presentation.js'
+      - 'lib/vision-product-presentation.js'
       - 'docs/architecture/**'
       - 'tests/architecture-contract-baseline.test.js'
       - 'tests/core-vision-surface-parity.test.js'
       - 'tests/settings-impersonation-closure.test.js'
+      - 'tests/presentation-convergence-parity.test.js'
       - 'tests/session-runtime-core-wiring.test.js'
       - 'tests/session-vision-runtime-parity.test.js'
       - 'tests/vision-execution-order-core-wiring.test.js'
@@ -44,10 +49,15 @@ on:
       - 'lib/catalog-corrections.js'
       - 'lib/web/**'
       - 'lib/vision-capability-shadow.js'
+      - 'lib/vision-capability-benchmark-service.js'
+      - 'lib/vision-capability-benchmark-client.js'
+      - 'lib/vision-capability-benchmark-presentation.js'
+      - 'lib/vision-product-presentation.js'
       - 'docs/architecture/**'
       - 'tests/architecture-contract-baseline.test.js'
       - 'tests/core-vision-surface-parity.test.js'
       - 'tests/settings-impersonation-closure.test.js'
+      - 'tests/presentation-convergence-parity.test.js'
       - 'tests/session-runtime-core-wiring.test.js'
       - 'tests/session-vision-runtime-parity.test.js'
       - 'tests/vision-execution-order-core-wiring.test.js'
@@ -85,6 +95,7 @@ jobs:
           tests/architecture-contract-baseline.test.js
           tests/core-vision-surface-parity.test.js
           tests/settings-impersonation-closure.test.js
+          tests/presentation-convergence-parity.test.js
           tests/session-runtime-core-wiring.test.js
           tests/session-vision-runtime-parity.test.js
           tests/vision-execution-order-core-wiring.test.js

--- a/lib/runtime-composition.js
+++ b/lib/runtime-composition.js
@@ -31,6 +31,7 @@ import { installVisionToolRuntimeBoundary } from './vision-tool-runtime-boundary
 import { installVisionRoutingRuntime } from './vision-routing-runtime.js'
 import { createCapabilityProfileStore } from './vision-capability-probe.js'
 import { installCapabilityBenchmarkService } from './vision-capability-benchmark-service.js'
+import { attachCapabilityBenchmarkPresentation } from './vision-capability-benchmark-presentation.js'
 import { resolveVisionRoutingProduct } from './vision-routing-product.js'
 import {
   normalizeBackgroundMeasurementAuthority,
@@ -263,9 +264,15 @@ export function applyVisionRuntimeComposition(ctx, config = {}, core) {
     evidenceSource: (provider, model) => liveDiscovery.evidenceSource?.(provider, model),
     logger: logging.logger,
   })
-  installCapabilityBenchmarkService(backendRuntimeCtx, runtimeConfig, core, {
+  const capabilityBenchmark = installCapabilityBenchmarkService(backendRuntimeCtx, runtimeConfig, core, {
     logger: logging.logger,
     store: capabilityStore,
+  })
+  attachCapabilityBenchmarkPresentation(capabilityBenchmark, {
+    ctx: backendRuntimeCtx,
+    config: runtimeConfig,
+    core,
+    healthForCandidate: breakerShadowHealth.healthForCandidate,
   })
   installTesseractExecFileCompat(backendRuntimeCtx)
 

--- a/lib/vision-capability-benchmark-presentation.js
+++ b/lib/vision-capability-benchmark-presentation.js
@@ -1,0 +1,81 @@
+import { collectCapabilityShadowCandidates } from './vision-capability-shadow.js'
+import { resolveVisionRoutingAuthority } from './vision-routing-authority.js'
+import {
+  VISION_PRESENTATION_DTO_REVISION,
+  projectVisionProductCandidate,
+  publicVisionAuthority,
+} from './vision-product-presentation.js'
+
+const attachedManagers = new WeakSet()
+
+function activeSettings(ctx, fallback) {
+  try {
+    const settings = ctx?.get?.('settings')
+    const current = settings?.get?.('vision-router')
+    return current && typeof current === 'object' && !Array.isArray(current) ? current : fallback
+  } catch {
+    return fallback
+  }
+}
+
+async function rawCandidates(ctx, config, core, store) {
+  try {
+    return await collectCapabilityShadowCandidates(ctx, config, core, store)
+  } catch {
+    return []
+  }
+}
+
+/**
+ * C2-A additive migration seam.
+ *
+ * The existing benchmark route keeps its mature manager and polling contract.
+ * This decorator adds the versioned Host presentation DTO to that same
+ * snapshot without changing benchmark execution or browser consumption. It is
+ * intentionally removable once the service owns the projection directly.
+ */
+export function attachCapabilityBenchmarkPresentation(manager, {
+  ctx,
+  config = {},
+  core,
+  healthForCandidate,
+} = {}) {
+  if (!manager || typeof manager !== 'object' || typeof manager.snapshot !== 'function') return manager
+  if (attachedManagers.has(manager)) return manager
+
+  const baseSnapshot = manager.snapshot.bind(manager)
+  manager.snapshot = async () => {
+    const base = await baseSnapshot()
+    const current = activeSettings(ctx, config)
+    const authority = resolveVisionRoutingAuthority(current)
+    const rows = await rawCandidates(ctx, current, core, manager.store)
+    const byKey = new Map(rows.map((candidate) => [candidate?.key, candidate]))
+    const candidates = await Promise.all((Array.isArray(base?.candidates) ? base.candidates : []).map(async (candidate) => {
+      const raw = byKey.get(candidate?.key) ?? candidate
+      let health
+      if (typeof healthForCandidate === 'function') {
+        try { health = await healthForCandidate(raw) } catch {}
+      }
+      const presentationInput = {
+        ...raw,
+        measured: candidate?.measured,
+        cloudCostWarning: candidate?.cloudCostWarning,
+      }
+      return Object.freeze({
+        ...candidate,
+        presentation: projectVisionProductCandidate(presentationInput, health, authority),
+      })
+    }))
+
+    return Object.freeze({
+      ...base,
+      presentationRevision: VISION_PRESENTATION_DTO_REVISION,
+      routingMode: authority.execution,
+      currentAuthority: publicVisionAuthority(authority),
+      candidates: Object.freeze(candidates),
+    })
+  }
+
+  attachedManagers.add(manager)
+  return manager
+}

--- a/lib/vision-product-presentation.js
+++ b/lib/vision-product-presentation.js
@@ -1,0 +1,78 @@
+export const VISION_PRESENTATION_DTO_REVISION = 1
+
+function healthClassOf(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return 'unknown'
+  if (value.circuitOpen === true && value.rateLimited === true) return 'rate-limited'
+  if (value.circuitOpen === true) return 'blocked'
+  if (value.circuitOpen === false) return 'healthy'
+  return 'unknown'
+}
+
+function capabilityStateOf(candidate) {
+  const measured = candidate?.measured
+  if (measured && typeof measured === 'object' && Object.keys(measured).length > 0) return 'measured'
+  return candidate?.benchmarkable === true ? 'unmeasured' : 'unavailable'
+}
+
+function benchmarkReasonOf(candidate) {
+  if (!candidate) return 'candidate-unavailable'
+  if (candidate.benchmarkable !== true) return 'stable-benchmark-identity-unavailable'
+  return null
+}
+
+function localOrFree(candidate) {
+  if (candidate?.local === true) return true
+  if (candidate?.cost === 0) return true
+  return candidate?.cloudCostWarning === false
+}
+
+function backgroundEligibilityOf(candidate, authority) {
+  if (!authority?.backgroundMeasurementActive) {
+    return { eligible: false, reason: 'background-measurement-not-active' }
+  }
+  if (candidate?.benchmarkable !== true) {
+    return { eligible: false, reason: 'benchmark-unavailable' }
+  }
+  if (authority.backgroundMeasurement === 'all') return { eligible: true, reason: null }
+  if (authority.backgroundMeasurement !== 'local-free') {
+    return { eligible: false, reason: 'background-measurement-off' }
+  }
+  return localOrFree(candidate)
+    ? { eligible: true, reason: null }
+    : { eligible: false, reason: 'local-free-policy-excludes-cloud-cost' }
+}
+
+export function publicVisionAuthority(authority) {
+  return Object.freeze({
+    execution: authority?.execution,
+    autoSelectionAuthorized: authority?.autoSelectionAuthorized === true,
+    backgroundMeasurement: authority?.backgroundMeasurement,
+    backgroundMeasurementAuthorized: authority?.backgroundMeasurementAuthorized === true,
+    backgroundMeasurementActive: authority?.backgroundMeasurementActive === true,
+  })
+}
+
+/**
+ * Host-owned product decision projection for presentation surfaces.
+ *
+ * Inputs may be raw Host evidence candidates or the sanitized benchmark
+ * candidate shape. Only stable product decisions are returned; transport,
+ * credential, endpoint, fingerprint and breaker internals never cross this
+ * boundary.
+ */
+export function projectVisionProductCandidate(candidate, health, authority) {
+  const background = backgroundEligibilityOf(candidate, authority)
+  return Object.freeze({
+    key: String(candidate?.key ?? ''),
+    provider: String(candidate?.provider ?? ''),
+    model: String(candidate?.model ?? ''),
+    canBenchmark: candidate?.benchmarkable === true,
+    benchmarkReason: benchmarkReasonOf(candidate),
+    routingMode: authority?.execution,
+    currentAuthority: publicVisionAuthority(authority),
+    healthClass: healthClassOf(health),
+    capabilityState: capabilityStateOf(candidate),
+    backgroundEligible: background.eligible,
+    backgroundReason: background.reason,
+  })
+}

--- a/lib/vision-product-presentation.js
+++ b/lib/vision-product-presentation.js
@@ -45,10 +45,10 @@ function backgroundEligibilityOf(candidate, authority) {
 export function publicVisionAuthority(authority) {
   return Object.freeze({
     execution: authority?.execution,
-    autoSelectionAuthorized: authority?.autoSelectionAuthorized === true,
+    autoSelectionAuthorized: authority?.autoSelectionAuthorized,
     backgroundMeasurement: authority?.backgroundMeasurement,
-    backgroundMeasurementAuthorized: authority?.backgroundMeasurementAuthorized === true,
-    backgroundMeasurementActive: authority?.backgroundMeasurementActive === true,
+    backgroundMeasurementAuthorized: authority?.backgroundMeasurementAuthorized,
+    backgroundMeasurementActive: authority?.backgroundMeasurementActive,
   })
 }
 

--- a/lib/web/product-state.js
+++ b/lib/web/product-state.js
@@ -1,5 +1,15 @@
 import { collectVisionRoutingEvidence } from '../vision-routing-evidence.js'
 import { resolveVisionRoutingAuthority } from '../vision-routing-authority.js'
+import {
+  VISION_PRESENTATION_DTO_REVISION,
+  projectVisionProductCandidate,
+  publicVisionAuthority,
+} from '../vision-product-presentation.js'
+
+export {
+  VISION_PRESENTATION_DTO_REVISION,
+  projectVisionProductCandidate,
+} from '../vision-product-presentation.js'
 
 function activeSettings(ctx, fallback) {
   try {
@@ -9,70 +19,6 @@ function activeSettings(ctx, fallback) {
   } catch {
     return fallback
   }
-}
-
-function healthClassOf(value) {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return 'unknown'
-  if (value.circuitOpen === true && value.rateLimited === true) return 'rate-limited'
-  if (value.circuitOpen === true) return 'blocked'
-  if (value.circuitOpen === false) return 'healthy'
-  return 'unknown'
-}
-
-function capabilityStateOf(candidate) {
-  const measured = candidate?.measured
-  if (measured && typeof measured === 'object' && Object.keys(measured).length > 0) return 'measured'
-  return candidate?.benchmarkable === true ? 'unmeasured' : 'unavailable'
-}
-
-function benchmarkReasonOf(candidate) {
-  if (!candidate) return 'candidate-unavailable'
-  if (candidate.benchmarkable !== true) return 'stable-benchmark-identity-unavailable'
-  return null
-}
-
-function backgroundEligibilityOf(candidate, authority) {
-  if (!authority?.backgroundMeasurementActive) {
-    return { eligible: false, reason: 'background-measurement-not-active' }
-  }
-  if (candidate?.benchmarkable !== true) {
-    return { eligible: false, reason: 'benchmark-unavailable' }
-  }
-  if (authority.backgroundMeasurement === 'all') return { eligible: true, reason: null }
-  if (authority.backgroundMeasurement !== 'local-free') {
-    return { eligible: false, reason: 'background-measurement-off' }
-  }
-  const localOrFree = candidate?.local === true || candidate?.cost === 0
-  return localOrFree
-    ? { eligible: true, reason: null }
-    : { eligible: false, reason: 'local-free-policy-excludes-cloud-cost' }
-}
-
-function publicAuthority(authority) {
-  return Object.freeze({
-    execution: authority.execution,
-    autoSelectionAuthorized: authority.autoSelectionAuthorized,
-    backgroundMeasurement: authority.backgroundMeasurement,
-    backgroundMeasurementAuthorized: authority.backgroundMeasurementAuthorized,
-    backgroundMeasurementActive: authority.backgroundMeasurementActive,
-  })
-}
-
-export function projectVisionProductCandidate(candidate, health, authority) {
-  const background = backgroundEligibilityOf(candidate, authority)
-  return Object.freeze({
-    key: String(candidate?.key ?? ''),
-    provider: String(candidate?.provider ?? ''),
-    model: String(candidate?.model ?? ''),
-    canBenchmark: candidate?.benchmarkable === true,
-    benchmarkReason: benchmarkReasonOf(candidate),
-    routingMode: authority.execution,
-    currentAuthority: publicAuthority(authority),
-    healthClass: healthClassOf(health),
-    capabilityState: capabilityStateOf(candidate),
-    backgroundEligible: background.eligible,
-    backgroundReason: background.reason,
-  })
 }
 
 /**
@@ -105,8 +51,9 @@ export async function createVisionProductStateSnapshot({
 
   return Object.freeze({
     ok: true,
+    presentationRevision: VISION_PRESENTATION_DTO_REVISION,
     routingMode: authority.execution,
-    currentAuthority: publicAuthority(authority),
+    currentAuthority: publicVisionAuthority(authority),
     candidates: Object.freeze(candidates),
   })
 }

--- a/tests/presentation-convergence-parity.test.js
+++ b/tests/presentation-convergence-parity.test.js
@@ -1,0 +1,204 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  VISION_PRESENTATION_DTO_REVISION,
+  projectVisionProductCandidate,
+} from '../lib/vision-product-presentation.js'
+import { attachCapabilityBenchmarkPresentation } from '../lib/vision-capability-benchmark-presentation.js'
+
+const MODES = ['off', 'local-free', 'all']
+
+function legacyBrowserBackgroundEligible(candidate, authority) {
+  const background = {
+    active: authority.backgroundMeasurementActive,
+    mode: authority.backgroundMeasurement,
+    excluded: [],
+  }
+  if (
+    !background ||
+    background.active !== true ||
+    !candidate ||
+    candidate.benchmarkable !== true ||
+    background.excluded.some((item) => item?.key === candidate.key)
+  ) return false
+  if (background.mode === 'all') return true
+  if (background.mode !== 'local-free') return false
+  return candidate.local === true || candidate.cloudCostWarning === false
+}
+
+function expectedCapabilityState(candidate) {
+  if (candidate?.measured && typeof candidate.measured === 'object' && Object.keys(candidate.measured).length > 0) {
+    return 'measured'
+  }
+  return candidate?.benchmarkable === true ? 'unmeasured' : 'unavailable'
+}
+
+test('C2-A Host projector matches the legacy browser base eligibility matrix exactly', () => {
+  for (const benchmarkable of [false, true]) {
+    for (const local of [false, true]) {
+      for (const cost of [0, 1]) {
+        for (const measured of [undefined, { scores: { ocr: 0.8 } }]) {
+          for (const backgroundMeasurement of MODES) {
+            for (const backgroundMeasurementActive of [false, true]) {
+              const authority = {
+                execution: 'ordered',
+                autoSelectionAuthorized: false,
+                backgroundMeasurement,
+                backgroundMeasurementAuthorized: backgroundMeasurement !== 'off',
+                backgroundMeasurementActive,
+              }
+              const raw = {
+                key: 'provider/model',
+                provider: 'provider',
+                model: 'model',
+                benchmarkable,
+                local,
+                cost,
+                measured,
+              }
+              const sanitized = {
+                key: raw.key,
+                provider: raw.provider,
+                model: raw.model,
+                benchmarkable,
+                local,
+                cloudCostWarning: local !== true && cost !== 0,
+                measured,
+              }
+              const projectedRaw = projectVisionProductCandidate(raw, undefined, authority)
+              const projectedSanitized = projectVisionProductCandidate(sanitized, undefined, authority)
+
+              assert.equal(projectedRaw.canBenchmark, benchmarkable)
+              assert.equal(projectedRaw.capabilityState, expectedCapabilityState(raw))
+              assert.equal(
+                projectedRaw.backgroundEligible,
+                legacyBrowserBackgroundEligible(sanitized, authority),
+                JSON.stringify({ benchmarkable, local, cost, backgroundMeasurement, backgroundMeasurementActive }),
+              )
+              assert.deepEqual(projectedSanitized, projectedRaw)
+            }
+          }
+        }
+      }
+    }
+  }
+})
+
+test('C2-A benchmark snapshot adds a versioned DTO without replacing legacy candidate fields', async () => {
+  const live = {
+    routingMode: 'auto',
+    backgroundBenchmarking: 'local-free',
+  }
+  const originalCandidate = {
+    key: 'http:free/model',
+    provider: 'vision-http',
+    model: 'free/model',
+    local: false,
+    cloudCostWarning: false,
+    benchmarkable: true,
+    evidenceScope: 'endpoint',
+    protocol: 'openai-completions',
+    fingerprint: 'transport-fingerprint-stays-on-legacy-snapshot',
+    imageCapability: 'declared',
+    measured: { scores: { ocr: 0.9 }, measuredAxes: ['ocr'] },
+  }
+  const manager = {
+    store: {},
+    async snapshot() {
+      return {
+        ok: true,
+        suiteRevision: 3,
+        queueLength: 0,
+        candidates: [originalCandidate],
+        jobs: [],
+      }
+    },
+  }
+  const ctx = {
+    get(name) {
+      if (name === 'settings') return { get: () => live }
+      return undefined
+    },
+    llm: { listProviders: () => [] },
+  }
+
+  attachCapabilityBenchmarkPresentation(manager, {
+    ctx,
+    config: {},
+    core: {
+      localProvidersOf: () => [],
+      httpProvidersOf: () => [],
+      DEFAULT_HTTP_PROVIDERS: [],
+    },
+    healthForCandidate: async () => ({ circuitOpen: true, rateLimited: true }),
+  })
+  attachCapabilityBenchmarkPresentation(manager, { ctx })
+
+  const snapshot = await manager.snapshot()
+  assert.equal(snapshot.presentationRevision, VISION_PRESENTATION_DTO_REVISION)
+  assert.equal(snapshot.routingMode, 'auto')
+  assert.equal(snapshot.currentAuthority.execution, 'auto')
+  assert.equal(snapshot.candidates.length, 1)
+  assert.equal(snapshot.candidates[0].fingerprint, originalCandidate.fingerprint)
+  assert.deepEqual(snapshot.candidates[0].measured, originalCandidate.measured)
+
+  const presentation = snapshot.candidates[0].presentation
+  assert.equal(presentation.canBenchmark, true)
+  assert.equal(presentation.capabilityState, 'measured')
+  assert.equal(presentation.backgroundEligible, true)
+  assert.equal(presentation.healthClass, 'rate-limited')
+  assert.equal(Object.hasOwn(presentation, 'fingerprint'), false)
+  assert.equal(Object.hasOwn(presentation, 'protocol'), false)
+  assert.equal(Object.hasOwn(presentation, 'endpoint'), false)
+})
+
+test('C2-A presentation reads live Host authority on every snapshot', async () => {
+  const live = {
+    routingMode: 'ordered',
+    backgroundBenchmarking: 'off',
+  }
+  const manager = {
+    store: {},
+    async snapshot() {
+      return {
+        ok: true,
+        candidates: [{
+          key: 'local/model',
+          provider: 'local',
+          model: 'model',
+          local: true,
+          cloudCostWarning: false,
+          benchmarkable: true,
+        }],
+        jobs: [],
+      }
+    },
+  }
+  const ctx = {
+    get(name) {
+      if (name === 'settings') return { get: () => live }
+      return undefined
+    },
+    llm: { listProviders: () => [] },
+  }
+
+  attachCapabilityBenchmarkPresentation(manager, {
+    ctx,
+    core: {
+      localProvidersOf: () => [],
+      httpProvidersOf: () => [],
+      DEFAULT_HTTP_PROVIDERS: [],
+    },
+  })
+
+  const before = await manager.snapshot()
+  assert.equal(before.routingMode, 'ordered')
+  assert.equal(before.candidates[0].presentation.backgroundEligible, false)
+
+  live.routingMode = 'auto'
+  live.backgroundBenchmarking = 'all'
+  const after = await manager.snapshot()
+  assert.equal(after.routingMode, 'auto')
+  assert.equal(after.candidates[0].presentation.backgroundEligible, true)
+})


### PR DESCRIPTION
## Scope

Architecture Closure C2-A: add the new Host-owned presentation path without switching browser behavior yet.

This PR:

- extracts the existing Host product decision projector into `lib/vision-product-presentation.js`
- versions the stable presentation DTO as revision 1
- keeps `/_dsh/vision-router/product-state` compatible while making it reuse the single projector
- decorates the existing capability-benchmark manager snapshot with additive `presentationRevision`, `routingMode`, `currentAuthority`, and per-candidate `presentation`
- keeps the existing benchmark route, queue, execution, cancellation, persistence and browser polling behavior unchanged
- adds a Node 22/24 Architecture Closure parity matrix against the current browser base eligibility algorithm

## Migration stage

This is the **Add + Compare** stage only.

The legacy browser still computes its existing presentation decisions and remains the production oracle. No browser algorithm is deleted or switched in this PR. A green run therefore proves the Host DTO can coexist without rescuing or changing the current UI path.

## Product behavior

No intended user-visible behavior change.

- benchmark candidate/job fields remain present
- benchmark POST/DELETE behavior is unchanged
- Auto/background settings meanings are unchanged
- `/product-state` remains available
- no additional polling route is introduced
- credentials/endpoints/fingerprints/breaker internals are not added to the presentation DTO

## Authority

The new DTO is read-only. It resolves only the existing live Host routing/background authority and projects presentation-safe decisions. It cannot grant Auto, background measurement, benchmark execution or provider authority.

## Follow-up

C2-B will extend the same Host path with the runtime background state needed to cover `excluded/deferred/running/paused`, prove exact old/new parity, and only then switch the browser to consume Host decisions. Browser-owned eligibility helpers are deleted only after that switch is green.

C2 is not complete until the browser no longer re-derives product authority/eligibility and merged-main gates are green.