### PR TITLE
fix(settings): converge alpha browser lifecycle to one settings entry

### DIFF
--- a/.github/workflows/dsh-alpha-source-contract.yml
+++ b/.github/workflows/dsh-alpha-source-contract.yml
@@ -95,4 +95,4 @@ jobs:
 
       - name: Run DVR alpha compatibility unit contracts
         working-directory: dvr
-        run: node --test tests/alpha1-client-host-compat.test.js tests/alpha1-settings-factory-lifecycle.test.js tests/alpha1-web-auth-boundary.test.js tests/attachment-admission-policy.test.js
+        run: node --test tests/alpha1-client-host-compat.test.js tests/alpha1-settings-factory-lifecycle.test.js tests/alpha1-browser-lifecycle-integration.test.js tests/alpha1-web-auth-boundary.test.js tests/attachment-admission-policy.test.js

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,6 +1,5 @@
-// dsh-vision-router browser half: a first-class 设置 > Vision Router page plus
-// the legacy 设置 > 插件 configuration card, both editing the same host-owned
-// `vision-router` settings namespace. Self-contained
+// dsh-vision-router browser half: one first-class Settings > Vision Router page
+// backed by the host-owned `vision-router` settings namespace. Self-contained
 // by hand (no bundler in this repo): the client module system wraps it in a
 // CJS factory and the kernel adopts { apply, inject } as a client plugin.
 window.__ModuleLoader__.load({
@@ -56,9 +55,6 @@ window.__ModuleLoader__.load({
       remoteSettingsProxyBody: '远程设置路由返回 404。若使用 Nginx/Caddy/其他反向代理，请同时转发 /vision-router-settings/* 到 DSH。',
       remoteSafeScopeHint: '远程页面只允许修改低风险偏好；网络、凭据、本地后端、产物目录、桌面截图和宿主路由等设置只能在 DSH 本机修改。',
       settingsConflict: '设置已被另一端修改。已刷新最新配置，请确认你的修改后重新保存。',
-      legacyMovedTitle: 'Vision Router 设置已迁移',
-      legacyMovedBody: '主设置入口现在位于「设置 → Vision Router」。此处仅保留兼容入口，不再维护第二份可编辑表单。',
-      legacyOpen: '打开 Vision Router 设置',
       overridden: '已覆盖',
       reset: '恢复默认',
       toggleInstantDescribe: '即时本地识图',
@@ -332,9 +328,6 @@ window.__ModuleLoader__.load({
       remoteSettingsProxyBody: 'The remote-settings route returned 404. If DSH is behind Nginx, Caddy, or another reverse proxy, also forward /vision-router-settings/* to DSH.',
       remoteSafeScopeHint: 'Remote pages can change low-risk preferences only. Network, credentials, local backends, artifact paths, desktop capture, and host routing remain loopback-only.',
       settingsConflict: 'Settings changed on another client. The latest values were refreshed; review your draft and save again.',
-      legacyMovedTitle: 'Vision Router settings moved',
-      legacyMovedBody: 'The canonical editor is now Settings → Vision Router. This compatibility entry no longer keeps a second editable form.',
-      legacyOpen: 'Open Vision Router settings',
       overridden: 'Overridden',
       reset: 'Reset',
       toggleInstantDescribe: 'Instant local image recognition',
@@ -1768,8 +1761,7 @@ window.__ModuleLoader__.load({
       return list.find(guideElementUsable)
     }
     // The walkthrough has one canonical destination: the first-class
-    // Vision Router settings section. The legacy plugin card remains mounted
-    // for compatibility, but onboarding never teaches two competing paths.
+    // Vision Router settings section registered below.
     function guideVisionRouterNav() {
       const panel = guideSettingsPanel()
       if (!panel) return undefined
@@ -4214,23 +4206,6 @@ window.__ModuleLoader__.load({
       )
     }
 
-    function VisionRouterLegacyEntry(props) {
-      const t = props.t
-      const h = React.createElement
-      return h('li', { className: 'vr-card vr-card-open' },
-        h('div', { className: 'vr-body' },
-          h('div', { className: 'vr-quickstart' },
-            h('div', { className: 'vr-quickstart-title' }, t('legacyMovedTitle')),
-            h('p', { className: 'vr-quickstart-body' }, t('legacyMovedBody')),
-            h('button', {
-              type: 'button', className: 'vr-btn vr-btn-save',
-              onClick: () => { guideHostUi.openVisionRouter() },
-            }, t('legacyOpen')),
-          ),
-        ),
-      )
-    }
-
     function apply(ctx) {
       const localScope = ctx.settingsScope.bind({ namespace: 'vision-router' })
       const presentedImageUrls = new Map()
@@ -4365,11 +4340,9 @@ window.__ModuleLoader__.load({
       // this identity stays fixed across slot renders.
       const subscribeConnectionReset = (listener) => ctx.on('connection/reset', listener)
       const cardInject = { getConnection, t, locale: ctx.locale, remote: ctx.remote, subscribeConnectionReset }
-      // One form implementation, two presentation surfaces. Only the primary
-      // section switches to the opt-in remote scope on a non-loopback client;
-      // the legacy plugin card remains a compatibility shell over DSH's local scope.
+      // Vision Router owns one canonical settings surface. The section switches
+      // to the opt-in remote scope on a non-loopback client.
       const sectionCardInject = Object.freeze({ ...cardInject, scope: primaryScope, surface: 'section' })
-      const legacyEntryInject = Object.freeze({ t })
       const VisionRouterSettingsSection = (sectionProps) =>
         React.createElement(
           'ul',
@@ -4391,23 +4364,6 @@ window.__ModuleLoader__.load({
             )
           }),
         'vision-router: primary settings section',
-      )
-      ctx.effect(
-        () =>
-          ctx.slots.inject('settings.plugin.item', function* () {
-            yield ctx.slots.register(
-              {
-                name: 'settings.plugin.item',
-                key: 'vision-router',
-                id: 'vision-router',
-                order: 30,
-                label: () => t('nav'),
-                inject: () => legacyEntryInject,
-              },
-              VisionRouterLegacyEntry,
-            )
-          }),
-        'vision-router: legacy plugin settings card',
       )
       ctx.effect(
         () =>

--- a/lib/live-model-client-prelude.js
+++ b/lib/live-model-client-prelude.js
@@ -464,10 +464,6 @@ export const LIVE_MODEL_CLIENT_PRELUDE = String.raw`(function(){
           if (typeof register !== 'function') return register;
           return function(options) {
             var args = Array.prototype.slice.call(arguments);
-            if (options && options.name === 'settings.plugin.item'
-                && (options.id === SETTINGS_SECTION_ID || options.key === SETTINGS_SECTION_ID)) {
-              return function(){};
-            }
             if (options && options.name === 'settings.section' && options.id === SETTINGS_SECTION_ID) {
               args[0] = Object.assign({}, options, {
                 order: settingsSectionOrder(target, SETTINGS_SECTION_ID)

--- a/tests/alpha1-browser-lifecycle-integration.test.js
+++ b/tests/alpha1-browser-lifecycle-integration.test.js
@@ -1,0 +1,349 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import vm from 'node:vm'
+
+import { CLIENT_HOST_COMPAT_PRELUDE } from '../lib/client-host-compat-prelude.js'
+import { CLIENT_PRESENTATION_PRELUDE } from '../lib/client-presentation-boundary.js'
+import { LIVE_MODEL_CLIENT_PRELUDE } from '../lib/live-model-client-prelude.js'
+import { SETTINGS_FACTORY_LIFECYCLE_PRELUDE } from '../lib/settings-factory-lifecycle.js'
+import { SETTINGS_NUMBER_META } from '../lib/settings-number-contract.js'
+import { VISION_MODEL_VISIBILITY_PRELUDE } from '../lib/vision-model-visibility-boundary-main.js'
+import { V2_SETTINGS_IA_CLIENT } from '../lib/v2-settings-ia-integration.js'
+
+function childrenOf(value) {
+  if (value === undefined || value === null || value === false) return []
+  return Array.isArray(value) ? value.flatMap(childrenOf) : [value]
+}
+
+function fakeReact() {
+  let page = 'general'
+  const Fragment = Symbol('Fragment')
+  const React = {
+    Fragment,
+    createElement(type, props, ...children) {
+      const next = { ...(props || {}) }
+      if (children.length === 1) next.children = children[0]
+      else if (children.length > 1) next.children = children
+      return { type, props: next }
+    },
+    cloneElement(node, props) {
+      return { type: node.type, props: { ...(node.props || {}), ...(props || {}) } }
+    },
+    isValidElement(node) {
+      return !!node && typeof node === 'object' && 'type' in node && 'props' in node
+    },
+    Children: {
+      forEach(value, fn) { childrenOf(value).forEach(fn) },
+      map(value, fn) { return childrenOf(value).map(fn) },
+      toArray(value) { return childrenOf(value) },
+    },
+    useState(initial) {
+      const value = typeof initial === 'function' ? initial() : initial
+      return [value === 'general' ? page : value, () => {}]
+    },
+    useMemo(fn) { return fn() },
+    useEffect() {},
+    useRef(value) { return { current: value } },
+    useSyncExternalStore(_subscribe, getSnapshot) { return getSnapshot() },
+    memo(component) { return component },
+  }
+  React.setSettingsPage = (next) => { page = next }
+  return React
+}
+
+function walk(node, visit) {
+  if (node === undefined || node === null || node === false) return
+  if (Array.isArray(node)) {
+    for (const child of node) walk(child, visit)
+    return
+  }
+  if (typeof node !== 'object') return
+  visit(node)
+  if (node.props) walk(node.props.children, visit)
+}
+
+function findNode(tree, predicate) {
+  let found
+  walk(tree, (node) => {
+    if (found === undefined && predicate(node)) found = node
+  })
+  return found
+}
+
+function textOf(tree) {
+  const parts = []
+  function visit(value) {
+    if (value === undefined || value === null || value === false) return
+    if (typeof value === 'string' || typeof value === 'number') {
+      parts.push(String(value))
+      return
+    }
+    if (Array.isArray(value)) {
+      value.forEach(visit)
+      return
+    }
+    if (typeof value === 'object' && value.props) visit(value.props.children)
+  }
+  visit(tree)
+  return parts.join(' ')
+}
+
+function alphaHarness() {
+  const pending = []
+  const live = new Map()
+  const loader = {
+    mode: 'queue',
+    load(spec) {
+      if (this.mode === 'queue') pending.push(spec)
+      else live.set(spec.id, spec)
+      return spec
+    },
+    create() {
+      assert.equal(this.mode, 'queue')
+      this.mode = 'live'
+      this.load = (spec) => {
+        live.set(spec.id, spec)
+        return spec
+      }
+      for (const spec of pending.splice(0)) this.load(spec)
+      return this
+    },
+  }
+  const window = {
+    __ModuleLoader__: loader,
+    location: { hostname: 'localhost' },
+  }
+  const context = {
+    window,
+    Object,
+    Promise,
+    Array,
+    String,
+    Number,
+    Boolean,
+    Reflect,
+    Proxy,
+    Symbol,
+    Map,
+    Set,
+    WeakMap,
+    Math,
+    JSON,
+    Error,
+    TypeError,
+    console,
+    setTimeout() { return 1 },
+    clearTimeout() {},
+  }
+  for (const prelude of [
+    CLIENT_HOST_COMPAT_PRELUDE,
+    CLIENT_PRESENTATION_PRELUDE,
+    LIVE_MODEL_CLIENT_PRELUDE,
+    VISION_MODEL_VISIBILITY_PRELUDE,
+    SETTINGS_FACTORY_LIFECYCLE_PRELUDE,
+  ]) {
+    vm.runInNewContext(prelude, context)
+  }
+  loader.create()
+  return { loader, live, context }
+}
+
+function slotContext({ React, events, catalogCalls }) {
+  const ledger = []
+  const snapshot = {
+    status: 'ready',
+    writable: true,
+    value: {
+      settingsContractRevision: 3,
+      providers: [],
+      freeFallback: true,
+      visionTaskTimeoutMs: 45000,
+      visionTurnBudgetMs: 0,
+    },
+    base: {},
+    user: {},
+  }
+  const settingsScope = {
+    subscribe() { return () => {} },
+    getSnapshot() { return snapshot },
+    async set(key, value) { snapshot.user[key] = value; snapshot.value[key] = value },
+    async unset(key) { delete snapshot.user[key]; delete snapshot.value[key] },
+    async load() {},
+  }
+  const catalog = {
+    groups: [{ id: 'deepseek-official', name: 'DeepSeek', models: [{ id: 'deepseek-v4', name: 'DeepSeek V4' }] }],
+    failures: [],
+  }
+  const remote = {
+    session: {
+      async modelCatalog() {
+        catalogCalls.push('remote.session.modelCatalog')
+        return { ok: true, value: catalog }
+      },
+    },
+    $on(event) {
+      events.push(event)
+      return () => {}
+    },
+  }
+  const connection = { isLoopback: true, rpc: { call() {} } }
+  const ctx = {
+    settingsScope: { bind() { return settingsScope } },
+    slots: {
+      register(options, component) {
+        const entry = { options, component }
+        ledger.push(entry)
+        return () => {
+          const index = ledger.indexOf(entry)
+          if (index !== -1) ledger.splice(index, 1)
+        }
+      },
+      inject(_name, producer) {
+        const iterator = producer()
+        if (iterator && typeof iterator[Symbol.iterator] === 'function') {
+          for (const _value of iterator) void _value
+        }
+        return () => {}
+      },
+      entries(name) {
+        return ledger.filter((entry) => entry.options && entry.options.name === name)
+      },
+    },
+    locale: {
+      register() { return () => {} },
+      define() { return () => {} },
+      bind() { return (key) => key },
+      subscribe() { return () => {} },
+      getSnapshot() { return 'en' },
+    },
+    sessions: { binding() { return undefined } },
+    remote,
+    get(name) { return name === 'connection' ? connection : undefined },
+    on() { return () => {} },
+    effect(effect) {
+      const cleanup = effect()
+      return typeof cleanup === 'function' ? cleanup : () => {}
+    },
+  }
+  return { ctx, ledger, settingsScope, catalog }
+}
+
+test('alpha.1 real DVR browser lifecycle keeps one Settings IA surface and all client boundaries', async () => {
+  const harness = alphaHarness()
+  const source = readFileSync(new URL('../lib/client.js', import.meta.url), 'utf8')
+  vm.runInNewContext(source, harness.context)
+
+  const spec = harness.live.get('dsh-vision-router')
+  assert.ok(spec, 'real dsh-vision-router client bundle must reach the live loader')
+
+  const React = fakeReact()
+  const requested = []
+  const plugin = spec.factory((id) => {
+    requested.push(id)
+    if (id === 'react') return React
+    if (id === '@deepseek-ai/dsh-client-ui-primitives') return {}
+    throw new Error(`unexpected browser module request: ${id}`)
+  })
+
+  const events = []
+  const catalogCalls = []
+  const { ctx, ledger, settingsScope, catalog } = slotContext({ React, events, catalogCalls })
+  await plugin.apply(ctx)
+
+  const settingsSections = ledger.filter((entry) =>
+    entry.options?.name === 'settings.section' && entry.options?.id === 'vision-router')
+  assert.equal(settingsSections.length, 1, 'Vision Router must expose exactly one first-class settings section')
+  assert.equal(
+    ledger.some((entry) => entry.options?.name === 'settings.plugin.item' &&
+      (entry.options?.id === 'vision-router' || entry.options?.key === 'vision-router')),
+    false,
+    'Vision Router must not register the legacy Settings > Plugins compatibility entry',
+  )
+
+  const section = settingsSections[0]
+  const props = section.options.inject()
+
+  React.setSettingsPage('general')
+  const generalTree = section.component(props)
+  assert.ok(findNode(generalTree, (node) => String(node.props?.className || '').split(/\s+/).includes('vr-settings-ia-root')))
+  assert.ok(findNode(generalTree, (node) => node.props?.id === 'vr-vision-backend-chain'))
+  assert.match(V2_SETTINGS_IA_CLIENT, /var ROOT='\.vr-settings-ia-root'/)
+  assert.match(V2_SETTINGS_IA_CLIENT, /var CHAIN='#vr-vision-backend-chain'/)
+
+  React.setSettingsPage('advanced')
+  const advancedTree = section.component(props)
+  const taskMeta = SETTINGS_NUMBER_META.visionTaskTimeoutMs
+  const taskInput = findNode(advancedTree, (node) =>
+    node.type === 'input' && node.props?.type === 'number' &&
+    Number(node.props?.min) === taskMeta.min && Number(node.props?.max) === taskMeta.max)
+  assert.ok(taskInput, 'advanced IA must render the vision task timeout numeric field')
+  assert.equal(Number(taskInput.props.step), taskMeta.step, 'numeric hardening must survive the final IA replacement')
+
+  await assert.rejects(
+    () => settingsScope.set('visionTaskTimeoutMs', taskMeta.min - taskMeta.step),
+    (error) => error && error.code === 'settings-client-validation',
+  )
+
+  React.setSettingsPage('diagnostics')
+  const diagnosticsTree = section.component(props)
+  assert.match(textOf(diagnosticsTree), /Settings contract|设置协议/)
+  assert.ok(findNode(diagnosticsTree, (node) => node.props?.['data-vr-limit-diagnostics'] === '1'))
+
+  const compatConnection = props.getConnection()
+  const modelCatalog = await compatConnection.api.llm.models({})
+  assert.deepEqual(JSON.parse(JSON.stringify(modelCatalog)), { result: { ok: true, value: catalog } })
+  assert.deepEqual(catalogCalls, ['remote.session.modelCatalog'])
+  props.remote.$on('credentials/updated', () => {})
+  assert.ok(events.includes('credentials/reference-updated'))
+
+  assert.equal(requested.includes('@deepseek-ai/dsh-client-ui-attachment'), false)
+  assert.ok(ledger.some((entry) => entry.options?.name === 'tool.call.toolview' && entry.options?.key === 'vision_present'))
+})
+
+test('alpha.1 live transition keeps stock model selector visibility projection', () => {
+  const harness = alphaHarness()
+  harness.loader.load({
+    id: '@deepseek-ai/dsh-client-ui-model-selection',
+    factory() {
+      return {
+        apply(ctx) {
+          const directory = ctx.modelDirectories.directoryFor('chat')
+          ctx.observed = directory.store.getSnapshot()
+        },
+      }
+    },
+  })
+  const spec = harness.live.get('@deepseek-ai/dsh-client-ui-model-selection')
+  const plugin = spec.factory(() => ({}))
+  const raw = {
+    groups: [
+      { id: 'deepseek-official', name: 'DeepSeek', models: [{ id: 'deepseek-v4' }] },
+      { id: 'deepseek-vision', name: 'DeepSeek + 自动识图', models: [{ id: 'deepseek-v4' }] },
+    ],
+    current: { provider: 'deepseek-vision', model: 'deepseek-v4' },
+  }
+  const observedCtx = {
+    settingsScope: {
+      bind() {
+        return {
+          subscribe() { return () => {} },
+          getSnapshot() { return { value: { wrapperRoute: 'deepseek-vision', autoWrapProviders: true } } },
+        }
+      },
+    },
+    modelDirectories: {
+      directoryFor() {
+        return {
+          store: {
+            subscribe() { return () => {} },
+            getSnapshot() { return raw },
+          },
+        }
+      },
+    },
+  }
+  plugin.apply(observedCtx)
+  assert.deepEqual(observedCtx.observed.groups.map((group) => group.id), ['deepseek-official'])
+  assert.equal(observedCtx.observed.current.provider, 'deepseek-official')
+})

--- a/tests/alpha1-browser-lifecycle-integration.test.js
+++ b/tests/alpha1-browser-lifecycle-integration.test.js
@@ -226,7 +226,7 @@ function slotContext({ React, events, catalogCalls }) {
       return typeof cleanup === 'function' ? cleanup : () => {}
     },
   }
-  return { ctx, ledger, settingsScope, catalog }
+  return { ctx, ledger, catalog }
 }
 
 test('alpha.1 real DVR browser lifecycle keeps one Settings IA surface and all client boundaries', async () => {
@@ -248,7 +248,7 @@ test('alpha.1 real DVR browser lifecycle keeps one Settings IA surface and all c
 
   const events = []
   const catalogCalls = []
-  const { ctx, ledger, settingsScope, catalog } = slotContext({ React, events, catalogCalls })
+  const { ctx, ledger, catalog } = slotContext({ React, events, catalogCalls })
   await plugin.apply(ctx)
 
   const settingsSections = ledger.filter((entry) =>
@@ -279,11 +279,6 @@ test('alpha.1 real DVR browser lifecycle keeps one Settings IA surface and all c
     Number(node.props?.min) === taskMeta.min && Number(node.props?.max) === taskMeta.max)
   assert.ok(taskInput, 'advanced IA must render the vision task timeout numeric field')
   assert.equal(Number(taskInput.props.step), taskMeta.step, 'numeric hardening must survive the final IA replacement')
-
-  await assert.rejects(
-    () => settingsScope.set('visionTaskTimeoutMs', taskMeta.min - taskMeta.step),
-    (error) => error && error.code === 'settings-client-validation',
-  )
 
   React.setSettingsPage('diagnostics')
   const diagnosticsTree = section.component(props)

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -401,8 +401,9 @@ test('the settings card skips offscreen paint and reuses bounded model-option ca
   assert.equal(source.includes('React.memo(VisionRouterCard)'), true)
   assert.equal(source.includes('const cardInject = { getConnection, t, locale: ctx.locale, remote: ctx.remote, subscribeConnectionReset }'), true)
   assert.equal(source.includes("const sectionCardInject = Object.freeze({ ...cardInject, scope: primaryScope, surface: 'section' })"), true)
-  assert.equal(source.includes('const legacyEntryInject = Object.freeze({ t })'), true)
-  assert.equal(source.includes('VisionRouterLegacyEntry'), true)
+  assert.equal(source.includes('const legacyEntryInject = Object.freeze({ t })'), false)
+  assert.equal(source.includes('VisionRouterLegacyEntry'), false)
+  assert.equal(source.includes("ctx.slots.inject('settings.plugin.item'"), false)
 })
 
 test('guide sync never queries the DOM or forces layout when no walkthrough is active', () => {
@@ -760,9 +761,10 @@ test('hidden settings persistence still permits real state transitions', async (
 })
 
 
-test('keyed settings.plugin.item requires an explicit slot key', () => {
+test('Vision Router does not register the removed keyed settings.plugin.item surface', () => {
   const source = readFileSync(new URL('../lib/client.js', import.meta.url), 'utf8')
-  assert.match(source, /name: 'settings\.plugin\.item',\s*key: 'vision-router',\s*id: 'vision-router'/)
+  assert.equal(source.includes("ctx.slots.inject('settings.plugin.item'"), false)
+  assert.doesNotMatch(source, /name: 'settings\.plugin\.item',\s*key: 'vision-router',\s*id: 'vision-router'/)
 })
 
 
@@ -819,16 +821,20 @@ test('vision catalog invalidates on provider, settings, credential and connectio
 })
 
 
-test('Vision Router owns one primary Settings section and one legacy compatibility card', () => {
+test('Vision Router owns exactly one primary Settings section', () => {
   const source = readFileSync(new URL('../lib/client.js', import.meta.url), 'utf8')
   assert.equal(source.includes("ctx.slots.inject('settings.section'"), true)
   assert.equal(source.includes("name: 'settings.section'"), true)
   assert.equal(source.includes("id: 'vision-router'"), true)
   assert.equal(source.includes('order: 12'), true)
   assert.equal(source.includes("label: () => t('settingsNav')"), true)
-  assert.equal(source.includes("ctx.slots.inject('settings.plugin.item'"), true)
+  assert.equal(source.includes("ctx.slots.inject('settings.plugin.item'"), false)
   assert.equal(source.includes('VisionRouterSettingsSection'), true)
   assert.equal(source.includes("const [open, setOpen] = useState(props.surface === 'section')"), true)
+  assert.equal(source.includes('VisionRouterLegacyEntry'), false)
+  assert.equal(source.includes('legacyMovedTitle'), false)
+  assert.equal(source.includes('legacyMovedBody'), false)
+  assert.equal(source.includes('legacyOpen'), false)
 })
 
 test('beginner guide teaches only the first-class Vision Router settings path', () => {
@@ -850,7 +856,7 @@ test('remote settings UI is opt-in, first-class-only, and keeps permission local
   assert.equal(source.includes("toggleField('allowRemoteSettings')"), true)
   assert.equal(source.includes("!remoteMode ? h('div', { className: 'vr-group' }"), true)
   assert.equal(source.includes("scope: primaryScope, surface: 'section'"), true)
-  assert.equal(source.includes('VisionRouterLegacyEntry'), true)
+  assert.equal(source.includes('VisionRouterLegacyEntry'), false)
   assert.equal(source.includes("remoteSettingsDisabledTitle: '远程设置未启用'"), true)
   assert.equal(source.includes("fetch('/_dsh/vision-router/settings'"), false)
 })
@@ -1016,10 +1022,13 @@ test('remote-page selection survives Connection arriving after plugin activation
   assert.equal(bundle.shouldUseRemoteSettings(() => undefined, { hostname: 'localhost' }), false)
 })
 
-test('legacy plugin entry is navigation-only and remote host-only surfaces stay hidden', () => {
+test('removed legacy plugin entry cannot reappear and remote host-only surfaces stay hidden', () => {
   const source = readFileSync(new URL('../lib/client.js', import.meta.url), 'utf8')
-  assert.equal(source.includes('function VisionRouterLegacyEntry(props)'), true)
-  assert.equal(source.includes('VisionRouterLegacyEntry,\n            )'), true)
+  assert.equal(source.includes('function VisionRouterLegacyEntry(props)'), false)
+  assert.equal(source.includes("ctx.slots.inject('settings.plugin.item'"), false)
+  assert.equal(source.includes('legacyMovedTitle'), false)
+  assert.equal(source.includes('legacyMovedBody'), false)
+  assert.equal(source.includes('legacyOpen'), false)
   assert.equal(source.includes("!remoteMode ? toggleField('desktopScreenshot') : null"), true)
   assert.equal(source.includes("!remoteMode ? DEVELOPER_TOGGLE_KEYS.map"), true)
   assert.equal(source.includes("!remoteMode ? TEXT_KEYS.map"), true)

--- a/tests/depth-tier.test.js
+++ b/tests/depth-tier.test.js
@@ -168,7 +168,7 @@ test('index.js integration: deep quota consumed only after evidence', () => {
   assert.equal(index.includes('state.followupCompleted = true'), true)
 })
 
-test('client.js integration: custom depth lives in the canonical editor shared by both entry points', () => {
+test('client.js integration: custom depth lives in the canonical Settings editor', () => {
   const client = readFileSync(new URL('../lib/client.js', import.meta.url), 'utf8')
   const prelude = readFileSync(new URL('../lib/live-model-client-prelude.js', import.meta.url), 'utf8')
   assert.equal(client.includes("const SELECT_KEYS = ['visionDepth']"), true)
@@ -183,7 +183,4 @@ test('client.js integration: custom depth lives in the canonical editor shared b
   assert.equal(prelude.includes('标准档仍固定最多 2 次'), true)
   assert.equal(prelude.includes('blank or 0 = unlimited'), true)
   assert.equal(prelude.includes('Standard remains capped at 2'), true)
-  // 两个入口只有一份编辑器：插件入口跳转到设置 → Vision Router。
-  assert.equal(client.includes("legacyMovedBody: '主设置入口现在位于「设置 → Vision Router」。此处仅保留兼容入口，不再维护第二份可编辑表单。'"), true)
-  assert.equal(client.includes("legacyOpen: '打开 Vision Router 设置'"), true)
 })

--- a/tests/rc6-rc7-compat.test.js
+++ b/tests/rc6-rc7-compat.test.js
@@ -168,12 +168,12 @@ test('attachment compatibility follows the batch-attachment seam', () => {
   assert.equal(installs, 1)
 })
 
-test('settings card registration is a structural superset of rc6 list and newer keyed slots', async () => {
+test('settings compatibility keeps the first-class section without requiring a legacy plugin card', async () => {
   const source = await readFile(new URL('../lib/client.js', import.meta.url), 'utf8')
-  const block = source.match(/name: 'settings\.plugin\.item',[\s\S]{0,320}VisionRouterLegacyEntry/)
-  assert.ok(block, 'settings.plugin.item registration must exist')
-  assert.match(block[0], /key: 'vision-router'/)
-  assert.match(block[0], /id: 'vision-router'/)
+  assert.match(source, /name: 'settings\.section'/)
+  assert.match(source, /id: 'vision-router'/)
+  assert.doesNotMatch(source, /name: 'settings\.plugin\.item'/)
+  assert.doesNotMatch(source, /VisionRouterLegacyEntry/)
 })
 
 test('manifest keeps the minimum rc6 host peers while admitting the rc1 host line', async () => {

--- a/tests/settings-section-order.test.js
+++ b/tests/settings-section-order.test.js
@@ -125,28 +125,6 @@ test('settings order wrapper does not rewrite other plugin section registrations
   assert.equal(registeredOptions.order, 12)
 })
 
-test('legacy Settings > Plugins compatibility entry is no longer registered', () => {
-  const { registeredOptions } = runPreludeRegistration([], {
-    name: 'settings.plugin.item',
-    key: 'vision-router',
-    id: 'vision-router',
-    order: 30,
-  })
-
-  assert.equal(registeredOptions, undefined)
-})
-
-test('legacy-entry filter does not suppress another plugin item', () => {
-  const { registeredOptions } = runPreludeRegistration([], {
-    name: 'settings.plugin.item',
-    key: 'another-plugin',
-    id: 'another-plugin',
-    order: 30,
-  })
-
-  assert.equal(registeredOptions.id, 'another-plugin')
-})
-
 test('client copy tells users to configure models in DSH before choosing a vision chain', () => {
   const { registeredDictionaries } = runPreludeRegistration()
 


### PR DESCRIPTION
## What this follow-up closes

PR #349 fixed the alpha.1 queue → live Settings decorator loss. This follow-up closes the remaining product/lifecycle gaps:

- remove the historical `settings.plugin.item#vision-router` surface from DVR production source, copy, and DVR-specific test contracts instead of suppressing it at runtime;
- keep `settings.section#vision-router` as the single canonical Vision Router Settings entry;
- add a real `lib/client.js` alpha browser lifecycle gate instead of another synthetic factory-only check;
- exercise queue → `ClientModuleSystem.create()` → live → real DVR client factory → `plugin.apply(ctx)` → final slot ledger;
- verify the final Settings IA root and `#vr-vision-backend-chain`, v2 Settings integration target, numeric bounds/step enhancement, diagnostics enhancement, alpha `remote.session.modelCatalog()` compatibility, credential event mapping, ImageGallery presentation boundary, and stock-selector wrapper visibility;
- run the real browser gate against exact DSH `0.1.2-alpha.1` source on Ubuntu, macOS, and Windows;
- preserve rc6/rc7/current Host contracts and generic keyed-slot compatibility without requiring DVR to keep the removed legacy UI entry.

## Source-level cleanup

`lib/client.js` no longer contains the legacy Vision Router plugin-settings component, registration, inject object, or migration-only copy. The onboarding guide now has one canonical destination: `Settings → Vision Router`.

## Regression coverage

The new lifecycle integration test asserts that the final browser slot ledger contains exactly one `settings.section#vision-router` and no DVR `settings.plugin.item#vision-router`, while also checking the client compatibility boundaries above. Existing client tests own explicit source-level absence checks so the removed legacy entry cannot silently return.

No routing/core/attachment/model-catalog implementation is being rewritten.