### PR TITLE
fix(doctor): distinguish legal overrides from duplicate mounts

### DIFF
--- a/lib/doctor.js
+++ b/lib/doctor.js
@@ -303,12 +303,53 @@ function stripYamlComment(line) {
   return line
 }
 
+function yamlIndent(line) {
+  return /^(\s*)/.exec(line)?.[1].length ?? 0
+}
+
+function rowIsInsideInsert(lines, rowIndex, rowIndent) {
+  for (let cursor = rowIndex - 1; cursor >= 0; cursor -= 1) {
+    const candidate = lines[cursor]
+    if (/^\s*$/.test(candidate)) continue
+    const indent = yamlIndent(candidate)
+    if (indent >= rowIndent) continue
+    return /^\s*-?\s*insert\s*:\s*$/.test(candidate)
+  }
+  return false
+}
+
+function inspectVisionRouterPatchRows(lines) {
+  let mountRows = 0
+  let overrideRows = 0
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const idMatch = /^(\s*)-\s+id\s*:\s*['"]?([^'"\s]+)['"]?\s*$/.exec(lines[index])
+    if (!idMatch) continue
+    const rowIndent = idMatch[1].length
+    let pluginName
+    for (let cursor = index + 1; cursor < lines.length; cursor += 1) {
+      const candidate = lines[cursor]
+      if (/^\s*$/.test(candidate)) continue
+      const indent = yamlIndent(candidate)
+      if (indent <= rowIndent) break
+      const nameMatch = /^\s*name\s*:\s*['"]?([^'"\s]+)['"]?\s*$/.exec(candidate)
+      if (nameMatch) pluginName = nameMatch[1]
+    }
+    if (idMatch[2] !== 'vision-router' && pluginName !== PLUGIN_NAME) continue
+    if (rowIsInsideInsert(lines, index, rowIndent)) mountRows += 1
+    else overrideRows += 1
+  }
+
+  return { mountRows, overrideRows }
+}
+
 export function inspectProfilePatch(patchPath) {
   if (!existsSync(patchPath)) {
     return {
       path: patchPath,
       exists: false,
       visionRouterRows: 0,
+      visionRouterOverrideRows: 0,
       manualVisionRouter: false,
       disablesOfficialDeepSeek: false,
     }
@@ -317,14 +358,13 @@ export function inspectProfilePatch(patchPath) {
   try {
     text = readFileBounded(patchPath).toString('utf8')
   } catch (error) {
-    return { path: patchPath, exists: true, visionRouterRows: 0, manualVisionRouter: false, disablesOfficialDeepSeek: false, error: error instanceof Error ? error.message : String(error), oversized: error?.code === 'DOCTOR_INPUT_TOO_LARGE' }
+    return { path: patchPath, exists: true, visionRouterRows: 0, visionRouterOverrideRows: 0, manualVisionRouter: false, disablesOfficialDeepSeek: false, error: error instanceof Error ? error.message : String(error), oversized: error?.code === 'DOCTOR_INPUT_TOO_LARGE' }
   }
   const lines = text.split(/\r?\n/).map(stripYamlComment)
-  let visionRouterRows = 0
+  const { mountRows: visionRouterRows, overrideRows: visionRouterOverrideRows } = inspectVisionRouterPatchRows(lines)
   let disablesOfficialDeepSeek = false
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index]
-    if (/^\s*name\s*:\s*['"]?dsh-vision-router['"]?\s*$/.test(line)) visionRouterRows += 1
     if (!/^\s*-?\s*id\s*:\s*['"]?llm-deepseek['"]?\s*$/.test(line)) continue
     for (let cursor = index + 1; cursor < Math.min(lines.length, index + 12); cursor += 1) {
       if (/^\s*-\s+id\s*:/.test(lines[cursor])) break
@@ -338,6 +378,7 @@ export function inspectProfilePatch(patchPath) {
     path: patchPath,
     exists: true,
     visionRouterRows,
+    visionRouterOverrideRows,
     manualVisionRouter: visionRouterRows > 0,
     disablesOfficialDeepSeek,
   }

--- a/tests/doctor-v2.test.js
+++ b/tests/doctor-v2.test.js
@@ -64,14 +64,38 @@ test('dependency-only install is unhealthy because the plugin is not mounted', (
   assert.equal(report.profiles[0].installation.mode, 'unmounted')
 })
 
-test('manual cordis.patch.yml mode is healthy but bundle plus manual row is a duplicate-load error', () => {
+test('manual cordis.patch.yml mode is healthy but bundle plus manual insert is a duplicate-load error', () => {
   const manualPatch = '- insert:\n    - id: vision-router\n      name: dsh-vision-router\n'
   let profile = makeProfile({ manifest: { dependencies: { 'dsh-vision-router': '^1.7.4' } }, installedVersion: '1.7.4', patch: manualPatch })
   assert.equal(doctorProfiles({ dshHome: profile.home, profile: 'web' }).ok, true)
+  assert.equal(inspectProfilePatch(path.join(profile.dir, 'cordis.patch.yml')).visionRouterRows, 1)
   profile = makeProfile({ manifest: bundleManifest(), installedVersion: '1.7.4', patch: manualPatch })
   const report = doctorProfiles({ dshHome: profile.home, profile: 'web' })
   assert.equal(report.ok, false)
   assert.equal(report.profiles[0].installation.mode, 'duplicate')
+})
+
+test('bundle plus legal by-id override remains one effective Vision Router mount', () => {
+  const overridePatch = '- id: vision-router\n  config:\n    progressiveTools: true\n'
+  const { home, dir } = makeProfile({ manifest: bundleManifest(), installedVersion: '1.7.4', patch: overridePatch })
+  const patch = inspectProfilePatch(path.join(dir, 'cordis.patch.yml'))
+  assert.equal(patch.visionRouterRows, 0)
+  assert.equal(patch.visionRouterOverrideRows, 1)
+  assert.equal(patch.manualVisionRouter, false)
+  const report = doctorProfiles({ dshHome: home, profile: 'web' })
+  assert.equal(report.ok, true)
+  assert.equal(report.profiles[0].installation.mode, 'bundle')
+})
+
+test('named by-id override is still an override rather than a second mount', () => {
+  const overridePatch = '- id: vision-router\n  name: dsh-vision-router\n  config:\n    progressiveTools: true\n'
+  const { home, dir } = makeProfile({ manifest: bundleManifest(), installedVersion: '1.7.4', patch: overridePatch })
+  const patch = inspectProfilePatch(path.join(dir, 'cordis.patch.yml'))
+  assert.equal(patch.visionRouterRows, 0)
+  assert.equal(patch.visionRouterOverrideRows, 1)
+  const report = doctorProfiles({ dshHome: home, profile: 'web' })
+  assert.equal(report.ok, true)
+  assert.equal(report.profiles[0].installation.mode, 'bundle')
 })
 
 test('legacy static llm-deepseek disable is detected as a warning', () => {
@@ -172,6 +196,6 @@ test('oversized profile inputs fail boundedly instead of being read without a sa
 test('installed package integrity rejects wrong package identity and missing bundle patch target', () => {
   let profile = makeProfile({ manifest: bundleManifest(), installedManifest: { name: 'not-vision-router', version: '1.7.4' } })
   assert.equal(doctorProfiles({ dshHome: profile.home, profile: 'web' }).ok, false)
-  profile = makeProfile({ manifest: bundleManifest(), createInstalledTargets: false, installedManifest: { name: 'dsh-vision-router', version: '1.7.4', dsh: { bundle: { patch: './missing.yml' } } } })
+  profile = makeProfile({ manifest: bundleManifest(), createInstalledTargets: false, installedManifest: { name: 'dsh-vision-router', version: '1.7.4', dsh: { bundle: { patch: './missing.yml' } } })
   assert.equal(doctorProfiles({ dshHome: profile.home, profile: 'web' }).ok, false)
 })

--- a/tests/doctor-v2.test.js
+++ b/tests/doctor-v2.test.js
@@ -196,6 +196,6 @@ test('oversized profile inputs fail boundedly instead of being read without a sa
 test('installed package integrity rejects wrong package identity and missing bundle patch target', () => {
   let profile = makeProfile({ manifest: bundleManifest(), installedManifest: { name: 'not-vision-router', version: '1.7.4' } })
   assert.equal(doctorProfiles({ dshHome: profile.home, profile: 'web' }).ok, false)
-  profile = makeProfile({ manifest: bundleManifest(), createInstalledTargets: false, installedManifest: { name: 'dsh-vision-router', version: '1.7.4', dsh: { bundle: { patch: './missing.yml' } } })
+  profile = makeProfile({ manifest: bundleManifest(), createInstalledTargets: false, installedManifest: { name: 'dsh-vision-router', version: '1.7.4', dsh: { bundle: { patch: './missing.yml' } } } })
   assert.equal(doctorProfiles({ dshHome: profile.home, profile: 'web' }).ok, false)
 })


### PR DESCRIPTION
## Summary

Fixes #361.

Doctor previously treated any `name: dsh-vision-router` row in a profile `cordis.patch.yml` as a second manual mount. That contradicts DSH patch semantics: a top-level `- id: vision-router` row is a later by-id override of the bundle-owned row, while a child row under `- insert:` creates a new loader entry.

This change:
- counts only `insert` children as manual Vision Router mounts;
- tracks by-id overrides separately as `visionRouterOverrideRows`;
- preserves the real duplicate detection for stale/manual `insert` rows;
- adds regression fixtures for both unnamed and named legal by-id overrides.

The behavior matches the already verified migration contract from #43: stale manual `insert` crashes as a duplicate, while a plain by-id override composes to one effective `vision-router` row.

## Validation

CI should cover the full Node 22/24 and DSH contract matrices; the targeted Doctor tests now exercise both sides of the distinction.