### PR TITLE
chore(release): prepare v2.1.2

### DIFF
--- a/docs/releases/v2.1.2.md
+++ b/docs/releases/v2.1.2.md
@@ -1,0 +1,22 @@
+# v2.1.2
+
+DVR 2.1.2 is a reliability hotfix for image-session ownership and delegated vision routing. It also closes a CI blind spot that allowed valid regression tests to exist without being executed by the normal release gate.
+
+## Fixed
+
+- Keeps uploaded image blocks as durable Session facts. Vision Router no longer rewrites the current user image into internal `[attached image: sha256:…]` marker text through the legacy pre-step path. Model-specific projection now stays at adapter/request boundaries instead of leaking into the conversation transcript.
+- Fixes #374 and the wider delegated call-config class: when Vision Router actually hands a request to another provider/model, source-route `maxTokens`, `reasoningEffort`, sampling and stop settings no longer override the target adapter's own defaults. This fixes GLM routes such as `glm-4v-flash` rejecting a Router-supplied 4096-token limit when the configured model cap is 1024.
+- Refines that handoff rule so transparent Vision Router twins keep caller-owned generation settings, while tool, Vision Chain and `agent/request` provider/model handoffs restore target-route authority. Reasoning memory is scoped to the relevant session and route instead of becoming cross-route state.
+- Keeps the `vision_describe` cache as a successful-answer cache. Structured Vision Router failures (`ok: false` with `VISION_*` errors) are no longer retained across turns, so repaired credentials or recovered backends can be retried immediately.
+
+## Regression and CI hardening
+
+- Adds production-shaped coverage for delegated target defaults, transparent wrapper behavior, `agent/request` route handoffs and ordinary non-delegated LLM calls.
+- Adds transcript ownership coverage ensuring accepted user images remain raw Session content and the retired pre-step bridge cannot synthesize attachment markers into durable history.
+- Makes the default test manifest closed-world: every `tests/**/*.test.js` file must either run in the normal suite or have a documented PR-triggered specialist workflow owner.
+- Verifies specialist workflow ownership against the workflow source so exclusions cannot silently become stale or merely appear in a path trigger without being executed.
+- The new gate surfaced four historical stale assertions that had never been part of normal CI. They now track the current contracts: the old wrapper-scope prelude remains an inert compatibility tombstone, and visual-proof benchmark failures remain transient/per-axis rather than persistent across restart.
+
+## Upgrade
+
+Upgrade to 2.1.2 and restart the DSH Web/Desktop process so the new runtime boundary is loaded. No settings migration is required.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-vision-router",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Eyes for text-only DeepSeek Harness agents: built-in free vision chain (no key) + pixel-level vision tools (Q&A, grounding, crop, pixel diff, colors, OCR, SVG trace, cutout, screenshots). One-command install, no Python, image turns work like ordinary tool-calling turns.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

Prepare DVR `2.1.2` from the current post-2.1.1 hotfix line.

- bump `package.json` from `2.1.1` to `2.1.2`;
- add curated `docs/releases/v2.1.2.md` notes for the Session image-ownership fix, delegated target call-config authority / #374, describe-cache recovery fix, and the closed-world CI gate;
- no dependency or settings migration changes.

## Release scope since v2.1.1

- #375 — keep uploaded images as durable Session facts and retire legacy pre-step marker projection.
- #376 + #377 — restore target adapter generation-config authority at real provider/model handoffs while preserving transparent-wrapper caller config; closes #374.
- #378 — do not cache structured Vision Router failures as successful `vision_describe` knowledge.
- #379 — make test ownership closed-world and align previously-unowned stale contracts with current runtime semantics.

The intervening #373 only removed the old one-shot v2.1.1 dispatcher; v2.1.2 will use the repository's existing verified `Release` workflow directly instead of adding another dispatcher.

## Release plan

After this PR is green and merged, dispatch the existing `Release` workflow with `tag=v2.1.2` and `target_sha` equal to the exact then-current `main` HEAD. The workflow will re-run `pnpm test`, create the tag at that verified SHA, publish the exact npm tarball with provenance, and create the GitHub Release from the curated notes.