### PR TITLE
test(ci): close the default test manifest world

### DIFF
--- a/tests/manifest-dependencies.test.js
+++ b/tests/manifest-dependencies.test.js
@@ -21,10 +21,65 @@ async function discoverTests(directory = new URL('./', import.meta.url), prefix 
   return paths.sort()
 }
 
-// Keep this list exceptional and reviewable. A test may stay outside the
-// default `pnpm test` suite only when another stable CI owner runs it for a
-// documented environment/reason. The gate below also rejects stale entries.
-const DEFAULT_TEST_EXCLUSIONS = Object.freeze([])
+// These historical contracts had no stable CI owner. Keep the package.json
+// command untouched for this closure patch, but execute the tests from this
+// already-default manifest file so `pnpm test` and the release workflow both
+// cover them immediately. A future discovery-runner migration can move these
+// back into ordinary automatic discovery without changing the contract below.
+const DEFAULT_TEST_IMPORTS = Object.freeze([
+  'tests/auto-wrap-model-removal.test.js',
+  'tests/guard-stop-surface-shadow.test.js',
+  'tests/settings-card-race-safety.test.js',
+  'tests/settings-guide-replay-safety.test.js',
+  'tests/settings-ia-targeted-adversarial.test.js',
+  'tests/v2-release-acceptance-regressions.test.js',
+  'tests/vision-turn-budget-client-prelude.test.js',
+  'tests/wrapper-scope-client-prelude.test.js',
+])
+
+for (const path of DEFAULT_TEST_IMPORTS) {
+  await import(new URL(`./${path.slice('tests/'.length)}`, import.meta.url))
+}
+
+// A test may stay outside the default `pnpm test` process only when a stable,
+// PR-triggered workflow owns the exact file. The reasons are intentionally
+// grouped by execution environment/domain instead of becoming a generic
+// quarantine list.
+const DEFAULT_TEST_EXCLUSIONS = Object.freeze([
+  { path: 'tests/alpha1-client-host-compat.test.js', owner: '.github/workflows/dsh-alpha-source-contract.yml', reason: 'exact DSH alpha source compatibility matrix' },
+  { path: 'tests/alpha1-settings-factory-lifecycle.test.js', owner: '.github/workflows/dsh-alpha-source-contract.yml', reason: 'exact DSH alpha source compatibility matrix' },
+  { path: 'tests/alpha1-web-auth-boundary.test.js', owner: '.github/workflows/dsh-alpha-source-contract.yml', reason: 'exact DSH alpha source compatibility matrix' },
+  { path: 'tests/browser-p1-acceptance.test.js', owner: '.github/workflows/browser-p1-acceptance.yml', reason: 'real Chromium acceptance requires a browser executable' },
+
+  { path: 'tests/architecture-contract-baseline.test.js', owner: '.github/workflows/architecture-closure.yml', reason: 'architecture closure contract matrix' },
+  { path: 'tests/capability-shadow-retirement.test.js', owner: '.github/workflows/architecture-closure.yml', reason: 'architecture closure contract matrix' },
+  { path: 'tests/compat-inventory-completeness.test.js', owner: '.github/workflows/architecture-closure.yml', reason: 'architecture closure contract matrix' },
+  { path: 'tests/core-vision-surface-parity.test.js', owner: '.github/workflows/architecture-closure.yml', reason: 'architecture closure contract matrix' },
+  { path: 'tests/final-architecture-closure.test.js', owner: '.github/workflows/architecture-closure.yml', reason: 'architecture closure contract matrix' },
+  { path: 'tests/presentation-convergence-parity.test.js', owner: '.github/workflows/architecture-closure.yml', reason: 'architecture closure contract matrix' },
+  { path: 'tests/presentation-switch.test.js', owner: '.github/workflows/architecture-closure.yml', reason: 'architecture closure contract matrix' },
+  { path: 'tests/session-runtime-core-wiring.test.js', owner: '.github/workflows/architecture-closure.yml', reason: 'architecture closure contract matrix' },
+  { path: 'tests/session-vision-runtime-parity.test.js', owner: '.github/workflows/architecture-closure.yml', reason: 'architecture closure contract matrix' },
+  { path: 'tests/settings-impersonation-closure.test.js', owner: '.github/workflows/architecture-closure.yml', reason: 'architecture closure contract matrix' },
+
+  { path: 'tests/vision-execution-order-apply.test.js', owner: '.github/workflows/p1-routing-parity.yml', reason: 'always-on PR routing/authority parity matrix' },
+  { path: 'tests/vision-execution-order-core-wiring.test.js', owner: '.github/workflows/p1-routing-parity.yml', reason: 'always-on PR routing/authority parity matrix' },
+  { path: 'tests/vision-execution-order-plan-parity.test.js', owner: '.github/workflows/p1-routing-parity.yml', reason: 'always-on PR routing/authority parity matrix' },
+  { path: 'tests/vision-execution-order.test.js', owner: '.github/workflows/p1-routing-parity.yml', reason: 'always-on PR routing/authority parity matrix' },
+  { path: 'tests/vision-routing-evidence-parity.test.js', owner: '.github/workflows/p1-routing-parity.yml', reason: 'always-on PR routing/authority parity matrix' },
+  { path: 'tests/vision-routing-runtime-parity.test.js', owner: '.github/workflows/p1-routing-parity.yml', reason: 'always-on PR routing/authority parity matrix' },
+
+  { path: 'tests/legacy-global-proxy-boundary.test.js', owner: '.github/workflows/p2-data-boundary.yml', reason: 'provider/data-boundary Node 22/24 matrix' },
+  { path: 'tests/p2-exit-gate.test.js', owner: '.github/workflows/p2-data-boundary.yml', reason: 'provider/data-boundary Node 22/24 matrix' },
+  { path: 'tests/session-surface-policy.test.js', owner: '.github/workflows/p2-data-boundary.yml', reason: 'session/data-boundary Node 22/24 matrix' },
+  { path: 'tests/session-vision-index.test.js', owner: '.github/workflows/p2-data-boundary.yml', reason: 'session/data-boundary Node 22/24 matrix' },
+  { path: 'tests/vision-artifact-store.test.js', owner: '.github/workflows/p2-data-boundary.yml', reason: 'artifact/data-boundary Node 22/24 matrix' },
+  { path: 'tests/vision-provider-transport.test.js', owner: '.github/workflows/p2-data-boundary.yml', reason: 'provider/data-boundary Node 22/24 matrix' },
+
+  { path: 'tests/dsh-support-window.test.js', owner: '.github/workflows/p3-compat-convergence.yml', reason: 'compatibility convergence Node 22/24 matrix' },
+  { path: 'tests/p3-entry-composition.test.js', owner: '.github/workflows/p3-compat-convergence.yml', reason: 'compatibility convergence Node 22/24 matrix' },
+  { path: 'tests/p3-web-modularization.test.js', owner: '.github/workflows/p3-compat-convergence.yml', reason: 'compatibility convergence Node 22/24 matrix' },
+])
 
 test('host-provided DSH packages publish the active Host floor while retaining an installable legacy dev fixture', async () => {
   const pkg = await manifest()
@@ -39,9 +94,6 @@ test('host-provided DSH packages publish the active Host floor while retaining a
     assert.equal(typeof peer, 'string', `${name} must be a peerDependency`)
     assert.match(peer, /\^0\.1\.0-rc\.8/, `${name} must publish the DVR 2.1 rc8 Host floor`)
     assert.match(peer, /\^0\.1\.1-rc\.1/, `${name} must admit the released DSH 0.1.1 train`)
-    // Keep one explicit rc.6 development fixture as a best-effort historical
-    // compatibility fence. It is not the public DVR 2.1 support floor; the
-    // optional peer declaration above is what profile installs consume.
     assert.equal(typeof pkg.devDependencies?.[name], 'string', `${name} must remain available for tests`)
     assert.match(pkg.devDependencies[name], /\^0\.1\.0-rc\.6/)
   }
@@ -49,11 +101,6 @@ test('host-provided DSH packages publish the active Host floor while retaining a
 
 test('host-provided peers are optional so profile installs never warn about missing peers', async () => {
   const pkg = await manifest()
-  // The two DSH packages are resolved by the host's own module graph, and
-  // sharp falls back to the host instance — pnpm at the profile level cannot
-  // see any of them, so a mandatory peer would print "Issues with peer
-  // dependencies found" on every user install. Optional peers keep the
-  // prefer-host semantics without the warning.
   const optionalPeers = [
     '@deepseek-ai/dsh-anonymous-user-id',
     '@deepseek-ai/dsh-llm-deepseek',
@@ -80,9 +127,6 @@ test('undici stays below v8 and is lazy-loaded for plugin proxy use', async () =
   assert.match(pkg.dependencies?.undici ?? '', /^\^7\./)
 
   const source = await readFile(new URL('../index.js', import.meta.url), 'utf8')
-  // This is a semantic lazy-load contract, not a source-shape contract:
-  // caching import('undici') in a promise is valid and should not be forced
-  // into an `await import(...)` spelling just to satisfy this test.
   assert.match(source, /import\(['"]undici['"]\)/)
   assert.doesNotMatch(source, /^\s*import\s+.*from\s+['"]undici['"]/m)
 })
@@ -92,13 +136,23 @@ test('default test manifest is closed-world: every test is run or explicitly own
   const defaultScript = String(pkg.scripts?.test ?? '')
   const listed = new Set(defaultScript.match(/tests\/[A-Za-z0-9._/-]+\.test\.js/g) ?? [])
   const discovered = new Set(await discoverTests())
+  const imported = new Set()
   const excluded = new Map()
+
+  for (const path of DEFAULT_TEST_IMPORTS) {
+    assert.equal(imported.has(path), false, `${path}: duplicate default import`)
+    imported.add(path)
+    assert.equal(discovered.has(path), true, `${path}: stale default import`)
+    assert.equal(listed.has(path), false, `${path}: now listed directly; remove the compatibility import`)
+  }
 
   for (const entry of DEFAULT_TEST_EXCLUSIONS) {
     assert.equal(typeof entry?.path, 'string', 'every default-test exclusion needs a path')
     assert.equal(typeof entry?.owner, 'string', `${entry?.path ?? '<unknown>'}: exclusion needs an owner`)
     assert.equal(typeof entry?.reason, 'string', `${entry?.path ?? '<unknown>'}: exclusion needs a reason`)
     assert.equal(excluded.has(entry.path), false, `${entry.path}: duplicate default-test exclusion`)
+    assert.equal(imported.has(entry.path), false, `${entry.path}: cannot be both imported and excluded`)
+    assert.equal(listed.has(entry.path), false, `${entry.path}: now listed directly; remove the workflow exclusion`)
     excluded.set(entry.path, entry)
     assert.equal(discovered.has(entry.path), true, `${entry.path}: stale default-test exclusion`)
   }
@@ -107,12 +161,12 @@ test('default test manifest is closed-world: every test is run or explicitly own
   assert.deepEqual(staleListed, [], `default test script references missing tests: ${staleListed.join(', ')}`)
 
   const missing = [...discovered]
-    .filter((path) => !listed.has(path) && !excluded.has(path))
+    .filter((path) => !listed.has(path) && !imported.has(path) && !excluded.has(path))
     .sort()
   assert.deepEqual(
     missing,
     [],
-    `tests can never silently escape CI; add them to scripts.test or document a stable CI owner: ${missing.join(', ')}`,
+    `tests can never silently escape CI; add them to scripts.test/default imports or document a stable CI owner: ${missing.join(', ')}`,
   )
 })
 

--- a/tests/manifest-dependencies.test.js
+++ b/tests/manifest-dependencies.test.js
@@ -8,6 +8,24 @@ async function manifest() {
   return JSON.parse(await readFile(manifestPath, 'utf8'))
 }
 
+async function discoverTests(directory = new URL('./', import.meta.url), prefix = 'tests') {
+  const paths = []
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const relative = `${prefix}/${entry.name}`
+    if (entry.isDirectory()) {
+      paths.push(...await discoverTests(new URL(`${entry.name}/`, directory), relative))
+    } else if (entry.isFile() && entry.name.endsWith('.test.js')) {
+      paths.push(relative)
+    }
+  }
+  return paths.sort()
+}
+
+// Keep this list exceptional and reviewable. A test may stay outside the
+// default `pnpm test` suite only when another stable CI owner runs it for a
+// documented environment/reason. The gate below also rejects stale entries.
+const DEFAULT_TEST_EXCLUSIONS = Object.freeze([])
+
 test('host-provided DSH packages publish the active Host floor while retaining an installable legacy dev fixture', async () => {
   const pkg = await manifest()
   const hostPeers = [
@@ -67,6 +85,35 @@ test('undici stays below v8 and is lazy-loaded for plugin proxy use', async () =
   // into an `await import(...)` spelling just to satisfy this test.
   assert.match(source, /import\(['"]undici['"]\)/)
   assert.doesNotMatch(source, /^\s*import\s+.*from\s+['"]undici['"]/m)
+})
+
+test('default test manifest is closed-world: every test is run or explicitly owned elsewhere', async () => {
+  const pkg = await manifest()
+  const defaultScript = String(pkg.scripts?.test ?? '')
+  const listed = new Set(defaultScript.match(/tests\/[A-Za-z0-9._/-]+\.test\.js/g) ?? [])
+  const discovered = new Set(await discoverTests())
+  const excluded = new Map()
+
+  for (const entry of DEFAULT_TEST_EXCLUSIONS) {
+    assert.equal(typeof entry?.path, 'string', 'every default-test exclusion needs a path')
+    assert.equal(typeof entry?.owner, 'string', `${entry?.path ?? '<unknown>'}: exclusion needs an owner`)
+    assert.equal(typeof entry?.reason, 'string', `${entry?.path ?? '<unknown>'}: exclusion needs a reason`)
+    assert.equal(excluded.has(entry.path), false, `${entry.path}: duplicate default-test exclusion`)
+    excluded.set(entry.path, entry)
+    assert.equal(discovered.has(entry.path), true, `${entry.path}: stale default-test exclusion`)
+  }
+
+  const staleListed = [...listed].filter((path) => !discovered.has(path)).sort()
+  assert.deepEqual(staleListed, [], `default test script references missing tests: ${staleListed.join(', ')}`)
+
+  const missing = [...discovered]
+    .filter((path) => !listed.has(path) && !excluded.has(path))
+    .sort()
+  assert.deepEqual(
+    missing,
+    [],
+    `tests can never silently escape CI; add them to scripts.test or document a stable CI owner: ${missing.join(', ')}`,
+  )
 })
 
 test('all GitHub Actions dependencies are pinned to immutable commit SHAs', async () => {

--- a/tests/manifest-dependencies.test.js
+++ b/tests/manifest-dependencies.test.js
@@ -134,10 +134,15 @@ test('undici stays below v8 and is lazy-loaded for plugin proxy use', async () =
 test('default test manifest is closed-world: every test is run or explicitly owned elsewhere', async () => {
   const pkg = await manifest()
   const defaultScript = String(pkg.scripts?.test ?? '')
-  const listed = new Set(defaultScript.match(/tests\/[A-Za-z0-9._/-]+\.test\.js/g) ?? [])
+  const listedPaths = defaultScript.match(/tests\/[A-Za-z0-9._/-]+\.test\.js/g) ?? []
+  const listed = new Set(listedPaths)
   const discovered = new Set(await discoverTests())
   const imported = new Set()
   const excluded = new Map()
+  const workflowSources = new Map()
+
+  const duplicateListed = [...new Set(listedPaths.filter((path, index) => listedPaths.indexOf(path) !== index))].sort()
+  assert.deepEqual(duplicateListed, [], `default test script lists tests more than once: ${duplicateListed.join(', ')}`)
 
   for (const path of DEFAULT_TEST_IMPORTS) {
     assert.equal(imported.has(path), false, `${path}: duplicate default import`)
@@ -148,13 +153,29 @@ test('default test manifest is closed-world: every test is run or explicitly own
 
   for (const entry of DEFAULT_TEST_EXCLUSIONS) {
     assert.equal(typeof entry?.path, 'string', 'every default-test exclusion needs a path')
-    assert.equal(typeof entry?.owner, 'string', `${entry?.path ?? '<unknown>'}: exclusion needs an owner`)
-    assert.equal(typeof entry?.reason, 'string', `${entry?.path ?? '<unknown>'}: exclusion needs a reason`)
+    assert.match(entry.path, /^tests\/.+\.test\.js$/, `${entry.path}: exclusion path must be a test file`)
+    assert.equal(typeof entry?.owner, 'string', `${entry.path}: exclusion needs an owner`)
+    assert.match(entry.owner, /^\.github\/workflows\/.+\.ya?ml$/, `${entry.path}: owner must be a workflow file`)
+    assert.equal(typeof entry?.reason, 'string', `${entry.path}: exclusion needs a reason`)
+    assert.ok(entry.reason.trim().length > 0, `${entry.path}: exclusion reason must not be blank`)
     assert.equal(excluded.has(entry.path), false, `${entry.path}: duplicate default-test exclusion`)
     assert.equal(imported.has(entry.path), false, `${entry.path}: cannot be both imported and excluded`)
     assert.equal(listed.has(entry.path), false, `${entry.path}: now listed directly; remove the workflow exclusion`)
     excluded.set(entry.path, entry)
     assert.equal(discovered.has(entry.path), true, `${entry.path}: stale default-test exclusion`)
+
+    let workflow = workflowSources.get(entry.owner)
+    if (workflow === undefined) {
+      workflow = await readFile(new URL(`../${entry.owner}`, import.meta.url), 'utf8')
+      workflowSources.set(entry.owner, workflow)
+      assert.match(workflow, /^\s{0,2}pull_request\s*:/m, `${entry.owner}: specialist owner must run on pull requests`)
+      assert.notEqual(workflow.indexOf('node --test'), -1, `${entry.owner}: specialist owner must execute Node tests`)
+    }
+    const commandStart = workflow.indexOf('node --test')
+    assert.ok(
+      workflow.lastIndexOf(entry.path) > commandStart,
+      `${entry.path}: ${entry.owner} does not execute the claimed test`,
+    )
   }
 
   const staleListed = [...listed].filter((path) => !discovered.has(path)).sort()

--- a/tests/v2-release-acceptance-regressions.test.js
+++ b/tests/v2-release-acceptance-regressions.test.js
@@ -135,7 +135,7 @@ test('deployment-level unavailable stop survives profiler recreation and blocks 
   assert.equal(snapshot.deferred[0]?.retryable, false)
 })
 
-test('persisted visual-proof stop remains axis-scoped after restart', async () => {
+test('visual-proof failure is transient and axis-scoped without surviving restart', async () => {
   const config = configFor('opencode-go', 'kimi-k3')
   const stops = memoryStopStore()
   const first = profilerFor(config, async () => {
@@ -145,15 +145,19 @@ test('persisted visual-proof stop remains axis-scoped after restart', async () =
     throw error
   }, stops)
   await first.tick()
+  const firstSnapshot = first.snapshot()
   first.stop()
-  assert.equal(stops.records[0]?.axis, 'ocr')
-  assert.equal(stops.records[0]?.errorClass, 'visual-proof')
+
+  assert.equal(stops.records.length, 0)
+  assert.equal(firstSnapshot.deferred[0]?.axis, 'ocr')
+  assert.equal(firstSnapshot.deferred[0]?.errorClass, 'visual-proof')
+  assert.equal(firstSnapshot.deferred[0]?.retryable, true)
 
   const seen = []
   const restarted = profilerFor(config, async ({ axis }) => { seen.push(axis) }, stops)
   await restarted.tick()
   restarted.stop()
-  assert.deepEqual(seen, ['general'])
+  assert.deepEqual(seen, ['ocr'])
 })
 
 test('manual benchmark default budgets allow six legitimate 120s fixtures plus cleanup margin', async () => {

--- a/tests/wrapper-scope-client-prelude.test.js
+++ b/tests/wrapper-scope-client-prelude.test.js
@@ -1,186 +1,28 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import vm from 'node:vm'
 
-import { WRAPPER_SCOPE_CLIENT_PRELUDE } from '../lib/wrapper-scope-client-prelude.js'
+import {
+  WRAPPER_SCOPE_CLIENT_PRELUDE,
+  injectWrapperScopeClientPrelude,
+  installWrapperScopeClientPrelude,
+} from '../lib/wrapper-scope-client-prelude.js'
 
-function reactStub(stateValues = []) {
-  let stateIndex = 0
-  return {
-    Fragment: Symbol('Fragment'),
-    createElement(type, props, ...children) {
-      return { type, props: props ?? {}, children }
-    },
-    useMemo(factory) { return factory() },
-    useSyncExternalStore(_subscribe, getSnapshot) { return getSnapshot() },
-    useState(initial) {
-      const index = stateIndex++
-      const value = index < stateValues.length ? stateValues[index] : initial
-      return [value, () => {}]
-    },
-    useEffect() {},
-  }
-}
+test('wrapper scope compatibility prelude remains an inert tombstone', () => {
+  assert.equal(WRAPPER_SCOPE_CLIENT_PRELUDE, '')
 
-function walk(node, visit) {
-  if (!node || typeof node !== 'object') return
-  visit(node)
-  for (const child of Array.isArray(node.children) ? node.children : []) {
-    if (Array.isArray(child)) child.forEach((entry) => walk(entry, visit))
-    else walk(child, visit)
-  }
-}
-
-function createHarness(React) {
-  let captured
-  const loader = { load(spec) { captured = spec } }
-  const sandbox = {
-    window: { __ModuleLoader__: loader },
-    Object,
-    Promise,
-    Array,
-    String,
-    Map,
-    Set,
-    WeakMap,
-    Reflect,
-    JSON,
-  }
-  vm.runInNewContext(WRAPPER_SCOPE_CLIENT_PRELUDE, sandbox)
-
-  let dictionaries
-  let registeredComponent
-  const OriginalSection = function OriginalSection() { return null }
-  loader.load({
-    id: 'dsh-vision-router',
-    factory() {
-      return {
-        apply(ctx) {
-          ctx.locale.register('vision-router', {
-            zh: { groupWrappers: '旧包装范围' },
-            en: { groupWrappers: 'Old wrapper scope' },
-          })
-          ctx.slots.register(
-            { name: 'settings.section', id: 'vision-router', order: 12 },
-            OriginalSection,
-          )
-        },
-      }
-    },
-  })
-
-  const plugin = captured.factory((id) => {
-    assert.equal(id, 'react')
-    return React
-  })
-  const ctx = {
-    locale: {
-      register(_namespace, value) { dictionaries = value },
-    },
-    slots: {
-      register(_options, component) {
-        registeredComponent = component
-        return () => {}
-      },
-    },
-  }
-  plugin.apply(ctx)
-  return { dictionaries, registeredComponent, OriginalSection }
-}
-
-test('wrapper scope boundary promotes a primary settings card and labels the old advanced editor as a mirror', () => {
-  const React = reactStub()
-  const { dictionaries, registeredComponent, OriginalSection } = createHarness(React)
-
-  assert.equal(dictionaries.zh.wrapperScopeTitle, '识图模式可用范围')
-  assert.equal(dictionaries.en.wrapperScopeTitle, 'Vision mode scope')
-  assert.equal(dictionaries.zh.groupWrappers, '包装范围（高级同步入口）')
-  assert.notEqual(registeredComponent, OriginalSection)
-
-  const rendered = registeredComponent({})
-  assert.equal(rendered.type, React.Fragment)
-  assert.equal(rendered.children.length, 2)
-  assert.equal(typeof rendered.children[0].type, 'function')
-  assert.equal(rendered.children[1].type, OriginalSection)
+  const html = '<html><head></head><body>settings</body></html>'
+  assert.equal(injectWrapperScopeClientPrelude(html), html)
 })
 
-test('primary wrapper scope expands whole-provider and exact-model rows from the same wrappedProviders setting', () => {
-  const groups = [
-    { id: 'provider-a', name: 'Provider A', models: [{ id: 'a1', name: 'A1' }] },
-    { id: 'provider-b', name: 'Provider B', models: [{ id: 'b1', name: 'B1' }, { id: 'b2', name: 'B2' }] },
-  ]
-  const React = reactStub([
-    undefined,
-    { status: 'idle', error: undefined },
-    { status: 'ready', groups },
-  ])
-  const { registeredComponent } = createHarness(React)
-  const section = registeredComponent({})
-  const ScopeCard = section.children[0].type
-
-  const scope = {
-    subscribe() { return () => {} },
-    getSnapshot() {
-      return {
-        status: 'ready',
-        writable: true,
-        value: {
-          autoWrapProviders: false,
-          wrapperRoute: 'deepseek-vision',
-          chainRoute: 'vision-chain',
-          wrappedProviders: [
-            { provider: 'provider-a', models: [] },
-            { provider: 'provider-b', models: ['b1', 'b2'] },
-          ],
-        },
-      }
+test('wrapper scope compatibility installer cannot register a duplicate settings surface', () => {
+  let touched = false
+  const ctx = new Proxy({}, {
+    get() {
+      touched = true
+      throw new Error('compatibility tombstone must not inspect the Host context')
     },
-  }
-  const tree = ScopeCard({
-    scope,
-    t(key) { return key },
-    getConnection() { return undefined },
   })
 
-  const rows = []
-  const badges = []
-  walk(tree, (node) => {
-    if (String(node.props?.className || '').includes('vr-chain-row')) rows.push(node)
-    if (String(node.props?.className || '').includes('vr-badge')) badges.push(node)
-  })
-  assert.equal(rows.length, 3)
-  assert.equal(badges.some((node) => node.children.includes('wrapperScopeAutoOff')), true)
-})
-
-test('wrapper scope boundary survives the rc8 queue-to-live ModuleLoader replacement', () => {
-  let captured
-  const loader = {
-    load(spec) { captured = spec },
-    create() {
-      this.load = function liveLoad(spec) { captured = spec }
-      return this
-    },
-  }
-  const sandbox = {
-    window: { __ModuleLoader__: loader },
-    Object,
-    Promise,
-    Array,
-    String,
-    Map,
-    Set,
-    WeakMap,
-    Reflect,
-    JSON,
-  }
-  vm.runInNewContext(WRAPPER_SCOPE_CLIENT_PRELUDE, sandbox)
-  loader.create()
-  loader.load({
-    id: 'dsh-vision-router',
-    factory() { return { apply() {} } },
-  })
-
-  const React = reactStub()
-  const plugin = captured.factory(() => React)
-  assert.equal(plugin.apply.__visionRouterWrapperScope, true)
+  assert.doesNotThrow(() => installWrapperScopeClientPrelude(ctx))
+  assert.equal(touched, false)
 })


### PR DESCRIPTION
## Summary

Close the default test world instead of relying on a silently drifting hand-maintained command.

`manifest-dependencies.test.js` now discovers every `tests/**/*.test.js` file and requires every test to have a canonical execution owner:
- directly listed in `scripts.test`;
- one of eight previously-unowned historical contracts that this already-default manifest imports and therefore executes under normal `pnpm test` / release verification; or
- an explicit, documented PR-triggered specialist workflow owner (alpha-source, real-browser P1, architecture closure, P1 routing, P2 data boundary, or P3 compatibility convergence).

The gate rejects missing tests, stale CLI paths, stale/default imports, stale or duplicate exclusions, duplicate default-script entries, and tests that later become directly listed without cleaning up their old compatibility entry. Specialist exclusions are also verified against the workflow source: the owner must exist, run on `pull_request`, execute Node tests, and actually name the claimed test after its `node --test` command.

## Historical drift found by the new gate

The first closed-world run exposed four assertions that had silently outlived later architecture changes because their files had no CI owner:
- `wrapper-scope-client-prelude.test.js` still expected the retired duplicate wrapper-scope editor even though the module is now an intentional compatibility tombstone and Settings IA is the sole UI owner.
- `v2-release-acceptance-regressions.test.js` still expected visual-proof failures to persist across restart, although `c0e040d` deliberately made visual-proof a transient, per-axis retry and restricted persistent stops to auth/protocol/unavailable classes.

Those contracts now assert the current intended semantics instead of resurrecting retired behavior or excluding the files again.

## Why

#376 added a correct regression file but normal CI initially never executed it because `scripts.test` is a manually enumerated list. This makes that failure mode impossible to repeat silently while preserving tests that genuinely require dedicated environments/matrices.

## Verification

Latest head `da949b8` is green in CI (Node 22/24 plus host-sharp matrix), DSH Contract, P1 Routing Parity, and Native multimodal cold resume.

## Scope

This PR changes CI/test ownership and stale test contracts only; it does not alter runtime behavior or add a one-shot workflow.