### PR TITLE
fix(attachments): resolve DSH text-only image handles

### DIFF
--- a/lib/grounding-coordinate-runtime.js
+++ b/lib/grounding-coordinate-runtime.js
@@ -6,6 +6,7 @@ import {
   createGroundingFrame,
   groundingFrameBoxToSource,
 } from './grounding-coordinate-frame.js'
+import { wrapVisionAttachmentHandleDefinition } from './vision-attachment-handle-runtime.js'
 
 const GROUNDING_TOOL_NAMES = new Set(['vision_ground', 'vision_detect'])
 let sharpPromise
@@ -205,9 +206,10 @@ function wrapGroundingDefinition(ctx, options, def) {
  * Give vision_ground / vision_detect one explicit provider-independent
  * coordinate protocol: the model always receives an exact 1000x1000
  * letterboxed raster, while callers always receive Host-canonical source
- * pixels. Core still owns provider selection, fallback, retry and failure
- * semantics; this boundary owns only raster geometry and original-image
- * annotation.
+ * pixels. The same registration seam also canonicalizes DSH text-only image
+ * handles before any Vision Router tool sees them, so short model-facing
+ * sha256 prefixes can never fall through into filesystem-path resolution.
+ * Core still owns provider selection, fallback, retry and failure semantics.
  */
 export function contextWithGroundingCoordinateFrame(ctx, options = {}) {
   if (!ctx || (typeof ctx !== 'object' && typeof ctx !== 'function')) return ctx
@@ -221,11 +223,11 @@ export function contextWithGroundingCoordinateFrame(ctx, options = {}) {
         return typeof value === 'function' ? value.bind(target) : value
       }
       const register = Reflect.get(target, property, target)
-      return (def, ...rest) => register.call(
-        target,
-        wrapGroundingDefinition(ctx, options, def),
-        ...rest,
-      )
+      return (def, ...rest) => {
+        const grounded = wrapGroundingDefinition(ctx, options, def)
+        const attachmentResolved = wrapVisionAttachmentHandleDefinition(grounded, options)
+        return register.call(target, attachmentResolved, ...rest)
+      }
     },
   })
 

--- a/lib/vision-attachment-handle-runtime.js
+++ b/lib/vision-attachment-handle-runtime.js
@@ -1,3 +1,5 @@
+const SHA256_HANDLE_PREFIX = /^sha256:/i
+const CANONICAL_SHA256_ID = /^sha256:[0-9a-f]{64}$/i
 const PROJECTED_SHA256_HANDLE = /^sha256:[0-9a-f]{8,63}$/i
 
 const TOOL_FIELDS = Object.freeze({
@@ -80,6 +82,14 @@ export function isProjectedAttachmentHandle(value) {
   return typeof value === 'string' && PROJECTED_SHA256_HANDLE.test(value.trim())
 }
 
+function isSha256HandleLike(value) {
+  return typeof value === 'string' && SHA256_HANDLE_PREFIX.test(value.trim())
+}
+
+function isCanonicalSha256Id(value) {
+  return typeof value === 'string' && CANONICAL_SHA256_ID.test(value.trim())
+}
+
 /**
  * Resolve DSH's model-facing text-only image alias back to one canonical
  * attachment ref without changing durable attachment identity semantics.
@@ -108,27 +118,31 @@ export function resolveProjectedAttachmentHandle(handle, { core, sessionVisionIn
   const canonicalId = attachmentIdOf(candidate)
   if (canonicalId === undefined) return { kind: 'unknown', handle: token }
 
-  // Re-resolve through the canonical Session index when available so bounded
-  // cache eviction remains a performance detail and the returned ref is the
-  // same Host-owned identity every downstream tool already trusts.
-  let ref = candidate
-  if (sessionVisionIndex && typeof sessionVisionIndex.lookupAttachment === 'function') {
-    try {
-      ref = sessionVisionIndex.lookupAttachment(session, canonicalId) ?? candidate
-    } catch {
-      ref = candidate
-    }
-  }
+  // The Session event/inbox proves authorization; warm the canonical bounded
+  // index with that exact Host-owned ref, then require the index to hand it
+  // back. This keeps all downstream tools on the same recovery/identity seam.
   try {
-    sessionVisionIndex?.recordAttachments?.(session, [ref])
+    sessionVisionIndex?.recordAttachments?.(session, [candidate])
   } catch {
-    // Index warming is best effort; authorization came from this Session.
+    // A durable event can still be recovered by lookupAttachment below.
   }
+  if (!sessionVisionIndex || typeof sessionVisionIndex.lookupAttachment !== 'function') {
+    return { kind: 'unknown', handle: token }
+  }
+  const ref = sessionVisionIndex.lookupAttachment(session, canonicalId)
+  if (ref === undefined) return { kind: 'unknown', handle: token }
   return { kind: 'resolved', handle: token, canonicalId, ref }
 }
 
 function canonicalizeValue(value, context) {
-  if (!isProjectedAttachmentHandle(value)) return value
+  if (!isSha256HandleLike(value)) return value
+  if (isCanonicalSha256Id(value)) return value
+  if (!isProjectedAttachmentHandle(value)) {
+    throw new Error(
+      `${context.toolName}: invalid attachment handle "${String(value).trim()}" ` +
+        '(sha256 attachment handles must be a canonical id or a DSH-projected 8+ hex prefix)',
+    )
+  }
   const result = resolveProjectedAttachmentHandle(value, context)
   if (result.kind === 'resolved') return result.canonicalId
   if (result.kind === 'ambiguous') {
@@ -175,6 +189,8 @@ function canonicalizeArgs(args, context, fields) {
  * Canonicalize only image-source arguments of Vision Router tools. Ordinary
  * prose fields are never scanned, so a user mentioning `sha256:deadbeef` in a
  * question cannot be rewritten accidentally. Local paths remain untouched.
+ * Any sha256-shaped source is reserved for attachment identity and therefore
+ * fails closed rather than falling through to cwd-relative filesystem lookup.
  */
 export function wrapVisionAttachmentHandleDefinition(def, options = {}) {
   if (!def || typeof def !== 'object' || typeof def.execute !== 'function') return def

--- a/lib/vision-attachment-handle-runtime.js
+++ b/lib/vision-attachment-handle-runtime.js
@@ -1,0 +1,196 @@
+const PROJECTED_SHA256_HANDLE = /^sha256:[0-9a-f]{8,63}$/i
+
+const TOOL_FIELDS = Object.freeze({
+  vision_describe: { arrays: ['attachmentIds', 'paths'] },
+  vision_bootstrap: { arrays: ['attachmentIds', 'paths'] },
+  vision_materialize: { scalars: ['image'] },
+  vision_ground: { scalars: ['image'] },
+  vision_detect: { scalars: ['image'] },
+  vision_crop: { scalars: ['image'] },
+  vision_present: { scalars: ['image'] },
+  vision_pixel_diff: { scalars: ['original', 'rebuilt'] },
+  vision_colors: { scalars: ['image'] },
+  vision_ocr: { scalars: ['image'] },
+  vision_trace: { scalars: ['image'] },
+  vision_extract_foreground: { scalars: ['image'] },
+})
+
+function isObject(value) {
+  return value !== null && typeof value === 'object'
+}
+
+function attachmentIdOf(ref) {
+  if (!ref || typeof ref !== 'object') return undefined
+  const value = ref.attachmentId ?? ref.id
+  if (value === undefined || value === null) return undefined
+  const id = String(value).trim()
+  return id === '' ? undefined : id
+}
+
+function sessionEvents(session) {
+  try {
+    if (session && typeof session.snapshotEvents === 'function') {
+      const events = session.snapshotEvents()
+      return Array.isArray(events) ? events : []
+    }
+    return Array.isArray(session?.events) ? session.events : []
+  } catch {
+    return []
+  }
+}
+
+function collectImageRefsFromBlocks(blocks, out) {
+  if (!Array.isArray(blocks)) return
+  for (const block of blocks) {
+    if (!block || typeof block !== 'object') continue
+    if (block.type === 'image' && block.attachment) out.push(block.attachment)
+    if (Array.isArray(block.content)) collectImageRefsFromBlocks(block.content, out)
+  }
+}
+
+function collectImageRefsFromMessages(messages, out) {
+  if (!Array.isArray(messages)) return
+  for (const message of messages) collectImageRefsFromBlocks(message?.content, out)
+}
+
+function authorizedRefs(core, agent) {
+  const refs = []
+  const session = agent?.session
+  const events = sessionEvents(session)
+  if (typeof core?.collectEventAttachmentRefs === 'function') {
+    try {
+      const durable = core.collectEventAttachmentRefs(events)
+      if (Array.isArray(durable)) refs.push(...durable)
+    } catch {
+      // The resolver remains fail-closed; pending refs below may still suffice.
+    }
+  }
+  collectImageRefsFromMessages(agent?.inbox?.nextTurn, refs)
+  collectImageRefsFromMessages(agent?.inbox?.nextStep, refs)
+
+  const unique = new Map()
+  for (const ref of refs) {
+    const id = attachmentIdOf(ref)
+    if (id !== undefined && !unique.has(id)) unique.set(id, ref)
+  }
+  return [...unique.values()]
+}
+
+export function isProjectedAttachmentHandle(value) {
+  return typeof value === 'string' && PROJECTED_SHA256_HANDLE.test(value.trim())
+}
+
+/**
+ * Resolve DSH's model-facing text-only image alias back to one canonical
+ * attachment ref without changing durable attachment identity semantics.
+ *
+ * DSH currently projects `sha256:<full digest>` to a short `sha256:<prefix>`
+ * for text-only requests. The alias is not globally addressable: it is valid
+ * only when exactly one image authorized by the current Session has that
+ * prefix. Zero or multiple matches fail closed.
+ */
+export function resolveProjectedAttachmentHandle(handle, { core, sessionVisionIndex, agent } = {}) {
+  const token = typeof handle === 'string' ? handle.trim() : ''
+  if (!isProjectedAttachmentHandle(token)) return { kind: 'not-projected', value: handle }
+
+  const session = agent?.session
+  const refs = authorizedRefs(core, agent)
+  const wanted = token.toLowerCase()
+  const matches = refs.filter((ref) => {
+    const id = attachmentIdOf(ref)
+    return id !== undefined && id.toLowerCase().startsWith(wanted)
+  })
+
+  if (matches.length === 0) return { kind: 'unknown', handle: token }
+  if (matches.length > 1) return { kind: 'ambiguous', handle: token }
+
+  const candidate = matches[0]
+  const canonicalId = attachmentIdOf(candidate)
+  if (canonicalId === undefined) return { kind: 'unknown', handle: token }
+
+  // Re-resolve through the canonical Session index when available so bounded
+  // cache eviction remains a performance detail and the returned ref is the
+  // same Host-owned identity every downstream tool already trusts.
+  let ref = candidate
+  if (sessionVisionIndex && typeof sessionVisionIndex.lookupAttachment === 'function') {
+    try {
+      ref = sessionVisionIndex.lookupAttachment(session, canonicalId) ?? candidate
+    } catch {
+      ref = candidate
+    }
+  }
+  try {
+    sessionVisionIndex?.recordAttachments?.(session, [ref])
+  } catch {
+    // Index warming is best effort; authorization came from this Session.
+  }
+  return { kind: 'resolved', handle: token, canonicalId, ref }
+}
+
+function canonicalizeValue(value, context) {
+  if (!isProjectedAttachmentHandle(value)) return value
+  const result = resolveProjectedAttachmentHandle(value, context)
+  if (result.kind === 'resolved') return result.canonicalId
+  if (result.kind === 'ambiguous') {
+    throw new Error(
+      `${context.toolName}: ambiguous attachment handle "${result.handle}" ` +
+        '(multiple images in this conversation share that prefix; use a full attachment id or attach the image again)',
+    )
+  }
+  throw new Error(
+    `${context.toolName}: unknown attachment handle "${result.handle}" ` +
+      '(it is not authorized by an image in this conversation; attach the image again if needed)',
+  )
+}
+
+function canonicalizeArgs(args, context, fields) {
+  if (!isObject(args) || Array.isArray(args)) return args
+  let next
+  for (const field of fields.scalars ?? []) {
+    if (!Object.hasOwn(args, field)) continue
+    const value = canonicalizeValue(args[field], context)
+    if (value !== args[field]) {
+      next ??= { ...args }
+      next[field] = value
+    }
+  }
+  for (const field of fields.arrays ?? []) {
+    const values = args[field]
+    if (!Array.isArray(values)) continue
+    let changed = false
+    const mapped = values.map((value) => {
+      const canonical = canonicalizeValue(value, context)
+      if (canonical !== value) changed = true
+      return canonical
+    })
+    if (changed) {
+      next ??= { ...args }
+      next[field] = mapped
+    }
+  }
+  return next ?? args
+}
+
+/**
+ * Canonicalize only image-source arguments of Vision Router tools. Ordinary
+ * prose fields are never scanned, so a user mentioning `sha256:deadbeef` in a
+ * question cannot be rewritten accidentally. Local paths remain untouched.
+ */
+export function wrapVisionAttachmentHandleDefinition(def, options = {}) {
+  if (!def || typeof def !== 'object' || typeof def.execute !== 'function') return def
+  const fields = TOOL_FIELDS[def.name]
+  if (!fields || !options.sessionVisionIndex) return def
+  const execute = def.execute
+  return {
+    ...def,
+    execute(args, exec) {
+      const nextArgs = canonicalizeArgs(args, {
+        core: options.core,
+        sessionVisionIndex: options.sessionVisionIndex,
+        agent: exec?.agent,
+        toolName: def.name,
+      }, fields)
+      return execute.call(def, nextArgs, exec)
+    },
+  }
+}

--- a/tests/grounding-coordinate-runtime.test.js
+++ b/tests/grounding-coordinate-runtime.test.js
@@ -25,6 +25,13 @@ function fakeCore() {
     isAttachmentIdInput(value) {
       return typeof value === 'string' && /^[a-z0-9]+:[0-9a-f]{32,}$/i.test(value.trim())
     },
+    collectEventAttachmentRefs(events) {
+      const refs = []
+      for (const event of events ?? []) {
+        if (Array.isArray(event?.data?.refs)) refs.push(...event.data.refs)
+      }
+      return refs
+    },
     artifactStemOf(_source, suffix) {
       return `fixture-${suffix}`
     },
@@ -79,8 +86,13 @@ function harness(workspace, { attachmentBytes, attachmentId } = {}) {
   }
 }
 
-function execFor(workspace) {
-  return { agent: { session: { header: { cwd: workspace } } } }
+function execFor(workspace, { events = [], inbox } = {}) {
+  return {
+    agent: {
+      session: { header: { cwd: workspace }, events },
+      ...(inbox === undefined ? {} : { inbox }),
+    },
+  }
 }
 
 test('vision_ground sends a real 1000x1000 letterbox raster and remaps a wide-image box to source pixels', async () => {
@@ -237,7 +249,179 @@ test('attachment ids are resolved through the canonical SessionVisionIndex befor
   assert.deepEqual(h.counts(), { fsReads: 0, attachmentReads: 1 })
 })
 
-test('non-grounding tools pass through without execute replacement', () => {
+test('DSH text-only sha256 prefix is canonicalized before grounding and never falls through to a path', async () => {
+  const workspace = await mkdtemp(path.join(tmpdir(), 'vr-ground-short-handle-'))
+  const width = 1200
+  const height = 600
+  const prefix = '2e73d462'
+  const attachmentId = `sha256:${prefix}${'a'.repeat(56)}`
+  const handle = `sha256:${prefix}`
+  const ref = { attachmentId, mediaType: 'image/png', width, height, bytes: 1 }
+  const bytes = await sharp({
+    create: { width, height, channels: 3, background: { r: 230, g: 230, b: 230 } },
+  }).png().toBuffer()
+  ref.bytes = bytes.length
+  const h = harness(workspace, { attachmentBytes: bytes, attachmentId })
+  const lookedUp = []
+  const wrapped = contextWithGroundingCoordinateFrame(h.ctx, {
+    core: fakeCore(),
+    config: {},
+    sessionVisionIndex: {
+      lookupAttachment(_session, id) {
+        lookedUp.push(id)
+        return id === attachmentId ? ref : undefined
+      },
+      recordAttachments() {},
+    },
+  })
+  wrapped.tools.register({
+    name: 'vision_ground',
+    async execute() {
+      return JSON.stringify({ x1: 0, y1: 0, x2: 1000, y2: 1000 })
+    },
+  })
+
+  const result = JSON.parse(await h.registered.get('vision_ground').execute(
+    { image: handle, target: 'whole image', annotate: false },
+    execFor(workspace, { events: [{ type: 'user/message', data: { refs: [ref] } }] }),
+  ))
+  assert.equal(result.width, width)
+  assert.equal(result.height, height)
+  assert.deepEqual(lookedUp, [attachmentId, attachmentId])
+  assert.deepEqual(h.counts(), { fsReads: 0, attachmentReads: 1 })
+})
+
+test('vision_describe canonicalizes projected handles in attachmentIds and paths but leaves prose untouched', async () => {
+  const workspace = process.cwd()
+  const prefix = '1234abcd'
+  const attachmentId = `sha256:${prefix}${'b'.repeat(56)}`
+  const handle = `sha256:${prefix}`
+  const ref = { attachmentId, mediaType: 'image/png', width: 1, height: 1, bytes: 1 }
+  const h = harness(workspace)
+  const wrapped = contextWithGroundingCoordinateFrame(h.ctx, {
+    core: fakeCore(),
+    config: {},
+    sessionVisionIndex: {
+      lookupAttachment(_session, id) {
+        return id === attachmentId ? ref : undefined
+      },
+      recordAttachments() {},
+    },
+  })
+  let observed
+  wrapped.tools.register({
+    name: 'vision_describe',
+    execute(args) {
+      observed = args
+      return 'ok'
+    },
+  })
+  const exec = execFor(workspace, { events: [{ type: 'user/message', data: { refs: [ref] } }] })
+  const question = `what does ${handle} mean as text?`
+  assert.equal(
+    h.registered.get('vision_describe').execute({
+      attachmentIds: [handle],
+      paths: [handle, 'local.png'],
+      question,
+    }, exec),
+    'ok',
+  )
+  assert.deepEqual(observed.attachmentIds, [attachmentId])
+  assert.deepEqual(observed.paths, [attachmentId, 'local.png'])
+  assert.equal(observed.question, question)
+})
+
+test('projected handles fail closed on unknown, ambiguous, and cross-session references', () => {
+  const workspace = process.cwd()
+  const prefix = 'deadbeef'
+  const handle = `sha256:${prefix}`
+  const first = { attachmentId: `sha256:${prefix}${'1'.repeat(56)}`, mediaType: 'image/png' }
+  const second = { attachmentId: `sha256:${prefix}${'2'.repeat(56)}`, mediaType: 'image/png' }
+  const h = harness(workspace)
+  const wrapped = contextWithGroundingCoordinateFrame(h.ctx, {
+    core: fakeCore(),
+    config: {},
+    sessionVisionIndex: {
+      lookupAttachment() {
+        throw new Error('lookup must not authorize an unknown prefix by itself')
+      },
+      recordAttachments() {},
+    },
+  })
+  let delegated = 0
+  wrapped.tools.register({
+    name: 'vision_materialize',
+    execute() {
+      delegated += 1
+      return 'should-not-run'
+    },
+  })
+
+  assert.throws(
+    () => h.registered.get('vision_materialize').execute(
+      { image: handle },
+      execFor(workspace),
+    ),
+    /unknown attachment handle/,
+  )
+  assert.throws(
+    () => h.registered.get('vision_materialize').execute(
+      { image: handle },
+      execFor(workspace, { events: [{ data: { refs: [first, second] } }] }),
+    ),
+    /ambiguous attachment handle/,
+  )
+  const foreignExec = execFor(workspace, { events: [{ data: { refs: [first] } }] })
+  const currentExec = execFor(workspace)
+  assert.ok(foreignExec.agent.session.events.length > 0)
+  assert.throws(
+    () => h.registered.get('vision_materialize').execute({ image: handle }, currentExec),
+    /unknown attachment handle/,
+  )
+  assert.equal(delegated, 0)
+})
+
+test('pending current-session image refs can authorize the same projected handle without global lookup', () => {
+  const workspace = process.cwd()
+  const prefix = 'cafebabe'
+  const attachmentId = `sha256:${prefix}${'c'.repeat(56)}`
+  const handle = `sha256:${prefix}`
+  const ref = { attachmentId, mediaType: 'image/png', width: 1, height: 1, bytes: 1 }
+  const h = harness(workspace)
+  const wrapped = contextWithGroundingCoordinateFrame(h.ctx, {
+    core: fakeCore(),
+    config: {},
+    sessionVisionIndex: {
+      lookupAttachment(_session, id) {
+        return id === attachmentId ? ref : undefined
+      },
+      recordAttachments() {},
+    },
+  })
+  let observed
+  wrapped.tools.register({
+    name: 'vision_pixel_diff',
+    execute(args) {
+      observed = args
+      return 'ok'
+    },
+  })
+  const inbox = {
+    nextTurn: [{ role: 'user', content: [{ type: 'image', attachment: ref }] }],
+    nextStep: [],
+  }
+  assert.equal(
+    h.registered.get('vision_pixel_diff').execute(
+      { original: handle, rebuilt: 'rebuilt.png' },
+      execFor(workspace, { inbox }),
+    ),
+    'ok',
+  )
+  assert.equal(observed.original, attachmentId)
+  assert.equal(observed.rebuilt, 'rebuilt.png')
+})
+
+test('non-grounding tools pass through without execute replacement when no SessionVisionIndex is installed', () => {
   const h = harness(process.cwd())
   const wrapped = contextWithGroundingCoordinateFrame(h.ctx, { core: fakeCore(), config: {} })
   const execute = async () => 'ok'


### PR DESCRIPTION
## Problem

Current DSH keeps durable image history when a session switches to a text-only model. At request assembly it projects an image such as `sha256:<64 hex>` to a model-facing placeholder containing only `sha256:<8 hex>`. Vision Router tools still expect the canonical full attachment id. A text-only model can therefore call `vision_describe` with the projected handle and receive `unknown attachment id`; follow-up tools may then misinterpret the short `sha256:` token as a relative filesystem path.

## Root fix

- Add one transient attachment-handle compatibility boundary at Vision Router's existing image-tool registration seam.
- Keep canonical `sha256:<64 hex>` attachment ids unchanged. Treat DSH-shaped `sha256:<8..63 hex>` values only as model-facing prefixes, never as durable ids.
- Resolve a projected prefix only against image refs authorized by the **current Session**: the durable Session event log plus current pending inbox images. No global attachment-store scan and no cross-session search.
- Require exactly one matching canonical attachment id. Zero matches fail as unknown; multiple prefix matches fail as ambiguous. The unique Host-owned ref is warmed into and re-resolved through the existing `SessionVisionIndex` before tool execution.
- Reserve `sha256:`-shaped image-source inputs for attachment identity. Malformed/too-short/too-long sha256 handles fail explicitly instead of ever falling through to cwd-relative filesystem lookup.
- Canonicalize only schema-known image-source arguments (`attachmentIds`/`paths`, `image`, and pixel-diff `original`/`rebuilt`). Ordinary prose fields are never scanned or rewritten, and normal local paths remain untouched.
- Canonicalization runs outside the grounding wrapper, so `vision_ground`/`vision_detect` receive a full id before their existing attachment-vs-path branch. The same rule covers describe/bootstrap/materialize/crop/present/pixel-diff/colors/OCR/trace/foreground tools.
- No Session event, durable attachment-id, persistence, model-routing, Vision-mode, tool-enable, or attachment-store semantics change.

## Regression coverage

- projected handle -> unique full attachment -> grounding uses attachment bytes, never fs path;
- `vision_describe` resolves projected handles from both `attachmentIds` and `paths` while leaving question prose untouched;
- unknown, ambiguous, and cross-session prefixes fail closed before tool delegation;
- pending current-session image refs authorize the same projected handle;
- full canonical attachment ids retain the existing SessionVisionIndex path;
- deployments without the Session index retain the previous non-grounding pass-through behavior.

## Verification

- Node 22 and Node 24 default test suites green;
- Windows/macOS/Ubuntu packed-host + shared-sharp jobs green;
- DSH rc.6/rc.7/rc.8 contract checks green;
- P1 Routing Parity and Native multimodal cold-resume workflows green;
- CodeQL reports no new alerts.
