### PR TITLE
refactor(web): project runtime background presentation state

### DIFF
--- a/lib/vision-capability-benchmark-presentation.js
+++ b/lib/vision-capability-benchmark-presentation.js
@@ -2,6 +2,7 @@ import { collectCapabilityShadowCandidates } from './vision-capability-shadow.js
 import { resolveVisionRoutingAuthority } from './vision-routing-authority.js'
 import {
   VISION_PRESENTATION_DTO_REVISION,
+  projectVisionBackgroundRuntime,
   projectVisionProductCandidate,
   publicVisionAuthority,
 } from './vision-product-presentation.js'
@@ -26,13 +27,22 @@ async function rawCandidates(ctx, config, core, store) {
   }
 }
 
+function backgroundState(store) {
+  try {
+    const profiler = store?.backgroundProfiler
+    return typeof profiler?.snapshot === 'function' ? profiler.snapshot() : {}
+  } catch {
+    return {}
+  }
+}
+
 /**
- * C2-A additive migration seam.
+ * C2 additive migration seam.
  *
- * The existing benchmark route keeps its mature manager and polling contract.
- * This decorator adds the versioned Host presentation DTO to that same
- * snapshot without changing benchmark execution or browser consumption. It is
- * intentionally removable once the service owns the projection directly.
+ * The mature benchmark manager remains the sole queue/execution owner. This
+ * decorator adds versioned Host presentation decisions to the same snapshot,
+ * including the exact public background-runtime state. Browser consumption is
+ * switched only after old/new parity is characterized.
  */
 export function attachCapabilityBenchmarkPresentation(manager, {
   ctx,
@@ -48,6 +58,7 @@ export function attachCapabilityBenchmarkPresentation(manager, {
     const base = await baseSnapshot()
     const current = activeSettings(ctx, config)
     const authority = resolveVisionRoutingAuthority(current)
+    const background = projectVisionBackgroundRuntime(backgroundState(manager.store), authority)
     const rows = await rawCandidates(ctx, current, core, manager.store)
     const byKey = new Map(rows.map((candidate) => [candidate?.key, candidate]))
     const candidates = await Promise.all((Array.isArray(base?.candidates) ? base.candidates : []).map(async (candidate) => {
@@ -60,10 +71,14 @@ export function attachCapabilityBenchmarkPresentation(manager, {
         ...raw,
         measured: candidate?.measured,
         cloudCostWarning: candidate?.cloudCostWarning,
+        imageCapability: candidate?.imageCapability,
       }
       return Object.freeze({
         ...candidate,
-        presentation: projectVisionProductCandidate(presentationInput, health, authority),
+        presentation: projectVisionProductCandidate(presentationInput, health, authority, {
+          background,
+          core,
+        }),
       })
     }))
 
@@ -72,6 +87,7 @@ export function attachCapabilityBenchmarkPresentation(manager, {
       presentationRevision: VISION_PRESENTATION_DTO_REVISION,
       routingMode: authority.execution,
       currentAuthority: publicVisionAuthority(authority),
+      background,
       candidates: Object.freeze(candidates),
     })
   }

--- a/lib/vision-product-presentation.js
+++ b/lib/vision-product-presentation.js
@@ -1,4 +1,6 @@
-export const VISION_PRESENTATION_DTO_REVISION = 1
+export const VISION_PRESENTATION_DTO_REVISION = 2
+
+const PRESENTATION_AXES = Object.freeze(['structured', 'ocr', 'document', 'grounding', 'general'])
 
 function healthClassOf(value) {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return 'unknown'
@@ -42,6 +44,69 @@ function backgroundEligibilityOf(candidate, authority) {
     : { eligible: false, reason: 'local-free-policy-excludes-cloud-cost' }
 }
 
+function nonEmpty(value) {
+  return typeof value === 'string' && value.trim() !== '' ? value.trim() : undefined
+}
+
+function routeIdentity(entry) {
+  const name = nonEmpty(entry?.name)
+  const model = nonEmpty(entry?.model)
+  return name && model ? `${name}/${model}` : undefined
+}
+
+function normalizedEndpoint(value) {
+  return String(value ?? '').trim().replace(/\/+$/, '').toLowerCase()
+}
+
+function trustedBuiltinFree(candidate, core) {
+  if (!candidate || candidate.provider !== 'vision-http' || candidate.local === true) return false
+  const modelIdentity = nonEmpty(candidate.model)
+  if (!modelIdentity || !candidate.endpoint) return false
+  const builtins = Array.isArray(core?.DEFAULT_HTTP_PROVIDERS) ? core.DEFAULT_HTTP_PROVIDERS : []
+  return builtins.some((entry) =>
+    routeIdentity(entry) === modelIdentity &&
+    normalizedEndpoint(entry?.baseURL) === normalizedEndpoint(candidate.endpoint) &&
+    !nonEmpty(entry?.apiKeyEnv))
+}
+
+function schedulerEligibilityOf(candidate, background, core) {
+  if (!background?.active) return { eligible: false, reason: 'background-measurement-not-active' }
+  if (!candidate || candidate.benchmarkable !== true) {
+    return { eligible: false, reason: 'benchmark-unavailable' }
+  }
+  if (candidate.routeRole === 'fallback-only') {
+    return { eligible: false, reason: 'fallback-only-route' }
+  }
+  if (background.mode === 'all') return { eligible: true, reason: null }
+  if (background.mode !== 'local-free') {
+    return { eligible: false, reason: 'background-measurement-off' }
+  }
+  return candidate.local === true || trustedBuiltinFree(candidate, core)
+    ? { eligible: true, reason: null }
+    : { eligible: false, reason: 'local-free-policy-excludes-route' }
+}
+
+function coverageOf(measured) {
+  if (!measured || typeof measured !== 'object') return []
+  if (Array.isArray(measured.measuredAxes)) {
+    return PRESENTATION_AXES.filter((axis) => measured.measuredAxes.includes(axis))
+  }
+  if (Array.isArray(measured.coverage)) {
+    return PRESENTATION_AXES.filter((axis) => measured.coverage.includes(axis))
+  }
+  const scores = measured.scores && typeof measured.scores === 'object' ? measured.scores : {}
+  return PRESENTATION_AXES.filter((axis) => Number.isFinite(Number(scores[axis])))
+}
+
+function itemForKey(rows, key) {
+  return Array.isArray(rows) ? rows.find((item) => item?.key === key) : undefined
+}
+
+function frozenRecord(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return value
+  return Object.freeze({ ...value })
+}
+
 export function publicVisionAuthority(authority) {
   return Object.freeze({
     execution: authority?.execution,
@@ -53,6 +118,143 @@ export function publicVisionAuthority(authority) {
 }
 
 /**
+ * Exact public shape historically served by the capability-runtime GET route.
+ * Keeping this as a pure Host projection lets benchmark snapshots carry the
+ * same state before the browser stops polling the compatibility route.
+ */
+export function projectVisionBackgroundRuntime(state, authority) {
+  const source = state && typeof state === 'object' ? state : {}
+  const deferred = Array.isArray(source.deferred)
+    ? Object.freeze(source.deferred.map((item) => frozenRecord(item)))
+    : Object.freeze([])
+  const excluded = Array.isArray(source.excluded)
+    ? Object.freeze(source.excluded.map((item) => frozenRecord(item)))
+    : Object.freeze([])
+  return Object.freeze({
+    mode: authority?.backgroundMeasurement,
+    active: authority?.backgroundMeasurementActive,
+    paused: Number(source.activeForeground) > 0 || Number(source.activeManualBenchmarks) > 0,
+    idleRemainingMs: source.idleRemainingMs,
+    running: source.running ? frozenRecord(source.running) : null,
+    deferred,
+    excluded,
+  })
+}
+
+/**
+ * Scheduler-aware candidate state used by the capability UI. This is separate
+ * from the compatibility `backgroundEligible` field above: the latter keeps
+ * the existing /product-state meaning while this state mirrors real unattended
+ * scheduler rules, including fallback-only routes and trusted built-in free
+ * endpoints.
+ */
+export function projectVisionCandidateBackground(candidate, background, core) {
+  if (!background || typeof background !== 'object') return undefined
+  const key = String(candidate?.key ?? '')
+  const running = background.running?.key === key ? background.running : undefined
+  if (running) {
+    return Object.freeze({
+      state: 'running',
+      reason: null,
+      policyEligible: true,
+      needsWork: true,
+      workEligible: true,
+      running: frozenRecord(running),
+    })
+  }
+
+  const excluded = itemForKey(background.excluded, key)
+  if (excluded?.reason === 'measured-text-only') {
+    return Object.freeze({
+      state: 'measured-text-only',
+      reason: excluded.reason,
+      policyEligible: false,
+      needsWork: false,
+      workEligible: false,
+    })
+  }
+
+  const deferred = itemForKey(background.deferred, key)
+  if (deferred) {
+    return Object.freeze({
+      state: deferred.retryable === true ? 'deferred' : 'stopped',
+      reason: deferred.errorClass ?? 'provider',
+      policyEligible: false,
+      needsWork: true,
+      workEligible: false,
+      deferred: frozenRecord(deferred),
+    })
+  }
+
+  const eligibility = schedulerEligibilityOf(candidate, background, core)
+  const needsWork = coverageOf(candidate?.measured).length < PRESENTATION_AXES.length
+  const workEligible = eligibility.eligible && !excluded && needsWork
+
+  if (candidate?.measured) {
+    return Object.freeze({
+      state: workEligible ? 'measured-waiting' : 'measured',
+      reason: workEligible ? null : eligibility.reason,
+      policyEligible: eligibility.eligible,
+      needsWork,
+      workEligible,
+    })
+  }
+
+  if (workEligible) {
+    const state = background.paused === true
+      ? 'paused'
+      : candidate?.imageCapability === 'text-only'
+        ? 'awaiting-verification'
+        : 'waiting'
+    return Object.freeze({
+      state,
+      reason: null,
+      policyEligible: true,
+      needsWork: true,
+      workEligible: true,
+    })
+  }
+
+  if (candidate?.imageCapability === 'text-only') {
+    return Object.freeze({
+      state: 'declared-text-only',
+      reason: eligibility.reason,
+      policyEligible: eligibility.eligible,
+      needsWork,
+      workEligible: false,
+    })
+  }
+
+  if (candidate?.benchmarkable !== true) {
+    return Object.freeze({
+      state: 'unavailable',
+      reason: 'benchmark-unavailable',
+      policyEligible: false,
+      needsWork,
+      workEligible: false,
+    })
+  }
+
+  if (background.active === true && background.mode === 'local-free') {
+    return Object.freeze({
+      state: 'policy-excluded',
+      reason: eligibility.reason,
+      policyEligible: false,
+      needsWork,
+      workEligible: false,
+    })
+  }
+
+  return Object.freeze({
+    state: 'not-measured',
+    reason: eligibility.reason,
+    policyEligible: eligibility.eligible,
+    needsWork,
+    workEligible: false,
+  })
+}
+
+/**
  * Host-owned product decision projection for presentation surfaces.
  *
  * Inputs may be raw Host evidence candidates or the sanitized benchmark
@@ -60,8 +262,11 @@ export function publicVisionAuthority(authority) {
  * credential, endpoint, fingerprint and breaker internals never cross this
  * boundary.
  */
-export function projectVisionProductCandidate(candidate, health, authority) {
+export function projectVisionProductCandidate(candidate, health, authority, options = {}) {
   const background = backgroundEligibilityOf(candidate, authority)
+  const runtimeBackground = options.background
+    ? projectVisionCandidateBackground(candidate, options.background, options.core)
+    : undefined
   return Object.freeze({
     key: String(candidate?.key ?? ''),
     provider: String(candidate?.provider ?? ''),
@@ -74,5 +279,6 @@ export function projectVisionProductCandidate(candidate, health, authority) {
     capabilityState: capabilityStateOf(candidate),
     backgroundEligible: background.eligible,
     backgroundReason: background.reason,
+    ...(runtimeBackground ? { background: runtimeBackground } : {}),
   })
 }

--- a/tests/presentation-convergence-parity.test.js
+++ b/tests/presentation-convergence-parity.test.js
@@ -3,28 +3,72 @@ import assert from 'node:assert/strict'
 
 import {
   VISION_PRESENTATION_DTO_REVISION,
+  projectVisionBackgroundRuntime,
+  projectVisionCandidateBackground,
   projectVisionProductCandidate,
 } from '../lib/vision-product-presentation.js'
 import { attachCapabilityBenchmarkPresentation } from '../lib/vision-capability-benchmark-presentation.js'
 
 const MODES = ['off', 'local-free', 'all']
+const SCORE_ORDER = ['structured', 'ocr', 'document', 'grounding', 'general']
 
-function legacyBrowserBackgroundEligible(candidate, authority) {
-  const background = {
-    active: authority.backgroundMeasurementActive,
-    mode: authority.backgroundMeasurement,
-    excluded: [],
-  }
+function legacyBrowserBackgroundEligible(candidate, authorityOrBackground) {
+  const background = Object.hasOwn(authorityOrBackground ?? {}, 'active')
+    ? authorityOrBackground
+    : {
+        active: authorityOrBackground?.backgroundMeasurementActive,
+        mode: authorityOrBackground?.backgroundMeasurement,
+        excluded: [],
+      }
   if (
     !background ||
     background.active !== true ||
     !candidate ||
     candidate.benchmarkable !== true ||
-    background.excluded.some((item) => item?.key === candidate.key)
+    (Array.isArray(background.excluded) && background.excluded.some((item) => item?.key === candidate.key))
   ) return false
   if (background.mode === 'all') return true
   if (background.mode !== 'local-free') return false
   return candidate.local === true || candidate.cloudCostWarning === false
+}
+
+function legacyCoverageOf(measured) {
+  if (!measured) return []
+  if (Array.isArray(measured.measuredAxes)) {
+    return SCORE_ORDER.filter((axis) => measured.measuredAxes.includes(axis))
+  }
+  if (Array.isArray(measured.coverage)) {
+    return SCORE_ORDER.filter((axis) => measured.coverage.includes(axis))
+  }
+  const scores = measured.scores || {}
+  return SCORE_ORDER.filter((axis) => Number.isFinite(Number(scores[axis])))
+}
+
+function legacyBackgroundNeedsWork(candidate) {
+  return !!candidate && legacyCoverageOf(candidate.measured).length < SCORE_ORDER.length
+}
+
+function itemForKey(rows, key) {
+  return Array.isArray(rows) ? rows.find((item) => item?.key === key) : undefined
+}
+
+function legacyBrowserBackgroundState(candidate, background) {
+  if (background?.running?.key === candidate?.key) return 'running'
+  const excluded = itemForKey(background?.excluded, candidate?.key)
+  if (excluded?.reason === 'measured-text-only') return 'measured-text-only'
+  const deferred = itemForKey(background?.deferred, candidate?.key)
+  if (deferred) return deferred.retryable === true ? 'deferred' : 'stopped'
+  const eligible = legacyBrowserBackgroundEligible(candidate, background) && legacyBackgroundNeedsWork(candidate)
+  if (candidate?.measured) return eligible ? 'measured-waiting' : 'measured'
+  if (eligible) {
+    if (background?.paused === true) return 'paused'
+    if (candidate?.imageCapability === 'text-only') return 'awaiting-verification'
+    return 'waiting'
+  }
+  if (candidate?.imageCapability === 'text-only') return 'declared-text-only'
+  if (candidate?.benchmarkable !== true) return 'unavailable'
+  if (background?.active === true && background?.mode === 'local-free') return 'policy-excluded'
+  return 'not-measured'
 }
 
 function expectedCapabilityState(candidate) {
@@ -34,7 +78,7 @@ function expectedCapabilityState(candidate) {
   return candidate?.benchmarkable === true ? 'unmeasured' : 'unavailable'
 }
 
-test('C2-A Host projector matches the legacy browser base eligibility matrix exactly', () => {
+test('C2-A Host projector preserves the compatibility browser base eligibility matrix exactly', () => {
   for (const benchmarkable of [false, true]) {
     for (const local of [false, true]) {
       for (const cost of [0, 1]) {
@@ -85,7 +129,235 @@ test('C2-A Host projector matches the legacy browser base eligibility matrix exa
   }
 })
 
-test('C2-A benchmark snapshot adds a versioned DTO without replacing legacy candidate fields', async () => {
+test('C2-B runtime projection matches the capability-runtime public shape exactly', () => {
+  const authority = {
+    backgroundMeasurement: 'local-free',
+    backgroundMeasurementActive: true,
+  }
+  const state = {
+    activeForeground: 1,
+    activeManualBenchmarks: 0,
+    idleRemainingMs: 1234,
+    running: {
+      key: 'provider/model',
+      axis: 'ocr',
+      completed: 1,
+      total: 2,
+      elapsedMs: 90,
+    },
+    deferred: [{
+      key: 'deferred/model',
+      axis: 'general',
+      errorClass: 'rate-limit',
+      errorCode: 'RATE_LIMITED',
+      retryable: true,
+      until: 999,
+    }],
+    excluded: [{ key: 'text/model', reason: 'measured-text-only' }],
+  }
+
+  assert.deepEqual(
+    JSON.parse(JSON.stringify(projectVisionBackgroundRuntime(state, authority))),
+    {
+      mode: 'local-free',
+      active: true,
+      paused: true,
+      idleRemainingMs: 1234,
+      running: {
+        key: 'provider/model',
+        axis: 'ocr',
+        completed: 1,
+        total: 2,
+        elapsedMs: 90,
+      },
+      deferred: [{
+        key: 'deferred/model',
+        axis: 'general',
+        errorClass: 'rate-limit',
+        errorCode: 'RATE_LIMITED',
+        retryable: true,
+        until: 999,
+      }],
+      excluded: [{ key: 'text/model', reason: 'measured-text-only' }],
+    },
+  )
+})
+
+test('C2-B Host background state matches legacy render precedence where scheduler and browser agree', () => {
+  const core = {
+    DEFAULT_HTTP_PROVIDERS: [{
+      name: 'ovh-free',
+      model: 'vision',
+      baseURL: 'https://free.example/v1',
+      apiKeyEnv: '',
+    }],
+  }
+  const baseBackground = {
+    mode: 'all',
+    active: true,
+    paused: false,
+    running: null,
+    deferred: [],
+    excluded: [],
+  }
+  const scenarios = [
+    {
+      name: 'running wins over measured and other background state',
+      candidate: { key: 'p/m', benchmarkable: true, local: true, measured: { scores: { ocr: 1 } } },
+      background: {
+        ...baseBackground,
+        running: { key: 'p/m', axis: 'ocr', completed: 1, total: 2 },
+        excluded: [{ key: 'p/m', reason: 'measured-text-only' }],
+        deferred: [{ key: 'p/m', retryable: true, errorClass: 'network' }],
+      },
+    },
+    {
+      name: 'measured text-only wins over deferred',
+      candidate: { key: 'p/m', benchmarkable: true, local: true },
+      background: {
+        ...baseBackground,
+        excluded: [{ key: 'p/m', reason: 'measured-text-only' }],
+        deferred: [{ key: 'p/m', retryable: true, errorClass: 'network' }],
+      },
+    },
+    {
+      name: 'retryable deferred',
+      candidate: { key: 'p/m', benchmarkable: true, local: true },
+      background: {
+        ...baseBackground,
+        deferred: [{ key: 'p/m', retryable: true, errorClass: 'rate-limit' }],
+      },
+    },
+    {
+      name: 'nonretryable stopped',
+      candidate: { key: 'p/m', benchmarkable: true, local: true },
+      background: {
+        ...baseBackground,
+        deferred: [{ key: 'p/m', retryable: false, errorClass: 'auth' }],
+      },
+    },
+    {
+      name: 'partial measured waiting',
+      candidate: { key: 'p/m', benchmarkable: true, local: true, measured: { scores: { ocr: 1 } } },
+      background: baseBackground,
+    },
+    {
+      name: 'complete measured',
+      candidate: {
+        key: 'p/m',
+        benchmarkable: true,
+        local: true,
+        measured: { scores: Object.fromEntries(SCORE_ORDER.map((axis) => [axis, 1])) },
+      },
+      background: baseBackground,
+    },
+    {
+      name: 'paused eligible candidate',
+      candidate: { key: 'p/m', benchmarkable: true, local: true },
+      background: { ...baseBackground, paused: true },
+    },
+    {
+      name: 'declared text-only still awaits actual verification when eligible',
+      candidate: { key: 'p/m', benchmarkable: true, local: true, imageCapability: 'text-only' },
+      background: baseBackground,
+    },
+    {
+      name: 'benchmark unavailable',
+      candidate: { key: 'p/m', benchmarkable: false, local: true },
+      background: baseBackground,
+    },
+    {
+      name: 'paid cloud local-free policy exclusion',
+      candidate: { key: 'p/m', benchmarkable: true, local: false, cloudCostWarning: true },
+      background: { ...baseBackground, mode: 'local-free' },
+    },
+    {
+      name: 'trusted built-in free route is eligible under local-free',
+      candidate: {
+        key: 'http:ovh-free/vision',
+        provider: 'vision-http',
+        model: 'ovh-free/vision',
+        endpoint: 'https://free.example/v1',
+        benchmarkable: true,
+        local: false,
+        cloudCostWarning: false,
+        routeRole: 'user',
+      },
+      background: { ...baseBackground, mode: 'local-free' },
+    },
+    {
+      name: 'background off remains not measured',
+      candidate: { key: 'p/m', benchmarkable: true, local: true },
+      background: { ...baseBackground, mode: 'off', active: false },
+    },
+  ]
+
+  for (const scenario of scenarios) {
+    const actual = projectVisionCandidateBackground(scenario.candidate, scenario.background, core)
+    assert.equal(
+      actual.state,
+      legacyBrowserBackgroundState(scenario.candidate, scenario.background),
+      scenario.name,
+    )
+  }
+})
+
+test('C2-B records intentional legacy UI correction for untrusted zero-cost remote routes', () => {
+  const candidate = {
+    key: 'http:ovh-custom/vision',
+    provider: 'vision-http',
+    model: 'ovh-custom/vision',
+    endpoint: 'https://custom.example/v1',
+    benchmarkable: true,
+    local: false,
+    cost: 0,
+    cloudCostWarning: false,
+    routeRole: 'user',
+  }
+  const background = {
+    mode: 'local-free',
+    active: true,
+    paused: false,
+    running: null,
+    deferred: [],
+    excluded: [],
+  }
+
+  assert.equal(legacyBrowserBackgroundState(candidate, background), 'waiting')
+  const host = projectVisionCandidateBackground(candidate, background, { DEFAULT_HTTP_PROVIDERS: [] })
+  assert.equal(host.state, 'policy-excluded')
+  assert.equal(host.policyEligible, false)
+  assert.equal(host.reason, 'local-free-policy-excludes-route')
+})
+
+test('C2-B records intentional legacy UI correction for fallback-only routes', () => {
+  const candidate = {
+    key: 'http:fallback/vision',
+    provider: 'vision-http',
+    model: 'fallback/vision',
+    endpoint: 'https://fallback.example/v1',
+    benchmarkable: true,
+    local: false,
+    cloudCostWarning: true,
+    routeRole: 'fallback-only',
+  }
+  const background = {
+    mode: 'all',
+    active: true,
+    paused: false,
+    running: null,
+    deferred: [],
+    excluded: [],
+  }
+
+  assert.equal(legacyBrowserBackgroundState(candidate, background), 'waiting')
+  const host = projectVisionCandidateBackground(candidate, background, { DEFAULT_HTTP_PROVIDERS: [] })
+  assert.equal(host.state, 'not-measured')
+  assert.equal(host.policyEligible, false)
+  assert.equal(host.reason, 'fallback-only-route')
+})
+
+test('C2-B benchmark snapshot adds runtime DTO without replacing legacy candidate fields', async () => {
   const live = {
     routingMode: 'auto',
     backgroundBenchmarking: 'local-free',
@@ -104,7 +376,20 @@ test('C2-A benchmark snapshot adds a versioned DTO without replacing legacy cand
     measured: { scores: { ocr: 0.9 }, measuredAxes: ['ocr'] },
   }
   const manager = {
-    store: {},
+    store: {
+      backgroundProfiler: {
+        snapshot() {
+          return {
+            activeForeground: 1,
+            activeManualBenchmarks: 0,
+            idleRemainingMs: 750,
+            running: undefined,
+            deferred: [],
+            excluded: [],
+          }
+        },
+      },
+    },
     async snapshot() {
       return {
         ok: true,
@@ -139,6 +424,10 @@ test('C2-A benchmark snapshot adds a versioned DTO without replacing legacy cand
   assert.equal(snapshot.presentationRevision, VISION_PRESENTATION_DTO_REVISION)
   assert.equal(snapshot.routingMode, 'auto')
   assert.equal(snapshot.currentAuthority.execution, 'auto')
+  assert.equal(snapshot.background.mode, 'local-free')
+  assert.equal(snapshot.background.active, true)
+  assert.equal(snapshot.background.paused, true)
+  assert.equal(snapshot.background.idleRemainingMs, 750)
   assert.equal(snapshot.candidates.length, 1)
   assert.equal(snapshot.candidates[0].fingerprint, originalCandidate.fingerprint)
   assert.deepEqual(snapshot.candidates[0].measured, originalCandidate.measured)
@@ -148,18 +437,33 @@ test('C2-A benchmark snapshot adds a versioned DTO without replacing legacy cand
   assert.equal(presentation.capabilityState, 'measured')
   assert.equal(presentation.backgroundEligible, true)
   assert.equal(presentation.healthClass, 'rate-limited')
+  assert.equal(presentation.background.state, 'measured')
+  assert.equal(presentation.background.policyEligible, false)
+  assert.equal(presentation.background.reason, 'local-free-policy-excludes-route')
   assert.equal(Object.hasOwn(presentation, 'fingerprint'), false)
   assert.equal(Object.hasOwn(presentation, 'protocol'), false)
   assert.equal(Object.hasOwn(presentation, 'endpoint'), false)
 })
 
-test('C2-A presentation reads live Host authority on every snapshot', async () => {
+test('C2-B presentation and runtime state read live Host authority on every snapshot', async () => {
   const live = {
     routingMode: 'ordered',
     backgroundBenchmarking: 'off',
   }
   const manager = {
-    store: {},
+    store: {
+      backgroundProfiler: {
+        snapshot() {
+          return {
+            activeForeground: 0,
+            activeManualBenchmarks: 0,
+            idleRemainingMs: 0,
+            deferred: [],
+            excluded: [],
+          }
+        },
+      },
+    },
     async snapshot() {
       return {
         ok: true,
@@ -194,11 +498,17 @@ test('C2-A presentation reads live Host authority on every snapshot', async () =
 
   const before = await manager.snapshot()
   assert.equal(before.routingMode, 'ordered')
+  assert.equal(before.background.mode, 'off')
+  assert.equal(before.background.active, false)
   assert.equal(before.candidates[0].presentation.backgroundEligible, false)
+  assert.equal(before.candidates[0].presentation.background.state, 'not-measured')
 
   live.routingMode = 'auto'
   live.backgroundBenchmarking = 'all'
   const after = await manager.snapshot()
   assert.equal(after.routingMode, 'auto')
+  assert.equal(after.background.mode, 'all')
+  assert.equal(after.background.active, true)
   assert.equal(after.candidates[0].presentation.backgroundEligible, true)
+  assert.equal(after.candidates[0].presentation.background.state, 'waiting')
 })


### PR DESCRIPTION
## Scope

Architecture Closure C2-B: extend the additive Host presentation DTO with the exact public background-runtime state and a scheduler-aware per-candidate background disposition.

This PR is still **Add + Compare**. The browser remains unchanged and continues to be the production oracle for current rendering.

## Host DTO

Presentation revision advances to 2. The existing compatibility fields remain intact, including `backgroundEligible` / `backgroundReason` used by `/product-state`.

The benchmark snapshot now additionally carries:

- top-level `background`, matching the existing `capability-runtime` GET public shape
- per-candidate `presentation.background.state`
- `policyEligible`, `needsWork`, `workEligible`
- sanitized running/deferred detail where applicable

States cover running, measured-text-only, deferred/stopped, measured/waiting, paused, declared-text-only verification, unavailable, policy-excluded, and not-measured.

## Scheduler authority

The nested runtime presentation follows the real unattended scheduler semantics, including:

- fallback-only routes are never background candidates
- `local-free` means local or an exact trusted built-in free endpoint, not merely any remote row with a zero-cost-looking UI flag

The compatibility `backgroundEligible` field is deliberately not redefined in this PR.

## Characterized legacy differences

Two browser/scheduler mismatches are explicitly tested and treated as intentional presentation corrections for the later Switch:

1. an untrusted remote zero-cost route can look eligible in the legacy browser under `local-free`, while the Host scheduler correctly excludes it;
2. a `fallback-only` route can look eligible in the legacy browser under `all`, while the Host scheduler correctly suppresses unattended measurement.

All non-divergent render states are required to match the legacy browser precedence.

## Product behavior

No intended user-visible behavior change in this PR. The browser still performs its existing runtime fetch and eligibility calculations. Benchmark execution, queueing, cancellation, persistence, background scheduling, Settings, routing, and provider execution are untouched.

## Security / contract

No credentials, credential references, raw transport endpoints, fingerprints, or mutable breaker internals are added to the nested presentation DTO. Existing legacy candidate fields and compatibility routes remain unchanged.

## Follow-up

After this PR is merged and merged-main gates are green, C2-C will switch browser rendering to the Host revision-2 decisions and stop the redundant runtime fetch. Old browser decision helpers are deleted only after the Switch is green.