### PR TITLE
fix(session): keep user images out of pre-step projection

### DIFF
--- a/lib/legacy-core-vision-policy-bridge.js
+++ b/lib/legacy-core-vision-policy-bridge.js
@@ -1,150 +1,21 @@
-import { currentSessionSurfacePolicy } from './session-surface-policy.js'
-import { knownSessionVisionMemory } from './session-vision-state.js'
-
-function isObject(value) {
-  return value !== null && typeof value === 'object'
-}
-
-function collectAttachmentIds(messages) {
-  const ids = []
-  const seen = new Set()
-  const pending = []
-  for (const message of messages ?? []) {
-    if (message && Array.isArray(message.content)) pending.push(...message.content)
-  }
-  while (pending.length > 0) {
-    const block = pending.pop()
-    if (!block || typeof block !== 'object') continue
-    if (block.type === 'image') {
-      const ref = block.attachment
-      const raw = ref && (ref.attachmentId ?? ref.id)
-      if (raw !== undefined && raw !== null) {
-        const id = String(raw)
-        if (id !== '' && !seen.has(id)) {
-          seen.add(id)
-          ids.push(id)
-        }
-      }
-    }
-    if (Array.isArray(block.content)) pending.push(...block.content)
-  }
-  return ids.reverse()
-}
-
-function appendVisionRouterAttachmentHint(payload, decision, config) {
-  const policy = currentSessionSurfacePolicy(config)
-  if (decision?.kind === 'reject' || policy.ownership !== 'vision-router-owned') {
-    return decision
-  }
-
-  // Vision Router-owned wrappers may deliberately preserve raw pixels when the
-  // delegated source model is itself multimodal. The provider wire carries the
-  // bytes, but not DSH's durable attachmentId, so a model that chooses a
-  // precision Vision Router tool would otherwise have to guess an id. Surface
-  // the exact current-turn ids as read-only model context while leaving the raw
-  // image blocks and the session-scoped lookup fence unchanged.
-  const source = Array.isArray(payload?.messages) ? payload.messages : []
-  const ids = collectAttachmentIds(source)
-  if (ids.length === 0) return decision
-
-  const baseMessages = Array.isArray(decision?.messages)
-    ? decision.messages
-    : source
-  const turn = Number.isInteger(payload?.turn) ? payload.turn : 'current'
-  const step = Number.isInteger(payload?.step) ? payload.step : 'step'
-  const hintId = `vision-router-attachment-refs-${turn}-${step}`
-  if (baseMessages.some((message) => message?.id === hintId)) return decision
-
-  const quoted = ids.map((id) => `"${id}"`).join(', ')
-  const hint = {
-    role: 'user',
-    id: hintId,
-    content: [{
-      type: 'text',
-      text: `Vision Router attachment references for the image(s) in this step: ${quoted}. If a Vision Router tool requires attachmentIds or an attachment-id image argument, use only these exact ids. Never guess or invent an attachment id.`,
-    }],
-    source: { kind: 'plugin', plugin: 'dsh-vision-router' },
-  }
-  const messages = [...baseMessages, hint]
-  return isObject(decision)
-    ? { ...decision, messages }
-    : { kind: 'continue', messages }
-}
-
-function rewriteTextOnlyDecision(payload, decision, rewriteHistoryImages, config) {
-  const policy = currentSessionSurfacePolicy(config)
-  if (
-    decision?.kind === 'reject' ||
-    policy.rewriteCurrentImages !== true ||
-    typeof rewriteHistoryImages !== 'function'
-  ) {
-    return decision
-  }
-
-  const source = Array.isArray(decision?.messages)
-    ? decision.messages
-    : Array.isArray(payload?.messages)
-      ? payload.messages
-      : undefined
-  if (!source) return decision
-
-  // Core registers the exact SessionMemoryView while processing this same
-  // pre-step. Reuse it here so a text-only fallback preserves cached visual
-  // descriptions instead of degrading them back to a generic attachment marker.
-  const memory = knownSessionVisionMemory(payload?.agent?.session)
-  const rewritten = rewriteHistoryImages(source, memory)
-  const messages = rewritten?.messages
-  if (!Array.isArray(messages) || messages === source) return decision
-  if (isObject(decision)) return { ...decision, messages }
-  return { kind: 'continue', messages }
-}
-
 /**
- * Preserve the two remaining pre-step compatibility behaviors without
- * impersonating Settings/config for Core.
+ * Retired pre-step compatibility shell.
  *
- * Ownership classification remains native-image-coexistence's responsibility.
- * Core consumes its five policy-derived switches through CoreVisionSurface.
- * This boundary only reuses the exact SessionMemoryView for a text-only image
- * rewrite and surfaces current durable attachment ids for a Vision Router-owned
- * route. Every other context service, Settings object, injected child and config
- * value passes through unchanged.
+ * This module remains as a stable internal import while the 2.x composition is
+ * still being collapsed, but it deliberately owns no runtime behavior.
+ *
+ * Historical versions intercepted `agent/pre-step` for two model-only concerns:
+ * rewriting text-only image messages into `[attached image: ...]` markers and
+ * appending a synthetic attachment-id user message for Vision Router wrappers.
+ * DSH persists every admitted pre-step message as `user/message`, so both
+ * transforms crossed the durable transcript boundary and could surface in the
+ * Web conversation. User-owned image messages must instead remain byte-for-byte
+ * Session facts; request-only image projection belongs to the selected adapter.
+ *
+ * Keep this function identity-only until runtime-composition removes the import
+ * in a dedicated closure cleanup. No Settings/config/service identity is
+ * impersonated and no `agent/pre-step` listener is installed here.
  */
-export function installLegacyCoreVisionPolicyBridge(
-  ctx,
-  config = {},
-  { rewriteHistoryImages } = {},
-) {
-  if (!isObject(ctx)) return { ctx, config }
-
-  const wrappedCtx = new Proxy(ctx, {
-    get(target, property) {
-      if (property === 'on') {
-        const on = Reflect.get(target, property, target)
-        if (typeof on !== 'function') return on
-        return (event, handler, ...rest) => {
-          if (event !== 'agent/pre-step' || typeof handler !== 'function') {
-            return on.call(target, event, handler, ...rest)
-          }
-          return on.call(target, event, async function legacyCoreVisionPolicyPreStep(payload, next) {
-            const decision = await handler.call(this, payload, next)
-            const rewritten = rewriteTextOnlyDecision(
-              payload,
-              decision,
-              rewriteHistoryImages,
-              config,
-            )
-            return appendVisionRouterAttachmentHint(payload, rewritten, config)
-          }, ...rest)
-        }
-      }
-      const value = Reflect.get(target, property, target)
-      return typeof value === 'function' ? value.bind(target) : value
-    },
-  })
-
-  return {
-    ctx: wrappedCtx,
-    config,
-  }
+export function installLegacyCoreVisionPolicyBridge(ctx, config = {}) {
+  return { ctx, config }
 }

--- a/lib/session-surface-policy.js
+++ b/lib/session-surface-policy.js
@@ -26,6 +26,13 @@ function normalizedOwnership(policy) {
  * `visionPolicy` is evidence produced by native-image-coexistence; this module
  * only projects that already-authoritative ownership decision onto the legacy
  * configuration/surface questions that used to be answered in several places.
+ *
+ * Durable transcript invariant: once a real session policy exists, Core may
+ * observe/index image blocks but may never replace a user-owned image message
+ * before the Agent loop appends it to the Session log. Image projection belongs
+ * at the adapter/request boundary. The historical `rewriteCurrentImages` bit is
+ * therefore intentionally ignored even when an older policy producer still
+ * exposes it; the compatibility field below is permanently false.
  */
 export function resolveSessionSurfacePolicy({
   visionPolicy,
@@ -39,11 +46,11 @@ export function resolveSessionSurfacePolicy({
   const pluginOwned = ownership === OWNERSHIP.PLUGIN_OWNED
   const textOnly = ownership === OWNERSHIP.TEXT_ONLY
 
-  // No active session policy means no session-specific rewrite/preservation
-  // authority. This distinction is important: absence is not the same as an
-  // explicit UNKNOWN capability snapshot, whose contract is non-destructive.
-  const preserveRawImages = source?.preserveRawImages === true
-  const rewriteCurrentImages = source?.rewriteCurrentImages === true
+  // No active session policy means no session-specific preservation authority.
+  // During a real pre-step, every ownership result — including explicit
+  // text-only and unknown — preserves the durable user message unchanged.
+  const preserveRawImages = source !== undefined
+  const rewriteCurrentImages = false
   const allowStructuredBootstrap = source?.allowStructuredBootstrap !== false
   const allowGenericAutoMount = source?.suppressGenericAutoMount !== true
 
@@ -61,7 +68,11 @@ export function resolveSessionSurfacePolicy({
 
   const overrides = {}
   if (schemaBootstrapping === true && value.tool === false) overrides.tool = true
-  if (preserveRawImages && value.rewriteImages !== false) overrides.rewriteImages = false
+  // Core's historical rewriteImages switch controls an agent/pre-step message
+  // transform. Disable it for every real session policy so neither current nor
+  // historical user image blocks can be persisted as internal attachment text.
+  // Vision Router-owned adapters still perform their private request projection.
+  if (source !== undefined && value.rewriteImages !== false) overrides.rewriteImages = false
   if (native && value.instantDescribe !== false) overrides.instantDescribe = false
   if (native && value.autoActivateOnImage !== false) overrides.autoActivateOnImage = false
   if (!allowStructuredBootstrap && value.structuredVisionBootstrap !== false) {

--- a/tests/issue-276-entry-policy-bridge.test.js
+++ b/tests/issue-276-entry-policy-bridge.test.js
@@ -1,7 +1,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
-import { rewriteHistoryImages } from '../index.js'
+import { currentCoreVisionSurface } from '../lib/core-vision-surface.js'
 import { installLegacyCoreVisionPolicyBridge } from '../lib/legacy-core-vision-policy-bridge.js'
 import {
   IMAGE_OWNERSHIP,
@@ -9,7 +9,6 @@ import {
   currentSessionVisionPolicy,
 } from '../lib/native-image-coexistence.js'
 import { installLocalVisionStabilizer } from '../lib/local-vision-stabilizer.js'
-import { createSessionVisionStateStore } from '../lib/session-vision-state.js'
 import { installVisionToolRuntimeBoundary } from '../lib/vision-tool-runtime-boundary.js'
 
 function session(provider, model = 'model') {
@@ -126,11 +125,7 @@ function composeBridge(harness, options = {}) {
     ? installVisionToolRuntimeBoundary(harness.ctx, harness.persisted)
     : harness.ctx
   const native = contextWithNativeImageCoexistence(runtimeCtx, harness.persisted)
-  const bridge = installLegacyCoreVisionPolicyBridge(
-    native.ctx,
-    native.config,
-    { rewriteHistoryImages },
-  )
+  const bridge = installLegacyCoreVisionPolicyBridge(native.ctx, native.config)
   return { native, bridge }
 }
 
@@ -147,7 +142,7 @@ async function runCoreLikePreStep(harness, bridge, provider, messages, observe) 
   )
 }
 
-test('text-only session uses the canonical core writer even when a global wrapper exists', async () => {
+test('text-only session preserves the durable image even when a global wrapper exists', async () => {
   const harness = bridgeHarness({ inputModalities: ['text'] })
   harness.ctx.llm.registerAdapter(['deepseek-vision'], { stream() {} })
   const { bridge } = composeBridge(harness)
@@ -160,46 +155,42 @@ test('text-only session uses the canonical core writer even when a global wrappe
     messages,
     () => {
       const policy = currentSessionVisionPolicy()
+      const surface = currentCoreVisionSurface(harness.persisted)
       assert.equal(policy.ownership, IMAGE_OWNERSHIP.TEXT_ONLY)
-      assert.equal(policy.rewriteCurrentImages, true)
+      // The legacy policy producer may still expose rewriteCurrentImages, but
+      // the Core-facing surface permanently denies that destructive grant.
+      assert.equal(surface.preserveRawImages, true)
+      assert.equal(surface.rewriteCurrentImages, false)
+      assert.equal(surface.rewriteEnabled, false)
       assert.equal(bridge.config, harness.persisted)
       assert.equal(bridge.config.rewriteImages, true)
     },
   )
 
-  assert.deepEqual(result.messages[0].content[0].content, [
-    {
-      type: 'text',
-      text: '[attached image: sha256:text-route] The current model cannot see images. To examine it, call vision_describe with attachmentIds: ["sha256:text-route"] and a specific question.',
-    },
-  ])
+  assert.equal(result.messages, messages)
+  assert.equal(result.messages[0].content[0].content[0].type, 'image')
+  assert.equal(
+    result.messages[0].content[0].content[0].attachment.attachmentId,
+    'sha256:text-route',
+  )
 })
 
-test('text-only fallback reuses the exact core session memory instead of degrading cached descriptions', async () => {
+test('text-only pre-step never substitutes cached descriptions into the durable user message', async () => {
   const harness = bridgeHarness({ inputModalities: ['text'] })
   harness.ctx.llm.registerAdapter(['deepseek-vision'], { stream() {} })
   const { bridge } = composeBridge(harness)
-  const selectedSession = session('deepseek-official')
   const messages = [imageMessage('sha256:cached')]
-  const visionState = createSessionVisionStateStore()
 
-  bridge.ctx.on('agent/pre-step', async (payload) => {
-    const memory = visionState.memoryForSession(payload.agent.session)
-    memory.set('sha256:cached', '缓存里的电路图描述')
-    return { kind: 'continue', messages: payload.messages }
-  })
-
-  const handler = harness.handlers.get('agent/pre-step')
-  assert.ok(handler)
-  const result = await handler(
-    { agent: { session: selectedSession }, messages },
-    async () => ({ kind: 'continue', messages }),
+  const result = await runCoreLikePreStep(
+    harness,
+    bridge,
+    'deepseek-official',
+    messages,
   )
 
-  const text = result.messages[0].content[0].content[0].text
-  assert.match(text, /此前由视觉模型读取/)
-  assert.match(text, /缓存里的电路图描述/)
-  assert.doesNotMatch(text, /call vision_describe/)
+  assert.equal(result.messages, messages)
+  assert.equal(result.messages[0].content[0].content[0].type, 'image')
+  assert.equal(result.messages[0].content[0].content[0].attachment.attachmentId, 'sha256:cached')
 })
 
 test('Vision Router-owned adapter keeps raw image blocks at the adapter boundary', async () => {
@@ -210,12 +201,16 @@ test('Vision Router-owned adapter keeps raw image blocks at the adapter boundary
 
   const result = await runCoreLikePreStep(harness, bridge, 'owned-route', messages, () => {
     const policy = currentSessionVisionPolicy()
+    const surface = currentCoreVisionSurface(harness.persisted)
     assert.equal(policy.ownership, IMAGE_OWNERSHIP.VISION_ROUTER)
     assert.equal(policy.preserveRawImages, true)
+    assert.equal(surface.preserveRawImages, true)
+    assert.equal(surface.rewriteEnabled, false)
     assert.equal(bridge.config, harness.persisted)
     assert.equal(bridge.config.rewriteImages, true)
   })
 
+  assert.equal(result.messages, messages)
   assert.equal(result.messages[0].content[0].content[0].type, 'image')
 })
 
@@ -229,10 +224,16 @@ test('native session preserves pixels, suppresses automatic orchestration, and k
 
   const result = await runCoreLikePreStep(harness, bridge, 'deepseek-official', messages, () => {
     const policy = currentSessionVisionPolicy()
+    const surface = currentCoreVisionSurface(harness.persisted)
     assert.equal(policy.ownership, IMAGE_OWNERSHIP.NATIVE)
     assert.equal(policy.preserveRawImages, true)
     assert.equal(policy.suppressGenericAutoMount, true)
     assert.equal(policy.allowStructuredBootstrap, false)
+    assert.equal(surface.preserveRawImages, true)
+    assert.equal(surface.rewriteEnabled, false)
+    assert.equal(surface.instantDescribe, false)
+    assert.equal(surface.autoActivateOnImage, false)
+    assert.equal(surface.structuredBootstrap, false)
     assert.equal(bridge.config, harness.persisted)
     assert.equal(bridge.config.rewriteImages, true)
     assert.equal(bridge.config.instantDescribe, true)
@@ -241,6 +242,7 @@ test('native session preserves pixels, suppresses automatic orchestration, and k
     assert.equal(bridge.config.tool, true)
   })
 
+  assert.equal(result.messages, messages)
   assert.equal(result.messages[0].content[0].content[0].type, 'image')
 })
 
@@ -251,16 +253,20 @@ test('UNKNOWN capability preserves the existing Host image contract instead of f
 
   const result = await runCoreLikePreStep(harness, bridge, 'native-pi', messages, () => {
     const policy = currentSessionVisionPolicy()
+    const surface = currentCoreVisionSurface(harness.persisted)
     assert.equal(policy.ownership, IMAGE_OWNERSHIP.UNKNOWN)
     assert.equal(policy.preserveRawImages, true)
+    assert.equal(surface.preserveRawImages, true)
+    assert.equal(surface.rewriteEnabled, false)
     assert.equal(bridge.config, harness.persisted)
     assert.equal(bridge.config.rewriteImages, true)
   })
 
+  assert.equal(result.messages, messages)
   assert.equal(result.messages[0].content[0].content[0].type, 'image')
 })
 
-test('tool=false stays real through the pre-step bridge while execution follows live settings', async () => {
+test('tool=false stays real through the retired bridge while execution follows live settings', async () => {
   const harness = bridgeHarness({ config: { tool: false } })
   const { bridge } = composeBridge(harness, { toolRuntime: true })
 

--- a/tests/issue-284-attachment-id-hint.test.js
+++ b/tests/issue-284-attachment-id-hint.test.js
@@ -91,16 +91,12 @@ function harness({ inputModalities = ['text'] } = {}) {
 }
 
 function installPreStep(h, native) {
-  const bridge = installLegacyCoreVisionPolicyBridge(native.ctx, native.config, {
-    rewriteHistoryImages(messages) {
-      return { messages, attachments: [] }
-    },
-  })
+  const bridge = installLegacyCoreVisionPolicyBridge(native.ctx, native.config)
   bridge.ctx.on('agent/pre-step', async (_payload, next) => next())
   return bridge
 }
 
-test('issue #284 Vision Router-owned image route tells the model the exact durable attachment id', async () => {
+test('issue #284 Vision Router-owned image route keeps the exact durable user message and adds no synthetic hint', async () => {
   const h = harness({ inputModalities: ['text'] })
   const native = contextWithNativeImageCoexistence(h.ctx, h.config)
   native.ctx.llm.registerAdapter(['opencode-go-vision'], { stream() {} })
@@ -118,17 +114,17 @@ test('issue #284 Vision Router-owned image route tells the model the exact durab
     async () => ({ kind: 'continue', messages }),
   )
 
-  assert.equal(result.messages.length, 2)
-  assert.equal(result.messages[0].content[0].type, 'image', 'raw pixels must stay available')
-  const hint = result.messages[1]
-  assert.equal(hint.id, 'vision-router-attachment-refs-7-1')
-  assert.equal(hint.source.plugin, 'dsh-vision-router')
-  assert.equal(hint.content[0].text.includes(realId), true)
-  assert.match(hint.content[0].text, /use only these exact ids/i)
-  assert.match(hint.content[0].text, /Never guess or invent/i)
+  assert.equal(result.messages, messages)
+  assert.equal(result.messages.length, 1)
+  assert.equal(result.messages[0].content[0].type, 'image')
+  assert.equal(result.messages[0].content[0].attachment.attachmentId, realId)
+  assert.equal(
+    result.messages.some((message) => String(message?.id).startsWith('vision-router-attachment-refs-')),
+    false,
+  )
 })
 
-test('issue #284 ordinary Host-native image routes do not receive Vision Router attachment hints', async () => {
+test('issue #284 ordinary Host-native image routes remain untouched', async () => {
   const h = harness({ inputModalities: ['text', 'image'] })
   h.ctx.llm.registerAdapter(['native-image'], { stream() {} })
   const native = contextWithNativeImageCoexistence(h.ctx, h.config)
@@ -145,11 +141,11 @@ test('issue #284 ordinary Host-native image routes do not receive Vision Router 
     async () => ({ kind: 'continue', messages }),
   )
 
-  assert.equal(result.messages.length, 1)
+  assert.equal(result.messages, messages)
   assert.equal(result.messages[0], messages[0])
 })
 
-test('issue #284 attachment hint collects nested image refs without fabricating ids', async () => {
+test('nested image refs stay in the original transcript shape without fabricated model-only user messages', async () => {
   const h = harness({ inputModalities: ['text'] })
   const native = contextWithNativeImageCoexistence(h.ctx, h.config)
   native.ctx.llm.registerAdapter(['owned-vision'], { stream() {} })
@@ -180,8 +176,8 @@ test('issue #284 attachment hint collects nested image refs without fabricating 
     async () => ({ kind: 'continue', messages }),
   )
 
-  const text = result.messages.at(-1).content[0].text
-  assert.equal(text.includes(first), true)
-  assert.equal(text.includes(second), true)
-  assert.equal(text.includes('7f8e9d0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d'), false)
+  assert.equal(result.messages, messages)
+  assert.equal(result.messages.length, 1)
+  assert.equal(result.messages[0].content[0].content[0].attachment.attachmentId, first)
+  assert.equal(result.messages[0].content[0].content[2].attachment.attachmentId, second)
 })

--- a/tests/session-surface-policy.test.js
+++ b/tests/session-surface-policy.test.js
@@ -22,6 +22,9 @@ function visionPolicy(ownership, overrides = {}) {
   return {
     ownership,
     preserveRawImages: native || pluginOwned || ownership === 'unknown',
+    // Keep the historical producer shape in the fixture: the surface policy
+    // must ignore this legacy grant rather than depending on every caller being
+    // migrated in lock-step.
     rewriteCurrentImages: textOnly,
     suppressGenericAutoMount: native,
     allowStructuredBootstrap: !native,
@@ -75,19 +78,35 @@ test('Vision Router-owned session preserves pixels while retaining Router orches
   assert.deepEqual(policy.legacyConfigOverrides, { rewriteImages: false })
 })
 
-test('text-only session keeps the current rewrite bridge and optional orchestration surface', () => {
+test('text-only session preserves the durable image and disables Core pre-step rewriting', () => {
   const policy = resolveSessionSurfacePolicy({
     visionPolicy: visionPolicy('text-only'),
     config: config(),
   })
 
   assert.equal(policy.ownership, 'text-only')
-  assert.equal(policy.preserveRawImages, false)
-  assert.equal(policy.rewriteCurrentImages, true)
-  assert.equal(policy.surface.rewriteCurrentImages, true)
+  assert.equal(policy.preserveRawImages, true)
+  assert.equal(policy.rewriteCurrentImages, false)
+  assert.equal(policy.surface.preserveRawImages, true)
+  assert.equal(policy.surface.rewriteCurrentImages, false)
   assert.equal(policy.surface.structuredBootstrap, true)
   assert.equal(policy.surface.genericAutoMount, true)
-  assert.deepEqual(policy.legacyConfigOverrides, {})
+  assert.deepEqual(policy.legacyConfigOverrides, { rewriteImages: false })
+})
+
+test('legacy rewriteCurrentImages evidence can never grant a destructive transcript rewrite', () => {
+  const policy = resolveSessionSurfacePolicy({
+    visionPolicy: visionPolicy('text-only', {
+      preserveRawImages: false,
+      rewriteCurrentImages: true,
+    }),
+    config: config({ rewriteImages: true }),
+  })
+
+  assert.equal(policy.preserveRawImages, true)
+  assert.equal(policy.rewriteCurrentImages, false)
+  assert.equal(policy.surface.rewriteCurrentImages, false)
+  assert.equal(policy.legacyConfigOverrides.rewriteImages, false)
 })
 
 test('explicit UNKNOWN session remains non-destructive without being misclassified as text-only', () => {
@@ -141,7 +160,7 @@ test('explicit user-off settings remain off and are never expanded by the surfac
   })
 
   assert.deepEqual(policy.surface, {
-    preserveRawImages: false,
+    preserveRawImages: true,
     rewriteCurrentImages: false,
     visionTools: false,
     structuredBootstrap: false,

--- a/tests/settings-impersonation-closure.test.js
+++ b/tests/settings-impersonation-closure.test.js
@@ -4,7 +4,7 @@ import { readFile } from 'node:fs/promises'
 
 import { installLegacyCoreVisionPolicyBridge } from '../lib/legacy-core-vision-policy-bridge.js'
 
-test('legacy pre-step compatibility cannot impersonate Settings, scopes, injected children or config', async () => {
+test('retired legacy bridge cannot impersonate Settings, pre-step messages, injected children or config', async () => {
   const source = await readFile(
     new URL('../lib/legacy-core-vision-policy-bridge.js', import.meta.url),
     'utf8',
@@ -18,15 +18,19 @@ test('legacy pre-step compatibility cannot impersonate Settings, scopes, injecte
     'childContextView',
     'settingsCache',
     'finishSchemaBootstrap',
+    'rewriteHistoryImages',
+    'appendVisionRouterAttachmentHint',
+    'rewriteTextOnlyDecision',
   ]) {
-    assert.equal(source.includes(forbidden), false, `${forbidden} must not return to the legacy bridge`)
+    assert.equal(source.includes(forbidden), false, `${forbidden} must not return to the retired bridge`)
   }
   assert.doesNotMatch(source, /property === ['"]get['"]/, 'bridge must not intercept ctx.get/settings')
   assert.doesNotMatch(source, /property === ['"]inject['"]/, 'bridge must not intercept injected Settings children')
-  assert.match(source, /property === ['"]on['"]/, 'the retained compatibility seam is pre-step only')
+  assert.doesNotMatch(source, /property === ['"]on['"]/, 'bridge must not intercept agent/pre-step')
+  assert.doesNotMatch(source, /agent\/pre-step/, 'model-only content must not be synthesized through pre-step')
 })
 
-test('legacy pre-step compatibility preserves real config and Settings identities', () => {
+test('retired legacy bridge preserves real context, config and Settings identities', () => {
   const config = Object.freeze({
     tool: false,
     rewriteImages: true,
@@ -47,6 +51,7 @@ test('legacy pre-step compatibility preserves real config and Settings identitie
   }
 
   const bridge = installLegacyCoreVisionPolicyBridge(ctx, config)
+  assert.equal(bridge.ctx, ctx)
   assert.equal(bridge.config, config)
   assert.equal(bridge.ctx.get('settings'), settings)
 

--- a/tests/settings-impersonation-closure.test.js
+++ b/tests/settings-impersonation-closure.test.js
@@ -27,7 +27,7 @@ test('retired legacy bridge cannot impersonate Settings, pre-step messages, inje
   assert.doesNotMatch(source, /property === ['"]get['"]/, 'bridge must not intercept ctx.get/settings')
   assert.doesNotMatch(source, /property === ['"]inject['"]/, 'bridge must not intercept injected Settings children')
   assert.doesNotMatch(source, /property === ['"]on['"]/, 'bridge must not intercept agent/pre-step')
-  assert.doesNotMatch(source, /agent\/pre-step/, 'model-only content must not be synthesized through pre-step')
+  assert.doesNotMatch(source, /new Proxy\(/, 'retired bridge must remain an identity boundary')
 })
 
 test('retired legacy bridge preserves real context, config and Settings identities', () => {


### PR DESCRIPTION
## Problem

A text-only fallback could rewrite an uploaded image inside `agent/pre-step` into the internal `[attached image: sha256:...]` marker. DSH then persists every admitted pre-step message as `user/message`, so the model-only marker became the durable human transcript and the Web UI lost the image preview.

This is the same architectural class as the old #2 leak: request projection crossed the Session boundary.

## Root fix

- Make the session surface enforce a hard transcript invariant: once a real session ownership policy exists, Core may observe/index image blocks but `rewriteImages` is projected off for pre-step processing.
- Ignore the historical `rewriteCurrentImages` grant even if an older ownership-policy producer still exposes it; the Core-facing compatibility field is permanently false.
- Retire `legacy-core-vision-policy-bridge` to an identity-only shell. It no longer rewrites text-only messages and no longer appends synthetic attachment-id `user/message` hints.
- Keep Vision Router wrapper/twin behavior unchanged: adapter-owned request projection still rewrites images privately for text delegates, while the Session keeps the original image blocks.

## User-visible contract

- Vision ON + text model: the conversation keeps the original image preview; only the wrapper's private model request contains a marker/description.
- Native multimodal route: original image remains unchanged end-to-end.
- Plain text-only route: Vision Router no longer mutates the durable message to make it work. Modern DSH admission can reject the image explicitly instead of corrupting the transcript.

## Regression coverage

- text-only pre-step preserves the exact image block and attachment id;
- cached descriptions cannot replace the durable user image;
- Router-owned/native/unknown routes keep raw image identity;
- no synthetic `vision-router-attachment-refs-*` user message is appended;
- architecture closure asserts the retired bridge is identity-only and cannot intercept pre-step/Settings.

Follow-up cleanup can remove the now-identity bridge import from runtime composition once this behavioral boundary has baked; this PR intentionally keeps the import stable to minimize closure risk.