### PR TITLE
fix(ui): use fixed SVG icons for the Vision toggle

### DIFF
--- a/lib/client-presentation-boundary.js
+++ b/lib/client-presentation-boundary.js
@@ -1,6 +1,6 @@
 import { htmlHasScriptMarker } from './html-script-marker.js'
 import {
-  CLIENT_PRESENTATION_PRELUDE,
+  CLIENT_PRESENTATION_PRELUDE as BASE_CLIENT_PRESENTATION_PRELUDE,
   resolveVisionModePair,
 } from './client-presentation-boundary-main.js'
 import {
@@ -10,10 +10,61 @@ import { installVisionModelVisibilityBoundary } from './vision-model-visibility-
 
 const CLIENT_PRESENTATION_MARK = 'data-vision-router-presentation-boundary'
 
+const VISION_TOGGLE_TEXT_GLYPH = String.raw`          React.createElement('span', { 'aria-hidden': 'true', style: { fontSize: 13, lineHeight: 1 } }, '👁'),
+          React.createElement('span', null, t('label')),
+          active
+            ? React.createElement('span', {
+                'aria-hidden': 'true',
+                style: { fontSize: 12, lineHeight: 1, fontWeight: 800, marginLeft: 1 }
+              }, '✓')
+            : null`
+
+const VISION_TOGGLE_FIXED_SVG = String.raw`          React.createElement('svg', {
+            width: 14,
+            height: 14,
+            viewBox: '0 0 14 14',
+            fill: 'none',
+            'aria-hidden': 'true',
+            focusable: 'false',
+            style: { display: 'block', flex: '0 0 auto' }
+          }, React.createElement('path', {
+            fillRule: 'evenodd',
+            clipRule: 'evenodd',
+            d: 'M7 2.25c-2.84 0-5.04 1.69-6.25 4.25a1.15 1.15 0 0 0 0 1C1.96 10.06 4.16 11.75 7 11.75s5.04-1.69 6.25-4.25a1.15 1.15 0 0 0 0-1C12.04 3.94 9.84 2.25 7 2.25Zm0 1.25c2.16 0 3.96 1.21 5.05 3.5C10.96 9.29 9.16 10.5 7 10.5S3.04 9.29 1.95 7C3.04 4.71 4.84 3.5 7 3.5Zm0 1.25A2.25 2.25 0 1 0 7 9.25a2.25 2.25 0 0 0 0-4.5Zm0 1.25a1 1 0 1 1 0 2 1 1 0 0 1 0-2Z',
+            fill: 'currentColor'
+          })),
+          React.createElement('span', null, t('label')),
+          active
+            ? React.createElement('svg', {
+                width: 12,
+                height: 12,
+                viewBox: '0 0 14 14',
+                fill: 'none',
+                'aria-hidden': 'true',
+                focusable: 'false',
+                style: { display: 'block', flex: '0 0 auto', marginLeft: 1 }
+              }, React.createElement('path', {
+                d: 'M2.75 7.15 5.6 10 11.25 4.35',
+                stroke: 'currentColor',
+                strokeWidth: 1.5,
+                strokeLinecap: 'round',
+                strokeLinejoin: 'round'
+              }))
+            : null`
+
+export function transformVisionModeToggleIcons(source = BASE_CLIENT_PRESENTATION_PRELUDE) {
+  const input = String(source)
+  if (!input.includes(VISION_TOGGLE_TEXT_GLYPH)) {
+    throw new Error('vision toggle icon transform anchor missing')
+  }
+  return input.replace(VISION_TOGGLE_TEXT_GLYPH, VISION_TOGGLE_FIXED_SVG)
+}
+
+export const CLIENT_PRESENTATION_PRELUDE = transformVisionModeToggleIcons()
+
 export {
-  CLIENT_PRESENTATION_PRELUDE,
   resolveVisionModePair,
-} from './client-presentation-boundary-main.js'
+}
 
 export function injectClientPresentationBoundary(html) {
   if (typeof html !== 'string' || htmlHasScriptMarker(html, CLIENT_PRESENTATION_MARK)) return html

--- a/tests/issue-284-vision-mode-toggle.test.js
+++ b/tests/issue-284-vision-mode-toggle.test.js
@@ -353,6 +353,10 @@ test('issue #284 browser prelude wires the right-slot toggle to shared directory
   assert.equal(offButton.props['aria-pressed'], false)
   assert.equal(offButton.props.disabled, false)
   assert.equal(offButton.props['data-vision-router-mode-toggle'], 'true')
+  assert.equal(offButton.children[0]?.type, 'svg')
+  assert.equal(offButton.children[0]?.props.width, 14)
+  assert.equal(offButton.children[0]?.props.height, 14)
+  assert.equal(offButton.children[0]?.children[0]?.props.fill, 'currentColor')
   assert.equal(offButton.children[2], null)
   offButton.props.onClick()
   await Promise.resolve()
@@ -361,7 +365,9 @@ test('issue #284 browser prelude wires the right-slot toggle to shared directory
 
   const onButton = buttonOf(harness.render())
   assert.equal(onButton.props['aria-pressed'], true)
-  assert.equal(onButton.children[2]?.children[0], '✓')
+  assert.equal(onButton.children[2]?.type, 'svg')
+  assert.equal(onButton.children[2]?.props.width, 12)
+  assert.equal(onButton.children[2]?.children[0]?.props.stroke, 'currentColor')
   assert.match(onButton.props.style.boxShadow, /brand-primary/)
   onButton.props.onClick()
   await Promise.resolve()
@@ -401,7 +407,8 @@ test('issue #284 image-session rejection uses transient toast and keeps the real
 
   const before = buttonOf(harness.render())
   assert.equal(before.props['aria-pressed'], true)
-  assert.equal(before.children[2]?.children[0], '✓')
+  assert.equal(before.children[2]?.type, 'svg')
+  assert.equal(before.children[2]?.children[0]?.props.stroke, 'currentColor')
   before.props.onClick()
   await new Promise((resolve) => setImmediate(resolve))
 
@@ -413,8 +420,9 @@ test('issue #284 image-session rejection uses transient toast and keeps the real
   const toast = firstChildOfType(rendered, harness.primitives.Toast)
   assert.equal(button.props['aria-pressed'], true)
   assert.equal(button.props.disabled, false)
+  assert.equal(button.children[0]?.type, 'svg')
   assert.equal(button.children[1].children[0], '识图')
-  assert.equal(button.children[2]?.children[0], '✓')
+  assert.equal(button.children[2]?.type, 'svg')
   assert.equal(button.props.title, '关闭识图模式')
   assert.ok(toast)
   assert.equal(toast.props.text, `模型操作失败：${error}`)
@@ -446,6 +454,27 @@ test('issue #284 patches onboarding copy and accurately explains the guide spotl
   assert.match(main.dictionaries.en.quickStartBody, /a ✓ means it is on/)
 })
 
+test('issue #357 uses fixed SVG icons instead of platform-dependent text glyphs', () => {
+  const harness = createBrowserHarness()
+  const offButton = buttonOf(harness.render())
+  assert.equal(offButton.children[0]?.type, 'svg')
+  assert.equal(offButton.children[0]?.props.viewBox, '0 0 14 14')
+  assert.equal(offButton.children[0]?.children[0]?.props.fill, 'currentColor')
+
+  harness.setSnapshot({
+    current: { provider: 'opencode-go-vision', model: 'qwen3.6-plus', reasoningEffort: 'high' },
+    groups,
+    status: 'ready',
+    error: null,
+  })
+  const onButton = buttonOf(harness.render())
+  assert.equal(onButton.children[2]?.type, 'svg')
+  assert.equal(onButton.children[2]?.props.viewBox, '0 0 14 14')
+  assert.equal(onButton.children[2]?.children[0]?.props.stroke, 'currentColor')
+  assert.equal(CLIENT_PRESENTATION_PRELUDE.includes("}, '👁')"), false)
+  assert.equal(CLIENT_PRESENTATION_PRELUDE.includes("}, '✓')"), false)
+})
+
 test('issue #284 remains explicit and persistent with no send/image auto-reset hook', () => {
   const source = readFileSync(new URL('../lib/client-presentation-boundary.js', import.meta.url), 'utf8')
   assert.equal(CLIENT_PRESENTATION_PRELUDE.includes("ctx.inject(['slots', 'modelDirectories']"), true)
@@ -454,7 +483,10 @@ test('issue #284 remains explicit and persistent with no send/image auto-reset h
   assert.equal(CLIENT_PRESENTATION_PRELUDE.includes("'data-vision-router-mode-toggle': 'true'"), true)
   assert.equal(CLIENT_PRESENTATION_PRELUDE.includes("require('@deepseek-ai/dsh-client-ui-primitives')"), true)
   assert.equal(CLIENT_PRESENTATION_PRELUDE.includes("failed: '模型操作失败：{message}'"), true)
-  assert.equal(CLIENT_PRESENTATION_PRELUDE.includes("}, '✓')"), true)
+  assert.equal(CLIENT_PRESENTATION_PRELUDE.includes("fill: 'currentColor'"), true)
+  assert.equal(CLIENT_PRESENTATION_PRELUDE.includes("stroke: 'currentColor'"), true)
+  assert.equal(CLIENT_PRESENTATION_PRELUDE.includes("}, '👁')"), false)
+  assert.equal(CLIENT_PRESENTATION_PRELUDE.includes("}, '✓')"), false)
   assert.equal(CLIENT_PRESENTATION_PRELUDE.includes('failedShort'), false)
   assert.equal(source.includes('send-committed'), false)
   assert.equal(source.includes('conversation.input.attachments'), false)


### PR DESCRIPTION
Fixes #357.

## What changed
- replace the composer Vision toggle's platform-dependent `👁` glyph with a fixed 14px inline SVG;
- replace the active-state text `✓` glyph with a fixed 12px inline SVG check;
- both icons use `currentColor`, so existing DSH light/dark/active tokens keep controlling color;
- keep the large legacy presentation artifact byte-stable and apply the icon swap through an exact-anchor transform in `client-presentation-boundary.js`;
- extend the existing #284 toggle tests to pin SVG type, dimensions, `currentColor`, and absence of the old rendered glyph nodes.

This removes Windows/macOS/Linux emoji/font fallback differences without changing the toggle's routing or state semantics.