### PR TITLE
fix(web): dedupe duplicate clipboard screenshots

### DIFF
--- a/lib/client-presentation-boundary-main.js
+++ b/lib/client-presentation-boundary-main.js
@@ -530,6 +530,178 @@ export const CLIENT_PRESENTATION_PRELUDE = String.raw`(function(){
         return type === '' || bitmapTypes[type] === true;
       }
 
+      var normalizedBitmapFiles = new WeakSet();
+      var maxExactDedupeBytes = 8 * 1024 * 1024;
+      var maxVisualDedupeSourceBytes = 16 * 1024 * 1024;
+      var maxVisualDedupeDimension = 4096;
+      var maxVisualDedupePixels = 9000000;
+      var visualDedupeTile = 256;
+
+      function supportedImage(file) {
+        return !!file && supported[mediaType(file.type)] === true;
+      }
+
+      function syntheticClipboardName(name) {
+        var value = typeof name === 'string' ? name.trim() : '';
+        if (value === '') return true;
+        return /^(?:image|clipboard)(?:[ _-]?\d+)?\.(?:png|jpe?g|webp|gif)$/i.test(value);
+      }
+
+      function syntheticClipboardFile(file) {
+        return !!file && (normalizedBitmapFiles.has(file) || syntheticClipboardName(file.name));
+      }
+
+      function hasDedupeSignal(files) {
+        var images = files.filter(supportedImage);
+        for (var i = 0; i < images.length; i += 1) {
+          for (var j = i + 1; j < images.length; j += 1) {
+            var left = images[i];
+            var right = images[j];
+            if (
+              (Number.isFinite(left.size) && left.size > 0 && left.size === right.size) ||
+              (mediaType(left.type) === mediaType(right.type) &&
+                (syntheticClipboardFile(left) || syntheticClipboardFile(right)))
+            ) return true;
+          }
+        }
+        return false;
+      }
+
+      function bytesOf(file) {
+        if (!file || typeof file.arrayBuffer !== 'function') return Promise.resolve(undefined);
+        try {
+          return Promise.resolve(file.arrayBuffer()).then(function(buffer) {
+            return new Uint8Array(buffer);
+          }, function(){ return undefined; });
+        } catch (_) {
+          return Promise.resolve(undefined);
+        }
+      }
+
+      function sameBytes(left, right) {
+        if (
+          !left || !right ||
+          !Number.isFinite(left.size) || left.size <= 0 || left.size !== right.size ||
+          left.size > maxExactDedupeBytes
+        ) return Promise.resolve(false);
+        return Promise.all([bytesOf(left), bytesOf(right)]).then(function(values) {
+          var a = values[0];
+          var b = values[1];
+          if (!a || !b || a.length !== b.length) return false;
+          for (var i = 0; i < a.length; i += 1) if (a[i] !== b[i]) return false;
+          return true;
+        }, function(){ return false; });
+      }
+
+      function visualPairAllowed(left, right) {
+        if (!left || !right) return false;
+        if (mediaType(left.type) !== 'image/png' || mediaType(right.type) !== 'image/png') return false;
+        if (!(syntheticClipboardFile(left) || syntheticClipboardFile(right))) return false;
+        return Number.isFinite(left.size) && left.size > 0 && left.size <= maxVisualDedupeSourceBytes &&
+          Number.isFinite(right.size) && right.size > 0 && right.size <= maxVisualDedupeSourceBytes;
+      }
+
+      function closeBitmap(bitmap) {
+        try { if (bitmap && typeof bitmap.close === 'function') bitmap.close(); } catch (_) {}
+      }
+
+      function visualInfoAllowed(leftInfo, rightInfo) {
+        if (!leftInfo || !rightInfo || leftInfo.type !== 'image/png' || rightInfo.type !== 'image/png') return false;
+        var width = leftInfo.width;
+        var height = leftInfo.height;
+        return Number.isFinite(width) && Number.isFinite(height) && width > 0 && height > 0 &&
+          width === rightInfo.width && height === rightInfo.height &&
+          width <= maxVisualDedupeDimension && height <= maxVisualDedupeDimension &&
+          width * height <= maxVisualDedupePixels;
+      }
+
+      function bitmapPixelsMatch(left, right) {
+        if (!visualPairAllowed(left, right) || typeof window.createImageBitmap !== 'function') return Promise.resolve(false);
+        return Promise.all([headType(left), headType(right)]).then(function(infos) {
+          if (!visualInfoAllowed(infos[0], infos[1])) return false;
+          return Promise.resolve(window.createImageBitmap(left)).then(function(leftBitmap) {
+          return Promise.resolve(window.createImageBitmap(right)).then(function(rightBitmap) {
+            try {
+              var width = leftBitmap && leftBitmap.width;
+              var height = leftBitmap && leftBitmap.height;
+              if (
+                !Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0 ||
+                width !== rightBitmap.width || height !== rightBitmap.height ||
+                width > maxVisualDedupeDimension || height > maxVisualDedupeDimension ||
+                width * height > maxVisualDedupePixels
+              ) return false;
+              var canvas = doc.createElement('canvas');
+              var context = canvas.getContext && canvas.getContext('2d', { willReadFrequently: true });
+              if (!context || typeof context.drawImage !== 'function' || typeof context.getImageData !== 'function') return false;
+              for (var y = 0; y < height; y += visualDedupeTile) {
+                for (var x = 0; x < width; x += visualDedupeTile) {
+                  var tileWidth = Math.min(visualDedupeTile, width - x);
+                  var tileHeight = Math.min(visualDedupeTile, height - y);
+                  canvas.width = tileWidth;
+                  canvas.height = tileHeight;
+                  context.drawImage(leftBitmap, x, y, tileWidth, tileHeight, 0, 0, tileWidth, tileHeight);
+                  var leftPixels = context.getImageData(0, 0, tileWidth, tileHeight).data;
+                  context.drawImage(rightBitmap, x, y, tileWidth, tileHeight, 0, 0, tileWidth, tileHeight);
+                  var rightPixels = context.getImageData(0, 0, tileWidth, tileHeight).data;
+                  if (!leftPixels || !rightPixels || leftPixels.length !== rightPixels.length) return false;
+                  for (var i = 0; i < leftPixels.length; i += 1) {
+                    if (leftPixels[i] !== rightPixels[i]) return false;
+                  }
+                }
+              }
+              return true;
+            } catch (_) {
+              return false;
+            } finally {
+              closeBitmap(leftBitmap);
+              closeBitmap(rightBitmap);
+            }
+          }, function() {
+            closeBitmap(leftBitmap);
+            return false;
+          });
+          }, function(){ return false; });
+        }, function(){ return false; });
+      }
+
+      function duplicatePair(left, right) {
+        if (!supportedImage(left) || !supportedImage(right)) return Promise.resolve(false);
+        return sameBytes(left, right).then(function(exact) {
+          return exact ? true : bitmapPixelsMatch(left, right);
+        }, function(){ return false; });
+      }
+
+      function preferredDuplicate(left, right) {
+        if (syntheticClipboardFile(left) && !syntheticClipboardFile(right)) return right;
+        return left;
+      }
+
+      function dedupeBatch(files) {
+        if (!hasDedupeSignal(files)) return Promise.resolve(files);
+        var kept = [];
+        var chain = Promise.resolve();
+        files.forEach(function(file) {
+          chain = chain.then(function() {
+            var index = 0;
+            function compareNext() {
+              if (index >= kept.length) {
+                kept.push(file);
+                return Promise.resolve();
+              }
+              var current = index;
+              index += 1;
+              return duplicatePair(kept[current], file).then(function(duplicate) {
+                if (!duplicate) return compareNext();
+                kept[current] = preferredDuplicate(kept[current], file);
+                return undefined;
+              }, function(){ return compareNext(); });
+            }
+            return compareNext();
+          });
+        });
+        return chain.then(function(){ return kept; }, function(){ return files; });
+      }
+
       function composerEditable(target) {
         var element = target && target.nodeType === 1
           ? target
@@ -563,7 +735,19 @@ export const CLIENT_PRESENTATION_PRELUDE = String.raw`(function(){
           bytes.length >= 8 &&
           bytes[0] === 0x89 && bytes[1] === 0x50 && bytes[2] === 0x4e && bytes[3] === 0x47 &&
           bytes[4] === 0x0d && bytes[5] === 0x0a && bytes[6] === 0x1a && bytes[7] === 0x0a
-) return { type: 'image/png' };
+        ) {
+          if (bytes.length < 24 || typeof DataView !== 'function') return { type: 'image/png' };
+          try {
+            var pngView = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+            return {
+              type: 'image/png',
+              width: pngView.getUint32(16, false),
+              height: pngView.getUint32(20, false)
+            };
+          } catch (_) {
+            return { type: 'image/png' };
+          }
+        }
         if (bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) return { type: 'image/jpeg' };
         if (
           bytes.length >= 6 && bytes[0] === 0x47 && bytes[1] === 0x49 && bytes[2] === 0x46 &&
@@ -656,10 +840,12 @@ export const CLIENT_PRESENTATION_PRELUDE = String.raw`(function(){
                   return;
                 }
                 try {
-                  resolve(new window.File([blob], fileNameFor('image/png', file && file.name), {
+                  var normalized = new window.File([blob], fileNameFor('image/png', file && file.name), {
                     type: 'image/png',
                     lastModified: file && Number.isFinite(file.lastModified) ? file.lastModified : Date.now()
-                  }));
+                  });
+                  normalizedBitmapFiles.add(normalized);
+                  resolve(normalized);
                 } catch (error) {
                   reject(error);
                 }
@@ -723,7 +909,7 @@ export const CLIENT_PRESENTATION_PRELUDE = String.raw`(function(){
           .filter(function(item){ return item && item.kind === 'file'; })
           .map(function(item){ try { return item.getAsFile(); } catch (_) { return null; } })
           .filter(function(file){ return !!file; });
-        if (!files.some(needsNormalization)) return;
+        if (!files.some(needsNormalization) && !hasDedupeSignal(files)) return;
 
         // Snapshot every string flavor while the trusted paste event still owns
         // a readable clipboard data store. Build a known-good fallback replay
@@ -741,7 +927,9 @@ export const CLIENT_PRESENTATION_PRELUDE = String.raw`(function(){
             ? normalizeFile(file).catch(function(){ return file; })
             : Promise.resolve(file);
         })).then(function(normalized) {
-          dispatchReplay(target, replayEvent(normalized, textEntries), fallback);
+          return dedupeBatch(normalized).then(function(deduped) {
+            dispatchReplay(target, replayEvent(deduped, textEntries), fallback);
+          });
         }, function() {
           dispatchReplay(target, fallback, null);
         });

--- a/tests/clipboard-image-paste-compat.test.js
+++ b/tests/clipboard-image-paste-compat.test.js
@@ -79,12 +79,19 @@ class FakeClipboardEvent {
 function runtime(options = {}) {
   const listeners = new Map()
   const dispatched = []
+  let drawnBitmap = null
   const canvas = {
     width: 0,
     height: 0,
     getContext(type) {
       assert.equal(type, '2d')
-      return { drawImage() {} }
+      return {
+        drawImage(bitmap) { drawnBitmap = bitmap },
+        getImageData() {
+          const pixels = drawnBitmap?.pixels ?? new Uint8Array([0, 0, 0, 255])
+          return { data: Uint8Array.from(pixels) }
+        },
+      }
     },
     toBlob(callback, type) {
       assert.equal(type, 'image/png')
@@ -120,7 +127,10 @@ function runtime(options = {}) {
     ClipboardEvent: options.withoutReplayApis ? undefined : FakeClipboardEvent,
     File: FakeFile,
     Blob: FakeBlob,
-    createImageBitmap: async () => ({ width: 2, height: 3, close() {} }),
+    createImageBitmap: async (file) => {
+      if (typeof options.createImageBitmap === 'function') return options.createImageBitmap(file)
+      return { width: 2, height: 3, pixels: new Uint8Array([0, 0, 0, 255]), close() {} }
+    },
   }
   let registered
   window.__ModuleLoader__ = {
@@ -172,6 +182,16 @@ function bmpBytes(width = 2, height = 3) {
   view.setUint16(28, 24, true)
   view.setUint32(34, 4, true)
   bytes[54] = 255
+  return bytes
+}
+
+function pngBytes(width = 2, height = 1, tail = []) {
+  const bytes = new Uint8Array(24 + tail.length)
+  bytes.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0)
+  const view = new DataView(bytes.buffer)
+  view.setUint32(16, width, false)
+  view.setUint32(20, height, false)
+  bytes.set(tail, 24)
   return bytes
 }
 
@@ -289,4 +309,117 @@ test('oversized BMP dimensions are never decoded before DSH admission', async ()
   await settleUntil(() => rt.dispatched.length === 1)
   assert.equal(decoded, 0)
   assert.equal(rt.dispatched[0].clipboardData.files[0], huge)
+})
+
+test('same-byte supported images with different names are deduped within one paste batch', async () => {
+  const rt = runtime()
+  let decoded = 0
+  rt.window.createImageBitmap = async () => { decoded += 1; throw new Error('exact duplicate must not decode') }
+  const bytes = new Uint8Array([1, 2, 3, 4, 5])
+  const first = new FakeFile([bytes], 'a.png', { type: 'image/png' })
+  const second = new FakeFile([bytes], 'b.png', { type: 'image/png' })
+  const event = originalPaste(rt.editable, clipboard([first, second], 'caption'))
+  rt.paste(event)
+  assert.equal(event.prevented, true)
+  await settleUntil(() => rt.dispatched.length === 1)
+  assert.equal(rt.dispatched[0].clipboardData.files.length, 1)
+  assert.equal(rt.dispatched[0].clipboardData.files[0].name, 'a.png')
+  assert.equal(rt.dispatched[0].clipboardData.getData('text/plain'), 'caption')
+  assert.equal(decoded, 0)
+})
+
+test('same-name supported images with different bytes are never deduped', async () => {
+  const rt = runtime()
+  const first = new FakeFile([new Uint8Array([1, 2, 3, 4])], 'same.png', { type: 'image/png' })
+  const second = new FakeFile([new Uint8Array([4, 3, 2, 1])], 'same.png', { type: 'image/png' })
+  const event = originalPaste(rt.editable, clipboard([first, second]))
+  rt.paste(event)
+  await settleUntil(() => rt.dispatched.length === 1)
+  assert.equal(rt.dispatched[0].clipboardData.files.length, 2)
+  assert.equal(rt.dispatched[0].clipboardData.files[0], first)
+  assert.equal(rt.dispatched[0].clipboardData.files[1], second)
+})
+
+test('synthetic bitmap-style PNG and named FileDrop PNG dedupe by identical pixels without re-encoding', async () => {
+  let decoded = 0
+  const rt = runtime({
+    createImageBitmap: async (file) => {
+      decoded += 1
+      return {
+        width: 2,
+        height: 1,
+        pixels: file.name === 'image.png'
+          ? new Uint8Array([9, 8, 7, 255, 1, 2, 3, 255])
+          : new Uint8Array([9, 8, 7, 255, 1, 2, 3, 255]),
+        close() {},
+      }
+    },
+  })
+  const bitmapView = new FakeFile([pngBytes(2, 1, [1])], 'image.png', { type: 'image/png' })
+  const fileDrop = new FakeFile([pngBytes(2, 1, [2, 2, 2])], 'QQ-shot.png', { type: 'image/png' })
+  const event = originalPaste(rt.editable, clipboard([bitmapView, fileDrop], 'keep'))
+  rt.paste(event)
+  await settleUntil(() => rt.dispatched.length === 1)
+  const files = rt.dispatched[0].clipboardData.files
+  assert.equal(files.length, 1)
+  assert.equal(files[0], fileDrop)
+  assert.equal(rt.dispatched[0].clipboardData.getData('text/plain'), 'keep')
+  assert.equal(decoded, 2)
+})
+
+test('synthetic and named images with different pixels remain distinct', async () => {
+  const rt = runtime({
+    createImageBitmap: async (file) => ({
+      width: 1,
+      height: 1,
+      pixels: file.name === 'image.png'
+        ? new Uint8Array([1, 2, 3, 255])
+        : new Uint8Array([4, 5, 6, 255]),
+      close() {},
+    }),
+  })
+  const first = new FakeFile([pngBytes(1, 1, [1])], 'image.png', { type: 'image/png' })
+  const second = new FakeFile([pngBytes(1, 1, [2, 2, 2])], 'real.png', { type: 'image/png' })
+  const event = originalPaste(rt.editable, clipboard([first, second]))
+  rt.paste(event)
+  await settleUntil(() => rt.dispatched.length === 1)
+  assert.equal(rt.dispatched[0].clipboardData.files.length, 2)
+})
+
+test('ordinary multi-image paste with no duplicate signal stays on the native DSH path', async () => {
+  const rt = runtime()
+  const first = new FakeFile([new Uint8Array([1, 2, 3])], 'first.png', { type: 'image/png' })
+  const second = new FakeFile([new Uint8Array([4, 5, 6, 7])], 'second.png', { type: 'image/png' })
+  const event = originalPaste(rt.editable, clipboard([first, second]))
+  rt.paste(event)
+  await new Promise(resolve => setTimeout(resolve, 0))
+  assert.equal(event.prevented, false)
+  assert.equal(event.stopped, false)
+  assert.equal(rt.dispatched.length, 0)
+})
+
+test('oversized suspicious duplicate candidates fail open without pixel decoding', async () => {
+  let decoded = 0
+  const rt = runtime({ createImageBitmap: async () => { decoded += 1; throw new Error('must not decode') } })
+  const first = new FakeFile([pngBytes(2, 1, [1])], 'image.png', { type: 'image/png' })
+  const second = new FakeFile([pngBytes(2, 1, [2])], 'real.png', { type: 'image/png' })
+  Object.defineProperty(first, 'size', { value: 17 * 1024 * 1024 })
+  Object.defineProperty(second, 'size', { value: 17 * 1024 * 1024 })
+  const event = originalPaste(rt.editable, clipboard([first, second]))
+  rt.paste(event)
+  await settleUntil(() => rt.dispatched.length === 1)
+  assert.equal(rt.dispatched[0].clipboardData.files.length, 2)
+  assert.equal(decoded, 0)
+})
+
+test('oversized PNG dimensions are rejected before visual duplicate decoding', async () => {
+  let decoded = 0
+  const rt = runtime({ createImageBitmap: async () => { decoded += 1; throw new Error('must not decode oversized PNG') } })
+  const first = new FakeFile([pngBytes(5000, 2000, [1])], 'image.png', { type: 'image/png' })
+  const second = new FakeFile([pngBytes(5000, 2000, [2, 2])], 'real.png', { type: 'image/png' })
+  const event = originalPaste(rt.editable, clipboard([first, second]))
+  rt.paste(event)
+  await settleUntil(() => rt.dispatched.length === 1)
+  assert.equal(rt.dispatched[0].clipboardData.files.length, 2)
+  assert.equal(decoded, 0)
 })


### PR DESCRIPTION
## Summary

Fix Chrome/Edge clipboard batches where one QQ/WeChat/system screenshot is exposed twice (for example a browser-generated `image.png` plus a FileDrop PNG), causing two visually identical attachments.

- dedupe only within one paste batch
- leave ordinary multi-image pastes on DSH's native path when there is no duplicate signal
- compare exact bytes first (bounded to 8 MiB per candidate)
- use pixel comparison only for strongly suspicious PNG pairs where at least one side looks browser-generated / normalized
- preflight PNG IHDR dimensions before decoding; visual comparison is bounded to 16 MiB source files, 4096 px per side, and 9 MP
- compare rendered RGBA in 256×256 tiles and close both ImageBitmaps
- keep the original `File` object rather than re-encoding; prefer the real named FileDrop over a synthetic `image.png`/`clipboard.png`
- preserve text clipboard payloads and fail open on unsupported APIs, decode failures, or oversized candidates
- preserve distinct images even when filenames match

## Verification

- clipboard compatibility tests: 14/14 passed
- `pnpm test:web`: 125/125 passed
- full `pnpm test`: main suite 1261 tests / 1260 passed / 1 skipped / 0 failed; post runtime-policy suite 6/6 passed
- real Chrome: two PNG files with different bytes but identical pixels (`image.png` + `QQ-shot.png`) replay as one original `QQ-shot.png`, with `caption` preserved
- real Chrome 1920×1080 case completed the dedupe/replay path in about 66 ms on the local Mac test machine

## Safety / non-intervention

- same-name but different-byte images remain distinct
- suspicious images with different pixels remain distinct
- ordinary unrelated multi-image paste is not intercepted
- oversized source/dimension candidates are not pixel-decoded
- no cross-paste or persistent content index is introduced

## Scope

Exactly two files relative to `main@221aae0b`:

- `lib/client-presentation-boundary-main.js`
- `tests/clipboard-image-paste-compat.test.js`

Fixes #393