### PR TITLE
chore(release): prepare v2.1.3

### DIFF
--- a/docs/releases/v2.1.3.md
+++ b/docs/releases/v2.1.3.md
@@ -1,0 +1,34 @@
+# v2.1.3
+
+DVR 2.1.3 is a reliability and quality release for Structured 1+x vision. It closes the remaining evidence-completion edge cases from Round 1, then simplifies model-visible guidance so capable agents can choose the smallest useful visual tool instead of following prescriptive call recipes.
+
+## Structured 1+x reliability
+
+- Makes `structured-flow-hardening` the sole post-bootstrap completion authority. Core keeps bootstrap sequencing and presentation only; mixed classification remains advisory and never becomes a hidden branch quota.
+- Uses tool-specific usable-evidence validation for 1+x completion instead of generic execution metadata. Successful artifacts, engine names, chunk counts, or malformed payloads cannot masquerade as visual evidence.
+- Separates all-turn successful evidence accounting from post-bootstrap evidence accounting. Evidence collected before `vision_bootstrap` still consumes an explicit call cap when configured, but it cannot satisfy the required post-bootstrap `x >= 1` step.
+- Tightens `vision_detect`: malformed inventories fail instead of collapsing into fake zero-detection evidence, explicit `elements: []` remains a valid negative result, and fully off-image boxes are rejected before clamping while genuine partial overlaps remain supported.
+- Restores the public OCR contract everywhere: `vision_ocr` with omitted `engine` or `engine=auto` always tries local Tesseract first, then falls back to the vision model only when local OCR fails or returns no text. Structured mode does not silently rewrite this order.
+
+## Smarter, less prescriptive agent guidance
+
+- Removes the nonexistent `vision_ask` affordance from model-visible guidance and adds a closed-world contract test so future `vision_*` references must correspond to registered tools.
+- Treats bootstrap `recommended_followups` as task-independent suggestions, not a downstream plan. The agent chooses follow-up evidence from the user question and the evidence still missing.
+- Stops encouraging extra calls once the required post-bootstrap evidence is sufficient; depth strategies remain guidance rather than hidden call-count promises.
+- UI guidance no longer implies a fixed `detect + ground` sequence, code guidance requires verbatim fidelity only when the task truly depends on exact/executable code, and mixed images verify only the branch or branches relevant to the user question.
+
+## Settings, clipboard, and DSH compatibility
+
+- Aligns the vision-task timeout defaults across Settings and runtime behavior so the UI no longer advertises a different default from execution.
+- Marks progressive vision-tool exposure as restart-only, matching the actual tool-registration lifecycle instead of implying a hot runtime toggle.
+- Hardens Web clipboard intake across Windows, QQ/WeChat, bitmap-style screenshots, and misleading MIME declarations: duplicate screenshots are deduplicated and supported image types are reconciled against magic bytes before DSH intake.
+- Adds real alpha browser cold-toggle coverage and keeps the presentation/main source contract in CI so model-directory and Vision-toggle compatibility cannot silently regress between queue-loader and live-loader phases.
+
+## Validation
+
+- Release-candidate behavior is covered by the closed-world default test manifest, Node 22/24 CI, DSH rc.6/rc.7/rc.8 contracts, native multimodal cold-resume, P1 routing parity, architecture closure, large-image resource stress, and Windows/macOS/Linux host-sharp integration.
+- No settings migration is required. Restart the DSH Web/Desktop process after upgrading so restart-bound tool registration and the updated runtime guidance are loaded.
+
+## Upgrade
+
+Upgrade to 2.1.3 and restart DSH Web/Desktop. Existing Vision Router settings remain compatible.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-vision-router",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Eyes for text-only DeepSeek Harness agents: built-in free vision chain (no key) + pixel-level vision tools (Q&A, grounding, crop, pixel diff, colors, OCR, SVG trace, cutout, screenshots). One-command install, no Python, image turns work like ordinary tool-calling turns.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

Prepare DVR v2.1.3 as the reliability + quality release for the completed Vision Agent Quality Round 1 and slimmed Round 2 guidance pass.

- bump package version from 2.1.2 to 2.1.3
- add curated `docs/releases/v2.1.3.md` release notes
- document final Structured 1+x semantics only (single completion authority, tool-specific evidence, post-bootstrap evidence boundary, strict detect evidence, stable OCR auto contract)
- document the Round 2 guidance simplification without introducing a new planner/evaluator architecture
- include the Settings, clipboard, and alpha-browser compatibility fixes shipped since v2.1.2

## Validation

- local release-candidate full suite: 1271 passed, 0 failed, 1 skipped
- backend runtime policy: 6 passed, 0 failed
- `git diff --check` clean
- remote `v2.1.3` tag: absent
- npm `dsh-vision-router@2.1.3`: absent

After this PR merges, the existing immutable `release.yml` flow should be dispatched against the exact resulting `main` SHA.