### PR TITLE
fix(web): reconcile clipboard image MIME with magic bytes

### DIFF
--- a/.github/workflows/dsh-alpha-source-contract.yml
+++ b/.github/workflows/dsh-alpha-source-contract.yml
@@ -22,6 +22,7 @@ on:
       - 'tests/adapter-prepare-call-compat.test.js'
       - 'tests/alpha1-*.test.js'
       - 'tests/attachment-admission-policy.test.js'
+      - 'tests/clipboard-image-paste-compat.test.js'
       - '.github/workflows/dsh-alpha-source-contract.yml'
   push:
     branches: [main]
@@ -45,6 +46,7 @@ on:
       - 'tests/adapter-prepare-call-compat.test.js'
       - 'tests/alpha1-*.test.js'
       - 'tests/attachment-admission-policy.test.js'
+      - 'tests/clipboard-image-paste-compat.test.js'
       - '.github/workflows/dsh-alpha-source-contract.yml'
   workflow_dispatch:
 
@@ -111,3 +113,4 @@ jobs:
           tests/alpha1-browser-lifecycle-integration.test.js
           tests/alpha1-web-auth-boundary.test.js
           tests/attachment-admission-policy.test.js
+          tests/clipboard-image-paste-compat.test.js

--- a/lib/client-presentation-boundary-main.js
+++ b/lib/client-presentation-boundary-main.js
@@ -488,13 +488,13 @@ export const CLIENT_PRESENTATION_PRELUDE = String.raw`(function(){
     }
   }
 
-  // #138 Windows clipboard compatibility: Firefox and some desktop clipboards
-  // expose ordinary screenshots as BMP (or with an empty MIME). DSH alpha.4
-  // validates browser-declared image MIME before creating a draft, while newer
-  // Hosts route non-image MIME through generic file intake. Normalize only the
-  // affected clipboard files before Lexical's CRITICAL paste handler sees them.
-  // Ordinary PNG/JPEG/WebP/GIF and every paste outside the composer remain on
-  // DSH's native path unchanged.
+  // #138 Windows clipboard compatibility: desktop clipboards may expose an
+  // image as BMP/empty MIME, or may declare a supported MIME that disagrees with
+  // the actual bytes (for example .png + image/png carrying JPEG bytes). DSH
+  // validates the declaration before/while creating the draft, and its local
+  // attachment store rejects declaration/content mismatches. Inspect image-like
+  // clipboard files by magic bytes before Lexical's CRITICAL paste handler sees
+  // them; canonical files keep the original File object and are never re-encoded.
   function installClipboardImagePasteCompat(ctx) {
     if (!ctx || typeof ctx.effect !== 'function') return;
     ctx.effect(function() {
@@ -524,10 +524,14 @@ export const CLIENT_PRESENTATION_PRELUDE = String.raw`(function(){
         return typeof value === 'string' ? value.trim().toLowerCase() : '';
       }
 
-      function needsNormalization(file) {
+      function imageLikeName(value) {
+        return typeof value === 'string' && /\.(?:png|jpe?g|webp|gif|bmp|dib)$/i.test(value.trim());
+      }
+
+      function needsInspection(file) {
         if (!file) return false;
         var type = mediaType(file.type);
-        return type === '' || bitmapTypes[type] === true;
+        return type === '' || type.indexOf('image/') === 0 || imageLikeName(file.name);
       }
 
       var normalizedBitmapFiles = new WeakSet();
@@ -789,15 +793,16 @@ export const CLIENT_PRESENTATION_PRELUDE = String.raw`(function(){
 
       function fileNameFor(type, original) {
         var name = typeof original === 'string' ? original : '';
-        if (type === 'image/png') {
-          if (!name) return 'clipboard.png';
-          return /\.(?:bmp|dib)$/i.test(name) ? name.replace(/\.(?:bmp|dib)$/i, '.png') : name;
-        }
-        if (name) return name;
-        if (type === 'image/jpeg') return 'clipboard.jpg';
-        if (type === 'image/gif') return 'clipboard.gif';
-        if (type === 'image/webp') return 'clipboard.webp';
-        return 'clipboard-image';
+        var suffix = type === 'image/png' ? '.png'
+          : type === 'image/jpeg' ? '.jpg'
+          : type === 'image/gif' ? '.gif'
+          : type === 'image/webp' ? '.webp'
+          : '';
+        if (!name) return suffix ? 'clipboard' + suffix : 'clipboard-image';
+        if (!suffix) return name;
+        return /\.(?:png|jpe?g|webp|gif|bmp|dib)$/i.test(name)
+          ? name.replace(/\.(?:png|jpe?g|webp|gif|bmp|dib)$/i, suffix)
+          : name;
       }
 
       function retypeFile(file, type) {
@@ -861,7 +866,9 @@ export const CLIENT_PRESENTATION_PRELUDE = String.raw`(function(){
       function normalizeFile(file) {
         return headType(file).then(function(info) {
           var detected = info && info.type;
-          if (detected && supported[detected]) return retypeFile(file, detected);
+          if (detected && supported[detected]) {
+            return mediaType(file && file.type) === detected ? file : retypeFile(file, detected);
+          }
           if (detected === 'image/bmp' && bitmapDecodeAllowed(file, info)) return bitmapToPng(file);
           return file;
         }, function(){ return file; });
@@ -909,7 +916,7 @@ export const CLIENT_PRESENTATION_PRELUDE = String.raw`(function(){
           .filter(function(item){ return item && item.kind === 'file'; })
           .map(function(item){ try { return item.getAsFile(); } catch (_) { return null; } })
           .filter(function(file){ return !!file; });
-        if (!files.some(needsNormalization) && !hasDedupeSignal(files)) return;
+        if (!files.some(needsInspection) && !hasDedupeSignal(files)) return;
 
         // Snapshot every string flavor while the trusted paste event still owns
         // a readable clipboard data store. Build a known-good fallback replay
@@ -923,7 +930,7 @@ export const CLIENT_PRESENTATION_PRELUDE = String.raw`(function(){
         if (typeof event.stopImmediatePropagation === 'function') event.stopImmediatePropagation();
 
         Promise.all(files.map(function(file){
-          return needsNormalization(file)
+          return needsInspection(file)
             ? normalizeFile(file).catch(function(){ return file; })
             : Promise.resolve(file);
         })).then(function(normalized) {

--- a/tests/clipboard-image-paste-compat.test.js
+++ b/tests/clipboard-image-paste-compat.test.js
@@ -239,6 +239,68 @@ test('BMP clipboard image is converted to PNG and text/plain is preserved for DS
   assert.equal(rt.listeners.has('paste:true'), false)
 })
 
+test('QQ/WeChat .png declared as image/png but carrying JPEG bytes is corrected before DSH intake', async () => {
+  const rt = runtime()
+  let decoded = 0
+  rt.window.createImageBitmap = async () => { decoded += 1; throw new Error('canonical JPEG retype must not decode') }
+  const mislabeled = new FakeFile([new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10])], 'qq-export.png', {
+    type: 'image/png',
+    lastModified: 9,
+  })
+  const event = originalPaste(rt.editable, clipboard([mislabeled], 'caption'))
+  rt.paste(event)
+  await settleUntil(() => rt.dispatched.length === 1)
+  assert.equal(event.prevented, true)
+  assert.equal(event.stopped, true)
+  const file = rt.dispatched[0].clipboardData.files[0]
+  assert.equal(file.type, 'image/jpeg')
+  assert.equal(file.name, 'qq-export.jpg')
+  assert.equal(file.lastModified, 9)
+  assert.equal(rt.dispatched[0].clipboardData.getData('text/plain'), 'caption')
+  assert.equal(decoded, 0)
+})
+
+test('supported MIME mismatch is reconciled in both directions from magic bytes', async () => {
+  const rt = runtime()
+  const mislabeled = new FakeFile([pngBytes(2, 1, [7])], 'wechat.jpg', { type: 'image/jpeg' })
+  const event = originalPaste(rt.editable, clipboard([mislabeled]))
+  rt.paste(event)
+  await settleUntil(() => rt.dispatched.length === 1)
+  const file = rt.dispatched[0].clipboardData.files[0]
+  assert.equal(file.type, 'image/png')
+  assert.equal(file.name, 'wechat.png')
+})
+
+test('supported MIME that hides BMP bytes is converted instead of merely retyped', async () => {
+  const rt = runtime()
+  let decoded = 0
+  rt.window.createImageBitmap = async () => {
+    decoded += 1
+    return { width: 2, height: 3, close() {} }
+  }
+  const mislabeled = new FakeFile([bmpBytes()], 'clipboard.png', { type: 'image/png' })
+  const event = originalPaste(rt.editable, clipboard([mislabeled]))
+  rt.paste(event)
+  await settleUntil(() => rt.dispatched.length === 1)
+  const file = rt.dispatched[0].clipboardData.files[0]
+  assert.equal(file.type, 'image/png')
+  assert.equal(file.name, 'clipboard.png')
+  assert.equal(decoded, 1)
+})
+
+test('image-like filename is reconciled even when the browser declares application/octet-stream', async () => {
+  const rt = runtime()
+  const mislabeled = new FakeFile([new Uint8Array([0xff, 0xd8, 0xff, 0xe0])], 'qq-cache.png', {
+    type: 'application/octet-stream',
+  })
+  const event = originalPaste(rt.editable, clipboard([mislabeled]))
+  rt.paste(event)
+  await settleUntil(() => rt.dispatched.length === 1)
+  const file = rt.dispatched[0].clipboardData.files[0]
+  assert.equal(file.type, 'image/jpeg')
+  assert.equal(file.name, 'qq-cache.jpg')
+})
+
 test('empty MIME with PNG bytes is retyped without image decoding', async () => {
   const rt = runtime()
   let decoded = 0
@@ -251,15 +313,18 @@ test('empty MIME with PNG bytes is retyped without image decoding', async () => 
   assert.equal(decoded, 0)
 })
 
-test('ordinary supported image paste is byte-path transparent', async () => {
+test('ordinary supported image is magic-checked but replayed as the original File without decoding or re-encoding', async () => {
   const rt = runtime()
-  const png = new FakeFile([new Uint8Array([1, 2, 3])], 'ok.png', { type: 'image/png' })
+  let decoded = 0
+  rt.window.createImageBitmap = async () => { decoded += 1; throw new Error('canonical PNG must not decode') }
+  const png = new FakeFile([pngBytes(2, 1, [1])], 'ok.png', { type: 'image/png' })
   const event = originalPaste(rt.editable, clipboard([png]))
   rt.paste(event)
-  await new Promise(resolve => setTimeout(resolve, 0))
-  assert.equal(event.prevented, false)
-  assert.equal(event.stopped, false)
-  assert.equal(rt.dispatched.length, 0)
+  await settleUntil(() => rt.dispatched.length === 1)
+  assert.equal(event.prevented, true)
+  assert.equal(event.stopped, true)
+  assert.equal(rt.dispatched[0].clipboardData.files[0], png)
+  assert.equal(decoded, 0)
 })
 
 test('non-composer paste and empty-MIME non-image paste fail open', async () => {
@@ -386,16 +451,17 @@ test('synthetic and named images with different pixels remain distinct', async (
   assert.equal(rt.dispatched[0].clipboardData.files.length, 2)
 })
 
-test('ordinary multi-image paste with no duplicate signal stays on the native DSH path', async () => {
+test('ordinary multi-image paste is inspected once but preserves distinct canonical File objects', async () => {
   const rt = runtime()
-  const first = new FakeFile([new Uint8Array([1, 2, 3])], 'first.png', { type: 'image/png' })
-  const second = new FakeFile([new Uint8Array([4, 5, 6, 7])], 'second.png', { type: 'image/png' })
+  const first = new FakeFile([pngBytes(1, 1, [1])], 'first.png', { type: 'image/png' })
+  const second = new FakeFile([pngBytes(1, 1, [2, 2])], 'second.png', { type: 'image/png' })
   const event = originalPaste(rt.editable, clipboard([first, second]))
   rt.paste(event)
-  await new Promise(resolve => setTimeout(resolve, 0))
-  assert.equal(event.prevented, false)
-  assert.equal(event.stopped, false)
-  assert.equal(rt.dispatched.length, 0)
+  await settleUntil(() => rt.dispatched.length === 1)
+  const files = rt.dispatched[0].clipboardData.files
+  assert.equal(files.length, 2)
+  assert.equal(files[0], first)
+  assert.equal(files[1], second)
 })
 
 test('oversized suspicious duplicate candidates fail open without pixel decoding', async () => {


### PR DESCRIPTION
## Summary

Complete the #138 clipboard compatibility fix. #392/#394 covered BMP/empty-MIME normalization and duplicate screenshot entries, but left one branch from the original report unresolved: a clipboard file can already claim a supported MIME while its actual bytes are a different supported image format (for example `.png` + `image/png` carrying JPEG bytes). DSH then accepts the browser declaration but the attachment store rejects it as `IMAGE_TYPE_MISMATCH`.

This PR closes that gap by magic-checking every image-like clipboard file before Lexical intake:

- inspect at most the first 32 bytes for PNG/JPEG/GIF/WebP/BMP signatures
- if declared MIME and bytes already agree, replay the original `File` object unchanged (no decode/re-encode)
- if a supported declaration disagrees with supported bytes, correct both `file.type` and the known image extension
- if a supported declaration hides BMP bytes, convert the BMP to PNG as the existing bounded path already does
- also recover image-like filenames exposed as `application/octet-stream`
- preserve text clipboard flavors, existing duplicate suppression, BMP safety bounds, and fail-open behavior

## Regression case

A real user sample has a `.png` filename but begins with `FF D8 FF E0` (JPEG/JFIF). Before this PR, the compatibility layer skipped it solely because the browser declared `image/png`, so no magic-byte check ran and DSH later rejected the declaration/content mismatch. The new test reproduces exactly that shape and requires downstream intake to receive `.jpg` + `image/jpeg` without decoding or re-encoding the JPEG bytes.

## CI coverage

The clipboard compatibility suite is now also part of the exact DSH alpha.4 source-contract matrix on Ubuntu, macOS, and Windows. The workflow path filters include this test so future changes to the regression itself rerun the three-OS matrix.

## Verification

- `tests/clipboard-image-paste-compat.test.js`: 18/18 passed
- `pnpm test:web`: 129/129 passed
- full `pnpm test`: 1265 passed / 0 failed / 1 skipped; post runtime-policy suite 6/6 passed
- clipboard + manifest contract subset: 49/49 passed
- workflow YAML parses successfully
- `git diff --check` passed
- scope is exactly three files relative to `main@e37f5bf0`

Fixes #138