### PR TITLE
fix(cache): keep vision failures out of describe cache

### DIFF
--- a/lib/vision-tool-runtime-boundary.js
+++ b/lib/vision-tool-runtime-boundary.js
@@ -13,6 +13,7 @@ import {
   proxyRequestIsManaged,
 } from './runtime-reliability.js'
 import { projectDelegatedCallConfig } from './delegated-call-config.js'
+import { VISION_RESULT_CODES } from './vision-resilience.js'
 
 const toolRuntime = new AsyncLocalStorage()
 const wrappedContexts = new WeakMap()
@@ -26,6 +27,20 @@ const wrappedDelegatingAdapters = new WeakMap()
 const wrappedTransparentAdapters = new WeakMap()
 const VISION_ROUTER_ADAPTER_OWNER = Symbol.for('dsh-vision-router.adapter-owner')
 const MAX_TRANSPARENT_REASONING_MEMORY = 512
+const VISION_FAILURE_RESULT_CODES = new Set(Object.values(VISION_RESULT_CODES))
+
+function cacheableVisionDescribeResult(value) {
+  let parsed = value
+  if (typeof value === 'string') {
+    try {
+      parsed = JSON.parse(value)
+    } catch {
+      return true
+    }
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return true
+  return !(parsed.ok === false && VISION_FAILURE_RESULT_CODES.has(parsed.code))
+}
 
 function usableSignal(value) {
   return value && typeof value === 'object' && typeof value.aborted === 'boolean' ? value : undefined
@@ -562,7 +577,12 @@ async function executeVisionTool(def, args, exec, execute, wrappedCtx, runtimeSt
           }
         }
         const result = await execute(args, exec)
-        if (cacheKey && runtimeState.config().cache !== false && !state.signal?.aborted) {
+        if (
+          cacheKey &&
+          runtimeState.config().cache !== false &&
+          !state.signal?.aborted &&
+          cacheableVisionDescribeResult(result)
+        ) {
           runtimeState.cache.set(cacheKey, result)
         }
         return result

--- a/tests/qa-top5-reliability.test.js
+++ b/tests/qa-top5-reliability.test.js
@@ -102,6 +102,52 @@ test('vision_describe delegates all caching to the live order-sensitive cache wi
   assert.equal(scope.get().cache, true, 'cache suppression must remain invocation-local')
 })
 
+test('vision_describe answer cache publishes successes but never structured vision failures', async () => {
+  const harness = runtimeHarness({ scopeValue: { cache: true, cacheMaxEntries: 200, cacheTtlSeconds: 3600 } })
+  harness.wrapped.inject(['settings'], (child) => { child.settings.register('vision-router') })
+  const calls = new Map()
+  harness.wrapped.tools.register({
+    name: 'vision_describe',
+    async execute(args) {
+      const key = String(args.question)
+      calls.set(key, (calls.get(key) ?? 0) + 1)
+      if (key === 'failure') {
+        return JSON.stringify({
+          ok: false,
+          code: 'VISION_BACKEND_UNAVAILABLE',
+          retryable: false,
+          reason: 'temporary backend failure',
+        })
+      }
+      if (key === 'ordinary-json') {
+        return JSON.stringify({ ok: false, code: 'DOCUMENT_STATUS', text: 'visible evidence' })
+      }
+      return 'visible answer'
+    },
+  })
+  const exec = { agent: { session: { header: { cwd: '/workspace' } } } }
+
+  const failureArgs = { attachmentIds: ['A'], question: 'failure' }
+  const firstFailure = await harness.registered.execute(failureArgs, exec)
+  const secondFailure = await harness.registered.execute(failureArgs, exec)
+  assert.equal(firstFailure, secondFailure)
+  assert.equal(calls.get('failure'), 2, 'a repaired backend must get a fresh attempt instead of a cached failure')
+
+  const successArgs = { attachmentIds: ['A'], question: 'success' }
+  assert.equal(await harness.registered.execute(successArgs, exec), 'visible answer')
+  assert.equal(await harness.registered.execute(successArgs, exec), 'visible answer')
+  assert.equal(calls.get('success'), 1, 'successful visual knowledge remains cacheable')
+
+  const ordinaryJsonArgs = { attachmentIds: ['A'], question: 'ordinary-json' }
+  await harness.registered.execute(ordinaryJsonArgs, exec)
+  await harness.registered.execute(ordinaryJsonArgs, exec)
+  assert.equal(
+    calls.get('ordinary-json'),
+    1,
+    'only the exact Vision Router failure-code contract is excluded from the answer cache',
+  )
+})
+
 function legacyLimits() {
   return Object.freeze({
     maxImageBytes: 20 * 1024 * 1024,


### PR DESCRIPTION
## Summary

- Treat `vision_describe` as an answer cache, not a second failure-state store.
- Do not publish structured Vision Router failures (`ok:false` + a known `VISION_RESULT_CODES` code) into the live describe cache.
- Keep successful text and unrelated JSON-shaped visual answers cacheable.

## Why

Turn memory and the circuit breaker already own auth/rate-limit/backend failure state. Caching those same failures for the normal one-hour answer TTL can keep returning a stale failure after the user repairs a credential or backend.

## Regression coverage

`qa-top5-reliability.test.js` now proves that:
- the same structured vision failure executes again instead of hitting answer cache;
- successful visual knowledge still caches;
- arbitrary JSON with `ok:false` but no Vision Router failure code is not misclassified.
