### PR TITLE
fix(vision): make scene guidance task-conditioned

### DIFF
--- a/lib/depth-guidance.js
+++ b/lib/depth-guidance.js
@@ -49,15 +49,15 @@ function effectiveMaxCalls(explicit) {
 
 const SCENE_GUIDANCE = Object.freeze({
   zh: Object.assign(Object.create(null), {
-    code: '检测到代码内容。代码必须逐字转写，建议分区域转写 + 语义确认，避免概括。',
+    code: '检测到代码内容。按用户问题决定证据：只有当结论依赖可执行或逐字代码时才需要逐字保真；仅问语言、结构或语义时可直接做针对性语义复核。',
     document: '检测到文档内容。语义优先；仅当需要逐字引用（长文档/合同/表单）时才用 OCR。',
-    ui: '检测到界面内容。建议元素清单（detect）+ 关键元素定位（ground）。',
+    ui: '检测到界面内容。按用户问题选择最小必要证据：语义复核、元素盘点或精确定位均可，不固定组合工具。',
     chat: '检测到聊天截图。关注气泡顺序与关键信息提取。',
   }),
   en: Object.assign(Object.create(null), {
-    code: 'Code content detected. Transcribe code verbatim; use region-by-region transcription plus semantic verification instead of summarizing it.',
+    code: 'Code content detected. Let the user question determine the evidence: require verbatim fidelity only when the conclusion depends on executable or text-exact code; language, structure, or semantic questions can use targeted semantic verification.',
     document: 'Document content detected. Prefer semantic understanding; use OCR only when verbatim quotation is required, such as for long documents, contracts, or forms.',
-    ui: 'UI content detected. Prefer an element inventory (detect) plus grounding of the important elements (ground).',
+    ui: 'UI content detected. Choose the smallest evidence needed for the user question: semantic verification, element inventory, or precise localization; do not require a fixed tool combination.',
     chat: 'Chat screenshot detected. Preserve message-bubble order and extract the important information.',
   }),
 })

--- a/lib/mixed-router.js
+++ b/lib/mixed-router.js
@@ -19,22 +19,22 @@ void UI_SIGNAL_TYPES
 
 const BRANCH_GUIDANCE = Object.freeze({
   zh: new Map([
-    ['document:code', '逐字转写（代码可执行性例外）'],
+    ['document:code', '仅当任务依赖可执行或逐字代码时才做逐字转写；否则按语义问题查证'],
     ['document:form', '语义优先，逐字字段名/值确需引用时用 OCR'],
     ['document:table', '结构提取优先，数字/金额逐字（表格 OCR 专精场景）'],
     ['document:', '语义优先；仅当需要逐字引用（长文档/合同/表单）时才用 OCR'],
-    ['ui:', 'detect / ground 优先（元素清单与像素定位）'],
-    ['code:', '逐字转写（可执行性例外）'],
+    ['ui:', '按问题需要选择语义复核、元素盘点或精确定位，不固定工具组合'],
+    ['code:', '仅当任务依赖可执行或逐字代码时才要求逐字保真；否则按语义问题查证'],
     ['table:', '结构提取优先，数字/金额逐字'],
     ['_default', '放行（模型自由选择识别方式）'],
   ]),
   en: new Map([
-    ['document:code', 'transcribe verbatim (code executability requires text-exact evidence)'],
+    ['document:code', 'use verbatim transcription only when the task depends on executable or text-exact code; otherwise verify the semantic question directly'],
     ['document:form', 'prefer semantic understanding; use OCR when exact field names or values must be quoted'],
     ['document:table', 'prefer structural extraction; preserve numbers and amounts exactly (table OCR is a specialized case)'],
     ['document:', 'prefer semantic understanding; use OCR only when verbatim quotation is required for long documents, contracts, or forms'],
-    ['ui:', 'prefer detect / ground for element inventory and pixel localization'],
-    ['code:', 'transcribe verbatim (executability requires text-exact evidence)'],
+    ['ui:', 'choose semantic verification, element inventory, or precise localization according to the question; do not require a fixed tool combination'],
+    ['code:', 'require verbatim fidelity only when the task depends on executable or text-exact code; otherwise verify the semantic question directly'],
     ['table:', 'prefer structural extraction and preserve numbers/amounts exactly'],
     ['_default', 'allow the model to choose the recognition method freely'],
   ]),
@@ -137,7 +137,7 @@ export function renderMixedGuidance(plan, _depth, locale) {
   })
   const kinds = branches.map((branch) => branch.kind).join(' + ')
   const header = language === 'en'
-    ? `Mixed content detected (${kinds}). To avoid omissions or misclassification, verify each branch separately as needed before answering; do not reuse one branch's recognition method blindly for another branch.`
-    : `检测到混合内容（${kinds}）。为避免漏判/错判（精度优化），请按需分别验证各分支后再作答；分支之间不要盲目混用识别方式。`
+    ? `Mixed content detected (${kinds}). Focus on the branch or branches relevant to the user question. If the answer depends on more than one branch, verify those branches separately as needed; do not reuse one branch's recognition method blindly for another branch.`
+    : `检测到混合内容（${kinds}）。只关注与用户问题相关的分支；如果答案确实依赖多个分支，再按需分别验证这些分支。分支之间不要盲目混用识别方式。`
   return `${header}\n${lines.join('\n')}`
 }

--- a/lib/runtime-i18n-boundary.js
+++ b/lib/runtime-i18n-boundary.js
@@ -25,6 +25,11 @@ const LONG_SCREENSHOT_OCR_PROMPT_ZH =
   '请原样转述这张长截图分片中的所有文字，保持阅读顺序（从上到下、从左到右），不要添加解释，只输出文字本身。如果画面中没有可见文字，只输出 EMPTY，不要编造内容。'
 
 const EN_GUIDANCE_REPLACEMENTS = Object.freeze([
+  ['检测到代码内容。按用户问题决定证据：只有当结论依赖可执行或逐字代码时才需要逐字保真；仅问语言、结构或语义时可直接做针对性语义复核。', 'Code content detected. Let the user question determine the evidence: require verbatim fidelity only when the conclusion depends on executable or text-exact code; language, structure, or semantic questions can use targeted semantic verification.'],
+  ['检测到界面内容。按用户问题选择最小必要证据：语义复核、元素盘点或精确定位均可，不固定组合工具。', 'UI content detected. Choose the smallest evidence needed for the user question: semantic verification, element inventory, or precise localization; do not require a fixed tool combination.'],
+  ['仅当任务依赖可执行或逐字代码时才做逐字转写；否则按语义问题查证', 'use verbatim transcription only when the task depends on executable or text-exact code; otherwise verify the semantic question directly'],
+  ['按问题需要选择语义复核、元素盘点或精确定位，不固定工具组合', 'choose semantic verification, element inventory, or precise localization according to the question; do not require a fixed tool combination'],
+  ['仅当任务依赖可执行或逐字代码时才要求逐字保真；否则按语义问题查证', 'require verbatim fidelity only when the task depends on executable or text-exact code; otherwise verify the semantic question directly'],
   ['检测到代码内容。代码必须逐字转写，建议分区域转写 + 语义确认，避免概括。', 'Code content detected. Transcribe code verbatim; use region-by-region transcription plus semantic verification instead of summarizing it.'],
   ['检测到文档内容。语义优先；仅当需要逐字引用（长文档/合同/表单）时才用 OCR。', 'Document content detected. Prefer semantic understanding; use OCR only when verbatim quotation is required, such as for long documents, contracts, or forms.'],
   ['检测到界面内容。建议元素清单（detect）+ 关键元素定位（ground）。', 'UI content detected. Prefer an element inventory (detect) plus grounding of important elements (ground).'],
@@ -108,6 +113,10 @@ function localizeModelMetadata(value, i18n) {
 
 function translateGuidanceText(input) {
   let text = input
+  text = text.replace(
+    /检测到混合内容（([^）]+)）。只关注与用户问题相关的分支；如果答案确实依赖多个分支，再按需分别验证这些分支。分支之间不要盲目混用识别方式。/g,
+    "Mixed content detected ($1). Focus on the branch or branches relevant to the user question. If the answer depends on more than one branch, verify those branches separately as needed; do not reuse one branch's recognition method blindly for another branch.",
+  )
   text = text.replace(
     /检测到混合内容（([^）]+)）。本轮深度档位为 fast：先验证主分支（([^）]+)）一次；完整分路验证需升级档位。/g,
     'Mixed content detected ($1). Vision depth is fast for this turn: verify the primary branch ($2) once; raise the depth tier for full branch-by-branch verification.',

--- a/tests/depth-tier.test.js
+++ b/tests/depth-tier.test.js
@@ -93,9 +93,9 @@ test('runtime depth locale follows the host locale when no explicit locale is pa
 })
 
 test('sceneGuidanceFor: known kinds have guidance, general/unknown/mixed release', () => {
-  assert.match(sceneGuidanceFor('code'), /逐字/)
+  assert.match(sceneGuidanceFor('code'), /只有当.*依赖可执行或逐字代码.*逐字保真/)
   assert.match(sceneGuidanceFor('document'), /语义优先/)
-  assert.match(sceneGuidanceFor('ui'), /detect/)
+  assert.match(sceneGuidanceFor('ui'), /最小必要证据/)
   assert.match(sceneGuidanceFor('chat'), /气泡/)
   assert.equal(sceneGuidanceFor('general'), '')
   assert.equal(sceneGuidanceFor('unknown'), '')
@@ -134,7 +134,7 @@ test('renderDepthGuidance: general falls to self-judge guidance when content_kin
 
 test('renderDepthGuidance: fast stays lightweight without forbidding further evidence', () => {
   const text = renderDepthGuidance({ visualKind: 'ui', depth: 'fast' })
-  assert.match(text, /detect/)
+  assert.match(text, /最小必要证据/)
   assert.match(text, /看图策略为快速/)
   assert.match(text, /关键证据不确定/)
   assert.doesNotMatch(text, /升级档位|最多.*次/)
@@ -228,5 +228,5 @@ test('depth guidance separates scene, strategy, and optional cap sentences', () 
   const cap = depthCopyFor('standard', 6, 'en-US')
   assert.ok(cap.includes('\nA separate deep-dive call cap'))
   const rendered = renderDepthGuidance({ visualKind: 'ui', depth: 'standard', locale: 'en-US' })
-  assert.ok(rendered.includes('(ground).\nVision strategy is Standard'))
+  assert.ok(rendered.includes('do not require a fixed tool combination.\nVision strategy is Standard'))
 })

--- a/tests/mixed-router.test.js
+++ b/tests/mixed-router.test.js
@@ -55,7 +55,7 @@ test('planMixedBranches: ui+general mixed_of keeps both branches', () => {
 test('mixedGuidance: exact sub wins, kind falls back, default releases', () => {
   assert.match(mixedGuidance('document', 'code'), /逐字/)
   assert.match(mixedGuidance('document', 'table'), /逐字/)
-  assert.match(mixedGuidance('ui'), /detect/)
+  assert.match(mixedGuidance('ui'), /不固定工具组合/)
   assert.match(mixedGuidance('document'), /语义优先/)
   assert.match(mixedGuidance('chat'), /放行/)
 })
@@ -79,8 +79,8 @@ test('renderMixedGuidance: mixed plan renders per-branch guidance; fallback rend
   const plan = planMixedBranches({ visual_kind: 'mixed', mixed_of: ['document', 'ui'] })
   const text = renderMixedGuidance(plan)
   assert.match(text, /检测到混合内容（ui \+ document）/)
-  assert.match(text, /精度优化/)
-  assert.match(text, /detect \/ ground 优先/)
+  assert.match(text, /只关注与用户问题相关的分支/)
+  assert.match(text, /不固定工具组合/)
   assert.match(text, /语义优先/)
   assert.equal(renderMixedGuidance(planMixedBranches(undefined)), undefined)
 })
@@ -91,7 +91,7 @@ test('renderMixedGuidance: fast/standard/deep keep the same two-branch correctne
   const standard = renderMixedGuidance(plan, 'standard')
   const deep = renderMixedGuidance(plan, 'deep')
   for (const text of [fast, standard, deep]) {
-    assert.match(text, /ui：detect \/ ground 优先/)
+    assert.match(text, /ui：按问题需要选择语义复核、元素盘点或精确定位，不固定工具组合/)
     assert.match(text, /document：语义优先/)
     assert.doesNotMatch(text, /升级档位|深度档位为 fast|最多.*次/)
   }
@@ -109,7 +109,8 @@ test('mixed guidance follows runtime host locale when called without an explicit
     },
   )
   assert.match(text, /Mixed content detected/)
-  assert.match(text, /ui: prefer detect \/ ground/)
+  assert.match(text, /Focus on the branch or branches relevant to the user question/)
+  assert.match(text, /ui: choose semantic verification, element inventory, or precise localization/)
   assert.match(text, /document: prefer semantic understanding/)
   assert.doesNotMatch(text, /检测到混合内容|语义优先/)
 })


### PR DESCRIPTION
## Summary

Round 2 PR2 removes the remaining prescriptive soft-routing rules found during the post-#403 acceptance sweep.

- UI guidance no longer implies a fixed `detect + ground` sequence; it asks the model to choose the smallest evidence needed for the user question
- code guidance no longer requires unconditional verbatim transcription; text-exact evidence is required only when the conclusion depends on executable or exact code
- mixed guidance focuses only on branches relevant to the user question; multiple branches are verified only when the answer actually depends on them
- keep legacy English translation signatures for older injected guidance while adding translations for the new task-conditioned copy
- no changes to Round 1 hard ordering, x>=1 authority, OCR execution semantics, call caps, or mixed hard-gate behavior

## Validation

- targeted depth/mixed/i18n/guidance matrix: 49 passed, 0 failed
- full default suite: 1271 passed, 0 failed, 1 skipped
- backend runtime policy: 6 passed, 0 failed
- `git diff --check` clean

## Live acceptance note

A live free-backend smoke was attempted after #403, but every built-in anonymous OVH model bucket was currently rate-limited (429) and no local Ollama/LM Studio backend was running. No code path blindly retried the 429s. This PR therefore limits itself to source-observed over-guidance plus deterministic regression coverage rather than adding a synthetic evaluator framework.