### PR TITLE
fix(settings): converge alpha client factory lifecycle

### DIFF
--- a/.github/workflows/dsh-alpha-source-contract.yml
+++ b/.github/workflows/dsh-alpha-source-contract.yml
@@ -7,6 +7,12 @@ on:
       - 'package.json'
       - 'lib/client-host-compat-prelude.js'
       - 'lib/client-presentation-boundary.js'
+      - 'lib/settings-factory-lifecycle.js'
+      - 'lib/settings-ia-client-prelude.js'
+      - 'lib/settings-limit-client-prelude.js'
+      - 'lib/remote-settings-bridge.js'
+      - 'lib/web/index.js'
+      - 'lib/web/settings-controller.js'
       - 'lib/dsh-contract-compat.js'
       - 'lib/web-capability-boundary.js'
       - 'lib/client.js'
@@ -21,6 +27,12 @@ on:
       - 'package.json'
       - 'lib/client-host-compat-prelude.js'
       - 'lib/client-presentation-boundary.js'
+      - 'lib/settings-factory-lifecycle.js'
+      - 'lib/settings-ia-client-prelude.js'
+      - 'lib/settings-limit-client-prelude.js'
+      - 'lib/remote-settings-bridge.js'
+      - 'lib/web/index.js'
+      - 'lib/web/settings-controller.js'
       - 'lib/dsh-contract-compat.js'
       - 'lib/web-capability-boundary.js'
       - 'lib/client.js'
@@ -83,4 +95,4 @@ jobs:
 
       - name: Run DVR alpha compatibility unit contracts
         working-directory: dvr
-        run: node --test tests/alpha1-client-host-compat.test.js tests/alpha1-web-auth-boundary.test.js tests/attachment-admission-policy.test.js
+        run: node --test tests/alpha1-client-host-compat.test.js tests/alpha1-settings-factory-lifecycle.test.js tests/alpha1-web-auth-boundary.test.js tests/attachment-admission-policy.test.js

--- a/lib/settings-factory-lifecycle.js
+++ b/lib/settings-factory-lifecycle.js
@@ -1,0 +1,137 @@
+import {
+  SETTINGS_IA_CLIENT_PRELUDE,
+  injectSettingsIaClientPrelude,
+} from './settings-ia-client-prelude.js'
+import {
+  SETTINGS_LIMIT_CLIENT_PRELUDE,
+  injectSettingsLimitClientPrelude,
+} from './settings-limit-client-prelude.js'
+
+const CLIENT_MARK = 'data-vision-router-settings-factory-lifecycle'
+const IA_SCRIPT_MARK = 'data-vision-router-settings-ia'
+const LIMIT_SCRIPT_MARK = 'data-vision-router-settings-limit-hardening'
+
+function scriptMarkup(mark, source) {
+  const safe = source.replace(/<\/script/gi, '<\\/script')
+  return `<script ${mark}>${safe}</script>`
+}
+
+const IA_SCRIPT = scriptMarkup(IA_SCRIPT_MARK, SETTINGS_IA_CLIENT_PRELUDE)
+const LIMIT_SCRIPT = scriptMarkup(LIMIT_SCRIPT_MARK, SETTINGS_LIMIT_CLIENT_PRELUDE)
+
+/**
+ * One lifecycle owner for every decorator that shapes the Vision Router
+ * settings factory.
+ *
+ * DSH 0.1.2-alpha.1 keeps the bootstrap facade object but replaces its
+ * `load()` sink inside `create()`. A decorator installed only against the
+ * queue sink therefore disappears silently before the DVR bundle registers.
+ * Keep the mature IA and numeric-contract implementations unchanged and make
+ * this boundary solely responsible for their queue -> live transition.
+ *
+ * Order is intentional: Limit installs first, IA second. This makes the IA
+ * replacement reach the original settings.section registration before the
+ * Limit wrapper adds validation/diagnostics around the final IA component.
+ */
+export const SETTINGS_FACTORY_LIFECYCLE_PRELUDE = String.raw`(function(){
+  'use strict';
+
+  var installers = [
+    function installLimit(){
+      ${SETTINGS_LIMIT_CLIENT_PRELUDE}
+    },
+    function installIa(){
+      ${SETTINGS_IA_CLIENT_PRELUDE}
+    }
+  ];
+
+  function arm() {
+    for (var i = 0; i < installers.length; i += 1) {
+      try { installers[i](); } catch (_) {}
+    }
+  }
+
+  function patchCreate(loader) {
+    if (!loader || (typeof loader !== 'object' && typeof loader !== 'function')) return;
+    if (typeof loader.create !== 'function' || loader.create.__visionRouterSettingsFactoryLifecycle) return;
+    var originalCreate = loader.create;
+    function create() {
+      var result = originalCreate.apply(this, arguments);
+      // alpha.1 assigns a brand-new live load() inside create(). Re-arm the
+      // exact same Settings decorators immediately after that official switch.
+      arm();
+      return result;
+    }
+    try {
+      Object.defineProperty(create, '__visionRouterSettingsFactoryLifecycle', { value: true });
+    } catch (_) {}
+    loader.create = create;
+  }
+
+  function attach(loader) {
+    if (!loader || (typeof loader !== 'object' && typeof loader !== 'function')) return;
+    arm();
+    patchCreate(loader);
+  }
+
+  function install() {
+    if (window.__ModuleLoader__) {
+      attach(window.__ModuleLoader__);
+      return;
+    }
+    var descriptor = Object.getOwnPropertyDescriptor(window, '__ModuleLoader__');
+    if (descriptor && descriptor.configurable === false) return;
+    var previousGet = descriptor && descriptor.get;
+    var previousSet = descriptor && descriptor.set;
+    var stored = descriptor && Object.prototype.hasOwnProperty.call(descriptor, 'value')
+      ? descriptor.value
+      : undefined;
+    Object.defineProperty(window, '__ModuleLoader__', {
+      configurable: true,
+      enumerable: descriptor ? descriptor.enumerable === true : true,
+      get: function() {
+        return typeof previousGet === 'function' ? previousGet.call(window) : stored;
+      },
+      set: function(value) {
+        if (typeof previousSet === 'function') previousSet.call(window, value);
+        else stored = value;
+        var resolved = typeof previousGet === 'function' ? previousGet.call(window) : stored;
+        if (!resolved) resolved = value;
+        attach(resolved);
+      }
+    });
+  }
+
+  try { install(); } catch (_) {}
+})();`
+
+/**
+ * Collapse the two historical Settings factory scripts into one lifecycle-
+ * aware script while preserving the IA stylesheet. Calling the historical
+ * injectors first also keeps this transform self-sufficient if an installer is
+ * reordered later; their executable tags are then removed deterministically.
+ */
+export function injectSettingsFactoryLifecycle(html) {
+  if (typeof html !== 'string' || html.includes(CLIENT_MARK)) return html
+
+  let next = injectSettingsLimitClientPrelude(html)
+  next = injectSettingsIaClientPrelude(next)
+  next = next.split(LIMIT_SCRIPT).join('')
+  next = next.split(IA_SCRIPT).join('')
+
+  const safe = SETTINGS_FACTORY_LIFECYCLE_PRELUDE.replace(/<\/script/gi, '<\\/script')
+  const script = `<script ${CLIENT_MARK}>${safe}</script>`
+  const closeHead = next.indexOf('</head>')
+  return closeHead === -1
+    ? `${next}${script}`
+    : `${next.slice(0, closeHead)}${script}${next.slice(closeHead)}`
+}
+
+export function installSettingsFactoryLifecycle(ctx) {
+  ctx?.inject?.(['webServer'], (webCtx) => {
+    webCtx.effect(
+      () => webCtx.webServer.tapIndex(injectSettingsFactoryLifecycle),
+      'vision-router: converged settings client factory lifecycle',
+    )
+  })
+}

--- a/lib/web/index.js
+++ b/lib/web/index.js
@@ -8,10 +8,12 @@ import { installVisionOnboarding } from './onboarding.js'
 import { installVisionRoutingSection } from './routing-section.js'
 import { installVisionBenchmarkPanel } from './benchmark-panel.js'
 import { installVisionDiagnosticsPanel } from './diagnostics-panel.js'
+import { installSettingsFactoryLifecycle } from '../settings-factory-lifecycle.js'
 
 const DEFAULT_INSTALLERS = Object.freeze({
   settingsController: installVisionSettingsController,
   remoteSettings: installVisionRemoteSettingsClient,
+  settingsFactoryLifecycle: installSettingsFactoryLifecycle,
   modelPresentation: installVisionModelPickerPresentation,
   onboarding: installVisionOnboarding,
   modelControls: installVisionModelPickerControls,
@@ -31,6 +33,10 @@ export function installVisionSettingsWebBoundary(ctx, logger, overrides) {
   const installers = installersOf(overrides)
   installers.settingsController(ctx)
   installers.remoteSettings(ctx, logger)
+  // SettingsController and remoteSettings keep registering their mature
+  // transforms in historical order. Finalize them once, after both exist, so
+  // one boundary owns queue -> live factory lifecycle on alpha/newer Hosts.
+  installers.settingsFactoryLifecycle(ctx)
   return ctx
 }
 

--- a/tests/alpha1-settings-factory-lifecycle.test.js
+++ b/tests/alpha1-settings-factory-lifecycle.test.js
@@ -1,0 +1,167 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import vm from 'node:vm'
+
+import {
+  SETTINGS_FACTORY_LIFECYCLE_PRELUDE,
+  injectSettingsFactoryLifecycle,
+} from '../lib/settings-factory-lifecycle.js'
+
+function lifecycleHarness({ alpha = true } = {}) {
+  let registered
+  const pending = []
+  const loader = {
+    mode: alpha ? 'queue' : 'live',
+    load(spec) {
+      if (this.mode === 'queue') pending.push(spec)
+      else registered = spec
+      return spec
+    },
+  }
+  if (alpha) {
+    loader.create = function create() {
+      this.mode = 'live'
+      this.load = (spec) => {
+        registered = spec
+        return spec
+      }
+      for (const spec of pending.splice(0)) this.load(spec)
+      return this
+    }
+  }
+
+  const window = {
+    __ModuleLoader__: loader,
+    location: { hostname: 'localhost' },
+  }
+  const document = {
+    documentElement: { lang: 'zh-CN' },
+  }
+  const context = {
+    window,
+    document,
+    navigator: { language: 'zh-CN' },
+    Object,
+    Promise,
+    Array,
+    String,
+    Number,
+    Reflect,
+    Proxy,
+    Symbol,
+    Map,
+    Set,
+    WeakMap,
+    Math,
+    JSON,
+    Error,
+    TypeError,
+    console,
+    setTimeout() { return 1 },
+    clearTimeout() {},
+  }
+  vm.runInNewContext(SETTINGS_FACTORY_LIFECYCLE_PRELUDE, context)
+  if (alpha) loader.create()
+
+  return {
+    loader,
+    register(spec) {
+      loader.load(spec)
+      return registered
+    },
+  }
+}
+
+function exerciseSettingsFactory(harness) {
+  const localeDefinitions = []
+  let registeredSection
+  const legacy = function LegacySettingsSection() {}
+  const spec = {
+    id: 'dsh-vision-router',
+    factory(require) {
+      require('react')
+      return {
+        apply(ctx) {
+          ctx.locale.define('vision-router', {
+            zh: { quickStartTitle: '旧标题' },
+            en: { quickStartTitle: 'Old title' },
+          })
+          ctx.slots.register(
+            { name: 'settings.section', id: 'vision-router' },
+            legacy,
+          )
+        },
+      }
+    },
+  }
+  const registered = harness.register(spec)
+  const plugin = registered.factory((id) => {
+    if (id === 'react') return {}
+    throw new Error(`unexpected value request: ${id}`)
+  })
+  plugin.apply({
+    locale: {
+      define(namespace, dictionaries) {
+        localeDefinitions.push([namespace, dictionaries])
+      },
+    },
+    slots: {
+      register(options, component) {
+        registeredSection = { options, component }
+        return { options, component }
+      },
+    },
+  })
+  return { plugin, localeDefinitions, registeredSection, legacy }
+}
+
+test('alpha.1 queue-to-live switch keeps Settings IA and numeric boundary composed', () => {
+  const result = exerciseSettingsFactory(lifecycleHarness({ alpha: true }))
+
+  assert.equal(result.localeDefinitions.length, 1)
+  assert.equal(result.localeDefinitions[0][0], 'vision-router')
+  assert.equal(
+    result.localeDefinitions[0][1].zh.quickStartTitle,
+    '聊天模型和识图模型分开设置',
+  )
+  assert.equal(result.registeredSection.options.id, 'vision-router')
+  // Limit must remain the outer registration wrapper. If IA installs before
+  // Limit, IA replaces this wrapper and the numeric/diagnostic contract is lost.
+  assert.equal(result.registeredSection.component.name, 'VisionRouterIssue307SettingsBoundary')
+  assert.notEqual(result.registeredSection.component, result.legacy)
+  assert.equal(result.plugin.apply.__visionRouterLimitHardening, true)
+})
+
+test('pre-alpha live loader keeps the same converged Settings behavior', () => {
+  const result = exerciseSettingsFactory(lifecycleHarness({ alpha: false }))
+
+  assert.equal(
+    result.localeDefinitions[0][1].zh.quickStartTitle,
+    '聊天模型和识图模型分开设置',
+  )
+  assert.equal(result.registeredSection.component.name, 'VisionRouterIssue307SettingsBoundary')
+  assert.equal(result.plugin.apply.__visionRouterLimitHardening, true)
+})
+
+test('Settings factory lifecycle ignores unrelated client plugins', () => {
+  const harness = lifecycleHarness({ alpha: true })
+  const apply = () => {}
+  const registered = harness.register({
+    id: 'other-plugin',
+    factory: () => ({ apply }),
+  })
+  const plugin = registered.factory(() => ({}))
+  assert.equal(plugin.apply, apply)
+})
+
+test('HTML convergence emits one lifecycle script, preserves IA style, and is idempotent', () => {
+  const html = '<!doctype html><html><head></head><body></body></html>'
+  const once = injectSettingsFactoryLifecycle(html)
+  const twice = injectSettingsFactoryLifecycle(once)
+
+  assert.equal(twice, once)
+  assert.equal((once.match(/<script data-vision-router-settings-factory-lifecycle>/g) || []).length, 1)
+  assert.equal((once.match(/<style data-vision-router-settings-ia>/g) || []).length, 1)
+  assert.equal((once.match(/<script data-vision-router-settings-ia>/g) || []).length, 0)
+  assert.equal((once.match(/<script data-vision-router-settings-limit-hardening>/g) || []).length, 0)
+})


### PR DESCRIPTION
## Summary

Root-fix the DSH 0.1.2-alpha.1 Settings regression where queue-time client-factory decorators disappear when the Host replaces `window.__ModuleLoader__.load()` during `create()`.

- add one Settings factory lifecycle owner that composes the existing numeric/diagnostic boundary and Settings IA in stable `Limit -> IA` order
- collapse the two historical executable Settings prelude tags into one lifecycle-aware script while preserving the existing IA stylesheet
- re-arm the exact same decorators immediately after the Host queue -> live transition instead of teaching each Settings prelude its own lifecycle patch
- preserve pre-alpha behavior when no queue -> live replacement happens
- add a dedicated alpha lifecycle contract proving both IA copy/section replacement and Limit outer wrapping survive together
- wire the new contract into the exact alpha.1 three-OS source workflow and broaden its path triggers to the Settings browser boundaries

## Why this is the root fix

The UI regression was not a missing component or bad Settings schema. It was duplicate lifecycle ownership: mature Settings decorators each wrapped the queue sink independently, while alpha.1 makes `ClientModuleSystem.create()` replace that sink. This PR leaves the mature implementations byte-stable and gives the transition to one explicit owner.

## Validation target

The new contract simulates the alpha.1 queue facade, performs the live `load()` replacement, registers the real DVR factory shape, and requires:

- IA locale transformation still active
- `settings.section#vision-router` no longer resolves to the legacy section
- numeric/diagnostic boundary remains the outer final section wrapper
- unrelated client plugins remain untouched
- generated HTML has one lifecycle script, one IA style, and no duplicate historical executable Settings tags
