### PR TITLE
chore(release): publish v2.1.2

### DIFF
--- a/.github/workflows/dispatch-v2.1.2.yml
+++ b/.github/workflows/dispatch-v2.1.2.yml
@@ -1,0 +1,42 @@
+name: Dispatch v2.1.2
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  dispatch:
+    if: github.repository == 'ysr666/dsh-vision-router'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - name: Verify release identity
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="$(node -p "require('./package.json').version")"
+          [ "$VERSION" = "2.1.2" ] || {
+            echo "::error::expected package version 2.1.2, got $VERSION"
+            exit 1
+          }
+          [ -s docs/releases/v2.1.2.md ] || {
+            echo "::error::missing curated v2.1.2 release notes"
+            exit 1
+          }
+      - name: Dispatch verified release workflow
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh workflow run release.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref main \
+            -f tag=v2.1.2 \
+            -f target_sha="$GITHUB_SHA"

--- a/docs/releases/v2.1.2.md
+++ b/docs/releases/v2.1.2.md
@@ -1,6 +1,6 @@
 # v2.1.2
 
-DVR 2.1.2 is a reliability hotfix for image-session ownership and delegated vision routing. It also closes a CI blind spot that allowed valid regression tests to exist without being executed by the normal release gate.
+DVR 2.1.2 is a reliability hotfix for image-session ownership, delegated vision routing, text-only attachment projection, and composer Vision-mode authority. It also closes CI blind spots that could allow valid regression tests to exist without being executed by the normal release gate.
 
 ## Fixed
 
@@ -8,15 +8,23 @@ DVR 2.1.2 is a reliability hotfix for image-session ownership and delegated visi
 - Fixes #374 and the wider delegated call-config class: when Vision Router actually hands a request to another provider/model, source-route `maxTokens`, `reasoningEffort`, sampling and stop settings no longer override the target adapter's own defaults. This fixes GLM routes such as `glm-4v-flash` rejecting a Router-supplied 4096-token limit when the configured model cap is 1024.
 - Refines that handoff rule so transparent Vision Router twins keep caller-owned generation settings, while tool, Vision Chain and `agent/request` provider/model handoffs restore target-route authority. Reasoning memory is scoped to the relevant session and route instead of becoming cross-route state.
 - Keeps the `vision_describe` cache as a successful-answer cache. Structured Vision Router failures (`ok: false` with `VISION_*` errors) are no longer retained across turns, so repaired credentials or recovered backends can be retried immediately.
+- Recovers safely when a source adapter is incorrectly catalogued as image-capable. Generated Vision Router twins now recognize explicit runtime image-capability rejection before model-visible output, record bounded negative proof for the exact source route, and re-enter the canonical text-only fallback path instead of repeatedly sending raw pixels to a text-only backend. Generic 4xx/5xx, auth, rate-limit, media-format, cancellation and post-output failures do not trigger this fallback.
+- Resolves DSH text-only projected image handles such as `sha256:deadbeef` back to a canonical attachment only inside the current Session. Unique prefixes resolve, unknown or ambiguous prefixes fail closed, bounded cache eviction cannot erase ambiguity because durable Session history remains authoritative, and attachment-shaped input can no longer fall through into a guessed local filesystem path.
+- Makes the composer `👁 Vision` state the authoritative per-Session permission for Vision Router orchestration. Ordinary text-only and native-multimodal routes no longer receive Router-owned `vision_*` schemas, structured bootstrap, automatic deep-tool mounting or instant visual work while Vision is OFF. Native multimodal pixels remain Host-owned and continue to work normally without Router intervention.
+- Keeps the current Agent step internally stable if the model picker changes while it is running. The new selection is applied at the next real prompt-assembly boundary, while diagnostic/out-of-band prompt renders cannot clear or mutate the active step authority.
+- Keeps Settings `tool=false` as an independent global capability gate. Selecting a Vision Router wrapper cannot re-enable tools that the user explicitly disabled.
 
 ## Regression and CI hardening
 
 - Adds production-shaped coverage for delegated target defaults, transparent wrapper behavior, `agent/request` route handoffs and ordinary non-delegated LLM calls.
 - Adds transcript ownership coverage ensuring accepted user images remain raw Session content and the retired pre-step bridge cannot synthesize attachment markers into durable history.
+- Adds false-multimodal metadata regressions across generated twins, custom wrappers, lazy source registration, route changes and negative-proof isolation.
+- Adds attachment-handle regressions for exact IDs, DSH short projected handles, cache eviction, same-Session prefix collisions, cross-Session isolation, malformed handles and attachment-vs-filesystem dispatch.
+- Adds Session Vision-mode regressions for OFF/ON isolation, native multimodal non-intervention, prompt-assembly visibility, PTC/scoped-tool behavior, mid-step picker changes, diagnostic assemblies, foreign `vision_*` tools and Settings `tool=false`.
 - Makes the default test manifest closed-world: every `tests/**/*.test.js` file must either run in the normal suite or have a documented PR-triggered specialist workflow owner.
 - Verifies specialist workflow ownership against the workflow source so exclusions cannot silently become stale or merely appear in a path trigger without being executed.
-- The new gate surfaced four historical stale assertions that had never been part of normal CI. They now track the current contracts: the old wrapper-scope prelude remains an inert compatibility tombstone, and visual-proof benchmark failures remain transient/per-axis rather than persistent across restart.
+- The final release head passes Node 22/24, DSH rc.6/rc.7/rc.8 contracts, P1/P2/P3 architecture gates, native multimodal cold/process restart coverage, Ubuntu/macOS/Windows host-sharp checks, and CodeQL with no new alerts.
 
 ## Upgrade
 
-Upgrade to 2.1.2 and restart the DSH Web/Desktop process so the new runtime boundary is loaded. No settings migration is required.
+Upgrade to 2.1.2 and restart the DSH Web/Desktop process so the new runtime boundaries are loaded. No settings migration is required.


### PR DESCRIPTION
## Release

Publish `dsh-vision-router` v2.1.2 from the exact merged `main` head.

- finalizes the curated v2.1.2 release notes with the post-preparation reliability fixes from #381, #382 and #383;
- adds the temporary one-shot release dispatcher used by the repository's established verified release flow;
- leaves `package.json` at the already-prepared `2.1.2` version;
- the dispatcher invokes `.github/workflows/release.yml` with `tag=v2.1.2` and the exact merge SHA, so the release workflow verifies current `main`, creates the immutable tag, runs tests, publishes the exact npm tarball with provenance, verifies registry identity, and creates the GitHub Release.

After the release is verified, the temporary dispatcher should be removed in a follow-up cleanup PR.