### PR TITLE
test: relax v2.1 undici lazy-load source-shape contract

### DIFF
--- a/tests/manifest-dependencies.test.js
+++ b/tests/manifest-dependencies.test.js
@@ -60,9 +60,13 @@ test('schemastery remains a runtime dependency', async () => {
 test('undici stays below v8 and is lazy-loaded for plugin proxy use', async () => {
   const pkg = await manifest()
   assert.match(pkg.dependencies?.undici ?? '', /^\^7\./)
+
   const source = await readFile(new URL('../index.js', import.meta.url), 'utf8')
-  assert.match(source, /await import\(['"]undici['"]\)/)
-  assert.doesNotMatch(source, /^import .* from ['"]undici['"]/m)
+  // This is a semantic lazy-load contract, not a source-shape contract:
+  // caching import('undici') in a promise is valid and should not be forced
+  // into an `await import(...)` spelling just to satisfy this test.
+  assert.match(source, /import\(['"]undici['"]\)/)
+  assert.doesNotMatch(source, /^\s*import\s+.*from\s+['"]undici['"]/m)
 })
 
 test('all GitHub Actions dependencies are pinned to immutable commit SHAs', async () => {


### PR DESCRIPTION
## Problem
The v2.1 release branch tightened the Undici lazy-load test to require the exact source spelling `await import('undici')`.

The runtime intentionally caches the lazy import promise (`cachedAgentPromise = import('undici').then(...)`) so repeated proxy use shares one in-flight load. That still satisfies the real contract: Undici must not be imported at plugin/module load time and must only be loaded when Vision Router's selective proxy is used.

## Fix
- validate the presence of dynamic `import('undici')` without requiring an `await` spelling;
- continue rejecting static top-level Undici imports;
- document that this is a semantic lazy-load contract rather than a source-shape contract.

No runtime code is changed.