### PR TITLE
ci: split stable and preview DSH release canaries

### DIFF
--- a/.github/workflows/dsh-latest-canary.yml
+++ b/.github/workflows/dsh-latest-canary.yml
@@ -1,4 +1,4 @@
-name: Latest DSH Canary
+name: DSH Release Channel Canary
 
 on:
   schedule:
@@ -9,9 +9,17 @@ permissions:
   contents: read
 
 jobs:
-  latest-dsh:
-    name: latest-dsh
+  release-channel:
+    name: ${{ matrix.channel }}-${{ matrix.dist_tag }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - channel: stable
+            dist_tag: latest
+          - channel: preview
+            dist_tag: alpha
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -22,14 +30,19 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: '22'
-      - name: Resolve latest released DSH
+      - name: Resolve DSH release channel
         shell: bash
+        env:
+          DSH_CHANNEL: ${{ matrix.channel }}
+          DSH_DIST_TAG: ${{ matrix.dist_tag }}
         run: |
           set -euo pipefail
-          DSH_VERSION="$(npm view @deepseek-ai/dsh version)"
+          DSH_VERSION="$(npm view @deepseek-ai/dsh "dist-tags.${DSH_DIST_TAG}")"
           test -n "$DSH_VERSION"
+          echo "DSH_CHANNEL=$DSH_CHANNEL" >> "$GITHUB_ENV"
+          echo "DSH_DIST_TAG=$DSH_DIST_TAG" >> "$GITHUB_ENV"
           echo "DSH_VERSION=$DSH_VERSION" >> "$GITHUB_ENV"
-          echo "Testing latest published DSH release family: $DSH_VERSION"
+          echo "Testing DSH ${DSH_CHANNEL} channel (${DSH_DIST_TAG}): $DSH_VERSION"
       - name: Verify DSH release family is published
         shell: bash
         run: |
@@ -52,7 +65,7 @@ jobs:
             fi
           done
           if (( ${#missing[@]} > 0 )); then
-            echo "DSH root package @deepseek-ai/dsh@$DSH_VERSION is published, but the Host contract package family is incomplete:" >&2
+            echo "DSH ${DSH_CHANNEL} root package @deepseek-ai/dsh@$DSH_VERSION is published, but the Host contract package family is incomplete:" >&2
             for package in "${missing[@]}"; do
               printf '  - %s@%s\n' "$package" "$DSH_VERSION" >&2
             done
@@ -63,7 +76,7 @@ jobs:
         run: |
           mkdir -p tmp-pack
           pnpm pack --pack-destination tmp-pack
-      - name: Install isolated latest Host fixture
+      - name: Install isolated channel Host fixture
         shell: node {0}
         run: |
           const fs = require('node:fs')
@@ -72,7 +85,7 @@ jobs:
           const tgz = fs.readdirSync('tmp-pack').find((name) => name.endsWith('.tgz'))
           if (!tgz) throw new Error('packed plugin tarball not found')
           const tarball = path.resolve('tmp-pack', tgz).replaceAll('\\', '/')
-          const hostDir = path.join(process.env.RUNNER_TEMP, `dvr-latest-${process.env.DSH_VERSION}`)
+          const hostDir = path.join(process.env.RUNNER_TEMP, `dvr-${process.env.DSH_CHANNEL}-${process.env.DSH_VERSION}`)
           fs.rmSync(hostDir, { recursive: true, force: true })
           fs.mkdirSync(hostDir, { recursive: true })
           const v = process.env.DSH_VERSION
@@ -96,7 +109,7 @@ jobs:
           const installed = spawnSync('pnpm', ['install'], { cwd: hostDir, stdio: 'inherit' })
           if (installed.status !== 0) process.exit(installed.status ?? 1)
           fs.appendFileSync(process.env.GITHUB_ENV, `HOST_DIR=${hostDir}\n`)
-      - name: Verify latest Host contract
+      - name: Verify channel Host contract
         env:
           EXPECT_BATCH: 'true'
           EXPECT_DIMENSION: 'true'
@@ -107,8 +120,8 @@ jobs:
         shell: bash
         run: |
           {
-            echo '## Latest DSH compatibility investigation required'
+            echo "## DSH ${DSH_CHANNEL} compatibility investigation required"
             echo
-            echo "The scheduled canary failed against the @deepseek-ai/dsh ${DSH_VERSION} release family."
+            echo "The scheduled canary failed against the @deepseek-ai/dsh ${DSH_VERSION} release family from the ${DSH_DIST_TAG} dist-tag."
             echo 'This job is intentionally non-gating for normal pull requests. Confirm whether the release family is fully published and then confirm the changed Host capability before changing the supported contract or adding compatibility code.'
           } >> "$GITHUB_STEP_SUMMARY"

--- a/package.json
+++ b/package.json
@@ -54,8 +54,8 @@
     "undici": "^7.29.0"
   },
   "peerDependencies": {
-    "@deepseek-ai/dsh-anonymous-user-id": "^0.1.0-rc.8 || ^0.1.1-rc.1",
-    "@deepseek-ai/dsh-llm-deepseek": "^0.1.0-rc.8 || ^0.1.1-rc.1",
+    "@deepseek-ai/dsh-anonymous-user-id": "^0.1.0-rc.8 || ^0.1.1-rc.1 || ^0.1.3-alpha.2",
+    "@deepseek-ai/dsh-llm-deepseek": "^0.1.0-rc.8 || ^0.1.1-rc.1 || ^0.1.3-alpha.2",
     "sharp": ">=0.35.3 <1"
   },
   "peerDependenciesMeta": {

--- a/tests/manifest-dependencies.test.js
+++ b/tests/manifest-dependencies.test.js
@@ -94,6 +94,7 @@ test('host-provided DSH packages publish the active Host floor while retaining a
     assert.equal(typeof peer, 'string', `${name} must be a peerDependency`)
     assert.match(peer, /\^0\.1\.0-rc\.8/, `${name} must publish the DVR 2.1 rc8 Host floor`)
     assert.match(peer, /\^0\.1\.1-rc\.1/, `${name} must admit the released DSH 0.1.1 train`)
+    assert.match(peer, /\^0\.1\.3-alpha\.2/, `${name} must admit the verified DSH 0.1.3 alpha train`)
     assert.equal(typeof pkg.devDependencies?.[name], 'string', `${name} must remain available for tests`)
     assert.match(pkg.devDependencies[name], /\^0\.1\.0-rc\.6/)
   }

--- a/tests/rc6-rc7-compat.test.js
+++ b/tests/rc6-rc7-compat.test.js
@@ -176,9 +176,9 @@ test('settings compatibility keeps the first-class section without requiring a l
   assert.doesNotMatch(source, /VisionRouterLegacyEntry/)
 })
 
-test('manifest publishes the DVR 2.1 rc8 host floor while admitting the rc1 host line', async () => {
+test('manifest publishes the DVR 2.1 rc8 host floor while admitting verified stable and alpha host trains', async () => {
   const pkg = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8'))
-  const expectedHostPeerRange = '^0.1.0-rc.8 || ^0.1.1-rc.1'
+  const expectedHostPeerRange = '^0.1.0-rc.8 || ^0.1.1-rc.1 || ^0.1.3-alpha.2'
   assert.equal(pkg.engines.node, '^22.19.0 || >=24.0.0')
   assert.equal(pkg.peerDependencies['@deepseek-ai/dsh-llm-deepseek'], expectedHostPeerRange)
   assert.equal(pkg.peerDependencies['@deepseek-ai/dsh-anonymous-user-id'], expectedHostPeerRange)


### PR DESCRIPTION
## Summary

Close the remaining release-channel false-green from the DSH 0.1.3 adversarial compatibility audit.

- replace the ambiguous single `npm view @deepseek-ai/dsh version` canary with explicit `latest` (stable) and `alpha` (preview) dist-tag jobs;
- keep package-family completeness checks per resolved channel version so a partially published DSH train is classified before Host-contract probing;
- keep both jobs non-gating for ordinary PRs while producing channel-specific investigation summaries;
- declare the already verified `^0.1.3-alpha.2` Host peer train for the two optional DSH peers instead of leaving package metadata on the older rc-only ranges;
- extend the manifest contract so future edits cannot silently drop that verified alpha train.

Local verification on an isolated worktree:

- `git diff --check`
- workflow YAML syntax parse
- `node --test tests/manifest-dependencies.test.js` → 31/31 pass

The alpha compatibility claim is intentionally bounded to the verified 0.1.3 alpha train; it does not pretend arbitrary future prereleases are supported.