### PR TITLE
chore(release): dispatch v2.1.3

### DIFF
--- a/.github/workflows/dispatch-v2.1.3.yml
+++ b/.github/workflows/dispatch-v2.1.3.yml
@@ -1,0 +1,42 @@
+name: Dispatch v2.1.3
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  dispatch:
+    if: github.repository == 'ysr666/dsh-vision-router'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - name: Verify release identity
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="$(node -p "require('./package.json').version")"
+          [ "$VERSION" = "2.1.3" ] || {
+            echo "::error::expected package version 2.1.3, got $VERSION"
+            exit 1
+          }
+          [ -s docs/releases/v2.1.3.md ] || {
+            echo "::error::missing curated v2.1.3 release notes"
+            exit 1
+          }
+      - name: Dispatch verified release workflow
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh workflow run release.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref main \
+            -f tag=v2.1.3 \
+            -f target_sha="$GITHUB_SHA"


### PR DESCRIPTION
## Summary

Add the one-shot v2.1.3 dispatcher, following the exact v2.1.2 release pattern.

- verifies `package.json` is exactly `2.1.3`
- verifies curated `docs/releases/v2.1.3.md` exists
- runs only after this workflow lands on `main`
- dispatches the existing immutable `release.yml` with `tag=v2.1.3` and `target_sha=$GITHUB_SHA`

The release workflow then re-verifies that the requested SHA is the exact current `origin/main`, creates the immutable tag, reruns tests, publishes through npm trusted OIDC, verifies tarball identity, and creates the GitHub Release.

After the release succeeds, this dispatcher should be removed in a follow-up cleanup PR.