### PR TITLE
fix: restore target adapter authority for delegated vision calls

### DIFF
--- a/lib/delegated-call-config.js
+++ b/lib/delegated-call-config.js
@@ -1,0 +1,27 @@
+const ROUTE_OWNED_CALL_FIELDS = Object.freeze([
+  'reasoningEffort',
+  'temperature',
+  'maxTokens',
+  'stop',
+])
+
+/**
+ * Project an internal Vision Router delegation onto a different provider/model.
+ *
+ * The delegated route owns its own call defaults and compatibility. Carry the
+ * request payload and lifecycle through, but never leak source-route sampling,
+ * reasoning or output-limit state into the target adapter. DSH will materialize
+ * the target adapter's configured defaults when these fields are absent.
+ *
+ * Direct transports owned by Vision Router do not use this projection; their
+ * wire compatibility remains the Router's responsibility.
+ */
+export function projectDelegatedCallConfig(options) {
+  if (!options || typeof options !== 'object' || Array.isArray(options)) return options
+  if (!ROUTE_OWNED_CALL_FIELDS.some((field) => Object.hasOwn(options, field))) return options
+  const next = { ...options }
+  for (const field of ROUTE_OWNED_CALL_FIELDS) delete next[field]
+  return next
+}
+
+export const delegatedRouteOwnedCallFields = ROUTE_OWNED_CALL_FIELDS

--- a/lib/vision-tool-runtime-boundary.js
+++ b/lib/vision-tool-runtime-boundary.js
@@ -12,6 +12,7 @@ import {
   ProxyDispatcherTracker,
   proxyRequestIsManaged,
 } from './runtime-reliability.js'
+import { projectDelegatedCallConfig } from './delegated-call-config.js'
 
 const toolRuntime = new AsyncLocalStorage()
 const wrappedContexts = new WeakMap()
@@ -21,6 +22,8 @@ const wrappedSettings = new WeakMap()
 const wrappedScopes = new WeakMap()
 const wrappedLlms = new WeakMap()
 const wrappedAdapters = new WeakMap()
+const wrappedDelegatingAdapters = new WeakMap()
+const VISION_ROUTER_ADAPTER_OWNER = Symbol.for('dsh-vision-router.adapter-owner')
 
 function usableSignal(value) {
   return value && typeof value === 'object' && typeof value.aborted === 'boolean' ? value : undefined
@@ -134,6 +137,10 @@ function stateFor(name, exec) {
     signal: usableSignal(exec?.signal),
     artifactRunId: `.vision-run-${Date.now().toString(36)}-${randomUUID()}`,
     disableCoreCache: name === 'vision_describe',
+    // Every model call made from a Vision Router tool is an internal
+    // delegation. The selected target adapter, not the source tool's generic
+    // defaults, owns reasoning/sampling/output-limit call config.
+    delegatedCall: true,
   }
 }
 
@@ -309,6 +316,76 @@ function wrapVisionHttpAdapter(adapter, runtimeState) {
   return wrapped
 }
 
+function visionRouterDelegatingAdapter(adapter, routes) {
+  if (!adapter || (typeof adapter !== 'object' && typeof adapter !== 'function')) return false
+  try {
+    if (adapter[VISION_ROUTER_ADAPTER_OWNER] !== undefined) return true
+  } catch {
+    // Fall through to route/provider metadata.
+  }
+  if (typeof adapter.providerInfo !== 'function') return false
+  for (const route of routes) {
+    try {
+      const name = adapter.providerInfo(String(route))?.name
+      if (name === 'Vision Chain') return true
+    } catch {
+      // Provider metadata is advisory; another route may still identify it.
+    }
+  }
+  return false
+}
+
+async function* iterateUnderRuntimeState(iterable, state) {
+  const iterator = toolRuntime.run(state, () => iterable[Symbol.asyncIterator]())
+  let completed = false
+  try {
+    while (true) {
+      const item = await toolRuntime.run(state, () => iterator.next())
+      if (item.done) {
+        completed = true
+        return
+      }
+      yield item.value
+    }
+  } finally {
+    if (!completed && typeof iterator.return === 'function') {
+      await toolRuntime.run(state, () => iterator.return())
+    }
+  }
+}
+
+function wrapDelegatingAdapter(adapter, runtimeState) {
+  if (!adapter || (typeof adapter !== 'object' && typeof adapter !== 'function')) return adapter
+  let byRuntime = wrappedDelegatingAdapters.get(adapter)
+  if (!byRuntime) {
+    byRuntime = new WeakMap()
+    wrappedDelegatingAdapters.set(adapter, byRuntime)
+  }
+  const cached = byRuntime.get(runtimeState)
+  if (cached) return cached
+  const wrapped = new Proxy(adapter, {
+    get(target, property) {
+      if (property !== 'stream') {
+        const value = Reflect.get(target, property, target)
+        return typeof value === 'function' ? value.bind(target) : value
+      }
+      const stream = Reflect.get(target, property, target)
+      if (typeof stream !== 'function') return stream
+      return function streamWithDelegatedCallAuthority(options) {
+        const parent = toolRuntime.getStore()
+        const state = {
+          ...(parent && typeof parent === 'object' ? parent : {}),
+          delegatedCall: true,
+          delegationOwner: 'vision-router-adapter',
+        }
+        return iterateUnderRuntimeState(stream.call(target, options), state)
+      }
+    },
+  })
+  byRuntime.set(runtimeState, wrapped)
+  return wrapped
+}
+
 function wrapLlm(llm, runtimeState) {
   if (!llm || (typeof llm !== 'object' && typeof llm !== 'function')) return llm
   let byRuntime = wrappedLlms.get(llm)
@@ -320,14 +397,28 @@ function wrapLlm(llm, runtimeState) {
   if (cached) return cached
   const wrapped = new Proxy(llm, {
     get(target, property) {
+      if (property === 'stream') {
+        const stream = Reflect.get(target, property, target)
+        if (typeof stream !== 'function') return stream
+        return (options) => {
+          const state = toolRuntime.getStore()
+          const projected = state?.delegatedCall === true
+            ? projectDelegatedCallConfig(options)
+            : options
+          return stream.call(target, projected)
+        }
+      }
       if (property === 'registerAdapter') {
         const register = Reflect.get(target, property, target)
         if (typeof register !== 'function') return register
         return (routes, adapter, ...rest) => {
           const list = Array.isArray(routes) ? routes : [routes]
-          const nextAdapter = list.some((route) => String(route) === 'vision-http')
+          let nextAdapter = list.some((route) => String(route) === 'vision-http')
             ? wrapVisionHttpAdapter(adapter, runtimeState)
             : adapter
+          if (visionRouterDelegatingAdapter(nextAdapter, list)) {
+            nextAdapter = wrapDelegatingAdapter(nextAdapter, runtimeState)
+          }
           return register.call(target, routes, nextAdapter, ...rest)
         }
       }

--- a/tests/issue-374-delegated-call-config.test.js
+++ b/tests/issue-374-delegated-call-config.test.js
@@ -1,0 +1,179 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { projectDelegatedCallConfig } from '../lib/delegated-call-config.js'
+import { installVisionToolRuntimeBoundary } from '../lib/vision-tool-runtime-boundary.js'
+
+function finishStream() {
+  return (async function* () {
+    yield { type: 'finish', reason: { kind: 'stop' } }
+  })()
+}
+
+async function drain(iterable) {
+  for await (const _chunk of iterable) {
+    // Drain the stream so AsyncLocalStorage-backed adapter delegation runs.
+  }
+}
+
+test('delegated projection removes source-route call config and preserves request payload/lifecycle', () => {
+  const messages = [{ role: 'user', content: [{ type: 'text', text: 'look' }] }]
+  const tools = [{ name: 'tool', description: 'x', parameters: {} }]
+  const signal = new AbortController().signal
+  const source = Object.freeze({
+    provider: 'source',
+    model: 'source-model',
+    reasoningEffort: 'max',
+    temperature: 0.7,
+    maxTokens: 4096,
+    stop: ['END'],
+    messages,
+    system: 'system',
+    tools,
+    signal,
+    sessionId: 'session-1',
+    purpose: 'session-title',
+  })
+
+  const projected = projectDelegatedCallConfig(source)
+
+  assert.notEqual(projected, source)
+  assert.equal(projected.provider, 'source')
+  assert.equal(projected.model, 'source-model')
+  assert.equal(projected.messages, messages)
+  assert.equal(projected.system, 'system')
+  assert.equal(projected.tools, tools)
+  assert.equal(projected.signal, signal)
+  assert.equal(projected.sessionId, 'session-1')
+  assert.equal(projected.purpose, 'session-title')
+  assert.equal(Object.hasOwn(projected, 'reasoningEffort'), false)
+  assert.equal(Object.hasOwn(projected, 'temperature'), false)
+  assert.equal(Object.hasOwn(projected, 'maxTokens'), false)
+  assert.equal(Object.hasOwn(projected, 'stop'), false)
+  assert.equal(source.maxTokens, 4096, 'projection must never mutate frozen caller requests')
+})
+
+test('vision tool adapter calls omit generic 4096 so the target adapter can materialize its own default', async () => {
+  let registered
+  let seen
+  let wrapped
+  const ctx = {
+    tools: {
+      register(def) {
+        registered = def
+        return () => {}
+      },
+    },
+    llm: {
+      stream(options) {
+        seen = options
+        return finishStream()
+      },
+    },
+  }
+  wrapped = installVisionToolRuntimeBoundary(ctx, { cache: false })
+  wrapped.tools.register({
+    name: 'vision_describe',
+    async execute() {
+      await drain(wrapped.llm.stream({
+        provider: 'zhipu',
+        model: 'glm-4v-flash',
+        messages: [{ role: 'user', content: [{ type: 'text', text: 'describe' }] }],
+        maxTokens: 4096,
+        reasoningEffort: 'max',
+        temperature: 0.3,
+        stop: ['END'],
+      }))
+      return 'ok'
+    },
+  })
+
+  await registered.execute({}, {})
+
+  assert.equal(seen.provider, 'zhipu')
+  assert.equal(seen.model, 'glm-4v-flash')
+  assert.equal(Object.hasOwn(seen, 'maxTokens'), false)
+  assert.equal(Object.hasOwn(seen, 'reasoningEffort'), false)
+  assert.equal(Object.hasOwn(seen, 'temperature'), false)
+  assert.equal(Object.hasOwn(seen, 'stop'), false)
+})
+
+test('Vision Chain nested adapter calls re-enter target call-config authority instead of forwarding outer options', async () => {
+  const adapters = new Map()
+  let delegated
+  let wrapped
+  const ctx = {
+    llm: {
+      registerAdapter(routes, adapter) {
+        for (const route of routes) adapters.set(route, adapter)
+        return () => {}
+      },
+      stream(options) {
+        delegated = options
+        return finishStream()
+      },
+    },
+  }
+  wrapped = installVisionToolRuntimeBoundary(ctx)
+  wrapped.llm.registerAdapter(['vision-chain'], {
+    providerInfo(provider) {
+      return { id: provider, name: 'Vision Chain' }
+    },
+    async *stream(options) {
+      yield* wrapped.llm.stream({
+        ...options,
+        provider: 'zhipu',
+        model: 'glm-4v-flash',
+        maxTokens: 65536,
+        reasoningEffort: 'high',
+        temperature: 0.9,
+        stop: ['SOURCE_ONLY'],
+      })
+    },
+  })
+
+  await drain(adapters.get('vision-chain').stream({
+    provider: 'vision-chain',
+    model: 'zhipu/glm-4v-flash',
+    messages: [{ role: 'user', content: [{ type: 'text', text: 'image turn' }] }],
+    system: 'keep task semantics',
+    tools: [{ name: 'vision_crop', description: 'crop', parameters: {} }],
+    maxTokens: 65536,
+    temperature: 1,
+  }))
+
+  assert.equal(delegated.provider, 'zhipu')
+  assert.equal(delegated.model, 'glm-4v-flash')
+  assert.equal(delegated.system, 'keep task semantics')
+  assert.equal(delegated.tools[0].name, 'vision_crop')
+  assert.equal(Object.hasOwn(delegated, 'maxTokens'), false)
+  assert.equal(Object.hasOwn(delegated, 'reasoningEffort'), false)
+  assert.equal(Object.hasOwn(delegated, 'temperature'), false)
+  assert.equal(Object.hasOwn(delegated, 'stop'), false)
+})
+
+test('ordinary non-delegated llm calls remain byte-for-byte caller-owned', async () => {
+  let seen
+  const source = {
+    provider: 'zhipu',
+    model: 'glm-4v-flash',
+    messages: [],
+    maxTokens: 777,
+    temperature: 0.4,
+    stop: ['DONE'],
+  }
+  const ctx = {
+    llm: {
+      stream(options) {
+        seen = options
+        return finishStream()
+      },
+    },
+  }
+  const wrapped = installVisionToolRuntimeBoundary(ctx)
+  await drain(wrapped.llm.stream(source))
+  assert.equal(seen, source)
+  assert.equal(seen.maxTokens, 777)
+  assert.equal(seen.temperature, 0.4)
+  assert.deepEqual(seen.stop, ['DONE'])
+})


### PR DESCRIPTION
Closes #374.

## Root cause

Vision Router's internal delegations were crossing provider/model boundaries while carrying source-route call config (`maxTokens`, `reasoningEffort`, sampling and stop state). For `vision_describe`, the generic `maxTokens: 4096` therefore became an explicit target request. DSH correctly preserves an explicit caller value, so the target adapter's configured `defaultMaxTokens` (for example GLM-4V-Flash = 1024) never got a chance to materialize.

The same class existed in Vision Chain: its nested `ctx.llm.stream({...options, provider, model})` forwarded the outer route's call config into every fallback model.

## Root fix

- add one provider-neutral delegated-call projection that removes route-owned call fields: `reasoningEffort`, `temperature`, `maxTokens`, and `stop`;
- apply that projection only while executing Vision Router tools or inside a Vision Router-owned delegating adapter;
- keep messages, system/tool payload, session identity, purpose, cancellation and target provider/model intact;
- ordinary non-delegated DSH calls are untouched;
- direct provider transports owned by Vision Router remain outside this DSH adapter projection and keep their existing provider compatibility rules.

This restores the intended authority boundary: Vision Router chooses the target route and task payload; DSH/that target adapter chooses its model defaults and provider-valid call config.

## Regression coverage

- generic 4096 from `vision_describe` does not reach the target adapter;
- Vision Chain cannot leak outer maxTokens/reasoning/temperature/stop to fallback models;
- payload/lifecycle fields survive projection;
- ordinary direct `ctx.llm.stream` callers remain unchanged;
- frozen caller options are never mutated.