### PR TITLE
docs(architecture): complete compatibility cleanup contracts

### DIFF
--- a/.github/workflows/architecture-closure.yml
+++ b/.github/workflows/architecture-closure.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'entry.js'
       - 'index.js'
+      - 'lib/public-entry.js'
       - 'lib/runtime-composition.js'
       - 'lib/core-vision-surface.js'
       - 'lib/session-vision-*.js'
@@ -22,6 +23,7 @@ on:
       - 'lib/vision-product-presentation.js'
       - 'docs/architecture/**'
       - 'tests/architecture-contract-baseline.test.js'
+      - 'tests/compat-inventory-completeness.test.js'
       - 'tests/core-vision-surface-parity.test.js'
       - 'tests/settings-impersonation-closure.test.js'
       - 'tests/presentation-convergence-parity.test.js'
@@ -43,6 +45,7 @@ on:
     paths:
       - 'entry.js'
       - 'index.js'
+      - 'lib/public-entry.js'
       - 'lib/runtime-composition.js'
       - 'lib/core-vision-surface.js'
       - 'lib/session-vision-*.js'
@@ -60,6 +63,7 @@ on:
       - 'lib/vision-product-presentation.js'
       - 'docs/architecture/**'
       - 'tests/architecture-contract-baseline.test.js'
+      - 'tests/compat-inventory-completeness.test.js'
       - 'tests/core-vision-surface-parity.test.js'
       - 'tests/settings-impersonation-closure.test.js'
       - 'tests/presentation-convergence-parity.test.js'
@@ -101,6 +105,7 @@ jobs:
         run: >-
           node --test
           tests/architecture-contract-baseline.test.js
+          tests/compat-inventory-completeness.test.js
           tests/core-vision-surface-parity.test.js
           tests/settings-impersonation-closure.test.js
           tests/presentation-convergence-parity.test.js

--- a/docs/architecture/compat-inventory.md
+++ b/docs/architecture/compat-inventory.md
@@ -65,6 +65,15 @@ P0 records why each major compatibility seam exists and the condition that permi
 - **Removal condition:** upstream endpoint behavior becomes generic-compatible for a rule and regression evidence confirms the preset is no longer needed.
 - **Tests:** `http-compat`, provider HTTP regression tests.
 
+## `lib/vision-provider-transport.js` process/profile registry
+
+- **Reason:** carry the Router-owned provider transport into compatibility callers whose mature function signatures still accept only a raw `fetch` or use an internal direct HTTP call, while keeping Router traffic off the process-global fetch patch.
+- **Host gap:** this is an internal composition gap rather than a DSH version persona: `fetchWithOpenAICompatibility(...)` and the Anthropic catalog-correction path do not yet receive a `VisionProviderTransport` parameter explicitly.
+- **First needed for:** provider-scoped transport ownership and proxy narrowing without rewriting the mature compatibility call signatures in the same migration.
+- **Feature detection:** explicit transport-aware callers bypass the registry; only compatibility paths that call `currentVisionProviderTransport()` consume the currently installed process/profile transport. The registry never patches `globalThis.fetch`.
+- **Removal condition:** every Router-owned compatibility caller receives `VisionProviderTransport` explicitly, production has zero reads of `currentVisionProviderTransport()`, and the install/release registry can be removed without changing proxy, credential, bounded-body or cancellation behavior.
+- **Tests:** `vision-provider-transport`, `http-compat`, `catalog-corrections`, P2 Data Boundary provider-transport Node 22/24, Host pack/install smoke.
+
 ## `lib/legacy-global-proxy-boundary.js`
 
 - **Reason:** retain the process-global proxy patch only for Host-owned/raw-fetch visual providers that still lack a provider-scoped proxy seam. Router-owned `vision-http` and direct protocol-correction traffic already uses `VisionProviderTransport` with an explicit dispatcher.
@@ -73,6 +82,15 @@ P0 records why each major compatibility seam exists and the condition that permi
 - **Feature detection:** live visual-chain ownership. Router-owned routes bypass the legacy patch; any unknown/Host-owned provider conservatively keeps it available. This is capability/ownership detection, not a Host-version persona.
 - **Removal condition:** **the minimum supported DSH provides a provider-scoped/shared HTTP proxy seam** that covers the remaining Host-owned/raw-fetch provider compatibility requirement.
 - **Tests:** `legacy-global-proxy-boundary`, `vision-provider-transport`, `adversarial-hardening`, P2 Data Boundary Node 22/24.
+
+## `lib/legacy-core-vision-policy-bridge.js`
+
+- **Reason:** preserve the two remaining pre-step compatibility behaviors after Core policy ownership moved to explicit session/Core surfaces: reuse the exact `SessionMemoryView` for text-only image-history rewrite, and expose exact current-turn durable attachment IDs as read-only model context for Vision Router-owned wrappers.
+- **Host gap:** the supported Host pre-step path does not natively provide both an exact session-scoped visual-memory rewrite seam for text-only fallback and a model-readable durable attachment-reference seam for Router-owned image turns.
+- **First needed for:** the Core/session ownership migration that removed Settings/config impersonation while retaining these two real pre-step behaviors.
+- **Feature detection:** live `SessionSurfacePolicy` (`rewriteCurrentImages` and ownership), exact known session visual memory, and actual current-turn image attachment IDs. No Host version-string branch and no Settings/config projection.
+- **Removal condition:** the minimum supported Host exposes native pre-step/session-memory and durable attachment-reference capabilities that make both behaviors redundant, and contract/parity tests prove the bridge can be removed without reintroducing Settings impersonation or degrading text-only/native image turns.
+- **Tests:** `settings-impersonation-closure`, `session-surface-policy`, session/runtime parity and native cold-resume coverage.
 
 ## `lib/tesseract-exec-compat.js`
 
@@ -91,4 +109,4 @@ A compatibility seam may be deleted only when all of the following are true:
 2. the relevant capability is proved by a gating Host contract fixture or direct feature test;
 3. deleting the seam leaves Node 22/24, minimum/legacy/current Host contracts and relevant platform tests green;
 4. no Authority, Session, Storage or native-multimodal invariant changes as a side effect;
-5. the deletion is a focused change, not bundled into an unrelated P1/P2 refactor.
+5. the deletion is a focused change, not bundled into an unrelated routing/data-boundary refactor.

--- a/lib/public-entry.js
+++ b/lib/public-entry.js
@@ -22,13 +22,13 @@ function liveVisionConfig(ctx, fallback) {
 
 /**
  * Public package entry: keep the mature entry.js implementation intact and
- * place the #284 hardening at its outermost registration/browser boundary.
+ * place root hardening at its outermost registration/browser boundary.
  *
- * P2 installs the Router-owned provider transport before base.apply can install
- * the legacy process-wide proxy fetch patch. After base.apply has installed the
- * old lifecycle-safe seam, P2-E adds a compatibility gate above it: Router-only
- * visual chains bypass the global patch completely; only a configured
- * Host-owned/raw-fetch visual provider keeps the legacy seam active.
+ * Router-owned provider transport is installed before base.apply can install
+ * the legacy process-wide proxy fetch patch. After base.apply installs that
+ * lifecycle-safe seam, the explicit ownership boundary keeps Router-only
+ * visual chains off the global patch; only a configured Host-owned/raw-fetch
+ * visual provider keeps the legacy seam active.
  */
 export function apply(ctx, config = {}) {
   const hardening = createVisionToggleRootHardening(ctx, config)

--- a/lib/runtime-composition.js
+++ b/lib/runtime-composition.js
@@ -1,4 +1,4 @@
-// Final P3 runtime composition boundary.
+// Runtime composition boundary.
 //
 // This module owns orchestration only. It deliberately does not own product
 // settings, route scoring, provider transports, session persistence, or browser
@@ -134,8 +134,8 @@ export function applyVisionRuntimeComposition(ctx, config = {}, core) {
   const batchAttachmentHost = hasBatchAttachmentContract(stabilizedCtx)
   if (batchAttachmentHost) installVisionAttachmentAdmissionPolicy(stabilizedCtx, logging.logger)
 
-  // P3-C keeps browser/settings ownership behind explicit Web boundaries while
-  // preserving the exact historical pre-settings/client install order.
+  // Browser/settings ownership stays behind explicit Web boundaries while
+  // preserving the historical pre-settings/client install order.
   installVisionSettingsWebBoundary(stabilizedCtx, logging.logger)
   const ownershipCtx = batchAttachmentHost ? protectHostProviderOwnership(stabilizedCtx) : stabilizedCtx
   const settingsCtx = batchAttachmentHost
@@ -154,11 +154,12 @@ export function applyVisionRuntimeComposition(ctx, config = {}, core) {
     config: () => liveVisionSettings(nativeImageCompat.ctx, nativeImageCompat.config),
   })
 
-  // C1 production owner: one explicit bounded store + one explicit index. The
-  // index reads the same live Host settings namespace but never discovers the
-  // store through a module-global current pointer and never monkey-patches its
-  // lookup API. Core receives this same narrow runtime through its optional
-  // internal runtime argument; direct legacy core callers keep the old fallback.
+  // Session vision ownership is one explicit bounded store plus one explicit
+  // index. The index reads the same live Host settings namespace but never
+  // discovers the store through a module-global current pointer and never
+  // monkey-patches its lookup API. Core receives this same narrow runtime
+  // through its optional internal runtime argument; direct legacy core callers
+  // keep the old fallback.
   const sessionVisionRuntime = createSessionVisionRuntime({
     core,
     config: () => liveVisionSettings(nativeImageCompat.ctx, nativeImageCompat.config),
@@ -170,9 +171,9 @@ export function applyVisionRuntimeComposition(ctx, config = {}, core) {
     core,
     { logger: logging.logger, index: sessionVisionRuntime.index },
   )
-  // C1-E keeps only the real pre-step compatibility behaviors here. Session
-  // policy is no longer projected through fake Settings/config views; Core's
-  // policy-derived switches come exclusively from CoreVisionSurfaceRuntime.
+  // Only the real pre-step compatibility behaviors remain here. Session policy
+  // is not projected through fake Settings/config views; Core's policy-derived
+  // switches come exclusively from CoreVisionSurfaceRuntime.
   const legacyCoreCompat = installLegacyCoreVisionPolicyBridge(
     sessionIndexCtx,
     nativeImageCompat.config,

--- a/lib/vision-capability-benchmark-presentation.js
+++ b/lib/vision-capability-benchmark-presentation.js
@@ -37,12 +37,12 @@ function backgroundState(store) {
 }
 
 /**
- * C2 additive migration seam.
+ * Versioned Host presentation projection for the benchmark snapshot.
  *
- * The mature benchmark manager remains the sole queue/execution owner. This
- * decorator adds versioned Host presentation decisions to the same snapshot,
- * including the exact public background-runtime state. Browser consumption is
- * switched only after old/new parity is characterized.
+ * The benchmark manager remains the sole queue/execution owner. This decorator
+ * adds the authoritative presentation DTO plus public background-runtime state
+ * without moving scheduling, benchmark ownership or policy decisions into the
+ * browser.
  */
 export function attachCapabilityBenchmarkPresentation(manager, {
   ctx,

--- a/lib/vision-provider-transport.js
+++ b/lib/vision-provider-transport.js
@@ -18,8 +18,8 @@ const DEFAULT_PROXY_HOSTS = Object.freeze([
 ])
 
 // Capture before core.apply installs the legacy process-wide fetch patch. The
-// P2 transport uses this original function explicitly, so Router-owned provider
-// calls are no longer coupled to globalThis.fetch mutation.
+// Router-owned transport uses this original function explicitly, so direct
+// provider calls are not coupled to later globalThis.fetch mutation.
 const moduleFetch =
   typeof globalThis.fetch === 'function'
     ? globalThis.fetch.bind(globalThis)
@@ -170,11 +170,12 @@ export function createVisionProviderTransport({
 }
 
 /**
- * Transitional process/profile registration used while the monolithic core
- * still calls `fetchWithOpenAICompatibility(fetch, ...)` without an injected
- * transport parameter. This registry affects only Router-owned compatibility
- * calls; it never patches global fetch. P3 can delete it once every caller
- * accepts the transport explicitly.
+ * Scoped process/profile carrier for Router-owned compatibility calls whose
+ * mature signatures do not yet accept an explicit VisionProviderTransport.
+ * The registry never patches global fetch and is released with the public
+ * plugin lifecycle. Remove it only after every production compatibility caller
+ * receives the transport explicitly and no production code reads
+ * currentVisionProviderTransport().
  */
 export function installVisionProviderTransport(transport) {
   if (!transport || typeof transport.fetch !== 'function') {

--- a/tests/compat-inventory-completeness.test.js
+++ b/tests/compat-inventory-completeness.test.js
@@ -1,0 +1,87 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+
+const REQUIRED_SEAMS = [
+  'lib/dsh-contract-compat.js',
+  'lib/adapter-update-coalescer.js',
+  'lib/android-attachment-compat.js',
+  'lib/replay-envelope-v2-compat.js',
+  'lib/pi-ai-bridge-wire-compat.js',
+  'lib/settings-client-rc8-lifecycle.js',
+  'lib/http-compat.js',
+  'lib/vision-provider-transport.js',
+  'lib/legacy-global-proxy-boundary.js',
+  'lib/legacy-core-vision-policy-bridge.js',
+  'lib/tesseract-exec-compat.js',
+]
+
+const REQUIRED_FIELDS = [
+  'Reason',
+  'Host gap',
+  'Feature detection',
+  'Removal condition',
+  'Tests',
+]
+
+function sectionFor(inventory, seam) {
+  const marker = `## \`${seam}\``
+  const start = inventory.indexOf(marker)
+  if (start < 0) return undefined
+  const next = inventory.indexOf('\n## ', start + marker.length)
+  return inventory.slice(start, next < 0 ? inventory.length : next)
+}
+
+test('every retained compatibility seam has a complete removal contract', async () => {
+  const inventory = await readFile(
+    new URL('../docs/architecture/compat-inventory.md', import.meta.url),
+    'utf8',
+  )
+
+  for (const seam of REQUIRED_SEAMS) {
+    const section = sectionFor(inventory, seam)
+    assert.ok(section, `${seam} must be listed in compat-inventory.md`)
+    for (const field of REQUIRED_FIELDS) {
+      assert.ok(
+        section.includes(`- **${field}:**`),
+        `${seam} must document ${field}`,
+      )
+    }
+  }
+})
+
+test('completed architecture phase labels do not survive as production migration instructions', async () => {
+  const files = [
+    '../lib/runtime-composition.js',
+    '../lib/public-entry.js',
+    '../lib/vision-capability-benchmark-presentation.js',
+    '../lib/vision-provider-transport.js',
+  ]
+  const forbidden = [
+    'Final P3 runtime composition boundary',
+    'P3-C keeps browser/settings ownership',
+    'C1 production owner',
+    'C1-E keeps only',
+    'P2 installs the Router-owned provider transport',
+    'P2-E adds a compatibility gate',
+    'C2 additive migration seam',
+    'Transitional process/profile registration',
+    'P3 can delete it',
+  ]
+
+  for (const path of files) {
+    const source = await readFile(new URL(path, import.meta.url), 'utf8')
+    for (const phrase of forbidden) {
+      assert.equal(source.includes(phrase), false, `${path} still contains stale phase text: ${phrase}`)
+    }
+  }
+})
+
+test('provider transport registry documents its concrete removal trigger', async () => {
+  const source = await readFile(
+    new URL('../lib/vision-provider-transport.js', import.meta.url),
+    'utf8',
+  )
+  assert.match(source, /Remove it only after every production compatibility caller/)
+  assert.match(source, /no production code reads\s+\*?\/?\s*currentVisionProviderTransport\(\)/s)
+})


### PR DESCRIPTION
## Scope

Architecture Closure C3-B: bounded cleanup of retained compatibility documentation and completed migration comments.

No runtime behavior is changed. This PR documents concrete compatibility exit conditions and freezes inventory completeness in Architecture Closure.

## Changes

- add the retained `legacy-core-vision-policy-bridge.js` seam to the normative compatibility inventory
- document the scoped `vision-provider-transport.js` process/profile registry as a retained compatibility carrier with a concrete removal trigger
- replace completed C1/C2/P2/P3 phase labels in production comments with stable current-ownership descriptions
- add `tests/compat-inventory-completeness.test.js`
  - requires all 11 retained compatibility seams to be inventoried
  - requires Reason / Host gap / Feature detection / Removal condition / Tests for every seam
  - forbids the completed migration instructions from returning to production source
  - requires the provider-transport registry comment to state its concrete exit trigger
- extend Architecture Closure paths to `lib/public-entry.js` and the new completeness test, and execute that test on Node 22/24

## Retained by design

- rc.6/rc.7/rc.8 Host compatibility remains supported
- `legacy-core-vision-policy-bridge.js` remains because its two real pre-step behaviors are not Host-native yet
- the VisionProviderTransport registry remains because `http-compat.js` and `catalog-corrections.js` still consume `currentVisionProviderTransport()` while `public-entry.js` owns its install/release lifecycle
- historical P2/P3 architecture documents remain as records; only misleading production migration comments are cleaned

## Diff discipline

Relative to verified main `f3047a824bc6728fdac0fd05a0c86543314e5819`, this branch changes exactly seven files: one architecture document, four production files with comment-only edits, one source-structure test, and Architecture Closure workflow wiring. PR-level patch inspection confirms the four production files contain comment-only hunks: no function body, import, export, condition, ordering, or runtime value changes.

## Validation

Head: `eaa0ede9bbdec9160735d197edd5e186cf54f559`

Green on this head:
- Architecture Closure: Node 22 / 24, including the new compatibility-inventory completeness gate
- P3 Compatibility Convergence
- P2 Data Boundary
- P1 Routing Parity
- DSH Contract
- Native multimodal cold resume
- CI full tests: Node 22 / 24
- released DSH contracts: 0.1.0-rc.6 / rc.7 / rc.8
- host-sharp: Ubuntu / macOS / Windows
- CodeQL: actions + JavaScript/TypeScript
- PR discussion: 0 reviews, 0 review threads, 0 comments

GitHub's separate "Code scanning AI findings" agent did not produce a finding: its own runtime failed before review creation with `CAPIError: 400 The requested model is not supported` while requesting `sweagent-capi:claude-opus-4.6`. GitHub does not allow this dynamic job to be manually rerun through the Actions API. This is an external review-agent/model configuration failure; normal CodeQL and all repository security/contract/runtime gates above are green.
