### PR TITLE
fix: bound vision tool lifetime across Host attachment saves

### DIFF
--- a/lib/vision-tool-runtime-boundary.js
+++ b/lib/vision-tool-runtime-boundary.js
@@ -167,11 +167,28 @@ function createRuntimeState(initialConfig = {}) {
   }
 }
 
-function stateFor(name, exec) {
+function configuredVisionTaskSignal(config) {
+  const timeoutMs = Number(config?.visionTaskTimeoutMs)
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) return undefined
+  return AbortSignal.timeout(Math.max(1, Math.floor(timeoutMs)))
+}
+
+function stateFor(name, exec, config) {
+  const ambient = currentVisionTurnBudget()
   return {
     name,
     cwd: sessionCwd(exec),
-    signal: usableSignal(exec?.signal),
+    // Own the complete wall-clock task budget at the outermost runtime seam.
+    // Some Host services (notably AttachmentStore.saveImage in DSH 0.1.3) do
+    // not accept an AbortSignal. executeAbortable still races this signal so a
+    // hung Host promise cannot keep the user turn open forever; every wrapped
+    // fs/LLM call also observes the same merged cancellation after a late
+    // continuation settles.
+    signal: combineSignals(
+      ambient?.signal,
+      usableSignal(exec?.signal),
+      configuredVisionTaskSignal(config),
+    ),
     artifactRunId: `.vision-run-${Date.now().toString(36)}-${randomUUID()}`,
     disableCoreCache: name === 'vision_describe',
     // Every model call made from a Vision Router tool is a real authority
@@ -557,7 +574,7 @@ async function executeVisionTool(def, args, exec, execute, wrappedCtx, runtimeSt
   const liveConfig = runtimeState.config()
   if (liveConfig?.tool === false) throw toolDisabledError(def.name)
 
-  const state = stateFor(def.name, exec)
+  const state = stateFor(def.name, exec, liveConfig)
   const releaseArtifactRun = retainArtifactRun(state.artifactRunId)
   try {
     return await toolRuntime.run(state, () => withMergedTurnSignal(state, () =>

--- a/scripts/dsh-preview-mixed-attachment-paste-smoke.mjs
+++ b/scripts/dsh-preview-mixed-attachment-paste-smoke.mjs
@@ -86,6 +86,34 @@ async function adoptRealWorkspace(page, workspacePath) {
   await picker.waitFor({ state: 'hidden', timeout: 30_000 })
 }
 
+async function waitForNativeComposerPasteReady(page) {
+  const probe = '__dvr_native_paste_ready_probe__'
+  await page.waitForFunction((token) => {
+    const target = document.querySelector('[data-composer-input]')
+    if (!(target instanceof HTMLElement)) return false
+    if (target.textContent?.includes(token)) return true
+    const transfer = new DataTransfer()
+    transfer.setData('text/plain', token)
+    target.dispatchEvent(new ClipboardEvent('paste', {
+      clipboardData: transfer,
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+    }))
+    return false
+  }, probe, { polling: 100, timeout: 30_000 })
+
+  const composer = page.locator('[data-composer-input]').first()
+  await composer.fill('')
+  await page.waitForFunction(() => {
+    const input = document.querySelector('[data-composer-input]')
+    return (input?.textContent ?? '') === ''
+  }, undefined, { timeout: 10_000 })
+  await page.evaluate(() => {
+    globalThis.__DVR_SMOKE_COMPOSER_PASTE_DISPATCHES__ = 0
+  })
+}
+
 async function dispatchMixedPaste(page) {
   await page.evaluate(() => {
     const target = document.querySelector('[data-composer-input]')
@@ -141,6 +169,7 @@ async function capturePageState(page) {
       composerCardText: (document.querySelector('[data-composer-card]')?.textContent ?? '').trim().slice(0, 4000),
       bodyTextTail: (document.body?.textContent ?? '').trim().slice(-4000),
       clipboardCompatHookReady: globalThis.__DVR_SMOKE_CLIPBOARD_COMPAT_READY__ === true,
+      composerPasteDispatches: Number(globalThis.__DVR_SMOKE_COMPOSER_PASTE_DISPATCHES__ ?? 0),
     }))
   } catch (error) {
     return { available: false, captureError: error instanceof Error ? error.message : String(error) }
@@ -203,6 +232,14 @@ try {
       }
       return Reflect.apply(original, this, [type, listener, options])
     }
+    globalThis.__DVR_SMOKE_COMPOSER_PASTE_DISPATCHES__ = 0
+    const originalDispatch = EventTarget.prototype.dispatchEvent
+    EventTarget.prototype.dispatchEvent = function(event) {
+      if (event?.type === 'paste' && this instanceof Element && this.matches('[data-composer-input]')) {
+        globalThis.__DVR_SMOKE_COMPOSER_PASTE_DISPATCHES__ += 1
+      }
+      return Reflect.apply(originalDispatch, this, [event])
+    }
   })
   page.on('pageerror', error => pageErrors.push(error.message))
 
@@ -215,12 +252,18 @@ try {
 
   const composer = page.locator('[data-composer-input]').first()
   await composer.waitFor({ state: 'visible', timeout: 30_000 })
+  await waitForNativeComposerPasteReady(page)
   await page.waitForFunction(
     () => globalThis.__DVR_SMOKE_CLIPBOARD_COMPAT_READY__ === true,
     undefined,
     { timeout: 30_000 },
   )
   await dispatchMixedPaste(page)
+  await page.waitForFunction(
+    () => Number(globalThis.__DVR_SMOKE_COMPOSER_PASTE_DISPATCHES__ ?? 0) >= 2,
+    undefined,
+    { timeout: 30_000 },
+  )
 
   await page.waitForFunction(() => {
     const input = document.querySelector('[data-composer-input]')

--- a/scripts/dsh-preview-mixed-attachment-paste-smoke.mjs
+++ b/scripts/dsh-preview-mixed-attachment-paste-smoke.mjs
@@ -140,6 +140,7 @@ async function capturePageState(page) {
       })),
       composerCardText: (document.querySelector('[data-composer-card]')?.textContent ?? '').trim().slice(0, 4000),
       bodyTextTail: (document.body?.textContent ?? '').trim().slice(-4000),
+      clipboardCompatHookReady: globalThis.__DVR_SMOKE_CLIPBOARD_COMPAT_READY__ === true,
     }))
   } catch (error) {
     return { available: false, captureError: error instanceof Error ? error.message : String(error) }
@@ -182,6 +183,27 @@ try {
   browser = await chromium.launch({ headless: true })
   const context = await browser.newContext({ locale: 'en-US' })
   page = await context.newPage()
+  // Observe the real client lifecycle before any page script runs. The Router
+  // installs its clipboard compatibility as a document-level capture listener;
+  // composer visibility and the Vision slot can become visible before that
+  // Cordis effect has actually executed. Waiting on this registration avoids
+  // racing a synthetic paste into a not-yet-owned event boundary without adding
+  // a production-only readiness marker or arbitrary sleeps.
+  await page.addInitScript(() => {
+    globalThis.__DVR_SMOKE_CLIPBOARD_COMPAT_READY__ = false
+    const original = EventTarget.prototype.addEventListener
+    EventTarget.prototype.addEventListener = function(type, listener, options) {
+      if (this === document && type === 'paste' && options === true && typeof listener === 'function') {
+        try {
+          const source = Function.prototype.toString.call(listener)
+          if (source.includes('replayed.has(event)') && source.includes('needsInspection')) {
+            globalThis.__DVR_SMOKE_CLIPBOARD_COMPAT_READY__ = true
+          }
+        } catch {}
+      }
+      return Reflect.apply(original, this, [type, listener, options])
+    }
+  })
   page.on('pageerror', error => pageErrors.push(error.message))
 
   await page.goto(readyUrl)
@@ -193,6 +215,11 @@ try {
 
   const composer = page.locator('[data-composer-input]').first()
   await composer.waitFor({ state: 'visible', timeout: 30_000 })
+  await page.waitForFunction(
+    () => globalThis.__DVR_SMOKE_CLIPBOARD_COMPAT_READY__ === true,
+    undefined,
+    { timeout: 30_000 },
+  )
   await dispatchMixedPaste(page)
 
   await page.waitForFunction(() => {

--- a/tests/qa-cancellation-publication.test.js
+++ b/tests/qa-cancellation-publication.test.js
@@ -74,16 +74,25 @@ test('vision task deadline releases a turn when an uncooperative Host attachment
     },
   })
 
-  await assert.rejects(
-    registered.execute({}, { agent: { session: { header: { cwd: '/workspace' } } } }),
-    (error) => error?.code === 'ABORT_ERR',
-  )
-  // The current Host contract cannot cancel saveImage itself. Drain the fake
-  // continuation explicitly: the runtime promise has already released the turn
-  // and no late completion may become an unhandled rejection.
-  finishUnderlying?.({ attachmentId: 'late' })
-  const signal = await lateSignal
-  assert.equal(signal?.aborted, true, 'detached late continuation must inherit the spent task signal')
+  // AbortSignal.timeout() intentionally does not keep Node's event loop alive.
+  // A real DSH Host has server/runtime handles; this isolated test otherwise has
+  // only the deliberately never-settling Promise on Node 22, which would make
+  // node:test exit before the deadline can fire. Keep one test-only handle live.
+  const keepAlive = setInterval(() => {}, 1_000)
+  try {
+    await assert.rejects(
+      registered.execute({}, { agent: { session: { header: { cwd: '/workspace' } } } }),
+      (error) => error?.code === 'ABORT_ERR',
+    )
+    // The current Host contract cannot cancel saveImage itself. Drain the fake
+    // continuation explicitly: the runtime promise has already released the turn
+    // and no late completion may become an unhandled rejection.
+    finishUnderlying?.({ attachmentId: 'late' })
+    const signal = await lateSignal
+    assert.equal(signal?.aborted, true, 'detached late continuation must inherit the spent task signal')
+  } finally {
+    clearInterval(keepAlive)
+  }
 })
 
 test('cancelled vision work cannot publish a temp artifact to its final target', async () => {

--- a/tests/qa-cancellation-publication.test.js
+++ b/tests/qa-cancellation-publication.test.js
@@ -36,6 +36,56 @@ test('vision tool promise rejects promptly when the agent execution is cancelled
   finishUnderlying?.('late')
 })
 
+test('vision task deadline releases a turn when an uncooperative Host attachment save never settles', { timeout: 2_000 }, async () => {
+  let registered
+  let finishUnderlying
+  let observeLateSignal
+  const lateSignal = new Promise((resolve) => { observeLateSignal = resolve })
+  const attachments = {
+    saveImage() {
+      return new Promise((resolve) => { finishUnderlying = resolve })
+    },
+  }
+  const ctx = {
+    get(name) {
+      return name === 'attachments' ? attachments : undefined
+    },
+    fs: {
+      async readBytes(_target, signal) {
+        observeLateSignal?.(signal)
+        signal?.throwIfAborted?.()
+        return Buffer.from('late')
+      },
+    },
+    tools: {
+      register(def) {
+        registered = def
+        return () => {}
+      },
+    },
+  }
+  const wrapped = installVisionToolRuntimeBoundary(ctx, { visionTaskTimeoutMs: 25 })
+  wrapped.tools.register({
+    name: 'vision_present',
+    async execute() {
+      await wrapped.get('attachments').saveImage({ data: Buffer.from('png'), mediaType: 'image/png' })
+      await wrapped.fs.readBytes('late.png')
+      return 'late-success'
+    },
+  })
+
+  await assert.rejects(
+    registered.execute({}, { agent: { session: { header: { cwd: '/workspace' } } } }),
+    (error) => error?.code === 'ABORT_ERR',
+  )
+  // The current Host contract cannot cancel saveImage itself. Drain the fake
+  // continuation explicitly: the runtime promise has already released the turn
+  // and no late completion may become an unhandled rejection.
+  finishUnderlying?.({ attachmentId: 'late' })
+  const signal = await lateSignal
+  assert.equal(signal?.aborted, true, 'detached late continuation must inherit the spent task signal')
+})
+
 test('cancelled vision work cannot publish a temp artifact to its final target', async () => {
   const controller = new AbortController()
   const events = []


### PR DESCRIPTION
## Summary

Close a newly exposed timeout gap in the Vision Router runtime boundary against the current DSH attachment contract.

DSH 0.1.3-alpha.2 `AttachmentStore.saveImage()` / `saveImages()` do not accept an `AbortSignal`. DSH's tool timeout policy is cooperative: it places a deadline on `exec.signal` but deliberately does not race or abandon an uncooperative tool promise. Vision Router already has its own outer `executeAbortable()` race, but before this change that race listened only to the Host-provided `exec.signal`; the plugin's live `visionTaskTimeoutMs` did not start until deeper visual/backend stages in several paths.

That left Host attachment preparation outside the documented total vision-task wall-clock budget. A stalled `attachments.saveImage()` in `vision_present`, `vision_describe` preparation, or similar visual-tool paths could therefore keep the user turn open indefinitely.

### Change

- create the configured `visionTaskTimeoutMs` deadline at the outermost Vision Router tool runtime seam;
- merge it with any ambient structured-turn cancellation and Host `exec.signal`;
- reuse the existing `executeAbortable()` race so an uncooperative Host attachment save cannot hold the user-facing tool promise forever;
- keep the same spent signal in AsyncLocalStorage so any late continuation that eventually resumes sees cancellation before wrapped filesystem / LLM work can continue.

This intentionally does **not** claim to physically cancel the current DSH attachment-store operation itself. The alpha.2 Host API has no signal parameter for `saveImage` / `saveImages`; true storage cancellation requires an upstream Host contract that accepts and honors cancellation. This patch bounds the Vision Router turn and prevents late plugin continuation while preserving that upstream limitation.

### Adversarial regression

The new test supplies a fake Host `attachments.saveImage()` that never settles, with no Host timeout policy involved. A 25 ms Vision Router task deadline must release the registered tool with `ABORT_ERR`. The fake save is then allowed to settle late, and the continuation proves it inherits an already-aborted task signal rather than silently continuing filesystem work.

### Verification

- focused runtime/cancellation/reliability suite: **20/20 pass**
- budget-specific contracts: **33/33 pass**
- full `pnpm test`: **1292 tests, 1291 pass, 0 fail, 1 expected skip**, plus backend-policy **6/6 pass**
- `git diff --check`

The fix is deliberately scoped to the runtime boundary: no Host schema change, no per-tool timeout duplication, and no change to public timeout defaults.

### Browser lifecycle gate hardening

The exact alpha.2 browser gate exposed a separate smoke-test lifecycle race while validating this fix: the composer and Vision slot can be visible, and the Router document-level clipboard effect can already be installed, before DSH/Lexical's native composer paste intake is actually ready. In that window a synthetic mixed paste is consumed/replayed with no browser error but leaves the composer empty.

The smoke now proves each real boundary in order instead of sleeping or treating DOM visibility as readiness:

1. a text-only synthetic paste must first be accepted by DSH's native composer;
2. the Router's document capture normalization hook must be installed;
3. the mixed event must cause at least one Router synthetic replay;
4. text, normalized PNG, PDF and empty-MIME generic file must each appear exactly once;
5. generic-file uploads must reach Ready and the page must remain pageerror-free.

This is test-only instrumentation installed with Playwright `addInitScript`; no production readiness marker was added.

### Final verification

- focused runtime/cancellation/reliability suite: **20/20 pass**
- budget-specific contracts: **33/33 pass**
- full local `pnpm test`: **1292 tests, 1291 pass, 0 fail, 1 expected skip**, plus backend-policy **6/6 pass**
- real Node 22.19 cancellation fixture: **3/3 pass**
- clipboard/presentation contracts after smoke hardening: **26/26 pass**
- current PR head: all Node 22/24, rc6/7/8, alpha.2 adversarial, Windows Node24 screenshot, routing parity, artifact/data-boundary, DSH contract and CodeQL gates pass
- current PR head: **DSH 0.1.3-alpha.2 real Host + Chromium pass** (cold Vision toggle + mixed generic-file lifecycle)
- production runtime bytes were also manually exercised against immutable alpha.2 source on **Ubuntu, macOS and Windows** before the later smoke-only commits; all three passed
