### PR TITLE
fix(vision): reject out-of-frame detect boxes

### DIFF
--- a/index.js
+++ b/index.js
@@ -1490,6 +1490,12 @@ export function normalizeDetectResult(parsed, width, height) {
     const raw = [item.box.x1, item.box.y1, item.box.x2, item.box.y2]
     if (!raw.every((value) => typeof value === 'number' && Number.isFinite(value))) return undefined
     const [x1, y1, x2, y2] = raw.map(Math.round)
+    // Preserve small coordinate drift by clamping only boxes that still
+    // describe a real rectangle intersecting the image. A box entirely
+    // outside the frame must not collapse into a synthetic 1px edge box and
+    // become fake positive evidence.
+    if (x2 <= x1 || y2 <= y1) return undefined
+    if (x2 <= 0 || y2 <= 0 || x1 >= width || y1 >= height) return undefined
     const box = {
       x1: clamp(x1, 0, width - 1),
       y1: clamp(y1, 0, height - 1),

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -2171,6 +2171,24 @@ test('normalizeDetectResult preserves explicit zero detections but rejects parti
   assert.equal(normalizeDetectResult({ elements: [{ label: '', box: { x1: 1, y1: 1, x2: 10, y2: 10 } }] }, 640, 480), undefined)
   assert.equal(normalizeDetectResult({ elements: [{ label: 'button', box: { x1: '1', y1: 1, x2: 10, y2: 10 } }] }, 640, 480), undefined)
   assert.equal(normalizeDetectResult({ elements: [{ label: 'button', box: { x1: 50, y1: 50, x2: 10, y2: 10 } }] }, 640, 480), undefined)
+  // Small overlaps are clampable, but fully out-of-frame boxes are not real
+  // detections and must never collapse into synthetic edge evidence.
+  assert.deepEqual(
+    normalizeDetectResult({ elements: [{ label: 'button', box: { x1: -5, y1: 2, x2: 30, y2: 40 } }] }, 640, 480),
+    { width: 640, height: 480, elements: [{ number: 1, label: 'button', box: { x1: 0, y1: 2, x2: 30, y2: 40 } }] },
+  )
+  assert.deepEqual(
+    normalizeDetectResult({ elements: [{ label: 'button', box: { x1: 630, y1: 2, x2: 650, y2: 40 } }] }, 640, 480),
+    { width: 640, height: 480, elements: [{ number: 1, label: 'button', box: { x1: 630, y1: 2, x2: 640, y2: 40 } }] },
+  )
+  for (const box of [
+    { x1: -100, y1: 10, x2: -50, y2: 20 },
+    { x1: 700, y1: 10, x2: 750, y2: 20 },
+    { x1: 10, y1: -100, x2: 20, y2: -50 },
+    { x1: 10, y1: 500, x2: 20, y2: 550 },
+  ]) {
+    assert.equal(normalizeDetectResult({ elements: [{ label: 'button', box }] }, 640, 480), undefined)
+  }
 })
 
 test('normalizeDescribeResult fills the documented keys', () => {


### PR DESCRIPTION
## Vision Agent Quality Round 1 — final coordinate evidence boundary

Post-merge Exit Gate auditing after #401 found one more false-evidence path in `vision_detect` normalization.

### Problem

`normalizeDetectResult()` intentionally rounds/clamps small coordinate drift, but it did so **before proving that the model's box intersects the image at all**.

That meant a completely out-of-frame box such as:

```json
{"x1":150,"y1":10,"x2":200,"y2":20}
```

for a `100x80` image was normalized into the synthetic edge box:

```json
{"x1":99,"y1":10,"x2":100,"y2":20}
```

The resulting canonical-looking detection then passed `producedUsableToolEvidence()` and could satisfy Structured `x >= 1`, even though the model had not located anything inside the image.

### Fix

Before clamping a claimed detection box:

- require positive raw extent after numeric rounding (`x2 > x1`, `y2 > y1`);
- require the raw rectangle to intersect the image (`x2 > 0`, `y2 > 0`, `x1 < width`, `y1 < height`);
- only then apply the existing clamp behavior.

This preserves tolerance for small partial overflow, e.g. `x1=-5,x2=30` clamps to the left edge, while boxes wholly left/right/above/below the image invalidate the inventory and therefore enter #401's existing strict retry path.

`vision_ground` was audited separately and does not need this change: negative left/top coordinates are rejected by `parseBox`, while wholly right/bottom boxes clamp to a 1px sliver and trigger its existing strict retry/degenerate-box failure path.

### Round 1 invariants preserved

- no new Structured state or authority;
- `structured-flow-hardening` remains the sole hard `x >= 1` completion owner;
- mixed routing remains advisory;
- explicit `visionDepthMaxCalls` semantics are unchanged;
- OCR semantics are unchanged;
- explicit `elements:[]` remains a valid negative `vision_detect` observation;
- partial coordinate overlap remains clampable for model tolerance.

## Validation

Base: `main@b606646` (#401).

- coordinate black-box: all four fully out-of-frame directions -> invalid; partial left/right overlap -> canonical clamped boxes
- Core + Round 1 targeted matrix: **165 passed, 0 failed**
- full `pnpm test`: **1268 passed, 0 failed, 1 existing skip**
- post-suite `vision-backend-runtime-policy`: **6/6 passed**
- `git diff --check`: clean
