### PR TITLE
fix(vision): use tool-specific structured evidence semantics

### DIFF
--- a/lib/structured-flow-hardening.js
+++ b/lib/structured-flow-hardening.js
@@ -21,7 +21,6 @@ const MAX_GUIDANCE_OVERRIDES = 14
 const MAX_GUIDANCE_CHARS = 2_000
 const MAX_NON_PROGRESS_ATTEMPTS = 3
 const BUDGETED_TIMEOUT_FIELDS = ['timeoutMs', 'visionTaskTimeoutMs', 'ocrTimeoutMs']
-const EVIDENCE_META_KEYS = new Set(['ok', 'code', 'retryable', 'reason', 'phase', 'next'])
 const GUIDANCE_KINDS = new Set([
   'code',
   'document',
@@ -78,39 +77,143 @@ export function producedStructuredEvidence(value) {
   return true
 }
 
-function meaningfulEvidenceValue(value) {
-  if (value === undefined || value === null) return false
-  if (typeof value === 'string') return value.trim() !== ''
-  if (typeof value === 'number') return Number.isFinite(value)
-  if (typeof value === 'boolean') return true
-  if (Array.isArray(value)) return value.length > 0 && value.some(meaningfulEvidenceValue)
-  if (!isObject(value) || value.ok === false) return false
-  return Object.entries(value).some(([key, child]) => (
-    !EVIDENCE_META_KEYS.has(key) && meaningfulEvidenceValue(child)
+function finiteNumber(value) {
+  return typeof value === 'number' && Number.isFinite(value)
+}
+
+function positiveInteger(value) {
+  return Number.isInteger(value) && value > 0
+}
+
+function nonEmptyText(value) {
+  return typeof value === 'string' && value.trim() !== ''
+}
+
+function canonicalBox(value, width, height) {
+  if (!isObject(value) || Array.isArray(value)) return false
+  const { x1, y1, x2, y2 } = value
+  if (![x1, y1, x2, y2].every(Number.isInteger)) return false
+  if (x1 < 0 || y1 < 0 || x2 <= x1 || y2 <= y1) return false
+  if (positiveInteger(width) && x2 > width) return false
+  if (positiveInteger(height) && y2 > height) return false
+  return true
+}
+
+function structuredDescribeEvidence(value) {
+  if (!isObject(value) || Array.isArray(value)) return false
+  if (nonEmptyText(value.summary) || nonEmptyText(value.text)) return true
+  if (Array.isArray(value.layout) && value.layout.some((row) => (
+    isObject(row) && nonEmptyText(row.region) && nonEmptyText(row.content)
+  ))) return true
+  return Array.isArray(value.entities) && value.entities.some((entity) => (
+    isObject(entity) && nonEmptyText(entity.type) && nonEmptyText(entity.label)
   ))
 }
 
+function groundEvidence(value) {
+  if (!isObject(value) || Array.isArray(value)) return false
+  const { width, height } = value
+  return positiveInteger(width) && positiveInteger(height) && canonicalBox(value, width, height)
+}
+
+function detectEvidence(value) {
+  if (!isObject(value) || Array.isArray(value)) return false
+  const { width, height, elements } = value
+  if (!positiveInteger(width) || !positiveInteger(height) || !Array.isArray(elements)) return false
+  return elements.every((element, index) => (
+    isObject(element) &&
+    element.number === index + 1 &&
+    nonEmptyText(element.label) &&
+    canonicalBox(element.box, width, height)
+  ))
+}
+
+function ocrEvidence(value) {
+  if (!isObject(value) || Array.isArray(value)) return false
+  if (value.engine !== 'tesseract' && value.engine !== 'vision') return false
+  return typeof value.text === 'string'
+}
+
+function colorEvidence(value) {
+  if (!Array.isArray(value)) return false
+  return value.every((entry) => (
+    isObject(entry) &&
+    typeof entry.hex === 'string' && /^#[0-9a-f]{6}$/i.test(entry.hex) &&
+    positiveInteger(entry.count) &&
+    finiteNumber(entry.share) && entry.share > 0 && entry.share <= 1
+  ))
+}
+
+function pixelDiffEvidence(value) {
+  if (!isObject(value) || Array.isArray(value)) return false
+  const { width, height, differingPixels, totalPixels, diffRatio, worstRegions } = value
+  if (!positiveInteger(width) || !positiveInteger(height) || totalPixels !== width * height) return false
+  if (!Number.isInteger(differingPixels) || differingPixels < 0 || differingPixels > totalPixels) return false
+  if (!finiteNumber(diffRatio) || diffRatio < 0 || diffRatio > 1) return false
+  if (Math.abs(diffRatio - differingPixels / totalPixels) > 0.000051) return false
+  if (!Array.isArray(worstRegions)) return false
+  return worstRegions.every((region) => (
+    isObject(region) &&
+    canonicalBox(region, width, height) &&
+    Number.isInteger(region.differing) && region.differing > 0 &&
+    positiveInteger(region.total) && region.differing <= region.total &&
+    finiteNumber(region.ratio) && region.ratio > 0 && region.ratio <= 1
+  ))
+}
+
+function longOcrEvidence(value) {
+  if (!isObject(value) || Array.isArray(value)) return false
+  if (typeof value.text !== 'string' || !positiveInteger(value.chunks)) return false
+  if (!isObject(value.engines) || Array.isArray(value.engines)) return false
+  if (![value.markdownPath, value.manifestPath, value.artifactsDir].every(nonEmptyText)) return false
+  const engineCounts = Object.values(value.engines)
+  if (engineCounts.length === 0 || !engineCounts.every((count) => Number.isInteger(count) && count >= 0)) return false
+  if (engineCounts.reduce((sum, count) => sum + count, 0) !== value.chunks) return false
+  if (nonEmptyText(value.text)) return true
+  const completed = (value.engines.tesseract ?? 0) + (value.engines.vision ?? 0)
+  return completed > 0
+}
+
 /**
- * Evidence that is strong enough to advance the 1+x flow and consume an
- * explicit deep-dive call cap. Empty arrays/objects and metadata-only success
- * envelopes do not count. Negative facts such as { match: false } or
- * { count: 0 } still count because they are real observations, not emptiness.
+ * Decide whether one registered evidence tool completed a real observation.
  *
- * This generic classifier is intentionally retained for Round 1. Tool-specific
- * observation semantics replace it in the next Vision Agent Quality change.
+ * This deliberately follows each tool's output contract instead of treating
+ * arbitrary non-empty containers as evidence. Valid negative observations
+ * (for example zero detections, empty OCR text, or a 0 pixel diff) still count;
+ * transport failures, malformed envelopes, and describe's empty-content
+ * sentinel do not.
  */
-export function producedUsableStructuredEvidence(value) {
-  if (value === undefined || value === null) return false
-  if (typeof value === 'string') {
-    const text = value.trim()
-    if (text === '') return false
-    const parsed = parseJson(text)
-    if (parsed === undefined) return true
-    return producedUsableStructuredEvidence(parsed)
+export function producedUsableToolEvidence(toolName, value, args = {}) {
+  if (!STRUCTURED_EVIDENCE_TOOLS.has(toolName) || value === undefined || value === null) return false
+  const parsed = parseJson(value)
+  if (isObject(parsed) && !Array.isArray(parsed) && parsed.ok === false) return false
+
+  switch (toolName) {
+    case 'vision_describe': {
+      if (typeof value !== 'string') return false
+      const text = value.trim()
+      if (text === '' || text === '(the vision model returned empty content)') return false
+      if (args?.json === true) {
+        if (text.startsWith('vision_describe: the model did not produce valid JSON.')) return false
+        return structuredDescribeEvidence(parsed)
+      }
+      return true
+    }
+    case 'vision_ground':
+      return groundEvidence(parsed)
+    case 'vision_detect':
+      return detectEvidence(parsed)
+    case 'vision_ocr':
+      return ocrEvidence(parsed)
+    case 'vision_colors':
+      return colorEvidence(parsed)
+    case 'vision_pixel_diff':
+      return pixelDiffEvidence(parsed)
+    case 'vision_long_screenshot_ocr':
+      return longOcrEvidence(parsed)
+    default:
+      return false
   }
-  if (Array.isArray(value)) return value.length > 0 && value.some(meaningfulEvidenceValue)
-  if (!isObject(value) || value.ok === false) return false
-  return meaningfulEvidenceValue(value)
 }
 
 /**
@@ -476,7 +579,7 @@ function wrapRegisteredTool(def, states, getConfig) {
         )
         const code = resultCode(result)
         if (code === 'VISION_TURN_BUDGET_EXCEEDED') state.budgetExhausted = true
-        if (producedUsableStructuredEvidence(result)) {
+        if (producedUsableToolEvidence(def.name, result, args)) {
           state.successfulEvidenceCalls += 1
           refreshDepthExhaustion(state, active)
           resetNonProgress(state)

--- a/tests/depth-quota-behavior.test.js
+++ b/tests/depth-quota-behavior.test.js
@@ -180,7 +180,7 @@ test('explicit call cap: failed evidence does not consume it, successful evidenc
     hardenedCtx.tools.register({
       name: 'vision_ground',
       async execute() {
-        return JSON.stringify({ boxes: [{ x: 0, y: 0, w: 1, h: 1, label: 'verified-ui-region' }] })
+        return JSON.stringify({ x1: 0, y1: 0, x2: 10, y2: 10, width: 100, height: 100 })
       },
     })
 
@@ -242,7 +242,7 @@ test('explicit call cap: failed evidence does not consume it, successful evidenc
     assert.ok(ground)
     const requestsBefore = server.requests.length
     const r2 = await ground.execute({ question: 'locate the UI region' }, exec)
-    assert.equal(Array.isArray(JSON.parse(r2).boxes), true)
+    assert.deepEqual(JSON.parse(r2), { x1: 0, y1: 0, x2: 10, y2: 10, width: 100, height: 100 })
     assert.equal(server.requests.length, requestsBefore)
 
     const d4 = await preStep(imagePayload, next)

--- a/tests/structured-flow-adversarial.test.js
+++ b/tests/structured-flow-adversarial.test.js
@@ -2,7 +2,7 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 import {
   installStructuredFlowHardening,
-  producedUsableStructuredEvidence,
+  producedUsableToolEvidence,
 } from '../lib/structured-flow-hardening.js'
 
 function harness(config = {}) {
@@ -55,25 +55,108 @@ function evidenceGuard(decision) {
   return decision.messages.find((message) => String(message?.id).includes('structured-evidence-guard'))
 }
 
-test('quota evidence classifier rejects empty containers and metadata-only success', () => {
-  for (const empty of [
-    undefined,
-    null,
-    '',
-    [],
-    {},
-    { ok: true },
-    { elements: [] },
-    { ok: true, elements: [] },
-    JSON.stringify({ ok: true, elements: [] }),
-  ]) {
-    assert.equal(producedUsableStructuredEvidence(empty), false)
-  }
+test('tool-specific evidence semantics distinguish observations from empty or malformed results', () => {
+  const cases = [
+    ['vision_describe', 'visible text', {}, true],
+    ['vision_describe', '(the vision model returned empty content)', {}, false],
+    ['vision_describe', JSON.stringify({ ok: false, code: 'VISION_TIMEOUT' }), {}, false],
+    [
+      'vision_describe',
+      JSON.stringify({ summary: 'No matching control is visible.', layout: [], entities: [], text: '' }),
+      { json: true },
+      true,
+    ],
+    [
+      'vision_describe',
+      JSON.stringify({ summary: '', layout: [], entities: [], text: '' }),
+      { json: true },
+      false,
+    ],
+    [
+      'vision_describe',
+      'vision_describe: the model did not produce valid JSON. Raw output:\nbutton',
+      { json: true },
+      false,
+    ],
+    ['vision_ground', JSON.stringify({ x1: 2, y1: 3, x2: 20, y2: 30, width: 100, height: 80 }), {}, true],
+    ['vision_ground', JSON.stringify({ count: 0 }), {}, false],
+    ['vision_detect', JSON.stringify({ width: 100, height: 80, elements: [] }), {}, true],
+    [
+      'vision_detect',
+      JSON.stringify({ width: 100, height: 80, elements: [{ number: 2, label: 'button', box: { x1: 1, y1: 1, x2: 10, y2: 10 } }] }),
+      {},
+      false,
+    ],
+    ['vision_detect', JSON.stringify({ elements: [] }), {}, false],
+    ['vision_ocr', JSON.stringify({ engine: 'tesseract', text: '' }), {}, true],
+    ['vision_ocr', JSON.stringify({ engine: 'vision', text: '42' }), {}, true],
+    ['vision_ocr', JSON.stringify({ engine: 'none', text: '' }), {}, false],
+    ['vision_colors', JSON.stringify([]), {}, true],
+    ['vision_colors', JSON.stringify([{ hex: '#102030', count: 8, share: 0.5 }]), {}, true],
+    ['vision_colors', JSON.stringify([{ hex: '#102030', count: 0, share: 0 }]), {}, false],
+    ['vision_colors', JSON.stringify([{ hex: 'blue', count: 8, share: 0.5 }]), {}, false],
+    [
+      'vision_pixel_diff',
+      JSON.stringify({ width: 10, height: 10, differingPixels: 0, totalPixels: 100, diffRatio: 0, worstRegions: [] }),
+      {},
+      true,
+    ],
+    [
+      'vision_pixel_diff',
+      JSON.stringify({ width: 10, height: 10, differingPixels: 101, totalPixels: 100, diffRatio: 1, worstRegions: [] }),
+      {},
+      false,
+    ],
+    ['vision_pixel_diff', JSON.stringify({ diffRatio: 0 }), {}, false],
+    [
+      'vision_long_screenshot_ocr',
+      JSON.stringify({
+        text: '',
+        chunks: 2,
+        engines: { tesseract: 2 },
+        markdownPath: '/tmp/ocr.md',
+        manifestPath: '/tmp/manifest.json',
+        artifactsDir: '/tmp/ocr',
+      }),
+      {},
+      true,
+    ],
+    [
+      'vision_long_screenshot_ocr',
+      JSON.stringify({
+        text: '',
+        chunks: 2,
+        engines: { tesseract: '2' },
+        markdownPath: '/tmp/ocr.md',
+        manifestPath: '/tmp/manifest.json',
+        artifactsDir: '/tmp/ocr',
+      }),
+      {},
+      false,
+    ],
+    [
+      'vision_long_screenshot_ocr',
+      JSON.stringify({
+        text: '',
+        chunks: 2,
+        engines: { failed: 1, skipped: 1 },
+        markdownPath: '/tmp/ocr.md',
+        manifestPath: '/tmp/manifest.json',
+        artifactsDir: '/tmp/ocr',
+      }),
+      {},
+      false,
+    ],
+    ['vision_crop', JSON.stringify({ path: '/tmp/crop.png' }), {}, false],
+  ]
 
-  assert.equal(producedUsableStructuredEvidence('visible text'), true)
-  assert.equal(producedUsableStructuredEvidence({ elements: [{ label: 'button' }] }), true)
-  assert.equal(producedUsableStructuredEvidence({ match: false }), true)
-  assert.equal(producedUsableStructuredEvidence({ count: 0 }), true)
+  for (const [toolName, value, args, expected] of cases) {
+    assert.equal(
+      producedUsableToolEvidence(toolName, value, args),
+      expected,
+      `${toolName}: ${value}`,
+    )
+  }
 })
 
 test('explicit deep-dive cap applies globally even when bootstrap is not used', async () => {
@@ -108,7 +191,7 @@ test('empty successful-looking results do not consume the explicit call cap', as
     async execute() {
       calls += 1
       return calls === 1
-        ? JSON.stringify({ ok: true, elements: [] })
+        ? '(the vision model returned empty content)'
         : 'real evidence'
     },
   })
@@ -116,7 +199,7 @@ test('empty successful-looking results do not consume the explicit call cap', as
   const session = {}
   const exec = { agent: { session } }
   await preStep(h, session)
-  assert.match(await h.defs.get('vision_describe').execute({ question: 'empty' }, exec), /"elements":\[\]/)
+  assert.equal(await h.defs.get('vision_describe').execute({ question: 'empty' }, exec), '(the vision model returned empty content)')
   assert.equal(await h.defs.get('vision_describe').execute({ question: 'real' }, exec), 'real evidence')
   const blocked = JSON.parse(await h.defs.get('vision_describe').execute({ question: 'third' }, exec))
   assert.equal(blocked.code, 'VISION_DEPTH_LIMIT')
@@ -136,7 +219,7 @@ test('three consecutive no-progress follow-ups trip a bounded fuse with unlimite
     name: 'vision_describe',
     async execute() {
       evidenceCalls += 1
-      return JSON.stringify({ ok: true, elements: [] })
+      return '(the vision model returned empty content)'
     },
   })
 
@@ -173,7 +256,7 @@ test('a successful evidence advance resets the non-progress fuse', async () => {
     name: 'vision_describe',
     async execute() {
       evidenceCalls += 1
-      if (evidenceCalls <= 2) return JSON.stringify({ ok: true, elements: [] })
+      if (evidenceCalls <= 2) return '(the vision model returned empty content)'
       return 'usable evidence'
     },
   })

--- a/tests/structured-flow-hardening.test.js
+++ b/tests/structured-flow-hardening.test.js
@@ -59,13 +59,13 @@ function registerMixedBranchTools(harness) {
   harness.wrapped.tools.register({
     name: 'vision_ground',
     async execute() {
-      return JSON.stringify({ boxes: [{ x: 1, y: 1, w: 10, h: 10, label: 'ui-control' }] })
+      return JSON.stringify({ x1: 1, y1: 1, x2: 11, y2: 11, width: 100, height: 100 })
     },
   })
   harness.wrapped.tools.register({
     name: 'vision_ocr',
     async execute() {
-      return JSON.stringify({ text: 'verified document text' })
+      return JSON.stringify({ engine: 'vision', text: 'verified document text' })
     },
   })
   return {


### PR DESCRIPTION
## Vision Agent Quality Round 1 — PR 2

Builds on #384 by making structured-flow evidence completion follow each evidence tool's actual output contract instead of one generic “non-empty container” heuristic.

### Root problem

After PR 1, `structured-flow-hardening` is the single hard authority for whether post-bootstrap `x >= 1` has completed. Its remaining generic evidence classifier still inferred progress from arbitrary result shape: any non-empty field could count, while some valid negative observations were rejected as empty.

That creates both false positives and false negatives. For example, `vision_describe`'s non-empty empty-content sentinel could satisfy `x >= 1`, while a canonical `vision_detect` result with zero elements or a zero-difference `vision_pixel_diff` result could be treated as no progress.

### Changes

- Replace the runtime generic evidence-shape heuristic with `producedUsableToolEvidence(toolName, result, args)`.
- Validate the canonical result contract for each structured evidence tool:
  - `vision_describe`
  - `vision_ground`
  - `vision_detect`
  - `vision_ocr`
  - `vision_colors`
  - `vision_pixel_diff`
  - `vision_long_screenshot_ocr`
- Count valid negative observations as evidence when the tool contract proves an observation actually completed:
  - zero detections;
  - empty OCR transcription from a real OCR engine;
  - no opaque dominant colors;
  - zero pixel differences;
  - empty long-OCR output when at least one chunk was actually processed.
- Reject infrastructure failures, malformed envelopes, inconsistent metrics, fake/partial schemas, and `vision_describe`'s empty-content / invalid-JSON fallback sentinels.
- Keep the historical `producedStructuredEvidence` helper intact for its compatibility-only structural callers; it no longer owns runtime completion.
- Update regression fixtures to use the real production schemas instead of generic fake evidence objects.

### Validation

- Tool-specific adversarial matrix covers positive observations, valid negative observations, malformed schemas, failure envelopes, metric inconsistencies and unsupported tools.
- Structured-flow / quota / idempotency / runtime-i18n targeted suite: green.
- Full `pnpm test`: 1245 passed, 0 failed, 1 existing skip; follow-up backend-policy suite: 6 passed.
- `git diff --check`: clean.

### Intentionally not in this PR

- no change to the hard completion rule (`successfulEvidenceCalls >= 1` remains the sole hard condition);
- no OCR engine/policy change, including the existing structured-flow `auto -> vision` override;
- no `vision_describe` empty-response fallback behavior change;
- no tool schema/description rewrite;
- no Core presentation-latch change;
- no routing/provider/capability/session ownership change.

OCR/model-visible alignment remains the next Vision Agent Quality PR.