### PR TITLE
fix(windows): make vision_screenshot mixed-DPI safe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,7 +215,7 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: Run cross-platform runtime and benchmark fixture regression tests
-        run: node --test tests/file-logger.test.js tests/logging-ui.test.js tests/runtime-boundary-fixes.test.js tests/vision-capability-benchmark.test.js
+        run: node --test tests/file-logger.test.js tests/logging-ui.test.js tests/runtime-boundary-fixes.test.js tests/qa-screenshot-runtime.test.js tests/vision-capability-benchmark.test.js
       - name: Prepare pack directory
         shell: node {0}
         run: |

--- a/docs/architecture/compat-inventory.md
+++ b/docs/architecture/compat-inventory.md
@@ -94,12 +94,12 @@ P0 records why each major compatibility seam exists and the condition that permi
 
 ## `lib/tesseract-exec-compat.js`
 
-- **Reason:** isolate runtime/Node process-exec differences around the local OCR binary.
-- **Host gap:** external executable behavior is not a DSH semantic seam, but remains a supported runtime compatibility boundary.
-- **First needed for:** Node 24/local Tesseract process execution reliability.
-- **Feature detection:** executable/process behavior rather than Node version persona where possible.
-- **Removal condition:** one supported execution path passes Node 22/24 and platform matrices without the compatibility wrapper.
-- **Tests:** `tesseract-node24-boot`, cross-platform Host tests.
+- **Reason:** own the single process-wide `promisify(execFile)` compatibility boundary for the two narrow child-process cases Vision Router still needs: materializing Tesseract stdin image bytes, and replacing only Core's exact legacy Windows `VirtualScreen`/`CopyFromScreen` desktop-capture command with a per-monitor-DPI-safe equivalent. One owner prevents cleanup-order bugs from independently stacked `execFile` wrappers.
+- **Host gap:** these are runtime/platform gaps rather than DSH semantic ownership: Node's async `execFile` path does not consume the historical OCR `options.input`, while non-DPI-aware Windows PowerShell virtualizes desktop metrics and can disagree with physical screen-copy coordinates on scaled/mixed-DPI displays.
+- **First needed for:** Node 24/local Tesseract process execution reliability; Windows scaled/mixed-DPI `vision_screenshot` correctness (#340).
+- **Feature detection:** exact executable/call fingerprints only. Tesseract handling requires `tesseract[.exe]` + stdin input; Windows screenshot handling requires `win32`, `powershell[.exe]`, `-Command`, and the exact legacy `SystemInformation.VirtualScreen` + `Graphics.CopyFromScreen` script shape. No Host/Node version persona and unrelated child processes delegate unchanged.
+- **Removal condition:** local OCR no longer needs an `execFile` stdin shim **and** Core/Host exposes a native DPI-correct desktop-capture seam (or the legacy PowerShell command is removed), with Node 22/24 and Windows platform matrices proving the shared wrapper is unreachable before deletion.
+- **Tests:** `tesseract-node24-boot`, `qa-screenshot-runtime` (PMv2/PMv1 ordering, context restoration, exact-match passthrough, Windows PowerShell compile smoke), cross-platform Host tests.
 
 ## Removal protocol
 

--- a/lib/tesseract-exec-compat.js
+++ b/lib/tesseract-exec-compat.js
@@ -4,14 +4,14 @@ import { tmpdir } from 'node:os'
 import { createRequire, syncBuiltinESMExports } from 'node:module'
 import { promisify } from 'node:util'
 
+import { rewriteWindowsScreenshotExecArgs } from './windows-screenshot-dpi-compat.js'
+
 const require = createRequire(import.meta.url)
 const childProcess = require('node:child_process')
 
-// Install state is keyed by every concrete execFile function exposed while our
-// shim is active. Modern Node marks execFile[promisify.custom] as read-only and
-// non-configurable, so the installer sometimes has to publish a callback-safe
-// wrapper through child_process.execFile and synchronize the builtin ESM live
-// binding. Multiple Vision Router contexts still share one shim/refcount.
+// One shared child-process compatibility seam. It owns every narrow transform
+// Vision Router needs around promisify(execFile), so lifecycle cleanup never
+// has to unwind multiple wrappers in a particular order.
 const installStates = new WeakMap()
 
 function bytesView(input) {
@@ -35,7 +35,7 @@ function extensionForBytes(input) {
   return '.img'
 }
 
-function isCompatCall(file, args, options) {
+function isTesseractCompatCall(file, args, options) {
   const isTesseract = typeof file === 'string' && /(^|[\\/])tesseract(?:\.exe)?$/i.test(file)
   const readsStdin = Array.isArray(args) && (args[0] === 'stdin' || args[0] === '-')
   const hasInput =
@@ -69,13 +69,8 @@ function nativePromisified(execFileImpl, originalCustom) {
 }
 
 /**
- * Create an async-only compatibility layer for promisify(execFile).
- *
- * Node's async execFile ignores an `options.input` field. Vision Router's OCR
- * caller historically supplied image bytes that way, so Tesseract waited on
- * stdin until timeout. The compatibility layer materializes the one OCR input
- * with fs/promises, delegates to the native promisified implementation, then
- * removes the temporary directory asynchronously.
+ * Create the historical Tesseract stdin compatibility layer. Kept as a public
+ * helper because tests/consumers already import it directly.
  */
 export function createTesseractPromisifyCompat(execFileImpl, originalCustom, options = {}) {
   if (typeof execFileImpl !== 'function') {
@@ -90,7 +85,7 @@ export function createTesseractPromisifyCompat(execFileImpl, originalCustom, opt
   let active = true
 
   async function tesseractPromisifyCompat(file, args, execOptions) {
-    if (!active || !isCompatCall(file, args, execOptions)) {
+    if (!active || !isTesseractCompatCall(file, args, execOptions)) {
       return delegate(file, args, execOptions)
     }
 
@@ -129,6 +124,41 @@ export function createTesseractPromisifyCompat(execFileImpl, originalCustom, opt
   })
 
   return tesseractPromisifyCompat
+}
+
+/**
+ * Compose every Vision Router execFile compatibility transform behind ONE
+ * promisify.custom function. The screenshot transform changes only the exact
+ * legacy Windows VirtualScreen/CopyFromScreen invocation emitted by core;
+ * every other child-process call remains byte-for-byte delegated.
+ */
+export function createVisionRouterExecFilePromisifyCompat(execFileImpl, originalCustom, options = {}) {
+  const tesseractCompat = createTesseractPromisifyCompat(execFileImpl, originalCustom, options)
+  let active = true
+
+  async function visionRouterExecFilePromisifyCompat(file, args, execOptions) {
+    if (!active) return tesseractCompat(file, args, execOptions)
+    const rewrittenArgs = rewriteWindowsScreenshotExecArgs(file, args, {
+      platform: options.platform ?? (typeof process !== 'undefined' ? process.platform : ''),
+    })
+    return tesseractCompat(file, rewrittenArgs, execOptions)
+  }
+
+  Object.defineProperty(visionRouterExecFilePromisifyCompat, 'deactivate', {
+    configurable: false,
+    enumerable: false,
+    value() {
+      active = false
+      tesseractCompat.deactivate?.()
+    },
+  })
+  Object.defineProperty(visionRouterExecFilePromisifyCompat, 'active', {
+    configurable: false,
+    enumerable: false,
+    get() { return active },
+  })
+
+  return visionRouterExecFilePromisifyCompat
 }
 
 function canReplaceCustomPromisify(execFileImpl) {
@@ -177,39 +207,31 @@ function syncIfBuiltin(moduleObject) {
 function warnInstallDegraded(ctx, reason) {
   try {
     ctx?.logger?.warn?.(
-      'vision-router: tesseract execFile compatibility could not be installed (%s); continuing without the local stdin shim',
+      'vision-router: execFile compatibility could not be installed (%s); continuing without local OCR / Windows DPI capture shims',
       reason,
     )
   } catch {
-    /* boot must never fail for optional local OCR compatibility */
+    /* boot must never fail for optional child-process compatibility */
   }
 }
 
 /**
- * Install the narrow promisify compatibility for the Vision Router context.
- *
- * Node 22/24 expose execFile[promisify.custom] as a non-writable,
- * non-configurable property. Direct assignment therefore throws during plugin
- * boot. When that native descriptor is locked, publish a callback-equivalent
- * execFile wrapper on the builtin module, give only the wrapper our custom
- * promisify hook, and call syncBuiltinESMExports() so existing ESM named-import
- * live bindings (including index.js) see the wrapper. Callback semantics stay
- * native; only promisified Tesseract stdin calls are specialized.
- *
- * Cleanup is chain-safe: if another plugin replaces either the module export or
- * the wrapper's custom promisify later, that newer value remains authoritative.
+ * Install the single process-wide execFile compatibility boundary used by
+ * Vision Router. The public runtime still calls the historical
+ * installTesseractExecFileCompat alias; keeping one owner prevents cleanup
+ * order bugs between independently stacked wrappers.
  */
-export function installTesseractExecFileCompat(ctx, options = {}) {
+export function installVisionRouterExecFileCompat(ctx, options = {}) {
   const moduleObject = options.childProcessModule ?? childProcess
   if (!moduleObject || typeof moduleObject !== 'object' || typeof moduleObject.execFile !== 'function') {
-    throw new TypeError('installTesseractExecFileCompat: childProcessModule.execFile must be a function')
+    throw new TypeError('installVisionRouterExecFileCompat: childProcessModule.execFile must be a function')
   }
 
   const execFileImpl = moduleObject.execFile
   let state = installStates.get(execFileImpl)
   if (state === undefined) {
     const originalCustom = execFileImpl[promisify.custom]
-    const patchedCustom = createTesseractPromisifyCompat(execFileImpl, originalCustom, options)
+    const patchedCustom = createVisionRouterExecFilePromisifyCompat(execFileImpl, originalCustom, options)
 
     if (canReplaceCustomPromisify(execFileImpl)) {
       try {
@@ -295,7 +317,11 @@ export function installTesseractExecFileCompat(ctx, options = {}) {
   }
 
   if (ctx && typeof ctx.effect === 'function') {
-    ctx.effect(() => dispose, 'vision-router: tesseract promisify input compatibility')
+    ctx.effect(() => dispose, 'vision-router: execFile compatibility')
   }
   return dispose
 }
+
+// Backward-compatible public name. Runtime composition and existing tests use
+// this symbol; the implementation now owns the full narrow execFile seam.
+export const installTesseractExecFileCompat = installVisionRouterExecFileCompat

--- a/lib/windows-screenshot-dpi-compat.js
+++ b/lib/windows-screenshot-dpi-compat.js
@@ -1,0 +1,148 @@
+const VIRTUAL_SCREEN_MARKER = '[System.Windows.Forms.SystemInformation]::VirtualScreen'
+const COPY_FROM_SCREEN_MARKER = '$g.CopyFromScreen($b.X,$b.Y,0,0,$bmp.Size)'
+const SAVE_PATTERN = /\$bmp\.Save\('((?:''|[^'])*)'\)/
+
+function powerShellBasename(file) {
+  return String(file ?? '').replace(/\\/g, '/').split('/').pop().toLowerCase()
+}
+
+function quotePowerShellSingle(value) {
+  return `'${String(value).replace(/'/g, "''")}'`
+}
+
+function savedPathFromLegacyScript(script) {
+  const match = SAVE_PATTERN.exec(String(script ?? ''))
+  return match ? match[1].replace(/''/g, "'") : undefined
+}
+
+export function isLegacyWindowsScreenshotScript(script) {
+  const source = String(script ?? '')
+  return (
+    source.includes('Add-Type -AssemblyName System.Windows.Forms,System.Drawing') &&
+    source.includes(VIRTUAL_SCREEN_MARKER) &&
+    source.includes('[System.Drawing.Graphics]::FromImage($bmp)') &&
+    source.includes(COPY_FROM_SCREEN_MARKER) &&
+    savedPathFromLegacyScript(source) !== undefined
+  )
+}
+
+export function buildPerMonitorWindowsScreenshotScript(outputPath) {
+  const quotedPath = quotePowerShellSingle(outputPath)
+  const source = String.raw`using System;
+using System.Drawing;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+
+public static class DshVisionDesktopCapture
+{
+    private static readonly IntPtr PerMonitorV2 = new IntPtr(-4);
+    private static readonly IntPtr PerMonitorV1 = new IntPtr(-3);
+
+    [DllImport("user32.dll")]
+    private static extern IntPtr SetThreadDpiAwarenessContext(IntPtr dpiContext);
+
+    private static IntPtr TrySetContext(IntPtr context)
+    {
+        try
+        {
+            return SetThreadDpiAwarenessContext(context);
+        }
+        catch (EntryPointNotFoundException)
+        {
+            return IntPtr.Zero;
+        }
+        catch (DllNotFoundException)
+        {
+            return IntPtr.Zero;
+        }
+    }
+
+    private static IntPtr EnterPerMonitorContext()
+    {
+        IntPtr previous = TrySetContext(PerMonitorV2);
+        if (previous == IntPtr.Zero)
+        {
+            previous = TrySetContext(PerMonitorV1);
+        }
+        if (previous == IntPtr.Zero)
+        {
+            throw new InvalidOperationException(
+                "could not enter a per-monitor DPI awareness context; refusing to return a potentially misaligned screenshot");
+        }
+        return previous;
+    }
+
+    private static void RestoreContext(IntPtr previous)
+    {
+        try
+        {
+            SetThreadDpiAwarenessContext(previous);
+        }
+        catch
+        {
+            // The helper process exits immediately after capture. Restoration
+            // is still attempted so this method is correct if reused.
+        }
+    }
+
+    public static void ValidateDpiContext()
+    {
+        IntPtr previous = EnterPerMonitorContext();
+        RestoreContext(previous);
+    }
+
+    public static void Capture(string outputPath)
+    {
+        IntPtr previous = EnterPerMonitorContext();
+        try
+        {
+            Rectangle bounds = SystemInformation.VirtualScreen;
+            if (bounds.Width <= 0 || bounds.Height <= 0)
+            {
+                throw new InvalidOperationException("the Windows virtual screen has no drawable area");
+            }
+
+            using (var bitmap = new Bitmap(bounds.Width, bounds.Height))
+            using (var graphics = Graphics.FromImage(bitmap))
+            {
+                graphics.CopyFromScreen(bounds.X, bounds.Y, 0, 0, bounds.Size);
+                bitmap.Save(outputPath);
+            }
+        }
+        finally
+        {
+            RestoreContext(previous);
+        }
+    }
+}`
+
+  return [
+    'Add-Type -AssemblyName System.Windows.Forms,System.Drawing',
+    `$__dshVisionCaptureSource = @'\n${source}\n'@`,
+    'try {',
+    "  Add-Type -TypeDefinition $__dshVisionCaptureSource -ReferencedAssemblies 'System.Windows.Forms.dll','System.Drawing.dll' -ErrorAction Stop",
+    '} catch {',
+    "  throw ('vision_screenshot: failed to initialize the Windows DPI-aware capture helper: ' + $_.Exception.Message)",
+    '}',
+    `[DshVisionDesktopCapture]::Capture(${quotedPath})`,
+  ].join('\n')
+}
+
+export function rewriteWindowsScreenshotExecArgs(file, args, options = {}) {
+  const platform = options.platform ?? (typeof process !== 'undefined' ? process.platform : '')
+  if (platform !== 'win32') return args
+  const executable = powerShellBasename(file)
+  if (executable !== 'powershell.exe' && executable !== 'powershell') return args
+  if (!Array.isArray(args)) return args
+
+  const commandIndex = args.findIndex((arg) => String(arg).toLowerCase() === '-command')
+  if (commandIndex < 0 || commandIndex + 1 >= args.length) return args
+  const script = args[commandIndex + 1]
+  if (!isLegacyWindowsScreenshotScript(script)) return args
+
+  const outputPath = savedPathFromLegacyScript(script)
+  if (outputPath === undefined) return args
+  const rewritten = args.slice()
+  rewritten[commandIndex + 1] = buildPerMonitorWindowsScreenshotScript(outputPath)
+  return rewritten
+}

--- a/tests/qa-screenshot-runtime.test.js
+++ b/tests/qa-screenshot-runtime.test.js
@@ -1,7 +1,16 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
+import { execFile } from 'node:child_process'
+import { readFile } from 'node:fs/promises'
+import { promisify } from 'node:util'
 
 import { createSecureHtmlScreenshotExecute } from '../lib/adversarial-hardening.js'
+import {
+  buildPerMonitorWindowsScreenshotScript,
+  isLegacyWindowsScreenshotScript,
+  rewriteWindowsScreenshotExecArgs,
+} from '../lib/windows-screenshot-dpi-compat.js'
+import { installVisionRouterExecFileCompat } from '../lib/tesseract-exec-compat.js'
 
 function screenshotHarness({ hangGoto = false } = {}) {
   const resolveCalls = []
@@ -96,4 +105,120 @@ test('aborting an active secure screenshot closes Chrome and prevents artifact p
   )
   assert.equal(harness.closeCalls, 1)
   assert.equal(harness.artifactWrites, 0)
+})
+
+function legacyDesktopScreenshotScript(outputPath) {
+  return [
+    'Add-Type -AssemblyName System.Windows.Forms,System.Drawing',
+    '$b=[System.Windows.Forms.SystemInformation]::VirtualScreen',
+    '$bmp=New-Object System.Drawing.Bitmap($b.Width,$b.Height)',
+    '$g=[System.Drawing.Graphics]::FromImage($bmp)',
+    '$g.CopyFromScreen($b.X,$b.Y,0,0,$bmp.Size)',
+    `$bmp.Save('${String(outputPath).replace(/'/g, "''")}')`,
+    '$g.Dispose();$bmp.Dispose()',
+  ].join('; ')
+}
+
+test('Windows desktop capture enters per-monitor v2 on the exact capture thread and restores it', () => {
+  const script = buildPerMonitorWindowsScreenshotScript("C:\\shot's\\screen.png")
+  const captureAt = script.indexOf('public static void Capture(string outputPath)')
+  const enterAt = script.indexOf('IntPtr previous = EnterPerMonitorContext();', captureAt)
+  const boundsAt = script.indexOf('Rectangle bounds = SystemInformation.VirtualScreen', enterAt)
+  const copyAt = script.indexOf('graphics.CopyFromScreen(bounds.X, bounds.Y, 0, 0, bounds.Size)', boundsAt)
+  const restoreAt = script.indexOf('RestoreContext(previous);', copyAt)
+  const pmv2At = script.indexOf('TrySetContext(PerMonitorV2)')
+  const pmv1At = script.indexOf('TrySetContext(PerMonitorV1)', pmv2At)
+
+  assert.ok(captureAt >= 0 && enterAt > captureAt && boundsAt > enterAt && copyAt > boundsAt && restoreAt > copyAt)
+  assert.ok(pmv2At >= 0 && pmv1At > pmv2At, 'PMv1 is fallback only after PMv2 fails')
+  assert.match(script, /PerMonitorV2 = new IntPtr\(-4\)/)
+  assert.match(script, /PerMonitorV1 = new IntPtr\(-3\)/)
+  assert.match(script, /finally/)
+  assert.match(script, /bounds\.X, bounds\.Y/)
+  assert.match(script, /refusing to return a potentially misaligned screenshot/)
+  assert.doesNotMatch(script, /SetProcessDPIAware|SetProcessDpiAwarenessContext/)
+  assert.match(script, /C:\\shot''s\\screen\.png/)
+})
+
+test('the compatibility matcher stays pinned to the legacy screenshot command emitted by core', async () => {
+  const core = await readFile(new URL('../index.js', import.meta.url), 'utf8')
+  const assemblyAt = core.indexOf("'Add-Type -AssemblyName System.Windows.Forms,System.Drawing'")
+  const boundsAt = core.indexOf("'$b=[System.Windows.Forms.SystemInformation]::VirtualScreen'", assemblyAt)
+  const graphicsAt = core.indexOf("'$g=[System.Drawing.Graphics]::FromImage($bmp)'", boundsAt)
+  const copyAt = core.indexOf("'$g.CopyFromScreen($b.X,$b.Y,0,0,$bmp.Size)'", graphicsAt)
+  const saveOffset = core.slice(copyAt).search(
+    /`\$bmp\.Save\('\$\{tmp\.replace\(\/'\/g,\s*\\?"''\\?"\)\}'\)`/,
+  )
+  const saveAt = saveOffset < 0 ? -1 : copyAt + saveOffset
+
+  assert.ok(
+    assemblyAt >= 0 && boundsAt > assemblyAt && graphicsAt > boundsAt && copyAt > graphicsAt && saveAt > copyAt,
+    'if core changes the legacy Windows capture command, update the exact compatibility matcher in the same change',
+  )
+  assert.equal(isLegacyWindowsScreenshotScript(legacyDesktopScreenshotScript('C:\\tmp\\shot.png')), true)
+})
+
+test('only the exact legacy Windows desktop screenshot command is rewritten', () => {
+  const original = ['-NoProfile', '-STA', '-Command', legacyDesktopScreenshotScript('C:\\tmp\\shot.png')]
+  const rewritten = rewriteWindowsScreenshotExecArgs('powershell.exe', original, { platform: 'win32' })
+  assert.notEqual(rewritten, original)
+  assert.match(rewritten[3], /DshVisionDesktopCapture/)
+
+  assert.equal(rewriteWindowsScreenshotExecArgs('powershell.exe', original, { platform: 'linux' }), original)
+  assert.equal(rewriteWindowsScreenshotExecArgs('cmd.exe', original, { platform: 'win32' }), original)
+  const unrelated = ['-NoProfile', '-Command', 'Write-Output hello']
+  assert.equal(rewriteWindowsScreenshotExecArgs('powershell.exe', unrelated, { platform: 'win32' }), unrelated)
+})
+
+test('the shared execFile seam rewrites desktop screenshot calls without disturbing unrelated calls', async () => {
+  const calls = []
+  const originalCustom = async (file, args, options) => {
+    calls.push({ file, args, options })
+    return { stdout: 'ok', stderr: '' }
+  }
+  const lockedExecFile = function lockedExecFile(_file, _args, _options, callback) {
+    callback?.(null, 'callback-ok', '')
+    return { pid: 1 }
+  }
+  Object.defineProperty(lockedExecFile, promisify.custom, {
+    configurable: false,
+    enumerable: false,
+    writable: false,
+    value: originalCustom,
+  })
+  const fakeModule = { execFile: lockedExecFile }
+  const dispose = installVisionRouterExecFileCompat(undefined, {
+    childProcessModule: fakeModule,
+    platform: 'win32',
+  })
+
+  try {
+    await promisify(fakeModule.execFile)(
+      'powershell.exe',
+      ['-NoProfile', '-STA', '-Command', legacyDesktopScreenshotScript("C:\\tmp\\O'Brien.png")],
+      { timeout: 1000 },
+    )
+    await promisify(fakeModule.execFile)('node', ['--version'], {})
+  } finally {
+    dispose()
+  }
+
+  assert.equal(calls.length, 2)
+  assert.match(calls[0].args[3], /PerMonitorV2/)
+  assert.match(calls[0].args[3], /O''Brien\.png/)
+  assert.deepEqual(calls[1].args, ['--version'])
+  assert.equal(fakeModule.execFile, lockedExecFile)
+})
+
+test('Windows PowerShell compiles the helper and can enter and restore a per-monitor DPI context', {
+  skip: process.platform !== 'win32',
+}, async () => {
+  const script = buildPerMonitorWindowsScreenshotScript('C:\\unused\\dpi-context-probe.png').replace(
+    /\[DshVisionDesktopCapture\]::Capture\([^\r\n]+\)\s*$/,
+    '[DshVisionDesktopCapture]::ValidateDpiContext()',
+  )
+  await promisify(execFile)('powershell.exe', ['-NoProfile', '-STA', '-Command', script], {
+    timeout: 15000,
+    windowsHide: true,
+  })
 })

--- a/tests/qa-screenshot-runtime.test.js
+++ b/tests/qa-screenshot-runtime.test.js
@@ -219,7 +219,10 @@ test('Windows PowerShell compiles the helper and can enter and restore a per-mon
     '[DshVisionDesktopCapture]::ValidateDpiContext()',
   )
   await promisify(execFile)('powershell.exe', ['-NoProfile', '-STA', '-Command', script], {
-    timeout: 15000,
+    // Hosted Windows images occasionally cold-start Add-Type far slower than
+    // the ~5s warm run. Keep this probe below product screenshot deadlines but
+    // high enough that CI load is not mistaken for a DPI implementation bug.
+    timeout: 60000,
     windowsHide: true,
   })
 })

--- a/tests/qa-screenshot-runtime.test.js
+++ b/tests/qa-screenshot-runtime.test.js
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 import { execFile } from 'node:child_process'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { promisify } from 'node:util'
 
 import { createSecureHtmlScreenshotExecute } from '../lib/adversarial-hardening.js'
@@ -83,7 +84,7 @@ test('secure screenshot renders the same session-cwd target that passed containm
     agent: { session: { header: { cwd: '/workspace' } } },
   }))
 
-  assert.equal(result.path, '/workspace/.artifacts/shot.png')
+  assert.equal(result.path, path.resolve('/workspace/.artifacts/shot.png'))
   const sourceResolutions = harness.resolveCalls.filter(([value]) => value === 'page.html')
   assert.equal(sourceResolutions.length, 1, 'renderer must not resolve the source string a second time')
   assert.equal(sourceResolutions[0][1].cwd, '/workspace')


### PR DESCRIPTION
## Summary

Fixes #340 by removing the DPI-coordinate mismatch in the Windows `vision_screenshot` path without changing the screenshot contract on macOS/Linux or touching routing/settings/tool ownership.

### Root fix

- Intercept only Core's exact legacy Windows `SystemInformation.VirtualScreen` + `Graphics.CopyFromScreen` PowerShell capture call.
- Execute capture in a synchronous C# helper on the same thread.
- Enter `PER_MONITOR_AWARE_V2` first, fall back to `PER_MONITOR_AWARE`, then restore the previous thread DPI context in `finally`.
- Preserve physical virtual-screen `X/Y` coordinates, including negative coordinates for monitors left/above the primary display.
- If no per-monitor DPI context can be entered, fail explicitly rather than returning a potentially misaligned screenshot.

### Regression containment

- Reuse the existing single `promisify(execFile)` compatibility owner instead of stacking another process-wide wrapper; the historical Tesseract stdin behavior remains behind the same refcounted lifecycle.
- Rewrite only Windows PowerShell calls matching the exact current screenshot command fingerprint; unrelated PowerShell/child-process calls pass through unchanged.
- No changes to macOS/Linux capture, screenshot privacy/mount semantics, routing, visual-model selection, attachment handling, identify/downscale behavior, or screenshot resolution policy.
- Keep the compatibility inventory/removal contract aligned with the 2.x Architecture Closure.

### Tests

- PMv2 → PMv1 ordering, exact capture-thread scope, `finally` restoration, negative-coordinate preservation, fail-closed semantics, path quoting, exact-match/pass-through behavior.
- Drift gate pins the compatibility matcher to the legacy screenshot command actually emitted by `index.js`.
- Existing locked-`promisify.custom` Tesseract/Node 22/24 compatibility remains covered.
- `qa-screenshot-runtime.test.js` is added to the existing Ubuntu/macOS/Windows runtime matrix; on Windows it compiles the C# helper and actually enters/restores a per-monitor DPI context without requiring an interactive desktop capture.

Real mixed-DPI display validation should cover at minimum 150% single-screen, 150%+100% dual-screen, and a monitor positioned left/above the primary screen.