### PR TITLE
fix(vision): decouple depth strategy from optional call caps

### DIFF
--- a/lib/depth-guidance.js
+++ b/lib/depth-guidance.js
@@ -22,6 +22,11 @@ export function runWithDepthConfig(config, execute) {
   return DEPTH_RUNTIME_CONTEXT.run(value, execute)
 }
 
+export function currentDepthRuntimeLocale() {
+  const value = DEPTH_RUNTIME_CONTEXT.getStore()?.__visionRouterLocale
+  return typeof value === 'string' && value.trim() !== '' ? value : undefined
+}
+
 function strategyDepth(depth) {
   const runtime = DEPTH_RUNTIME_CONTEXT.getStore()
   const candidate = runtime?.visionDepth ?? depth
@@ -103,7 +108,7 @@ const DEPTH_COPY = Object.freeze({
 })
 
 function languageFor(locale) {
-  return runtimeLanguageFor(locale, 'zh')
+  return runtimeLanguageFor(locale ?? currentDepthRuntimeLocale(), 'zh')
 }
 
 /**
@@ -115,7 +120,7 @@ export function depthLimitFor(_depth, maxCalls) {
 }
 
 /** Strategy guidance plus an optional, separately configured call-cap note. */
-export function depthCopyFor(depth, maxCalls, locale = 'zh') {
+export function depthCopyFor(depth, maxCalls, locale) {
   const language = languageFor(locale)
   const strategy = strategyDepth(depth)
   const strategyCopy = DEPTH_COPY[language][strategy] || DEPTH_COPY[language].standard
@@ -141,12 +146,12 @@ function resolveGuidance(kind, overrides, table, fallback = '') {
 }
 
 /** 场景引导：按 visual_kind 查表（覆盖优先）；无则空串（不硬套）。 */
-export function sceneGuidanceFor(visualKind, overrides, locale = 'zh') {
+export function sceneGuidanceFor(visualKind, overrides, locale) {
   return resolveGuidance(visualKind, overrides, SCENE_GUIDANCE[languageFor(locale)])
 }
 
 /** 内容引导：按 content_kind 大类查表（覆盖优先）；无则空串。 */
-export function contentGuidanceFor(contentKind, overrides, locale = 'zh') {
+export function contentGuidanceFor(contentKind, overrides, locale) {
   return resolveGuidance(contentKind, overrides, CONTENT_GUIDANCE[languageFor(locale)])
 }
 
@@ -154,9 +159,9 @@ export function contentGuidanceFor(contentKind, overrides, locale = 'zh') {
  * 拼接一条完整的深挖引导（场景/内容 + 策略 + 可选独立调用上限）。
  * general 时用 content_kind 内容引导（精确方向）；content_kind 未知 → 通用兜底句。
  * guidanceOverrides：可配置的引导覆盖表（默认 undefined = 内置表）。
- * locale：宿主 locale.preference；缺失时保留历史 zh 默认。
+ * locale：显式传入优先；否则跟随当前 Host runtime locale；缺失时保留历史 zh 默认。
  */
-export function renderDepthGuidance({ visualKind, contentKind, depth, guidanceOverrides, customMax, maxCalls, locale = 'zh' } = {}) {
+export function renderDepthGuidance({ visualKind, contentKind, depth, guidanceOverrides, customMax, maxCalls, locale } = {}) {
   const language = languageFor(locale)
   const callCap = maxCalls === undefined ? customMax : maxCalls
   const depthCopy = depthCopyFor(depth, callCap, language)

--- a/lib/depth-guidance.js
+++ b/lib/depth-guidance.js
@@ -3,43 +3,43 @@ import { runtimeLanguageFor } from './runtime-i18n.js'
 
 // 看图深度与场景引导（depth-guidance）。
 //
-// 移植自 dsh-vision 的「模板 + 路由」两层结构（prompts.py / vision_client.py）：
-// - 模板层：按大类各写一条引导（zoom_* 的等价物），彼此独立、无组合
-// - 档位层：fast/standard/deep/custom 只决定"深挖多少"（步骤/上限），不参与提示词组合
-// 因此这里是"模板集合"而非"提示词矩阵"——工作量 = 引导表 + 拼接函数。
+// 深度档位只决定模型如何查证，不再隐式决定调用次数：
+// - fast：整体优先，减少不必要的重复识别；
+// - standard：围绕用户问题按需查证；
+// - deep：主动做局部检查与交叉验证。
 //
-// 拼接规则（运行时）：
-//   guidance = 场景引导（按 visual_kind 查表）
-//            + general 时内容引导（按内容大类查表，纯提示词兜底）
-//            + 档位句（fast 附"档位不足"提示，搬 dsh-vision 回答节思想）
-// 语言模型的追问 question 由模型自己生成（现状已自由），本模块不生成。
+// 调用次数是独立的可选安全阀：visionDepthMaxCalls=0/空值表示不限，
+// 1-100 表示本轮成功深挖证据调用的硬上限。bootstrap 预识别不计入。
+// 旧配置 visionDepth=custom 继续兼容，按 standard 引导解释；正数
+// visionDepthMaxCalls 仍会作为独立次数上限生效。
 
 const MAX_OVERRIDE_CHARS = 2000
 const DEPTH_RUNTIME_CONTEXT = new AsyncLocalStorage()
 
-// index.js predates the custom tier and still normalizes an unknown depth to
-// standard before it calls the helpers below. Keep the public core untouched:
-// the entry-layer structured guard exposes the live settings through this
-// async-local scope, so both the old inner quota and the outer hardening guard
-// see one authoritative fast=1 / standard=2 / deep=4 / custom=N policy.
 export function runWithDepthConfig(config, execute) {
   if (typeof execute !== 'function') return undefined
   const value = config && typeof config === 'object' ? config : {}
   return DEPTH_RUNTIME_CONTEXT.run(value, execute)
 }
 
-function activeDepth(depth, customMax) {
+function strategyDepth(depth) {
   const runtime = DEPTH_RUNTIME_CONTEXT.getStore()
-  if (runtime && runtime.visionDepth === 'custom') {
-    return { depth: 'custom', customMax: runtime.visionDepthMaxCalls }
-  }
-  return { depth, customMax }
+  const candidate = runtime?.visionDepth ?? depth
+  return candidate === 'fast' || candidate === 'deep' ? candidate : 'standard'
 }
 
-function normalizeCustomMax(value) {
+function normalizeMaxCalls(value) {
   const number = Number(value)
-  if (!Number.isFinite(number) || number <= 0) return 0
+  if (!Number.isFinite(number) || number <= 0) return undefined
   return Math.min(100, Math.max(1, Math.floor(number)))
+}
+
+function effectiveMaxCalls(explicit) {
+  const runtime = DEPTH_RUNTIME_CONTEXT.getStore()
+  if (runtime && Object.prototype.hasOwnProperty.call(runtime, 'visionDepthMaxCalls')) {
+    return normalizeMaxCalls(runtime.visionDepthMaxCalls)
+  }
+  return normalizeMaxCalls(explicit)
 }
 
 const SCENE_GUIDANCE = Object.freeze({
@@ -91,14 +91,14 @@ const GENERAL_FALLBACK_GUIDANCE = Object.freeze({
 
 const DEPTH_COPY = Object.freeze({
   zh: Object.freeze({
-    fast: '本轮深度档位为 fast：仅做初步判断 + 1 次深挖即可；若你的问题需要深度定向识别，请告知用户升级档位。',
-    standard: '本轮深度档位为 standard：深挖 1-2 次即可；第 2 次之后会停止新的证据调用。',
-    deep: '本轮深度档位为 deep：可做 2-4 次充分深挖（定位→裁剪→比对→OCR 等）后再作答。',
+    fast: '本轮看图策略为快速：先做整体判断，优先使用已有视觉基线；只有关键证据不确定，或用户明确要求精确定位/逐字信息时，再调用必要的视觉工具。避免重复泛化识别。',
+    standard: '本轮看图策略为标准：围绕用户问题按需查证关键区域；需要时使用定位、裁剪、OCR、比对等工具补充或验证证据。证据充分后直接作答，不必为了流程继续调用。',
+    deep: '本轮看图策略为细致：主动检查关键局部并做交叉验证；对重要文字、位置、细节或差异，按需组合定位、裁剪、OCR、比对等工具，重要结论尽量由独立证据相互印证后再作答。',
   }),
   en: Object.freeze({
-    fast: 'Vision depth is fast for this turn: make the initial judgment plus at most 1 deep-evidence call. If the question needs deeper targeted inspection, tell the user to raise the depth tier.',
-    standard: 'Vision depth is standard for this turn: use 1-2 deep-evidence calls as needed; no new evidence calls are allowed after the second.',
-    deep: 'Vision depth is deep for this turn: use 2-4 evidence calls as needed (for example grounding → crop → comparison → OCR) before answering.',
+    fast: 'Vision strategy is Quick for this turn: start from the whole-image judgment and reuse the existing visual baseline. Call an additional vision tool only when key evidence is uncertain or the user explicitly needs precise localization or verbatim text. Avoid repeating generic recognition.',
+    standard: "Vision strategy is Standard for this turn: verify the key regions required by the user's question as needed. Use grounding, cropping, OCR, comparison, or other tools when they can add or verify evidence. Answer once the evidence is sufficient; do not keep calling tools just to satisfy a workflow.",
+    deep: 'Vision strategy is Thorough for this turn: proactively inspect important regions and cross-check key claims. Combine grounding, cropping, OCR, comparison, and other precision tools as needed for important text, positions, details, or differences, and prefer independent evidence to corroborate important conclusions before answering.',
   }),
 })
 
@@ -107,37 +107,24 @@ function languageFor(locale) {
 }
 
 /**
- * 深度硬上限：fast=1、standard=2、deep=4。bootstrap 那 1 遍不计入。
- * custom=N（1-100）时 N 是本轮成功深挖调用的硬上限；custom=0/空值
- * 表示不设置次数上限。保存过的 custom 数值在切回内置档位后保留但不生效。
+ * Optional independent call cap. The depth strategy never supplies a cap.
+ * The depth parameter is retained for API/backward compatibility.
  */
-export function depthLimitFor(depth, customMax) {
-  const active = activeDepth(depth, customMax)
-  if (active.depth === 'custom') {
-    const custom = normalizeCustomMax(active.customMax)
-    return custom > 0 ? custom : undefined
-  }
-  if (active.depth === 'fast') return 1
-  if (active.depth === 'deep') return 4
-  return 2
+export function depthLimitFor(_depth, maxCalls) {
+  return effectiveMaxCalls(maxCalls)
 }
 
-/** 档位句，与 depthLimitFor 的实际硬限制保持一致。 */
-export function depthCopyFor(depth, customMax, locale = 'zh') {
-  const active = activeDepth(depth, customMax)
+/** Strategy guidance plus an optional, separately configured call-cap note. */
+export function depthCopyFor(depth, maxCalls, locale = 'zh') {
   const language = languageFor(locale)
-  if (active.depth === 'custom') {
-    const custom = normalizeCustomMax(active.customMax)
-    if (language === 'en') {
-      return custom > 0
-        ? `Vision depth has a custom limit of ${custom} deep-evidence calls for this turn; once reached, answer from the evidence already collected.`
-        : 'Vision depth is custom with no call-count limit for this turn; continue calling vision tools only when they can add or verify evidence.'
-    }
-    return custom > 0
-      ? `本轮已自定义深挖上限为 ${custom} 次；达到上限后请基于已有证据作答。`
-      : '本轮已选择自定义深挖：不设置次数上限；请只在能新增或验证证据时继续调用视觉工具。'
-  }
-  return DEPTH_COPY[language][active.depth === 'fast' || active.depth === 'deep' ? active.depth : 'standard'] || ''
+  const strategy = strategyDepth(depth)
+  const strategyCopy = DEPTH_COPY[language][strategy] || DEPTH_COPY[language].standard
+  const cap = effectiveMaxCalls(maxCalls)
+  if (cap === undefined) return strategyCopy
+  const capCopy = language === 'en'
+    ? `A separate deep-dive call cap is enabled for this turn: at most ${cap} successful evidence calls. The bootstrap pre-scan does not count, and failed or empty-evidence calls do not consume the cap.`
+    : `本轮另启用了深挖次数上限：最多 ${cap} 次成功证据调用；bootstrap 预识别不计入，失败或空证据调用不占次数。`
+  return `${strategyCopy}${capCopy}`
 }
 
 /** 查表：覆盖表（guidanceOverrides）优先，其次内置表，最后 fallback。 */
@@ -158,21 +145,21 @@ export function sceneGuidanceFor(visualKind, overrides, locale = 'zh') {
   return resolveGuidance(visualKind, overrides, SCENE_GUIDANCE[languageFor(locale)])
 }
 
-/** 内容引导：按内容大类查表（覆盖优先）；无则空串。 */
+/** 内容引导：按 content_kind 大类查表（覆盖优先）；无则空串。 */
 export function contentGuidanceFor(contentKind, overrides, locale = 'zh') {
   return resolveGuidance(contentKind, overrides, CONTENT_GUIDANCE[languageFor(locale)])
 }
 
 /**
- * 拼接一条完整的深挖引导（场景/内容 + 档位）。
+ * 拼接一条完整的深挖引导（场景/内容 + 策略 + 可选独立调用上限）。
  * general 时用 content_kind 内容引导（精确方向）；content_kind 未知 → 通用兜底句。
  * guidanceOverrides：可配置的引导覆盖表（默认 undefined = 内置表）。
  * locale：宿主 locale.preference；缺失时保留历史 zh 默认。
- * @returns {string} 空串表示无引导（放行）
  */
-export function renderDepthGuidance({ visualKind, contentKind, depth, guidanceOverrides, customMax, locale = 'zh' } = {}) {
+export function renderDepthGuidance({ visualKind, contentKind, depth, guidanceOverrides, customMax, maxCalls, locale = 'zh' } = {}) {
   const language = languageFor(locale)
-  const depthCopy = depthCopyFor(depth, customMax, language)
+  const callCap = maxCalls === undefined ? customMax : maxCalls
+  const depthCopy = depthCopyFor(depth, callCap, language)
   if (!depthCopy) return ''
   const scene = sceneGuidanceFor(visualKind, guidanceOverrides, language)
   const content = contentGuidanceFor(contentKind, guidanceOverrides, language)

--- a/lib/mixed-router.js
+++ b/lib/mixed-router.js
@@ -1,3 +1,4 @@
+import { currentDepthRuntimeLocale } from './depth-guidance.js'
 import { runtimeLanguageFor } from './runtime-i18n.js'
 
 // 场景级识图路由层 · mixed 分路识别（mixed-router）。
@@ -43,7 +44,7 @@ const KIND_PRIORITY = ['ui', 'document', 'code', 'table', 'chat', 'general']
 const MIXABLE_KINDS = new Set(['document', 'ui', 'code', 'chat', 'general'])
 
 function languageFor(locale) {
-  return runtimeLanguageFor(locale, 'zh')
+  return runtimeLanguageFor(locale ?? currentDepthRuntimeLocale(), 'zh')
 }
 
 export function normalizeMixedOf(mixedOf) {
@@ -67,7 +68,7 @@ export function normalizeMixedOf(mixedOf) {
 }
 
 /** 分支引导：(kind,sub) 精确 → (kind,'') → _default。 */
-export function mixedGuidance(kind, sub = '', locale = 'zh') {
+export function mixedGuidance(kind, sub = '', locale) {
   const table = BRANCH_GUIDANCE[languageFor(locale)]
   const exact = table.get(`${kind}:${sub}`)
   if (exact !== undefined) return exact
@@ -75,7 +76,7 @@ export function mixedGuidance(kind, sub = '', locale = 'zh') {
   return fallback !== undefined ? fallback : table.get('_default')
 }
 
-export function buildMixedBranches(mainKind, secondaryKinds = [], locale = 'zh') {
+export function buildMixedBranches(mainKind, secondaryKinds = [], locale) {
   const seen = new Set([mainKind])
   const out = [{ kind: mainKind, sub: '', guidance: mixedGuidance(mainKind, '', locale) }]
   for (const kind of secondaryKinds) {
@@ -87,7 +88,7 @@ export function buildMixedBranches(mainKind, secondaryKinds = [], locale = 'zh')
   return out
 }
 
-export function planMixedBranches(evidence, locale = 'zh') {
+export function planMixedBranches(evidence, locale) {
   const language = languageFor(locale)
   if (!evidence || typeof evidence !== 'object') {
     return {
@@ -124,7 +125,7 @@ export function planMixedBranches(evidence, locale = 'zh') {
  * Generate mixed-content follow-up guidance. Depth strategy does not change
  * branch coverage; every planned branch remains visible to the model.
  */
-export function renderMixedGuidance(plan, _depth, locale = 'zh') {
+export function renderMixedGuidance(plan, _depth, locale) {
   if (!plan || plan.fallback || plan.branches.length === 0) return undefined
   const language = languageFor(locale)
   const branches = plan.branches

--- a/lib/mixed-router.js
+++ b/lib/mixed-router.js
@@ -4,11 +4,10 @@ import { runtimeLanguageFor } from './runtime-i18n.js'
 //
 // 定位：**精度优化**（不是成本优化）。
 //
-// bootstrap 判定 visual_kind=mixed 后，1.5.3 没有任何后续处理——模型自由深挖
-// 可能漏判另一半内容、选错识别方式（§4.6 缺陷实证：第一遍只知道"这是混合的"，
-// 不知道"哪几种类型 + 各在哪些区域"）。本模块把混合内容拆分为 ≤2 个分支，各
-// 分支独立软引导识别方式，避免漏判/错判，**提升混合图的识别精度**；成本影响是
-// 副产品（MAX_MIXED_BRANCHES=2 封顶，混合图 ≤2 次视觉调用）。
+// bootstrap 判定 visual_kind=mixed 后，将混合内容拆为 ≤2 个分支，各分支独立
+// 软引导识别方式，避免漏判/错判。深度档位现在只决定查证策略，不再通过
+// fast/standard/deep 改写分支数或限制调用次数；调用次数若需要限制，由独立的
+// visionDepthMaxCalls 安全阀负责。
 
 export const MAX_MIXED_BRANCHES = 2
 
@@ -116,36 +115,28 @@ export function planMixedBranches(evidence, locale = 'zh') {
     branches: buildMixedBranches(kinds[0], kinds.slice(1), language),
     fallback: false,
     note: language === 'en'
-      ? `Mixed-content branch routing: precision optimization to avoid missing or misclassifying the other content type; ≤${MAX_MIXED_BRANCHES} branches, one recognition call per branch, with bounded cost.`
-      : `mixed 分路识别：**精度优化**（避免漏判/错判另一半内容）；≤${MAX_MIXED_BRANCHES} 分支，每分支一次识别调用，成本封顶`,
+      ? `Mixed-content branch routing: precision optimization to avoid missing or misclassifying another content type; at most ${MAX_MIXED_BRANCHES} branches.`
+      : `mixed 分路识别：**精度优化**（避免漏判/错判另一半内容）；最多 ${MAX_MIXED_BRANCHES} 个分支。`,
   }
 }
 
 /**
- * Generate the mixed-content follow-up guidance. fast uses only the primary
- * branch so its copy remains consistent with depthLimitFor('fast')=1.
+ * Generate mixed-content follow-up guidance. Depth strategy does not change
+ * branch coverage; every planned branch remains visible to the model.
  */
-export function renderMixedGuidance(plan, depth, locale = 'zh') {
+export function renderMixedGuidance(plan, _depth, locale = 'zh') {
   if (!plan || plan.fallback || plan.branches.length === 0) return undefined
   const language = languageFor(locale)
-  const fast = depth === 'fast'
-  const branches = fast ? plan.branches.slice(0, 1) : plan.branches
+  const branches = plan.branches
   const lines = branches.map((branch) => {
     const guidance = mixedGuidance(branch.kind, branch.sub, language)
     return language === 'en'
       ? `- ${branch.kind}${branch.sub ? `.${branch.sub}` : ''}: ${guidance}`
       : `- ${branch.kind}${branch.sub ? `.${branch.sub}` : ''}：${guidance}`
   })
-  const kinds = plan.branches.map((branch) => branch.kind).join(' + ')
-  let header
-  if (language === 'en') {
-    header = fast
-      ? `Mixed content detected (${kinds}). Vision depth is fast for this turn: verify the primary branch (${branches[0].kind}) once; raise the depth tier for full branch-by-branch verification.`
-      : `Mixed content detected (${kinds}). To avoid omissions or misclassification, verify each branch separately with at least one recognition call before answering; do not reuse one branch's recognition method blindly for another branch.`
-  } else {
-    header = fast
-      ? `检测到混合内容（${kinds}）。本轮深度档位为 fast：先验证主分支（${branches[0].kind}）一次；完整分路验证需升级档位。`
-      : `检测到混合内容（${kinds}）。为避免漏判/错判（精度优化），请按分支分别验证，各分支至少一次识别调用后再作答；分支之间不要混用识别方式。`
-  }
+  const kinds = branches.map((branch) => branch.kind).join(' + ')
+  const header = language === 'en'
+    ? `Mixed content detected (${kinds}). To avoid omissions or misclassification, verify each branch separately as needed before answering; do not reuse one branch's recognition method blindly for another branch.`
+    : `检测到混合内容（${kinds}）。为避免漏判/错判（精度优化），请按需分别验证各分支后再作答；分支之间不要盲目混用识别方式。`
   return `${header}\n${lines.join('\n')}`
 }

--- a/lib/structured-flow-hardening.js
+++ b/lib/structured-flow-hardening.js
@@ -128,6 +128,17 @@ function depthOf(config) {
     : 'standard'
 }
 
+function hostLocalePreference(ctx) {
+  try {
+    const settings = ctx?.get?.('settings')
+    const locale = settings?.get?.('locale')
+    const preference = locale && typeof locale === 'object' ? locale.preference : undefined
+    return typeof preference === 'string' && preference.trim() !== '' ? preference.trim() : undefined
+  } catch {
+    return undefined
+  }
+}
+
 /**
  * Clamp the core's own timeout settings to the remaining optional structured-
  * turn deadline. When the whole-turn budget is disabled (the default), there
@@ -541,7 +552,9 @@ export function installStructuredFlowHardening(ctx, config = {}) {
   const activeConfig = () => {
     try {
       const value = settingsScope && typeof settingsScope.get === 'function' ? settingsScope.get() : config
-      return value && typeof value === 'object' ? value : config
+      const base = value && typeof value === 'object' ? value : config
+      const locale = hostLocalePreference(ctx)
+      return locale === undefined ? base : { ...base, __visionRouterLocale: locale }
     } catch {
       return config
     }

--- a/lib/structured-flow-hardening.js
+++ b/lib/structured-flow-hardening.js
@@ -502,7 +502,12 @@ function wrapRegisteredTool(def, states, getConfig) {
         const code = resultCode(result)
         if (code === 'VISION_DEPTH_LIMIT') state.depthExhausted = true
         if (code === 'VISION_TURN_BUDGET_EXCEEDED') state.budgetExhausted = true
-        if (producedStructuredEvidence(result)) recordEvidenceSuccess(state, def.name)
+        if (producedStructuredEvidence(result)) {
+          recordEvidenceSuccess(state, def.name)
+          if (limit !== undefined && state.successfulEvidenceCalls >= limit) {
+            state.depthExhausted = true
+          }
+        }
         return result
       })
     },

--- a/lib/structured-flow-hardening.js
+++ b/lib/structured-flow-hardening.js
@@ -312,6 +312,14 @@ function appendSyntheticGuardOnce(decision, baseMessages, state, message, stripE
   }
 }
 
+function rearmEvidenceGuardAfterAttempt(state) {
+  const mixedPrefix = `vision-router-structured-mixed-guard-${state.turn}-`
+  const evidenceId = `vision-router-structured-evidence-guard-${state.turn}`
+  for (const id of state.emittedGuardIds) {
+    if (id === evidenceId || id.startsWith(mixedPrefix)) state.emittedGuardIds.delete(id)
+  }
+}
+
 function mixedReminder(state, config) {
   const language = languageOf(config)
   const overrides = normalizeGuidanceOverrides(config?.guidanceOverrides)
@@ -514,6 +522,11 @@ function wrapRegisteredTool(def, states, getConfig) {
         if (producedStructuredEvidence(result)) {
           recordEvidenceSuccess(state, def.name)
           refreshDepthExhaustion(state, active)
+        } else if (code !== 'VISION_TURN_BUDGET_EXCEEDED') {
+          // A real evidence attempt happened, but it did not add usable evidence.
+          // Re-arm the current reminder so the next pre-step can restate the
+          // unfinished branch without allowing repeated no-op pre-steps to spam it.
+          rearmEvidenceGuardAfterAttempt(state)
         }
         return result
       })

--- a/lib/structured-flow-hardening.js
+++ b/lib/structured-flow-hardening.js
@@ -103,6 +103,12 @@ export function structuredDepthLimit(_depth, maxCalls) {
   return Math.min(100, Math.max(1, Math.floor(value)))
 }
 
+function refreshDepthExhaustion(state, config) {
+  const limit = structuredDepthLimit(depthOf(config), config?.visionDepthMaxCalls)
+  state.depthExhausted = limit !== undefined && state.successfulEvidenceCalls >= limit
+  return limit
+}
+
 export function normalizeGuidanceOverrides(value) {
   if (!Array.isArray(value)) return []
   const byKind = new Map()
@@ -275,10 +281,15 @@ function hasCoreFollowup(messages) {
   )
 }
 
-function withoutCoreFollowup(messages) {
-  return (messages ?? []).filter(
-    (message) => !(message && typeof message.id === 'string' && message.id.includes('vision-router-structured-followup-')),
-  )
+function withoutEvidenceFollowups(messages) {
+  return (messages ?? []).filter((message) => {
+    const id = message && typeof message.id === 'string' ? message.id : ''
+    return !(
+      id.includes('vision-router-structured-followup-') ||
+      id.includes('vision-router-structured-mixed-guard-') ||
+      id.includes('vision-router-structured-evidence-guard-')
+    )
+  })
 }
 
 function hasMessageId(messages, id) {
@@ -287,12 +298,12 @@ function hasMessageId(messages, id) {
   )
 }
 
-function appendSyntheticGuardOnce(decision, baseMessages, state, message, stripCoreFollowup = false) {
-  const messages = stripCoreFollowup ? withoutCoreFollowup(baseMessages) : baseMessages
+function appendSyntheticGuardOnce(decision, baseMessages, state, message, stripEvidenceFollowups = false) {
+  const messages = stripEvidenceFollowups ? withoutEvidenceFollowups(baseMessages) : baseMessages
   const id = message?.id
   if (typeof id === 'string' && (state.emittedGuardIds.has(id) || hasMessageId(messages, id))) {
     state.emittedGuardIds.add(id)
-    return stripCoreFollowup ? { ...decision, messages } : decision
+    return stripEvidenceFollowups ? { ...decision, messages } : decision
   }
   if (typeof id === 'string') state.emittedGuardIds.add(id)
   return {
@@ -487,9 +498,8 @@ function wrapRegisteredTool(def, states, getConfig) {
         }
 
         const active = getConfig()
-        const limit = structuredDepthLimit(depthOf(active), active?.visionDepthMaxCalls)
-        if (limit !== undefined && state.successfulEvidenceCalls >= limit) {
-          state.depthExhausted = true
+        const limit = refreshDepthExhaustion(state, active)
+        if (state.depthExhausted) {
           return failure('VISION_DEPTH_LIMIT', `the configured deep-dive call cap allows at most ${limit} successful evidence call(s) in this turn`)
         }
 
@@ -500,13 +510,10 @@ function wrapRegisteredTool(def, states, getConfig) {
           active,
         )
         const code = resultCode(result)
-        if (code === 'VISION_DEPTH_LIMIT') state.depthExhausted = true
         if (code === 'VISION_TURN_BUDGET_EXCEEDED') state.budgetExhausted = true
         if (producedStructuredEvidence(result)) {
           recordEvidenceSuccess(state, def.name)
-          if (limit !== undefined && state.successfulEvidenceCalls >= limit) {
-            state.depthExhausted = true
-          }
+          refreshDepthExhaustion(state, active)
         }
         return result
       })
@@ -633,8 +640,12 @@ export function installStructuredFlowHardening(ctx, config = {}) {
             return runWithDepthConfig(current, async () => {
               const state = session ? ensureState(states, session, payload?.turn, current) : undefined
               const decision = await handler.call(this, payload, next)
-              if (state && budgetExceeded(state)) state.budgetExhausted = true
-              return state ? appendGuardMessage(decision, payload, state, activeConfig()) : decision
+              const latest = activeConfig()
+              if (state) {
+                if (budgetExceeded(state)) state.budgetExhausted = true
+                refreshDepthExhaustion(state, latest)
+              }
+              return state ? appendGuardMessage(decision, payload, state, latest) : decision
             })
           }, ...rest)
         }

--- a/lib/structured-flow-hardening.js
+++ b/lib/structured-flow-hardening.js
@@ -3,6 +3,7 @@ import {
   runWithVisionTurnBudget,
 } from './turn-budget-context.js'
 import { runWithDepthConfig } from './depth-guidance.js'
+import { runtimeLanguageFor } from './runtime-i18n.js'
 
 const STRUCTURED_EVIDENCE_TOOLS = new Set([
   'vision_describe',
@@ -37,11 +38,22 @@ const GUIDANCE_KINDS = new Set([
 ])
 
 const BUILTIN_MIXED_GUIDANCE = {
-  document: '语义优先；只有逐字引用、合同/表单字段或表格数字确需保真时才使用 OCR。',
-  ui: '优先用 vision_detect / vision_ground 验证元素、状态与位置。',
-  code: '逐字核对代码；对可执行字符、缩进和符号做交叉验证。',
-  chat: '按气泡顺序核对发言者、消息内容与时间/状态信息。',
-  general: '聚焦尚未归类的另一部分可见内容，自行选择最能新增证据的视觉工具。',
+  zh: {
+    document: '语义优先；只有逐字引用、合同/表单字段或表格数字确需保真时才使用 OCR。',
+    ui: '优先用 vision_detect / vision_ground 验证元素、状态与位置。',
+    code: '逐字核对代码；对可执行字符、缩进和符号做交叉验证。',
+    chat: '按气泡顺序核对发言者、消息内容与时间/状态信息。',
+    general: '聚焦尚未归类的另一部分可见内容，自行选择最能新增证据的视觉工具。',
+    fallback: '聚焦这个分支新增或验证可见证据。',
+  },
+  en: {
+    document: 'Prioritize semantics; use OCR only when verbatim quotes, contract/form fields, or table numbers require exact transcription.',
+    ui: 'Prefer vision_detect / vision_ground to verify elements, states, and positions.',
+    code: 'Verify code verbatim; cross-check executable characters, indentation, and symbols.',
+    chat: 'Verify speakers, message text, and time/status information in bubble order.',
+    general: 'Focus on the remaining unclassified visible content and choose the vision tool that adds the most useful evidence.',
+    fallback: 'Add or verify visible evidence for this branch.',
+  },
 }
 
 function isObject(value) {
@@ -108,12 +120,17 @@ export function normalizeGuidanceOverrides(value) {
     .map(([kind, text]) => ({ kind, text }))
 }
 
-function guidanceFor(kind, overrides) {
+function languageOf(config) {
+  return runtimeLanguageFor(config?.__visionRouterLocale, 'zh')
+}
+
+function guidanceFor(kind, overrides, language = 'zh') {
   for (let i = overrides.length - 1; i >= 0; i--) {
     const entry = overrides[i]
     if (entry.kind === kind) return entry.text
   }
-  return BUILTIN_MIXED_GUIDANCE[kind] ?? '聚焦这个分支新增或验证可见证据。'
+  const copy = BUILTIN_MIXED_GUIDANCE[language] ?? BUILTIN_MIXED_GUIDANCE.zh
+  return copy[kind] ?? copy.fallback
 }
 
 function turnBudgetMs(config) {
@@ -285,10 +302,18 @@ function appendSyntheticGuardOnce(decision, baseMessages, state, message, stripC
 }
 
 function mixedReminder(state, config) {
+  const language = languageOf(config)
   const overrides = normalizeGuidanceOverrides(config?.guidanceOverrides)
   const pending = state.mixedBranches.filter((kind) => !state.completedBranches.has(kind))
   const done = state.mixedBranches.filter((kind) => state.completedBranches.has(kind))
-  const lines = pending.map((kind) => `- ${kind}：${guidanceFor(kind, overrides)}`)
+  const separator = language === 'en' ? ': ' : '：'
+  const lines = pending.map((kind) => `- ${kind}${separator}${guidanceFor(kind, overrides, language)}`)
+  if (language === 'en') {
+    const doneText = done.length > 0 ? `Verified branches: ${done.join(' + ')}. ` : ''
+    return `${doneText}This mixed image still has unverified branches: ${pending.join(' + ')}. ` +
+      'Focus each vision call on one unfinished branch; answer only after each branch has produced at least one useful piece of evidence.\n' +
+      lines.join('\n')
+  }
   const doneText = done.length > 0 ? `已验证分支：${done.join(' + ')}。` : ''
   return `${doneText}混合图片仍有未验证分支：${pending.join(' + ')}。` +
     '每次视觉调用只聚焦一个尚未完成的分支；这些分支分别产生至少一次有效证据后再作答。\n' +
@@ -302,6 +327,7 @@ function appendGuardMessage(decision, payload, state, config) {
     : Array.isArray(payload?.messages)
       ? payload.messages
       : []
+  const language = languageOf(config)
 
   if (state.budgetExhausted || state.depthExhausted) {
     const message = {
@@ -309,9 +335,13 @@ function appendGuardMessage(decision, payload, state, config) {
       id: `vision-router-structured-guard-stop-${state.turn}`,
       content: [{
         type: 'text',
-        text: state.budgetExhausted
-          ? '本轮视觉总时间预算已耗尽。不要再调用视觉工具；请基于已经获得的证据作答，并明确仍存在的不确定性。'
-          : '本轮识图深度配额已耗尽。不要再调用视觉工具；请基于已经获得的证据作答，并明确仍存在的不确定性。',
+        text: language === 'en'
+          ? state.budgetExhausted
+            ? 'The visual turn time budget is exhausted. Do not call more vision tools; answer from the evidence already collected and state any remaining uncertainty.'
+            : 'The configured deep-dive call cap has been reached. Do not call more vision tools; answer from the evidence already collected and state any remaining uncertainty.'
+          : state.budgetExhausted
+            ? '本轮视觉总时间预算已耗尽。不要再调用视觉工具；请基于已经获得的证据作答，并明确仍存在的不确定性。'
+            : '已达到本轮设置的深挖次数上限。不要再调用视觉工具；请基于已经获得的证据作答，并明确仍存在的不确定性。',
       }],
       source: { kind: 'plugin', plugin: 'dsh-vision-router' },
     }
@@ -336,7 +366,9 @@ function appendGuardMessage(decision, payload, state, config) {
     id: `vision-router-structured-evidence-guard-${state.turn}`,
     content: [{
       type: 'text',
-      text: '结构化预识别已经完成，但上一条后续工具没有产出可用证据。请再调用至少一个能新增或验证证据的视觉工具，成功后再作答。',
+      text: language === 'en'
+        ? 'The structured bootstrap is complete, but the previous follow-up tool did not produce usable evidence. Call at least one more vision tool that can add or verify evidence, then answer after it succeeds.'
+        : '结构化预识别已经完成，但上一条后续工具没有产出可用证据。请再调用至少一个能新增或验证证据的视觉工具，成功后再作答。',
     }],
     source: { kind: 'plugin', plugin: 'dsh-vision-router' },
   }

--- a/lib/structured-flow-hardening.js
+++ b/lib/structured-flow-hardening.js
@@ -81,15 +81,14 @@ export function producedStructuredEvidence(value) {
   return true
 }
 
-export function structuredDepthLimit(depth, customMax) {
-  if (depth === 'custom') {
-    const value = Number(customMax)
-    if (!Number.isFinite(value) || value <= 0) return undefined
-    return Math.min(100, Math.max(1, Math.floor(value)))
-  }
-  if (depth === 'fast') return 1
-  if (depth === 'deep') return 4
-  return 2
+/**
+ * The depth tier is guidance only. A hard call cap exists only when the user
+ * explicitly configures a positive visionDepthMaxCalls value.
+ */
+export function structuredDepthLimit(_depth, maxCalls) {
+  const value = Number(maxCalls)
+  if (!Number.isFinite(value) || value <= 0) return undefined
+  return Math.min(100, Math.max(1, Math.floor(value)))
 }
 
 export function normalizeGuidanceOverrides(value) {
@@ -208,15 +207,14 @@ function bootstrapEvidence(raw) {
   return parsed.evidence
 }
 
-function normalizeMixedBranches(evidence, depth) {
+function normalizeMixedBranches(evidence, _depth) {
   if (!isObject(evidence) || evidence.visual_kind !== 'mixed' || !Array.isArray(evidence.mixed_of)) return []
   const allowed = ['ui', 'document', 'code', 'chat', 'general']
   const unique = []
   for (const kind of allowed) {
     if (evidence.mixed_of.includes(kind)) unique.push(kind)
   }
-  const capped = unique.slice(0, 2)
-  return depth === 'fast' ? capped.slice(0, 1) : capped
+  return unique.slice(0, 2)
 }
 
 function inferBranchForTool(name, pending) {
@@ -449,7 +447,7 @@ function wrapRegisteredTool(def, states, getConfig) {
         const limit = structuredDepthLimit(depthOf(active), active?.visionDepthMaxCalls)
         if (limit !== undefined && state.successfulEvidenceCalls >= limit) {
           state.depthExhausted = true
-          return failure('VISION_DEPTH_LIMIT', `the ${depthOf(active)} depth tier allows at most ${limit} successful deep-dive call(s) in this turn`)
+          return failure('VISION_DEPTH_LIMIT', `the configured deep-dive call cap allows at most ${limit} successful evidence call(s) in this turn`)
         }
 
         const result = await runBudgetedTool(

--- a/lib/vision-turn-budget-client-prelude.js
+++ b/lib/vision-turn-budget-client-prelude.js
@@ -4,17 +4,34 @@ export const VISION_TURN_BUDGET_CLIENT_PRELUDE = String.raw`(function(){
   'use strict';
   var TARGET = 'dsh-vision-router';
   var SETTINGS_SECTION_ID = 'vision-router';
-  var FIELD = 'visionTurnBudgetMs';
-  var DEFAULT_MS = 0;
-  var MIN_MS = 10000;
-  var MAX_MS = 600000;
+  var TURN_BUDGET_FIELD = 'visionTurnBudgetMs';
+  var DEPTH_CAP_FIELD = 'visionDepthMaxCalls';
+  var DEPTH_FIELD = 'visionDepth';
+  var DEFAULT_TURN_BUDGET_MS = 0;
+  var MIN_TURN_BUDGET_MS = 10000;
+  var MAX_TURN_BUDGET_MS = 600000;
+  var DEFAULT_DEPTH_CAP = 4;
+  var MIN_DEPTH_CAP = 1;
+  var MAX_DEPTH_CAP = 100;
   var contexts = typeof WeakMap === 'function' ? new WeakMap() : undefined;
+  var strategyScopes = typeof WeakMap === 'function' ? new WeakMap() : undefined;
+  var reactWrappers = typeof WeakMap === 'function' ? new WeakMap() : undefined;
 
   function patchCopy(namespace, dictionaries) {
     if (namespace !== SETTINGS_SECTION_ID || !dictionaries || typeof dictionaries !== 'object') return dictionaries;
     var next = Object.assign({}, dictionaries);
     if (next.zh && typeof next.zh === 'object') {
       next.zh = Object.assign({}, next.zh, {
+        visionDepthFast: '快速（优先整体判断）',
+        visionDepthStandard: '标准（按需查证，默认）',
+        visionDepthDeep: '细致（主动交叉验证）',
+        hintVisionDepth: '看图深度只决定识图策略，不限制调用次数：快速优先整体判断，标准按问题需要查证，细致会主动做更多局部检查与交叉验证。如需限制调用次数，请启用下方「限制深挖次数」。',
+        depthCapTitle: '限制深挖次数',
+        depthCapHint: '默认关闭，不限制视觉证据调用次数。启用后可设置本轮最多允许多少次成功的深挖证据调用；bootstrap 预识别不计入，失败或空证据调用不占次数。',
+        depthCapValueLabel: '最多深挖次数',
+        depthCapInvalid: '请输入 1–100 之间的整数。',
+        depthCapSaved: '已保存',
+        depthCapSaveFailed: '保存失败',
         visionTurnBudgetTitle: '整轮视觉工具时间上限',
         visionTurnBudgetHint: '可选的整轮 Vision Router 视觉工具总时间上限。默认不限制；填 0 表示不限制。单次视觉任务仍受独立超时保护。',
         visionTurnBudgetInvalid: '请输入 0，或 10000–600000 之间的整数毫秒值。',
@@ -24,6 +41,16 @@ export const VISION_TURN_BUDGET_CLIENT_PRELUDE = String.raw`(function(){
     }
     if (next.en && typeof next.en === 'object') {
       next.en = Object.assign({}, next.en, {
+        visionDepthFast: 'Quick (overall-first)',
+        visionDepthStandard: 'Standard (evidence as needed, default)',
+        visionDepthDeep: 'Thorough (proactive cross-checking)',
+        hintVisionDepth: 'Vision depth chooses the inspection strategy, not a call-count limit: Quick stays overall-first, Standard verifies evidence as needed, and Thorough proactively inspects details and cross-checks important claims. To cap calls, enable “Limit deep-dive calls” below.',
+        depthCapTitle: 'Limit deep-dive calls',
+        depthCapHint: 'Off by default, so visual evidence calls are unlimited. Enable this to cap successful deep-evidence calls for the turn. The bootstrap pre-scan does not count, and failed or empty-evidence calls do not consume the cap.',
+        depthCapValueLabel: 'Maximum deep-dive calls',
+        depthCapInvalid: 'Enter an integer from 1 to 100.',
+        depthCapSaved: 'Saved',
+        depthCapSaveFailed: 'Save failed',
         visionTurnBudgetTitle: 'Whole-turn vision time limit',
         visionTurnBudgetHint: 'Optional total time limit for Vision Router visual tools across the turn. Unlimited by default; enter 0 for unlimited. Individual visual tasks still have their own timeout.',
         visionTurnBudgetInvalid: 'Enter 0, or an integer from 10000 to 600000 milliseconds.',
@@ -52,6 +79,184 @@ export const VISION_TURN_BUDGET_CLIENT_PRELUDE = String.raw`(function(){
     });
   }
 
+  function collectOptionValues(node, out) {
+    if (Array.isArray(node)) {
+      node.forEach(function(entry){ collectOptionValues(entry, out); });
+      return;
+    }
+    if (!node || typeof node !== 'object') return;
+    if (node.type === 'option' && node.props && typeof node.props.value === 'string') out.add(node.props.value);
+    if (node.props && node.props.children !== undefined) collectOptionValues(node.props.children, out);
+  }
+
+  function stripLegacyCustomOption(node) {
+    if (Array.isArray(node)) {
+      return node.map(stripLegacyCustomOption).filter(function(entry){ return entry !== null; });
+    }
+    if (!node || typeof node !== 'object') return node;
+    if (node.type === 'option' && node.props && node.props.value === 'custom') return null;
+    return node;
+  }
+
+  function wrapReact(React) {
+    if (!React || typeof React !== 'object' || typeof React.createElement !== 'function') return React;
+    if (reactWrappers && reactWrappers.has(React)) return reactWrappers.get(React);
+    var wrapped = new Proxy(React, {
+      get: function(target, property) {
+        if (property !== 'createElement') return Reflect.get(target, property, target);
+        return function(type, props) {
+          var args = Array.prototype.slice.call(arguments);
+          if (type === 'select' && args.length > 2) {
+            var values = new Set();
+            for (var i = 2; i < args.length; i++) collectOptionValues(args[i], values);
+            if (values.has('fast') && values.has('standard') && values.has('deep') && values.has('custom')) {
+              for (var j = 2; j < args.length; j++) args[j] = stripLegacyCustomOption(args[j]);
+            }
+          }
+          return target.createElement.apply(target, args);
+        };
+      }
+    });
+    if (reactWrappers) reactWrappers.set(React, wrapped);
+    return wrapped;
+  }
+
+  function projectStrategySnapshot(snapshot) {
+    if (!snapshot || typeof snapshot !== 'object' || !snapshot.value || typeof snapshot.value !== 'object') return snapshot;
+    if (snapshot.value[DEPTH_FIELD] !== 'custom') return snapshot;
+    return Object.assign({}, snapshot, {
+      value: Object.assign({}, snapshot.value, { visionDepth: 'standard' })
+    });
+  }
+
+  function strategyScope(scope) {
+    if (!scope || (typeof scope !== 'object' && typeof scope !== 'function')) return scope;
+    if (strategyScopes && strategyScopes.has(scope)) return strategyScopes.get(scope);
+    var wrapped = new Proxy(scope, {
+      get: function(target, property) {
+        if (property === 'getSnapshot') {
+          var getSnapshot = Reflect.get(target, property, target);
+          if (typeof getSnapshot !== 'function') return getSnapshot;
+          return function(){ return projectStrategySnapshot(getSnapshot.call(target)); };
+        }
+        var value = Reflect.get(target, property, target);
+        return typeof value === 'function' ? value.bind(target) : value;
+      }
+    });
+    if (strategyScopes) strategyScopes.set(scope, wrapped);
+    return wrapped;
+  }
+
+  function makeDepthCapCard(React) {
+    return function VisionRouterDepthCapCard(props) {
+      var scope = props && props.scope;
+      var t = props && typeof props.t === 'function' ? props.t : function(key){ return key; };
+      var subscribe = React.useMemo(function() {
+        return scope && typeof scope.subscribe === 'function' ? scope.subscribe.bind(scope) : function(){ return function(){}; };
+      }, [scope]);
+      var getSnapshot = React.useMemo(function() {
+        return scope && typeof scope.getSnapshot === 'function' ? scope.getSnapshot.bind(scope) : function(){ return undefined; };
+      }, [scope]);
+      var snapshot = React.useSyncExternalStore(subscribe, getSnapshot);
+      var enabledPair = React.useState(undefined);
+      var enabledDraft = enabledPair[0];
+      var setEnabledDraft = enabledPair[1];
+      var capPair = React.useState(undefined);
+      var capDraft = capPair[0];
+      var setCapDraft = capPair[1];
+      var savePair = React.useState({ status: 'idle', error: undefined });
+      var saveState = savePair[0];
+      var setSaveState = savePair[1];
+
+      if (!snapshot || snapshot.status !== 'ready') return null;
+      var savedRaw = snapshot.value && snapshot.value[DEPTH_CAP_FIELD];
+      var saved = Number.isFinite(Number(savedRaw)) ? Math.max(0, Math.floor(Number(savedRaw))) : 0;
+      var savedEnabled = saved > 0;
+      var enabled = enabledDraft === undefined ? savedEnabled : enabledDraft;
+      var capText = capDraft === undefined ? String(savedEnabled ? saved : DEFAULT_DEPTH_CAP) : capDraft;
+      var parsed = Number(capText);
+      var validCap = capText.trim() !== '' && Number.isInteger(parsed) && parsed >= MIN_DEPTH_CAP && parsed <= MAX_DEPTH_CAP;
+      var desired = enabled && validCap ? parsed : 0;
+      var dirty = (enabled !== savedEnabled) || (enabled && validCap && parsed !== saved);
+      var writable = snapshot.writable === true;
+      var saving = saveState.status === 'saving';
+      var h = React.createElement;
+
+      async function save() {
+        if (!scope || typeof scope.set !== 'function' || !writable || saving || !dirty || (enabled && !validCap)) return;
+        setSaveState({ status: 'saving', error: undefined });
+        try {
+          await scope.set(DEPTH_CAP_FIELD, desired);
+          if (typeof scope.load === 'function') await scope.load();
+          setEnabledDraft(undefined);
+          setCapDraft(undefined);
+          setSaveState({ status: 'saved', error: undefined });
+        } catch (error) {
+          setSaveState({ status: 'error', error: error && error.message ? error.message : String(error) });
+        }
+      }
+
+      function discard() {
+        setEnabledDraft(undefined);
+        setCapDraft(undefined);
+        setSaveState({ status: 'idle', error: undefined });
+      }
+
+      return h('ul', { style: { listStyle: 'none', margin: '0 0 12px', padding: 0 } },
+        h('li', { className: 'vr-card vr-card-open' },
+          h('div', { className: 'vr-body', style: { borderTop: 0, paddingTop: 8 } },
+            h('label', { className: 'vr-toggle' },
+              h('input', {
+                type: 'checkbox',
+                checked: enabled,
+                disabled: !writable || saving,
+                onChange: function(event) {
+                  setEnabledDraft(event.target.checked === true);
+                  if (event.target.checked === true && capDraft === undefined && !savedEnabled) setCapDraft(String(DEFAULT_DEPTH_CAP));
+                  setSaveState({ status: 'idle', error: undefined });
+                }
+              }),
+              h('span', null, t('depthCapTitle'))
+            ),
+            h('p', { className: 'vr-hint' }, t('depthCapHint')),
+            enabled
+              ? h('div', { className: 'vr-field' },
+                  h('div', { className: 'vr-field-head' }, h('span', { className: 'vr-label' }, t('depthCapValueLabel'))),
+                  h('input', {
+                    className: 'vr-input',
+                    type: 'number',
+                    min: MIN_DEPTH_CAP,
+                    max: MAX_DEPTH_CAP,
+                    step: 1,
+                    value: capText,
+                    disabled: !writable || saving,
+                    onChange: function(event) {
+                      setCapDraft(event.target.value);
+                      setSaveState({ status: 'idle', error: undefined });
+                    }
+                  }),
+                  !validCap ? h('p', { className: 'vr-failed', role: 'alert' }, t('depthCapInvalid')) : null
+                )
+              : null,
+            h('div', { className: 'vr-quickstart-actions' },
+              dirty
+                ? h('button', { type: 'button', className: 'vr-btn', disabled: saving, onClick: discard }, t('discard'))
+                : null,
+              dirty
+                ? h('button', {
+                    type: 'button', className: 'vr-btn vr-btn-save', disabled: !writable || saving || (enabled && !validCap),
+                    onClick: function(){ void save(); }
+                  }, saving ? t('saving') : t('save'))
+                : null,
+              saveState.status === 'saved' ? h('span', { className: 'vr-hint' }, t('depthCapSaved')) : null,
+              saveState.status === 'error' ? h('span', { className: 'vr-failed' }, t('depthCapSaveFailed') + ': ' + String(saveState.error || 'unknown')) : null
+            )
+          )
+        )
+      );
+    };
+  }
+
   function makeBudgetCard(React) {
     return function VisionRouterTurnBudgetCard(props) {
       var scope = props && props.scope;
@@ -71,11 +276,11 @@ export const VISION_TURN_BUDGET_CLIENT_PRELUDE = String.raw`(function(){
       var setSaveState = savePair[1];
 
       if (!snapshot || snapshot.status !== 'ready') return null;
-      var savedRaw = snapshot.value && snapshot.value[FIELD];
-      var saved = Number.isFinite(Number(savedRaw)) ? Number(savedRaw) : DEFAULT_MS;
+      var savedRaw = snapshot.value && snapshot.value[TURN_BUDGET_FIELD];
+      var saved = Number.isFinite(Number(savedRaw)) ? Number(savedRaw) : DEFAULT_TURN_BUDGET_MS;
       var text = draft === undefined ? String(saved) : draft;
       var parsed = Number(text);
-      var valid = text.trim() !== '' && Number.isInteger(parsed) && (parsed === 0 || (parsed >= MIN_MS && parsed <= MAX_MS));
+      var valid = text.trim() !== '' && Number.isInteger(parsed) && (parsed === 0 || (parsed >= MIN_TURN_BUDGET_MS && parsed <= MAX_TURN_BUDGET_MS));
       var dirty = valid && parsed !== saved;
       var writable = snapshot.writable === true;
       var saving = saveState.status === 'saving';
@@ -85,7 +290,7 @@ export const VISION_TURN_BUDGET_CLIENT_PRELUDE = String.raw`(function(){
         if (!scope || typeof scope.set !== 'function' || !writable || saving || !dirty) return;
         setSaveState({ status: 'saving', error: undefined });
         try {
-          await scope.set(FIELD, parsed);
+          await scope.set(TURN_BUDGET_FIELD, parsed);
           if (typeof scope.load === 'function') await scope.load();
           setDraft(undefined);
           setSaveState({ status: 'saved', error: undefined });
@@ -105,7 +310,7 @@ export const VISION_TURN_BUDGET_CLIENT_PRELUDE = String.raw`(function(){
                 className: 'vr-input',
                 type: 'number',
                 min: 0,
-                max: MAX_MS,
+                max: MAX_TURN_BUDGET_MS,
                 step: 1000,
                 value: text,
                 disabled: !writable || saving,
@@ -143,6 +348,7 @@ export const VISION_TURN_BUDGET_CLIENT_PRELUDE = String.raw`(function(){
 
   function wrapSlots(slots, React) {
     if (!slots || (typeof slots !== 'object' && typeof slots !== 'function')) return slots;
+    var DepthCapCard = makeDepthCapCard(React);
     var BudgetCard = makeBudgetCard(React);
     return new Proxy(slots, {
       get: function(target, property) {
@@ -153,11 +359,13 @@ export const VISION_TURN_BUDGET_CLIENT_PRELUDE = String.raw`(function(){
             var args = Array.prototype.slice.call(arguments);
             if (options && options.name === 'settings.section' && options.id === SETTINGS_SECTION_ID && component) {
               var Original = component;
-              args[1] = function VisionRouterSectionWithTurnBudget(props) {
+              args[1] = function VisionRouterSectionWithLimits(props) {
+                var originalProps = Object.assign({}, props, { scope: strategyScope(props && props.scope) });
                 return React.createElement(
                   React.Fragment,
                   null,
-                  React.createElement(Original, props),
+                  React.createElement(Original, originalProps),
+                  React.createElement(DepthCapCard, props),
                   React.createElement(BudgetCard, props)
                 );
               };
@@ -197,9 +405,15 @@ export const VISION_TURN_BUDGET_CLIENT_PRELUDE = String.raw`(function(){
           var factory = spec.factory;
           spec = Object.assign({}, spec, {
             factory: function(require) {
-              var exports = factory(require);
-              var React;
-              try { React = require('react'); } catch (_) { React = undefined; }
+              var realReact;
+              try { realReact = require('react'); } catch (_) { realReact = undefined; }
+              var scopedReact = wrapReact(realReact);
+              function scopedRequire(id) {
+                if (id === 'react' && scopedReact) return scopedReact;
+                return require(id);
+              }
+              var exports = factory(scopedRequire);
+              var React = scopedReact || realReact;
               if (React && exports && typeof exports.apply === 'function' && !exports.apply.__visionRouterTurnBudget) {
                 var apply = exports.apply;
                 var wrappedApply = function(ctx) {

--- a/tests/depth-quota-behavior.test.js
+++ b/tests/depth-quota-behavior.test.js
@@ -1,10 +1,11 @@
 // 行为级独立次数上限测试：
 // 驱动真实 wrapper（apply 注册的工具），验证用户显式开启的深挖次数上限只在
-// 工具真正产出证据后消费——失败调用（ok:false）不烧配额、不置
-// followupCompleted，模型保有提醒并可重试；成功后下一次调用命中
+// 工具真正产出证据后消费——ok:false 的“无可用证据”结果不烧配额、不置
+// followupCompleted，模型保有提醒并可继续；成功后下一次调用命中
 // VISION_DEPTH_LIMIT。深度策略本身不提供次数上限。
-// 不 stub fetch：本地 OpenAI 兼容假服务驱动 bootstrap 与失败调用；
-// vision_colors（sharp 本地、无网络）作成功调用，避开 turn 级失败记忆与网络依赖。
+// 不 stub fetch：本地 OpenAI 兼容假服务驱动 bootstrap 与“无可用证据”调用；
+// vision_colors（sharp 本地、无网络）作成功调用。这里刻意不制造 provider outage，
+// 避免把熔断/失败记忆混进本测试要验证的 quota accounting。
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import { createServer } from 'node:http'
@@ -155,14 +156,14 @@ test('explicit call cap: failed evidence does not consume it, successful evidenc
     visible_text: [],
     entities: [],
   })
-  const FAIL_JSON = JSON.stringify({
+  const NO_EVIDENCE_JSON = JSON.stringify({
     ok: false,
-    code: 'VISION_BACKEND_UNAVAILABLE',
+    code: 'NO_USABLE_EVIDENCE',
     retryable: false,
-    reason: 'simulated backend outage',
+    reason: 'simulated successful request with no usable visual evidence',
   })
   const server = await startFakeVisionServer(async (_req, _body, nth) =>
-    chatOk(nth === 1 ? BOOTSTRAP_JSON : FAIL_JSON),
+    chatOk(nth === 1 ? BOOTSTRAP_JSON : NO_EVIDENCE_JSON),
   )
   try {
     const config = {
@@ -208,7 +209,7 @@ test('explicit call cap: failed evidence does not consume it, successful evidenc
     const r1 = await describe.execute({ paths: [pngPath], question: 'what is here?' }, exec)
     const j1 = JSON.parse(r1)
     assert.equal(j1.ok, false)
-    assert.notEqual(j1.code, 'VISION_DEPTH_LIMIT')
+    assert.equal(j1.code, 'NO_USABLE_EVIDENCE')
 
     const d3 = await preStep(imagePayload, next)
     assert.equal(hasFollowupReminder(d3), true)

--- a/tests/depth-quota-behavior.test.js
+++ b/tests/depth-quota-behavior.test.js
@@ -1,6 +1,6 @@
 // 行为级独立次数上限测试：
-// 驱动真实 wrapper（apply 注册的工具），验证用户显式开启的深挖次数上限只在
-// 工具真正产出证据后消费——ok:false 的“无可用证据”结果不烧配额、不置
+// 驱动真实 structured runtime wrapper（包入口同款 hardening + core 注册工具），验证用户显式开启的
+// 深挖次数上限只在工具真正产出证据后消费——ok:false 的“无可用证据”结果不烧配额、不置
 // followupCompleted，模型保有提醒并可继续；成功后下一次调用命中
 // VISION_DEPTH_LIMIT。深度策略本身不提供次数上限。
 // 不 stub fetch：本地 OpenAI 兼容假服务驱动 bootstrap 与“无可用证据”调用；
@@ -12,7 +12,9 @@ import { createServer } from 'node:http'
 import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
-import { apply, Config } from '../index.js'
+import { apply } from '../index.js'
+import { Config } from '../entry.js'
+import { installStructuredFlowHardening } from '../lib/structured-flow-hardening.js'
 
 const PNG_BYTES = Buffer.from(
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
@@ -174,7 +176,8 @@ test('explicit call cap: failed evidence does not consume it, successful evidenc
       localOllama: { enabled: true, baseURL: server.baseURL, model: 'm' },
     }
     const harness = bootHarness(config)
-    apply(harness.ctx, Config(config))
+    const hardenedCtx = installStructuredFlowHardening(harness.ctx, Config(config))
+    apply(hardenedCtx, Config(config))
 
     const session = { id: 'depth-behavior-session', events: [] }
     const exec = { agent: { session } }

--- a/tests/depth-quota-behavior.test.js
+++ b/tests/depth-quota-behavior.test.js
@@ -1,7 +1,7 @@
 // 行为级独立次数上限测试：
 // 驱动真实 structured runtime wrapper（包入口同款 hardening + core 注册工具），验证用户显式开启的
 // 深挖次数上限只在工具真正产出证据后消费——ok:false 的“无可用证据”结果不烧配额、不置
-// followupCompleted，模型保有提醒并可继续；成功后下一次调用命中
+// followupCompleted，模型保有提醒并可继续；成功消费最后一次额度后立即切到 stop guard，随后调用命中
 // VISION_DEPTH_LIMIT。深度策略本身不提供次数上限。
 // 不 stub fetch：本地 OpenAI 兼容假服务驱动 bootstrap 与“无可用证据”调用；
 // vision_colors（sharp 本地、无网络）作成功调用。这里刻意不制造 provider outage，
@@ -196,9 +196,15 @@ test('explicit call cap: failed evidence does not consume it, successful evidenc
           m.id.includes('vision-router-structured-mixed-guard-') ||
           m.id.includes('vision-router-structured-evidence-guard-')
       })
+    const hasStopGuard = (decision) =>
+      Array.isArray(decision && decision.messages) &&
+      decision.messages.some((m) =>
+        m && typeof m.id === 'string' && m.id.includes('vision-router-structured-guard-stop-'),
+      )
 
     const d1 = await preStep(imagePayload, next)
     assert.equal(hasEvidenceReminder(d1), false)
+    assert.equal(hasStopGuard(d1), false)
 
     const bootstrap = harness.toolDefs.get('vision_bootstrap')
     assert.ok(bootstrap)
@@ -209,6 +215,7 @@ test('explicit call cap: failed evidence does not consume it, successful evidenc
 
     const d2 = await preStep(imagePayload, next)
     assert.equal(hasEvidenceReminder(d2), true)
+    assert.equal(hasStopGuard(d2), false)
 
     const describe = harness.toolDefs.get('vision_describe')
     assert.ok(describe)
@@ -219,6 +226,7 @@ test('explicit call cap: failed evidence does not consume it, successful evidenc
 
     const d3 = await preStep(imagePayload, next)
     assert.equal(hasEvidenceReminder(d3), true)
+    assert.equal(hasStopGuard(d3), false)
 
     const colors = harness.toolDefs.get('vision_colors')
     assert.ok(colors)
@@ -229,6 +237,7 @@ test('explicit call cap: failed evidence does not consume it, successful evidenc
 
     const d4 = await preStep(imagePayload, next)
     assert.equal(hasEvidenceReminder(d4), false)
+    assert.equal(hasStopGuard(d4), true)
 
     const requestsBeforeBlock = server.requests.length
     const r3 = await describe.execute({ paths: [pngPath], question: 'again' }, exec)

--- a/tests/depth-quota-behavior.test.js
+++ b/tests/depth-quota-behavior.test.js
@@ -188,14 +188,17 @@ test('explicit call cap: failed evidence does not consume it, successful evidenc
     const preStep = harness.handlers.get('agent/pre-step')
     assert.ok(preStep)
     const next = async () => ({ kind: 'ok', messages: imageMessages })
-    const hasFollowupReminder = (decision) =>
+    const hasEvidenceReminder = (decision) =>
       Array.isArray(decision && decision.messages) &&
-      decision.messages.some(
-        (m) => m && typeof m.id === 'string' && m.id.includes('vision-router-structured-followup-'),
-      )
+      decision.messages.some((m) => {
+        if (!m || typeof m.id !== 'string') return false
+        return m.id.includes('vision-router-structured-followup-') ||
+          m.id.includes('vision-router-structured-mixed-guard-') ||
+          m.id.includes('vision-router-structured-evidence-guard-')
+      })
 
     const d1 = await preStep(imagePayload, next)
-    assert.equal(hasFollowupReminder(d1), false)
+    assert.equal(hasEvidenceReminder(d1), false)
 
     const bootstrap = harness.toolDefs.get('vision_bootstrap')
     assert.ok(bootstrap)
@@ -205,7 +208,7 @@ test('explicit call cap: failed evidence does not consume it, successful evidenc
     assert.equal(boot.phase, 'structured-bootstrap')
 
     const d2 = await preStep(imagePayload, next)
-    assert.equal(hasFollowupReminder(d2), true)
+    assert.equal(hasEvidenceReminder(d2), true)
 
     const describe = harness.toolDefs.get('vision_describe')
     assert.ok(describe)
@@ -215,7 +218,7 @@ test('explicit call cap: failed evidence does not consume it, successful evidenc
     assert.equal(j1.code, 'NO_USABLE_EVIDENCE')
 
     const d3 = await preStep(imagePayload, next)
-    assert.equal(hasFollowupReminder(d3), true)
+    assert.equal(hasEvidenceReminder(d3), true)
 
     const colors = harness.toolDefs.get('vision_colors')
     assert.ok(colors)
@@ -225,7 +228,7 @@ test('explicit call cap: failed evidence does not consume it, successful evidenc
     assert.equal(server.requests.length, requestsBefore)
 
     const d4 = await preStep(imagePayload, next)
-    assert.equal(hasFollowupReminder(d4), false)
+    assert.equal(hasEvidenceReminder(d4), false)
 
     const requestsBeforeBlock = server.requests.length
     const r3 = await describe.execute({ paths: [pngPath], question: 'again' }, exec)

--- a/tests/depth-quota-behavior.test.js
+++ b/tests/depth-quota-behavior.test.js
@@ -1,10 +1,10 @@
-// 行为级深度配额测试（maintainer review 要求）：
-// 驱动真实 wrapper（apply 注册的工具），验证 fast 档深度配额只在工具真正
-// 产出证据后消费——失败调用（ok:false）不烧配额、不置 followupCompleted，
-// 模型保有提醒并可重试；成功后第三次调用命中 VISION_DEPTH_LIMIT。
+// 行为级独立次数上限测试：
+// 驱动真实 wrapper（apply 注册的工具），验证用户显式开启的深挖次数上限只在
+// 工具真正产出证据后消费——失败调用（ok:false）不烧配额、不置
+// followupCompleted，模型保有提醒并可重试；成功后下一次调用命中
+// VISION_DEPTH_LIMIT。深度策略本身不提供次数上限。
 // 不 stub fetch：本地 OpenAI 兼容假服务驱动 bootstrap 与失败调用；
-// vision_colors（sharp 本地、无网络）作第二次成功调用，避开 turn 级失败
-// 记忆与网络依赖。CI 安全：只依赖内置模块与本机端口。
+// vision_colors（sharp 本地、无网络）作成功调用，避开 turn 级失败记忆与网络依赖。
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import { createServer } from 'node:http'
@@ -13,13 +13,11 @@ import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { apply, Config } from '../index.js'
 
-// 1x1 透明 PNG，真实图片字节（sharp 可读）。
 const PNG_BYTES = Buffer.from(
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
   'base64',
 )
 
-/** 本地 OpenAI 兼容假服务；responder(req, body, nth) 决定第 nth 次请求的响应。 */
 async function startFakeVisionServer(responder) {
   const requests = []
   const sockets = new Set()
@@ -63,13 +61,11 @@ async function startFakeVisionServer(responder) {
 
 const chatOk = (text) => ({ status: 200, body: JSON.stringify({ choices: [{ message: { content: text } }] }) })
 
-/** 最小 ctx harness（参照 runtime-e2e.test.js 的 bootHarness）。 */
 function bootHarness(config0 = {}) {
   const toolDefs = new Map()
   const registrations = new Map()
   const handlers = new Map()
-  let resolvedSettings = Config({ ...config0 })
-  let settingsWatcher
+  const resolvedSettings = Config({ ...config0 })
   const attachments = {
     saveImage: async (input) => ({
       attachmentId: `mock-att-${Date.now()}-${Math.floor(Math.random() * 1e6)}`,
@@ -103,12 +99,7 @@ function bootHarness(config0 = {}) {
     inject(_deps, callback) {
       const scope = {
         get: () => resolvedSettings,
-        watch: (watcher) => {
-          settingsWatcher = watcher
-          return () => {
-            if (settingsWatcher === watcher) settingsWatcher = undefined
-          }
-        },
+        watch: () => () => {},
       }
       callback({ settings: { register: () => scope }, effect: () => () => {} })
       return () => {}
@@ -137,9 +128,6 @@ function bootHarness(config0 = {}) {
       listProviders: () => [...registrations.keys()].map((id) => ({ id, name: id })),
       listModels: async () => [],
       resolveModelInfo: async () => ({ id: 'm', inputModalities: ['text', 'image'], image: true }),
-      // The real llm service routes stream() to the registered provider
-      // adapter; vision_describe goes through llm.stream(), so forward to the
-      // adapter (vision-http) instead of finishing empty.
       async *stream(options) {
         const registration = registrations.get(options && options.provider)
         if (registration && registration.adapter && typeof registration.adapter.stream === 'function') {
@@ -153,13 +141,11 @@ function bootHarness(config0 = {}) {
   return { ctx, toolDefs, handlers }
 }
 
-test('fast tier: failed evidence call does not burn the quota; success consumes it; third call hits VISION_DEPTH_LIMIT', async () => {
+test('explicit call cap: failed evidence does not consume it, successful evidence does', async () => {
   const dir = mkdtempSync(path.join(tmpdir(), 'vr-depth-behavior-'))
   const pngPath = path.join(dir, 'img.png')
   writeFileSync(pngPath, PNG_BYTES)
 
-  // Request 1 = bootstrap (structured schema); requests 2+ = the failed
-  // evidence call (ok:false business failure from the "backend").
   const BOOTSTRAP_JSON = JSON.stringify({
     visual_kind: 'mixed',
     mixed_of: ['document', 'ui'],
@@ -182,7 +168,8 @@ test('fast tier: failed evidence call does not burn the quota; success consumes 
     const config = {
       structuredVisionBootstrap: true,
       visionDepth: 'fast',
-      freeFallback: false, // single backend only: no OVH fallback noise
+      visionDepthMaxCalls: 1,
+      freeFallback: false,
       localOllama: { enabled: true, baseURL: server.baseURL, model: 'm' },
     }
     const harness = bootHarness(config)
@@ -190,14 +177,12 @@ test('fast tier: failed evidence call does not burn the quota; success consumes 
 
     const session = { id: 'depth-behavior-session', events: [] }
     const exec = { agent: { session } }
-    // pre-step reads `decision.messages ?? payload.messages` — next() must
-    // carry the image turn, not an empty array.
     const imageMessages = [
       { role: 'user', content: [{ type: 'image', attachment: { attachmentId: 'sha256:abc', mediaType: 'image/png' } }] },
     ]
     const imagePayload = { turn: 1, agent: { session }, messages: imageMessages }
     const preStep = harness.handlers.get('agent/pre-step')
-    assert.ok(preStep, 'pre-step hook must be registered')
+    assert.ok(preStep)
     const next = async () => ({ kind: 'ok', messages: imageMessages })
     const hasFollowupReminder = (decision) =>
       Array.isArray(decision && decision.messages) &&
@@ -205,57 +190,45 @@ test('fast tier: failed evidence call does not burn the quota; success consumes 
         (m) => m && typeof m.id === 'string' && m.id.includes('vision-router-structured-followup-'),
       )
 
-    // 1. Image turn: bootstrap state created (required) + deep tools auto-mounted.
     const d1 = await preStep(imagePayload, next)
-    assert.equal(hasFollowupReminder(d1), false, 'no followup reminder before bootstrap completes')
+    assert.equal(hasFollowupReminder(d1), false)
 
     const bootstrap = harness.toolDefs.get('vision_bootstrap')
-    assert.ok(bootstrap, 'vision_bootstrap must be mounted after the image turn')
+    assert.ok(bootstrap)
     const bootRaw = await bootstrap.execute({ paths: [pngPath] }, exec)
     const boot = JSON.parse(bootRaw)
-    assert.equal(boot.ok, true, 'bootstrap must succeed')
+    assert.equal(boot.ok, true)
     assert.equal(boot.phase, 'structured-bootstrap')
 
-    // 2. Bootstrap done, followup not: the followup reminder is injected.
     const d2 = await preStep(imagePayload, next)
-    assert.equal(hasFollowupReminder(d2), true, 'followup reminder injected after bootstrap')
+    assert.equal(hasFollowupReminder(d2), true)
 
-    // 3. First evidence call FAILS with ok:false — must NOT burn the fast quota.
     const describe = harness.toolDefs.get('vision_describe')
-    assert.ok(describe, 'vision_describe must be mounted')
+    assert.ok(describe)
     const r1 = await describe.execute({ paths: [pngPath], question: 'what is here?' }, exec)
     const j1 = JSON.parse(r1)
-    assert.equal(j1.ok, false, 'first evidence call reports failure')
-    assert.notEqual(j1.code, 'VISION_DEPTH_LIMIT', 'a failed call must not be blocked as over-limit')
+    assert.equal(j1.ok, false)
+    assert.notEqual(j1.code, 'VISION_DEPTH_LIMIT')
 
-    // 4. Still no evidence produced: the followup reminder is STILL injected
-    //    (followupCompleted stays false after a failure).
     const d3 = await preStep(imagePayload, next)
-    assert.equal(hasFollowupReminder(d3), true, 'followup reminder persists after a failed evidence call')
+    assert.equal(hasFollowupReminder(d3), true)
 
-    // 5. Second evidence call SUCCEEDS (vision_colors: sharp-local, no network,
-    //    immune to the turn-level failure memory) — consumes the quota.
     const colors = harness.toolDefs.get('vision_colors')
-    assert.ok(colors, 'vision_colors must be mounted')
+    assert.ok(colors)
     const requestsBefore = server.requests.length
     const r2 = await colors.execute({ image: pngPath }, exec)
-    assert.equal(JSON.parse(r2).ok, undefined, 'colors returns a plain inventory (no ok field)')
-    // If the old pre-decrement bug were present, this successful call would
-    // already be blocked (deepCalls would be 1 after the failed call).
-    assert.equal(server.requests.length, requestsBefore, 'vision_colors is sharp-local: no extra network')
+    assert.equal(JSON.parse(r2).ok, undefined)
+    assert.equal(server.requests.length, requestsBefore)
 
-    // 6. Evidence produced: the followup reminder is NO LONGER injected.
     const d4 = await preStep(imagePayload, next)
-    assert.equal(hasFollowupReminder(d4), false, 'followup reminder stops once evidence was produced')
+    assert.equal(hasFollowupReminder(d4), false)
 
-    // 7. Third evidence call (same turn, fast tier): VISION_DEPTH_LIMIT,
-    //    intercepted before any network request.
     const requestsBeforeBlock = server.requests.length
     const r3 = await describe.execute({ paths: [pngPath], question: 'again' }, exec)
     const j3 = JSON.parse(r3)
     assert.equal(j3.ok, false)
-    assert.equal(j3.code, 'VISION_DEPTH_LIMIT', 'third evidence call is hard-capped')
-    assert.equal(server.requests.length, requestsBeforeBlock, 'the capped call must not reach the network')
+    assert.equal(j3.code, 'VISION_DEPTH_LIMIT')
+    assert.equal(server.requests.length, requestsBeforeBlock)
   } finally {
     await server.close()
     rmSync(dir, { recursive: true, force: true })

--- a/tests/depth-tier.test.js
+++ b/tests/depth-tier.test.js
@@ -10,56 +10,86 @@ import {
   contentGuidanceFor,
 } from '../lib/depth-guidance.js'
 
-// 看图深度档位（移植自 dsh-vision PRECISION）：档位定深挖上限，不参与提示词
-// 组合（模板集合，非矩阵）；fast/standard/deep 分别硬限 1/2/4 次，custom=N。
+// 看图深度只控制查证策略；次数限制由独立的 visionDepthMaxCalls 安全阀负责。
 
-test('depthLimitFor: fast=1, standard=2, deep=4', () => {
-  assert.equal(depthLimitFor('fast'), 1)
-  assert.equal(depthLimitFor('standard'), 2)
-  assert.equal(depthLimitFor('deep'), 4)
-  assert.equal(depthLimitFor(undefined), 2)
+test('depthLimitFor: built-in depth strategies are unlimited by default', () => {
+  assert.equal(depthLimitFor('fast'), undefined)
+  assert.equal(depthLimitFor('standard'), undefined)
+  assert.equal(depthLimitFor('deep'), undefined)
+  assert.equal(depthLimitFor(undefined), undefined)
+  assert.equal(depthLimitFor('custom'), undefined)
 })
 
-test('depthLimitFor: custom N is its own cap and custom 0 is unlimited', () => {
-  assert.equal(depthLimitFor('custom', 1), 1)
-  assert.equal(depthLimitFor('custom', 6), 6)
-  assert.equal(depthLimitFor('custom', 100), 100)
-  assert.equal(depthLimitFor('custom', 101), 100)
-  assert.equal(depthLimitFor('custom', 6.9), 6)
-  assert.equal(depthLimitFor('custom', 0), undefined)
-  assert.equal(depthLimitFor('custom', undefined), undefined)
-  assert.equal(depthLimitFor('custom', null), undefined)
-  // 切回内置档位后，保存过的自定义数值保留但不生效。
-  assert.equal(depthLimitFor('fast', 8), 1)
-  assert.equal(depthLimitFor('standard', 8), 2)
-  assert.equal(depthLimitFor('deep', 8), 4)
+test('depthLimitFor: an explicit positive cap applies independently of strategy', () => {
+  for (const depth of ['fast', 'standard', 'deep', 'custom', 'bogus']) {
+    assert.equal(depthLimitFor(depth, 1), 1)
+    assert.equal(depthLimitFor(depth, 6), 6)
+    assert.equal(depthLimitFor(depth, 100), 100)
+    assert.equal(depthLimitFor(depth, 101), 100)
+    assert.equal(depthLimitFor(depth, 6.9), 6)
+    assert.equal(depthLimitFor(depth, 0), undefined)
+    assert.equal(depthLimitFor(depth, undefined), undefined)
+  }
 })
 
-test('runtime depth context carries custom through the legacy inner 1+x helper', async () => {
+test('runtime depth context carries the independent cap through the legacy inner helper', async () => {
   const capped = await runWithDepthConfig(
-    { visionDepth: 'custom', visionDepthMaxCalls: 6 },
+    { visionDepth: 'standard', visionDepthMaxCalls: 6 },
     async () => depthLimitFor('standard'),
   )
   assert.equal(capped, 6)
 
   const unlimited = await runWithDepthConfig(
-    { visionDepth: 'custom', visionDepthMaxCalls: 0 },
-    async () => depthLimitFor('standard'),
+    { visionDepth: 'deep', visionDepthMaxCalls: 0 },
+    async () => depthLimitFor('deep'),
   )
   assert.equal(unlimited, undefined)
 
-  const copy = await runWithDepthConfig(
+  const legacyCustom = await runWithDepthConfig(
     { visionDepth: 'custom', visionDepthMaxCalls: 6 },
     async () => renderDepthGuidance({ visualKind: 'document', depth: 'standard' }),
   )
-  assert.match(copy, /已自定义深挖上限为 6 次/)
-  assert.doesNotMatch(copy, /深度档位为 standard/)
+  assert.match(legacyCustom, /看图策略为标准/)
+  assert.match(legacyCustom, /另启用了深挖次数上限：最多 6 次/)
+  assert.doesNotMatch(legacyCustom, /看图策略为自定义|深度档位为 custom/)
 })
 
-test('depthCopyFor: custom cap and unlimited wording match runtime semantics', () => {
-  assert.match(depthCopyFor('custom', 6), /已自定义深挖上限为 6 次/)
-  assert.match(depthCopyFor('custom', 0), /不设置次数上限/)
-  assert.match(depthCopyFor('standard', 8), /第 2 次之后/)
+test('depthCopyFor: built-in tiers are guidance strategies, not count promises', () => {
+  const fast = depthCopyFor('fast')
+  const standard = depthCopyFor('standard')
+  const deep = depthCopyFor('deep')
+  assert.match(fast, /看图策略为快速/)
+  assert.match(fast, /整体判断/)
+  assert.match(standard, /看图策略为标准/)
+  assert.match(standard, /按需查证/)
+  assert.match(deep, /看图策略为细致/)
+  assert.match(deep, /交叉验证/)
+  for (const copy of [fast, standard, deep]) {
+    assert.doesNotMatch(copy, /最多.*次|1-2 次|2-4 次|第 2 次之后/)
+  }
+})
+
+test('depthCopyFor: explicit cap is a separate note and is bilingual', () => {
+  assert.match(depthCopyFor('standard', 6), /另启用了深挖次数上限：最多 6 次/)
+  assert.match(depthCopyFor('deep', 6, 'en-US'), /Thorough/)
+  assert.match(depthCopyFor('deep', 6, 'en-US'), /separate deep-dive call cap.*6 successful evidence calls/i)
+})
+
+test('runtime depth locale follows the host locale when no explicit locale is passed', async () => {
+  const en = await runWithDepthConfig(
+    { visionDepth: 'standard', visionDepthMaxCalls: 0, __visionRouterLocale: 'en-US' },
+    async () => renderDepthGuidance({ visualKind: 'ui', depth: 'standard' }),
+  )
+  assert.match(en, /UI content detected/)
+  assert.match(en, /Vision strategy is Standard/)
+  assert.doesNotMatch(en, /检测到|本轮看图策略/)
+
+  const zh = await runWithDepthConfig(
+    { visionDepth: 'deep', visionDepthMaxCalls: 0, __visionRouterLocale: 'zh-CN' },
+    async () => renderDepthGuidance({ visualKind: 'ui', depth: 'deep' }),
+  )
+  assert.match(zh, /检测到界面内容/)
+  assert.match(zh, /本轮看图策略为细致/)
 })
 
 test('sceneGuidanceFor: known kinds have guidance, general/unknown/mixed release', () => {
@@ -82,41 +112,43 @@ test('contentGuidanceFor: content kinds have guidance, unknown releases', () => 
   assert.equal(contentGuidanceFor('unknown'), '')
 })
 
-test('renderDepthGuidance: scene + depth for document', () => {
+test('renderDepthGuidance: scene + strategy for document', () => {
   const text = renderDepthGuidance({ visualKind: 'document', depth: 'deep' })
   assert.match(text, /语义优先/)
-  assert.match(text, /2-4 次充分深挖/)
+  assert.match(text, /主动检查关键局部并做交叉验证/)
+  assert.doesNotMatch(text, /2-4 次/)
 })
 
 test('renderDepthGuidance: general uses content_kind precise guidance when known', () => {
   const text = renderDepthGuidance({ visualKind: 'general', contentKind: 'food', depth: 'standard' })
   assert.match(text, /食物/)
-  assert.match(text, /standard/)
+  assert.match(text, /看图策略为标准/)
   assert.doesNotMatch(text, /请先判断/)
 })
 
 test('renderDepthGuidance: general falls to self-judge guidance when content_kind unknown', () => {
   const text = renderDepthGuidance({ visualKind: 'general', contentKind: 'unknown', depth: 'standard' })
   assert.match(text, /请先判断图中主体/)
-  assert.match(text, /standard/)
+  assert.match(text, /看图策略为标准/)
 })
 
-test('renderDepthGuidance: fast carries tier-insufficient note', () => {
+test('renderDepthGuidance: fast stays lightweight without forbidding further evidence', () => {
   const text = renderDepthGuidance({ visualKind: 'ui', depth: 'fast' })
   assert.match(text, /detect/)
-  assert.match(text, /fast/)
-  assert.match(text, /升级档位/)
+  assert.match(text, /看图策略为快速/)
+  assert.match(text, /关键证据不确定/)
+  assert.doesNotMatch(text, /升级档位|最多.*次/)
 })
 
-test('renderDepthGuidance: unknown releases depth copy only', () => {
+test('renderDepthGuidance: unknown releases strategy copy only', () => {
   const text = renderDepthGuidance({ visualKind: 'unknown', depth: 'standard' })
-  assert.match(text, /standard/)
+  assert.match(text, /看图策略为标准/)
   assert.doesNotMatch(text, /检测到/)
 })
 
-test('renderDepthGuidance: invalid depth falls back to standard copy', () => {
-  const text = renderDepthGuidance({ visualKind: 'document', depth: 'bogus' })
-  assert.match(text, /standard/)
+test('renderDepthGuidance: invalid and legacy custom depth fall back to standard strategy', () => {
+  assert.match(renderDepthGuidance({ visualKind: 'document', depth: 'bogus' }), /看图策略为标准/)
+  assert.match(renderDepthGuidance({ visualKind: 'document', depth: 'custom' }), /看图策略为标准/)
 })
 
 test('guidanceOverrides: user copy wins over built-in for scene kinds', () => {
@@ -124,7 +156,7 @@ test('guidanceOverrides: user copy wins over built-in for scene kinds', () => {
   const text = renderDepthGuidance({ visualKind: 'document', depth: 'standard', guidanceOverrides: overrides })
   assert.match(text, /合同条款与签名/)
   assert.doesNotMatch(text, /语义优先/)
-  assert.match(text, /standard/)
+  assert.match(text, /看图策略为标准/)
 })
 
 test('guidanceOverrides: duplicate kind is deterministic last-wins and bounded', () => {
@@ -135,7 +167,7 @@ test('guidanceOverrides: duplicate kind is deterministic last-wins and bounded',
   const text = renderDepthGuidance({ visualKind: 'document', depth: 'standard', guidanceOverrides: overrides })
   assert.match(text, /^new/)
   assert.doesNotMatch(text, /^old/)
-  assert.ok(text.length < 2300)
+  assert.ok(text.length < 2400)
 })
 
 test('guidanceOverrides: user copy wins over built-in for content kinds', () => {
@@ -152,7 +184,7 @@ test('guidanceOverrides: empty/undefined overrides keep built-in behavior', () =
   assert.match(withEmpty, /语义优先/)
 })
 
-test('index.js integration: existing inner depth pipeline remains intact', () => {
+test('index.js integration: legacy inner guard remains but receives the independent cap policy', () => {
   const index = readFileSync(new URL('../index.js', import.meta.url), 'utf8')
   assert.equal(index.includes("visionDepth: z.union(['fast', 'standard', 'deep']).default('standard')"), true)
   assert.equal(index.includes('depthLimitFor(visionDepth())'), true)
@@ -160,7 +192,7 @@ test('index.js integration: existing inner depth pipeline remains intact', () =>
   assert.equal(index.includes("code: 'VISION_DEPTH_LIMIT'"), true)
 })
 
-test('index.js integration: deep quota consumed only after evidence', () => {
+test('index.js integration: evidence calls are counted only after evidence is produced', () => {
   const index = readFileSync(new URL('../index.js', import.meta.url), 'utf8')
   assert.equal(index.includes('state.deepCalls = used + 1'), false)
   assert.equal(index.includes('state.deepCalls = (state.deepCalls || 0) + 1'), true)
@@ -168,19 +200,20 @@ test('index.js integration: deep quota consumed only after evidence', () => {
   assert.equal(index.includes('state.followupCompleted = true'), true)
 })
 
-test('client.js integration: custom depth lives in the canonical Settings editor', () => {
+test('client presentation: depth strategy and optional cap are separate bilingual controls', () => {
   const client = readFileSync(new URL('../lib/client.js', import.meta.url), 'utf8')
-  const prelude = readFileSync(new URL('../lib/live-model-client-prelude.js', import.meta.url), 'utf8')
+  const prelude = readFileSync(new URL('../lib/vision-turn-budget-client-prelude.js', import.meta.url), 'utf8')
   assert.equal(client.includes("const SELECT_KEYS = ['visionDepth']"), true)
-  assert.equal(client.includes("{ value: 'custom', label: t('visionDepthCustom') }"), true)
-  assert.equal(client.includes("format('visionDepth') === 'custom'"), true)
-  assert.equal(client.includes("const DEPTH_NUMBER_KEYS = ['visionDepthMaxCalls']"), true)
-  assert.equal(client.includes("labelVisionDepthMaxCalls: '自定义深挖次数上限'"), true)
-  assert.equal(client.includes("labelVisionDepthMaxCalls: 'Custom deep-dive call cap'"), true)
-  // The current-main client prelude owns the final user-visible correction:
-  // Standard stays capped at 2; only Custom 0/blank is unlimited.
-  assert.equal(prelude.includes('留空或填 0 = 不限制'), true)
-  assert.equal(prelude.includes('标准档仍固定最多 2 次'), true)
-  assert.equal(prelude.includes('blank or 0 = unlimited'), true)
-  assert.equal(prelude.includes('Standard remains capped at 2'), true)
+  assert.match(prelude, /快速（优先整体判断）/)
+  assert.match(prelude, /标准（按需查证，默认）/)
+  assert.match(prelude, /细致（主动交叉验证）/)
+  assert.match(prelude, /Quick \(overall-first\)/)
+  assert.match(prelude, /Standard \(evidence as needed, default\)/)
+  assert.match(prelude, /Thorough \(proactive cross-checking\)/)
+  assert.match(prelude, /限制深挖次数/)
+  assert.match(prelude, /Limit deep-dive calls/)
+  assert.match(prelude, /DEPTH_CAP_FIELD = 'visionDepthMaxCalls'/)
+  assert.match(prelude, /values\.has\('fast'\).*values\.has\('standard'\).*values\.has\('deep'\).*values\.has\('custom'\)/s)
+  assert.match(prelude, /node\.props\.value === 'custom'/)
+  assert.doesNotMatch(prelude, /Standard remains capped at 2|标准档仍固定最多 2 次/)
 })

--- a/tests/mixed-router.test.js
+++ b/tests/mixed-router.test.js
@@ -1,6 +1,7 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
+import { runWithDepthConfig } from '../lib/depth-guidance.js'
 import {
   MAX_MIXED_BRANCHES,
   buildMixedBranches,
@@ -10,13 +11,12 @@ import {
   renderMixedGuidance,
 } from '../lib/mixed-router.js'
 
-// mixed 分路识别：精度优化（避免漏判/错判另一半内容），≤2 分支成本封顶。
-// 细分来源 = bootstrap 的 mixed_of（schema 枚举，视觉模型直接输出，与
-// content_kind 同一"免费收敛"哲学）——不再用 entities 启发式推断。
+// mixed 分路识别：精度优化（避免漏判/错判另一半内容），最多保留 2 个分支。
+// 深度档位只影响查证策略，不再改变 mixed 分支覆盖或调用次数。
 
 test('normalizeMixedOf: validates, dedupes, caps at MAX_MIXED_BRANCHES, orders by priority', () => {
-  assert.deepEqual(normalizeMixedOf(['document', 'ui']), ['ui', 'document']) // ui 优先作主分支
-  assert.deepEqual(normalizeMixedOf(['ui', 'ui', 'document', 'code']), ['ui', 'document']) // 去重 + ≤2
+  assert.deepEqual(normalizeMixedOf(['document', 'ui']), ['ui', 'document'])
+  assert.deepEqual(normalizeMixedOf(['ui', 'ui', 'document', 'code']), ['ui', 'document'])
   assert.deepEqual(normalizeMixedOf(['bogus']), [])
   assert.deepEqual(normalizeMixedOf(undefined), [])
   assert.deepEqual(normalizeMixedOf('not-an-array'), [])
@@ -34,20 +34,14 @@ test('buildMixedBranches: single branch when no secondary', () => {
   assert.equal(branches[0].kind, 'document')
 })
 
-test('buildMixedBranches: general is a legal secondary branch (maintainer review)', () => {
-  // mixed_of schema allows document|ui|code|chat|general; a mixed image of
-  // "ui + general" must keep BOTH branches so the unclassifiable half is not
-  // silently dropped from the guidance. general's guidance is the release
-  // copy (model chooses the recognition method freely).
+test('buildMixedBranches: general is a legal secondary branch', () => {
   const uiGeneral = buildMixedBranches('ui', ['general'])
   assert.deepEqual(uiGeneral.map((b) => b.kind), ['ui', 'general'])
   assert.match(uiGeneral[1].guidance, /放行/)
   const documentGeneral = buildMixedBranches('document', ['general'])
   assert.deepEqual(documentGeneral.map((b) => b.kind), ['document', 'general'])
-  // Cap still applies: general counts toward MAX_MIXED_BRANCHES.
   const capped = buildMixedBranches('ui', ['document', 'general'])
   assert.equal(capped.length, 2)
-  // unknown stays skipped (invalid value; normalizer already filters it).
   const unknownOnly = buildMixedBranches('ui', ['unknown', 'general'])
   assert.deepEqual(unknownOnly.map((b) => b.kind), ['ui', 'general'])
 })
@@ -66,12 +60,13 @@ test('mixedGuidance: exact sub wins, kind falls back, default releases', () => {
   assert.match(mixedGuidance('chat'), /放行/)
 })
 
-test('planMixedBranches: mixed_of drives the branches and carries the precision note', () => {
+test('planMixedBranches: mixed_of drives branches and carries the precision note', () => {
   const plan = planMixedBranches({ visual_kind: 'mixed', mixed_of: ['document', 'ui'] })
   assert.equal(plan.fallback, false)
   assert.equal(plan.visual_kind, 'mixed')
   assert.deepEqual(plan.branches.map((b) => b.kind), ['ui', 'document'])
   assert.match(plan.note, /精度优化/)
+  assert.match(plan.note, /最多 2 个分支/)
 })
 
 test('planMixedBranches: missing/empty mixed_of falls back (release, never hard-block)', () => {
@@ -90,23 +85,33 @@ test('renderMixedGuidance: mixed plan renders per-branch guidance; fallback rend
   assert.equal(renderMixedGuidance(planMixedBranches(undefined)), undefined)
 })
 
-test('renderMixedGuidance: fast degrades two-branch mixed to the primary branch (mixed x depth fix 1)', () => {
+test('renderMixedGuidance: fast/standard/deep keep the same two-branch correctness coverage', () => {
   const plan = planMixedBranches({ visual_kind: 'mixed', mixed_of: ['document', 'ui'] })
   const fast = renderMixedGuidance(plan, 'fast')
-  // fast 档位与 depthLimitFor('fast')=1 的硬上限一致：只引导主分支一次，
-  // 不再要求"各分支至少一次识别调用"（否则文案 ≥2 次与硬上限 1 次矛盾，
-  // 第二次调用必被 VISION_DEPTH_LIMIT 拒绝）。
-  assert.match(fast, /本轮深度档位为 fast：先验证主分支（ui）一次/)
-  assert.doesNotMatch(fast, /各分支至少一次识别调用/)
-  assert.doesNotMatch(fast, /document：语义优先/) // 次分支引导不注入
-  // standard/deep 保持完整双分支精度引导（与 fast 文案不再冲突）。
   const standard = renderMixedGuidance(plan, 'standard')
-  assert.match(standard, /各分支至少一次识别调用/)
-  assert.match(standard, /document：语义优先/)
   const deep = renderMixedGuidance(plan, 'deep')
+  for (const text of [fast, standard, deep]) {
+    assert.match(text, /ui：detect \/ ground 优先/)
+    assert.match(text, /document：语义优先/)
+    assert.doesNotMatch(text, /升级档位|深度档位为 fast|最多.*次/)
+  }
+  assert.equal(fast, standard)
   assert.equal(deep, standard)
-  // 默认（无 depth 参数）保持完整双分支——向后兼容。
   assert.equal(renderMixedGuidance(plan), standard)
+})
+
+test('mixed guidance follows runtime host locale when called without an explicit locale', async () => {
+  const text = await runWithDepthConfig(
+    { __visionRouterLocale: 'en-US' },
+    async () => {
+      const plan = planMixedBranches({ visual_kind: 'mixed', mixed_of: ['document', 'ui'] })
+      return renderMixedGuidance(plan, 'standard')
+    },
+  )
+  assert.match(text, /Mixed content detected/)
+  assert.match(text, /ui: prefer detect \/ ground/)
+  assert.match(text, /document: prefer semantic understanding/)
+  assert.doesNotMatch(text, /检测到混合内容|语义优先/)
 })
 
 test('index.js integration: mixed plan stored on bootstrap completion and injected in followup', () => {
@@ -116,12 +121,12 @@ test('index.js integration: mixed plan stored on bootstrap completion and inject
   assert.equal(index.includes("evidence.visual_kind === 'mixed'"), true)
 })
 
-test('mixed-router no longer uses the entities heuristic (schema convergence)', () => {
+test('mixed-router no longer uses the entities heuristic', () => {
   const source = readFileSync(new URL('../lib/mixed-router.js', import.meta.url), 'utf8')
-  assert.equal(source.includes('inferMixedKinds'), false) // 启发式已移除
-  assert.equal(source.includes('evidence.mixed_of'), true) // 消费 schema 输出
+  assert.equal(source.includes('inferMixedKinds'), false)
+  assert.equal(source.includes('evidence.mixed_of'), true)
 })
 
-test('MAX_MIXED_BRANCHES is two (cost cap)', () => {
+test('MAX_MIXED_BRANCHES is two (branch-shape cap, not a call-count cap)', () => {
   assert.equal(MAX_MIXED_BRANCHES, 2)
 })

--- a/tests/runtime-i18n.test.js
+++ b/tests/runtime-i18n.test.js
@@ -62,15 +62,17 @@ test('runtime translator reads locale.preference live instead of copying locale 
   assert.equal(i18n.t('attachmentName'), '图片')
 })
 
-test('depth and mixed guidance preserve zh default but render English for non-zh host locales', () => {
+test('strategy and mixed guidance preserve zh default but render English for non-zh host locales', () => {
   const zh = renderDepthGuidance({ visualKind: 'ui', depth: 'fast' })
   assert.match(zh, /检测到界面内容/)
-  assert.match(zh, /本轮深度档位为 fast/)
+  assert.match(zh, /本轮看图策略为快速/)
+  assert.doesNotMatch(zh, /最多.*次|升级档位/)
 
   const en = renderDepthGuidance({ visualKind: 'ui', depth: 'fast', locale: 'en-US' })
   assert.match(en, /UI content detected/)
-  assert.match(en, /Vision depth is fast/)
+  assert.match(en, /Vision strategy is Quick/)
   assert.doesNotMatch(en, /检测|本轮/)
+  assert.doesNotMatch(en, /at most 1 deep-evidence call/)
 
   const plan = planMixedBranches({ mixed_of: ['document', 'ui'] }, 'en')
   const mixed = renderMixedGuidance(plan, 'standard', 'en')
@@ -79,7 +81,9 @@ test('depth and mixed guidance preserve zh default but render English for non-zh
   assert.match(mixed, /ui/)
   assert.doesNotMatch(mixed, /检测到混合内容|语义优先/)
 
-  assert.match(depthCopyFor('custom', 3, 'en'), /custom limit of 3/)
+  const capped = depthCopyFor('standard', 3, 'en')
+  assert.match(capped, /Vision strategy is Standard/)
+  assert.match(capped, /separate deep-dive call cap.*3 successful evidence calls/i)
 })
 
 test('legacy host-injected notes are localized without translating arbitrary user text', () => {
@@ -222,8 +226,6 @@ test('runtime boundary replaces prose-based activation control flow with machine
 
   const wrapped = installRuntimeI18nBoundary(ctx, vision)
 
-  // Core sees auto activation disabled, because this boundary owns the stable
-  // machine-state implementation. The actual Host settings remain true.
   assert.equal(wrapped.get('settings').get('vision-router').autoActivateOnImage, false)
   assert.equal(settings.get('vision-router').autoActivateOnImage, true)
 
@@ -247,8 +249,6 @@ test('runtime boundary replaces prose-based activation control flow with machine
           return 'ok'
         },
       })
-      // Deliberately return text that does NOT contain the historical Chinese
-      // success token. Stable activation must still succeed.
       return 'totally different localized prose'
     },
   })
@@ -269,8 +269,6 @@ test('runtime boundary replaces prose-based activation control flow with machine
     ],
   }
   const decision = await preStep(payload, async () => ({ messages: payload.messages }))
-  // Manual activation already mounted the tools, so auto-mount correctly
-  // reports already-mounted internally and does not inject a duplicate notice.
   assert.equal(decision.messages.length, 1)
 })
 

--- a/tests/runtime-i18n.test.js
+++ b/tests/runtime-i18n.test.js
@@ -19,6 +19,7 @@ import {
 } from '../lib/runtime-i18n-boundary.js'
 import { createRuntimeI18nCoreFacade } from '../lib/runtime-i18n-core.js'
 import { createRuntimeI18nCoreScope } from '../lib/runtime-i18n-core-scope.js'
+import { installStructuredFlowHardening } from '../lib/structured-flow-hardening.js'
 
 function createSettings(localeRef, visionRef = {}) {
   return {
@@ -36,6 +37,67 @@ function createSettings(localeRef, visionRef = {}) {
       }
     },
   }
+}
+
+function createStructuredGuardHarness(localePreference) {
+  const handlers = new Map()
+  const defs = new Map()
+  const config = { visionDepth: 'standard', visionDepthMaxCalls: 1 }
+  const settings = {
+    get(namespace) {
+      if (namespace === 'locale') return { preference: localePreference }
+      if (namespace === 'vision-router') return config
+      return undefined
+    },
+  }
+  const ctx = {
+    get(name) { return name === 'settings' ? settings : undefined },
+    on(event, handler) {
+      handlers.set(event, handler)
+      return () => handlers.delete(event)
+    },
+    tools: {
+      register(def) {
+        defs.set(def.name, def)
+        return () => defs.delete(def.name)
+      },
+    },
+  }
+  const wrapped = installStructuredFlowHardening(ctx, config)
+  wrapped.on('agent/pre-step', async (_payload, next) => next())
+  wrapped.tools.register({
+    name: 'vision_bootstrap',
+    async execute() {
+      return JSON.stringify({
+        ok: true,
+        phase: 'structured-bootstrap',
+        evidence: { visual_kind: 'mixed', mixed_of: ['document', 'ui'] },
+      })
+    },
+  })
+  wrapped.tools.register({ name: 'vision_describe', async execute() { return 'evidence' } })
+  return { handlers, defs }
+}
+
+async function runStructuredGuardLocale(localePreference) {
+  const harness = createStructuredGuardHarness(localePreference)
+  const session = {}
+  const exec = { agent: { session } }
+  const payload = { turn: 1, agent: { session }, messages: [] }
+  const preStep = harness.handlers.get('agent/pre-step')
+  assert.ok(preStep)
+  await preStep(payload, async () => ({ kind: 'ok', messages: [] }))
+  await harness.defs.get('vision_bootstrap').execute({}, exec)
+  const mixedDecision = await preStep(payload, async () => ({ kind: 'ok', messages: [] }))
+  const mixed = mixedDecision.messages.find((message) => String(message.id).includes('structured-mixed-guard'))
+  assert.ok(mixed)
+  assert.equal(await harness.defs.get('vision_describe').execute({}, exec), 'evidence')
+  const blocked = JSON.parse(await harness.defs.get('vision_describe').execute({}, exec))
+  assert.equal(blocked.code, 'VISION_DEPTH_LIMIT')
+  const stopDecision = await preStep(payload, async () => ({ kind: 'ok', messages: [] }))
+  const stop = stopDecision.messages.find((message) => String(message.id).includes('structured-guard-stop'))
+  assert.ok(stop)
+  return { mixed: mixed.content[0].text, stop: stop.content[0].text }
 }
 
 test('runtime locale maps zh variants to zh and every other explicit locale to en', () => {
@@ -84,6 +146,26 @@ test('strategy and mixed guidance preserve zh default but render English for non
   const capped = depthCopyFor('standard', 3, 'en')
   assert.match(capped, /Vision strategy is Standard/)
   assert.match(capped, /separate deep-dive call cap.*3 successful evidence calls/i)
+})
+
+test('structured mixed and explicit-cap guards follow English host locale', async () => {
+  const { mixed, stop } = await runStructuredGuardLocale('en-US')
+  assert.match(mixed, /This mixed image still has unverified branches/)
+  assert.match(mixed, /Prioritize semantics/)
+  assert.match(mixed, /Prefer vision_detect \/ vision_ground/)
+  assert.doesNotMatch(mixed, /混合图片|语义优先|优先用/)
+  assert.match(stop, /configured deep-dive call cap has been reached/i)
+  assert.doesNotMatch(stop, /深度配额|深挖次数上限/)
+})
+
+test('structured mixed and explicit-cap guards preserve Chinese host locale', async () => {
+  const { mixed, stop } = await runStructuredGuardLocale('zh-CN')
+  assert.match(mixed, /混合图片仍有未验证分支/)
+  assert.match(mixed, /语义优先/)
+  assert.match(mixed, /优先用 vision_detect \/ vision_ground/)
+  assert.doesNotMatch(mixed, /This mixed image|Prioritize semantics/)
+  assert.match(stop, /达到本轮设置的深挖次数上限/)
+  assert.doesNotMatch(stop, /识图深度配额已耗尽/)
 })
 
 test('legacy host-injected notes are localized without translating arbitrary user text', () => {

--- a/tests/structured-flow-hardening.test.js
+++ b/tests/structured-flow-hardening.test.js
@@ -7,10 +7,14 @@ import {
   structuredDepthLimit,
 } from '../lib/structured-flow-hardening.js'
 
-function boot(config = {}) {
+function boot(config = {}, localePreference) {
   const handlers = new Map()
   const defs = new Map()
+  const settingsService = localePreference
+    ? { get(namespace) { return namespace === 'locale' ? { preference: localePreference } : undefined } }
+    : undefined
   const ctx = {
+    get(name) { return name === 'settings' ? settingsService : undefined },
     on(event, handler) {
       handlers.set(event, handler)
       return () => handlers.delete(event)
@@ -67,19 +71,14 @@ const bootstrapSuccess = (evidence) => JSON.stringify({
   next: 'continue',
 })
 
-test('structured depth limits are hard: fast=1, standard=2, deep=4, custom=N', () => {
-  assert.equal(structuredDepthLimit('fast'), 1)
-  assert.equal(structuredDepthLimit('standard'), 2)
-  assert.equal(structuredDepthLimit('deep'), 4)
-  assert.equal(structuredDepthLimit('bogus'), 2)
-  assert.equal(structuredDepthLimit('custom', 1), 1)
-  assert.equal(structuredDepthLimit('custom', 6), 6)
-  assert.equal(structuredDepthLimit('custom', 101), 100)
-  assert.equal(structuredDepthLimit('custom', 0), undefined)
-  assert.equal(structuredDepthLimit('custom', undefined), undefined)
-  assert.equal(structuredDepthLimit('fast', 9), 1)
-  assert.equal(structuredDepthLimit('standard', 9), 2)
-  assert.equal(structuredDepthLimit('deep', 9), 4)
+test('structured depth limit is explicit-only and independent of strategy', () => {
+  for (const depth of ['fast', 'standard', 'deep', 'custom', 'bogus']) {
+    assert.equal(structuredDepthLimit(depth), undefined)
+    assert.equal(structuredDepthLimit(depth, 0), undefined)
+    assert.equal(structuredDepthLimit(depth, 1), 1)
+    assert.equal(structuredDepthLimit(depth, 6), 6)
+    assert.equal(structuredDepthLimit(depth, 101), 100)
+  }
 })
 
 test('evidence classifier rejects empty and ok:false results', () => {
@@ -108,8 +107,8 @@ test('guidance overrides are bounded, valid-only and last-wins', () => {
   assert.equal(normalized.find((row) => row.kind === 'document').text.length, 2000)
 })
 
-test('bootstrap is one-shot per turn and repeated calls never hit the backend', async () => {
-  const harness = boot({ visionDepth: 'fast' })
+test('bootstrap is one-shot per turn while fast strategy does not cap evidence calls', async () => {
+  const harness = boot({ visionDepth: 'fast', visionDepthMaxCalls: 0 })
   const tools = registerFlowTools(
     harness,
     () => bootstrapSuccess({ visual_kind: 'general', mixed_of: [] }),
@@ -124,14 +123,12 @@ test('bootstrap is one-shot per turn and repeated calls never hit the backend', 
   assert.equal(second, first)
   assert.deepEqual(tools.counts(), { bootstrapCalls: 1, evidenceCalls: 0 })
 
-  await tools.describe().execute({}, exec)
-  const third = JSON.parse(await tools.describe().execute({}, exec))
-  assert.equal(third.code, 'VISION_DEPTH_LIMIT')
-  assert.deepEqual(tools.counts(), { bootstrapCalls: 1, evidenceCalls: 1 })
+  for (let i = 0; i < 4; i++) assert.equal(await tools.describe().execute({}, exec), 'evidence')
+  assert.deepEqual(tools.counts(), { bootstrapCalls: 1, evidenceCalls: 4 })
 })
 
-test('standard tier blocks the third successful deep-dive before tool execution', async () => {
-  const harness = boot({ visionDepth: 'standard' })
+test('standard strategy does not block the third or later successful deep-dive', async () => {
+  const harness = boot({ visionDepth: 'standard', visionDepthMaxCalls: 0 })
   const tools = registerFlowTools(
     harness,
     () => bootstrapSuccess({ visual_kind: 'general', mixed_of: [] }),
@@ -141,64 +138,94 @@ test('standard tier blocks the third successful deep-dive before tool execution'
   const exec = { agent: { session } }
   await preStep(harness, session, 1)
   await tools.bootstrap().execute({}, exec)
-  assert.equal(await tools.describe().execute({}, exec), 'evidence')
-  assert.equal(await tools.describe().execute({}, exec), 'evidence')
+  for (let i = 0; i < 7; i++) assert.equal(await tools.describe().execute({}, exec), 'evidence')
+  assert.equal(tools.counts().evidenceCalls, 7)
+})
+
+test('explicit positive cap blocks the next call regardless of strategy', async () => {
+  const harness = boot({ visionDepth: 'standard', visionDepthMaxCalls: 3 })
+  const tools = registerFlowTools(
+    harness,
+    () => bootstrapSuccess({ visual_kind: 'general', mixed_of: [] }),
+    () => 'evidence',
+  )
+  const session = {}
+  const exec = { agent: { session } }
+  await preStep(harness, session, 1)
+  await tools.bootstrap().execute({}, exec)
+  for (let i = 0; i < 3; i++) assert.equal(await tools.describe().execute({}, exec), 'evidence')
   const blocked = JSON.parse(await tools.describe().execute({}, exec))
   assert.equal(blocked.ok, false)
   assert.equal(blocked.code, 'VISION_DEPTH_LIMIT')
-  assert.equal(tools.counts().evidenceCalls, 2)
+  assert.match(blocked.reason, /configured deep-dive call cap/)
+  assert.equal(tools.counts().evidenceCalls, 3)
 })
 
-test('custom tier uses its own N and can exceed the built-in deep=4 cap', async () => {
-  const harness = boot({ visionDepth: 'custom', visionDepthMaxCalls: 6 })
+test('zero disables the cap while a retained positive cap applies to every built-in strategy', async () => {
+  const unlimitedHarness = boot({ visionDepth: 'deep', visionDepthMaxCalls: 0 })
+  const unlimitedTools = registerFlowTools(
+    unlimitedHarness,
+    () => bootstrapSuccess({ visual_kind: 'general', mixed_of: [] }),
+    () => 'evidence',
+  )
+  const unlimitedSession = {}
+  const unlimitedExec = { agent: { session: unlimitedSession } }
+  await preStep(unlimitedHarness, unlimitedSession, 1)
+  await unlimitedTools.bootstrap().execute({}, unlimitedExec)
+  for (let i = 0; i < 7; i++) assert.equal(await unlimitedTools.describe().execute({}, unlimitedExec), 'evidence')
+  assert.equal(unlimitedTools.counts().evidenceCalls, 7)
+
+  const cappedHarness = boot({ visionDepth: 'deep', visionDepthMaxCalls: 2 })
+  const cappedTools = registerFlowTools(
+    cappedHarness,
+    () => bootstrapSuccess({ visual_kind: 'general', mixed_of: [] }),
+    () => 'evidence',
+  )
+  const cappedSession = {}
+  const cappedExec = { agent: { session: cappedSession } }
+  await preStep(cappedHarness, cappedSession, 1)
+  await cappedTools.bootstrap().execute({}, cappedExec)
+  for (let i = 0; i < 2; i++) assert.equal(await cappedTools.describe().execute({}, cappedExec), 'evidence')
+  const blocked = JSON.parse(await cappedTools.describe().execute({}, cappedExec))
+  assert.equal(blocked.code, 'VISION_DEPTH_LIMIT')
+  assert.equal(cappedTools.counts().evidenceCalls, 2)
+})
+
+test('fast mixed flow still keeps both correctness branches', async () => {
+  const harness = boot({ visionDepth: 'fast', visionDepthMaxCalls: 0 })
   const tools = registerFlowTools(
     harness,
-    () => bootstrapSuccess({ visual_kind: 'general', mixed_of: [] }),
+    () => bootstrapSuccess({ visual_kind: 'mixed', mixed_of: ['document', 'ui'] }),
     () => 'evidence',
   )
   const session = {}
   const exec = { agent: { session } }
   await preStep(harness, session, 1)
   await tools.bootstrap().execute({}, exec)
-  for (let i = 0; i < 6; i++) assert.equal(await tools.describe().execute({}, exec), 'evidence')
-  const blocked = JSON.parse(await tools.describe().execute({}, exec))
-  assert.equal(blocked.code, 'VISION_DEPTH_LIMIT')
-  assert.equal(tools.counts().evidenceCalls, 6)
+
+  const before = await preStep(harness, session, 1)
+  const firstGuard = before.messages.find((message) => String(message.id).includes('structured-mixed-guard'))
+  assert.ok(firstGuard)
+  assert.match(firstGuard.content[0].text, /ui/)
+  assert.match(firstGuard.content[0].text, /document/)
+
+  await tools.describe().execute({}, exec)
+  const halfDone = await preStep(harness, session, 1)
+  const halfGuard = halfDone.messages.find((message) => String(message.id).includes('structured-mixed-guard'))
+  assert.ok(halfGuard, 'one successful evidence call must not complete a two-branch mixed flow')
+
+  await tools.describe().execute({}, exec)
+  const complete = await preStep(harness, session, 1)
+  assert.equal(
+    complete.messages.some((message) => String(message.id).includes('structured-mixed-guard')),
+    false,
+  )
 })
 
-test('custom zero is unlimited while retained custom values are inactive on built-in tiers', async () => {
-  const customHarness = boot({ visionDepth: 'custom', visionDepthMaxCalls: 0 })
-  const customTools = registerFlowTools(
-    customHarness,
-    () => bootstrapSuccess({ visual_kind: 'general', mixed_of: [] }),
-    () => 'evidence',
-  )
-  const customSession = {}
-  const customExec = { agent: { session: customSession } }
-  await preStep(customHarness, customSession, 1)
-  await customTools.bootstrap().execute({}, customExec)
-  for (let i = 0; i < 7; i++) assert.equal(await customTools.describe().execute({}, customExec), 'evidence')
-  assert.equal(customTools.counts().evidenceCalls, 7)
-
-  const deepHarness = boot({ visionDepth: 'deep', visionDepthMaxCalls: 2 })
-  const deepTools = registerFlowTools(
-    deepHarness,
-    () => bootstrapSuccess({ visual_kind: 'general', mixed_of: [] }),
-    () => 'evidence',
-  )
-  const deepSession = {}
-  const deepExec = { agent: { session: deepSession } }
-  await preStep(deepHarness, deepSession, 1)
-  await deepTools.bootstrap().execute({}, deepExec)
-  for (let i = 0; i < 4; i++) assert.equal(await deepTools.describe().execute({}, deepExec), 'evidence')
-  const deepBlocked = JSON.parse(await deepTools.describe().execute({}, deepExec))
-  assert.equal(deepBlocked.code, 'VISION_DEPTH_LIMIT')
-  assert.equal(deepTools.counts().evidenceCalls, 4)
-})
-
-test('mixed flow remains incomplete after only one branch and clears after two', async () => {
+test('standard mixed flow remains incomplete after one branch and clears after two', async () => {
   const harness = boot({
     visionDepth: 'standard',
+    visionDepthMaxCalls: 0,
     guidanceOverrides: [{ kind: 'document', text: 'CUSTOM DOCUMENT CHECK' }],
   })
   const tools = registerFlowTools(
@@ -220,8 +247,7 @@ test('mixed flow remains incomplete after only one branch and clears after two',
   await tools.describe().execute({}, exec)
   const halfDone = await preStep(harness, session, 1)
   const halfGuard = halfDone.messages.find((message) => String(message.id).includes('structured-mixed-guard'))
-  assert.ok(halfGuard, 'one successful evidence call must not complete a two-branch mixed flow')
-  assert.match(halfGuard.content[0].text, /document/)
+  assert.ok(halfGuard)
 
   await tools.describe().execute({}, exec)
   const complete = await preStep(harness, session, 1)

--- a/tests/structured-guard-idempotency.test.js
+++ b/tests/structured-guard-idempotency.test.js
@@ -89,8 +89,8 @@ test('budget exhaustion emits at most one stop guard across repeated pre-steps',
   }
 })
 
-test('depth exhaustion emits at most one stop guard across repeated pre-steps', async () => {
-  const harness = boot({ visionDepth: 'fast' })
+test('explicit call-cap exhaustion emits at most one stop guard across repeated pre-steps', async () => {
+  const harness = boot({ visionDepth: 'fast', visionDepthMaxCalls: 1 })
   const tools = registerTools(harness, { visual_kind: 'general', mixed_of: [] })
   const session = {}
   const exec = { agent: { session } }

--- a/tests/vision-turn-budget-client-prelude.test.js
+++ b/tests/vision-turn-budget-client-prelude.test.js
@@ -6,18 +6,49 @@ import {
   installVisionTurnBudgetClientPrelude,
 } from '../lib/vision-turn-budget-client-prelude.js'
 
-test('turn-budget prelude exposes unlimited as the default while preserving the explicit cap range', () => {
-  assert.match(VISION_TURN_BUDGET_CLIENT_PRELUDE, /visionTurnBudgetMs/)
-  assert.match(VISION_TURN_BUDGET_CLIENT_PRELUDE, /DEFAULT_MS = 0/)
-  assert.match(VISION_TURN_BUDGET_CLIENT_PRELUDE, /MIN_MS = 10000/)
-  assert.match(VISION_TURN_BUDGET_CLIENT_PRELUDE, /MAX_MS = 600000/)
+test('settings limits prelude keeps turn budget unlimited by default', () => {
+  assert.match(VISION_TURN_BUDGET_CLIENT_PRELUDE, /TURN_BUDGET_FIELD = 'visionTurnBudgetMs'/)
+  assert.match(VISION_TURN_BUDGET_CLIENT_PRELUDE, /DEFAULT_TURN_BUDGET_MS = 0/)
+  assert.match(VISION_TURN_BUDGET_CLIENT_PRELUDE, /MIN_TURN_BUDGET_MS = 10000/)
+  assert.match(VISION_TURN_BUDGET_CLIENT_PRELUDE, /MAX_TURN_BUDGET_MS = 600000/)
   assert.match(VISION_TURN_BUDGET_CLIENT_PRELUDE, /parsed === 0/)
-  assert.match(VISION_TURN_BUDGET_CLIENT_PRELUDE, /scope\.set\(FIELD, parsed\)/)
+  assert.match(VISION_TURN_BUDGET_CLIENT_PRELUDE, /scope\.set\(TURN_BUDGET_FIELD, parsed\)/)
   assert.match(VISION_TURN_BUDGET_CLIENT_PRELUDE, /默认不限制；填 0 表示不限制/)
   assert.match(VISION_TURN_BUDGET_CLIENT_PRELUDE, /Unlimited by default; enter 0 for unlimited/)
 })
 
-test('turn-budget prelude injection is idempotent and stays inside head when available', () => {
+test('depth strategy copy is bilingual and contains no built-in count promise', () => {
+  assert.match(VISION_TURN_BUDGET_CLIENT_PRELUDE, /快速（优先整体判断）/)
+  assert.match(VISION_TURN_BUDGET_CLIENT_PRELUDE, /标准（按需查证，默认）/)
+  assert.match(VISION_TURN_BUDGET_CLIENT_PRELUDE, /细致（主动交叉验证）/)
+  assert.match(VISION_TURN_BUDGET_CLIENT_PRELUDE, /Quick \(overall-first\)/)
+  assert.match(VISION_TURN_BUDGET_CLIENT_PRELUDE, /Standard \(evidence as needed, default\)/)
+  assert.match(VISION_TURN_BUDGET_CLIENT_PRELUDE, /Thorough \(proactive cross-checking\)/)
+  assert.match(VISION_TURN_BUDGET_CLIENT_PRELUDE, /看图深度只决定识图策略，不限制调用次数/)
+  assert.match(VISION_TURN_BUDGET_CLIENT_PRELUDE, /Vision depth chooses the inspection strategy, not a call-count limit/)
+  assert.doesNotMatch(VISION_TURN_BUDGET_CLIENT_PRELUDE, /Standard remains capped at 2|标准档仍固定最多 2 次/)
+})
+
+test('depth call cap is a separate opt-in checkbox backed by maxCalls=0/positive', () => {
+  assert.match(VISION_TURN_BUDGET_CLIENT_PRELUDE, /DEPTH_CAP_FIELD = 'visionDepthMaxCalls'/)
+  assert.match(VISION_TURN_BUDGET_CLIENT_PRELUDE, /depthCapTitle: '限制深挖次数'/)
+  assert.match(VISION_TURN_BUDGET_CLIENT_PRELUDE, /depthCapTitle: 'Limit deep-dive calls'/)
+  assert.match(VISION_TURN_BUDGET_CLIENT_PRELUDE, /type: 'checkbox'/)
+  assert.match(VISION_TURN_BUDGET_CLIENT_PRELUDE, /savedEnabled = saved > 0/)
+  assert.match(VISION_TURN_BUDGET_CLIENT_PRELUDE, /desired = enabled && validCap \? parsed : 0/)
+  assert.match(VISION_TURN_BUDGET_CLIENT_PRELUDE, /scope\.set\(DEPTH_CAP_FIELD, desired\)/)
+  assert.match(VISION_TURN_BUDGET_CLIENT_PRELUDE, /MIN_DEPTH_CAP = 1/)
+  assert.match(VISION_TURN_BUDGET_CLIENT_PRELUDE, /MAX_DEPTH_CAP = 100/)
+})
+
+test('legacy custom strategy is projected to standard and hidden by stable option values', () => {
+  assert.match(VISION_TURN_BUDGET_CLIENT_PRELUDE, /snapshot\.value\[DEPTH_FIELD\] !== 'custom'/)
+  assert.match(VISION_TURN_BUDGET_CLIENT_PRELUDE, /visionDepth: 'standard'/)
+  assert.match(VISION_TURN_BUDGET_CLIENT_PRELUDE, /values\.has\('fast'\).*values\.has\('standard'\).*values\.has\('deep'\).*values\.has\('custom'\)/s)
+  assert.match(VISION_TURN_BUDGET_CLIENT_PRELUDE, /node\.props\.value === 'custom'/)
+})
+
+test('settings limits prelude injection is idempotent and stays inside head when available', () => {
   const html = '<html><head><title>DSH</title></head><body></body></html>'
   const once = injectVisionTurnBudgetClientPrelude(html)
   const twice = injectVisionTurnBudgetClientPrelude(once)


### PR DESCRIPTION
## Summary

Fixes the user-visible case where image analysis can stop before the model has finished collecting evidence because the built-in vision-depth tier silently enforces a call-count quota.

### New product semantics

- `fast` / `standard` / `deep` are **guidance strategies only**.
  - **Quick / 快速**: overall-first; avoid redundant generic recognition.
  - **Standard / 标准** (default): verify the evidence needed by the user's question as needed.
  - **Thorough / 细致**: proactively inspect important regions and cross-check important claims.
- Built-in strategies no longer map to `1 / 2 / 4` hard evidence-call caps.
- `visionDepthMaxCalls` becomes an **independent opt-in safety cap**:
  - `0` = disabled / unlimited (default)
  - `1–100` = explicit maximum successful deep-evidence calls for the turn
  - bootstrap does not count; failed/empty-evidence calls do not consume the cap
- The Settings UI presents the cap as a separate **“限制深挖次数 / Limit deep-dive calls”** checkbox and only shows the numeric input when enabled.
- Historical `visionDepth: custom` configurations remain accepted and are projected to the Standard strategy; a retained positive `visionDepthMaxCalls` still acts as the explicit cap.

### i18n

Follows the runtime-locale boundary established by #348 / #351:

- strategy guidance is authored in both Chinese and English;
- model-facing depth and mixed-content guidance follows live `locale.preference`;
- no control-flow decision depends on translated prose;
- user-authored guidance overrides remain untouched;
- historical session-repair signatures remain unchanged.

### Mixed content

`fast` no longer drops the second mixed-content correctness branch merely to fit the old one-call quota. Mixed branch coverage remains bounded to at most two branches, but branch coverage is independent of the selected inspection strategy.

### Safety boundaries retained

This does **not** remove the real runaway-work protections: bootstrap one-shot behavior, repetition guards, per-task timeouts, optional whole-turn budget, cancellation propagation, attachment/resource limits, and explicit user-configured call caps remain in force.

### Compatibility

The legacy inner Core `VISION_DEPTH_LIMIT` path is retained as a compatibility fallback, but receives the same explicit-only cap policy through the structured-flow runtime context. Existing `visionDepthMaxCalls=0` profiles become unlimited without migration.