### PR TITLE
test: lock live vision timeout updates

### DIFF
--- a/tests/qa-cancellation-publication.test.js
+++ b/tests/qa-cancellation-publication.test.js
@@ -95,6 +95,64 @@ test('vision task deadline releases a turn when an uncooperative Host attachment
   }
 })
 
+test('live visionTaskTimeoutMs changes govern the next Host attachment save', { timeout: 2_500 }, async () => {
+  let registered
+  let watchCallback
+  let finishUnderlying
+  let config = { visionTaskTimeoutMs: 1_400 }
+  const scope = {
+    get() { return config },
+    watch(callback) { watchCallback = callback; return () => {} },
+  }
+  const ctx = {
+    get(name) {
+      if (name !== 'attachments') return undefined
+      return {
+        saveImage() {
+          return new Promise((resolve) => { finishUnderlying = resolve })
+        },
+      }
+    },
+    inject(deps, callback) {
+      if (!deps.includes('settings')) return undefined
+      return callback({ settings: { register() { return scope } } })
+    },
+    tools: {
+      register(def) { registered = def; return () => {} },
+    },
+  }
+  const wrapped = installVisionToolRuntimeBoundary(ctx)
+  wrapped.inject(['settings'], (child) => {
+    child.settings.register('vision-router').watch(() => {})
+  })
+  wrapped.tools.register({
+    name: 'vision_present',
+    async execute() {
+      await wrapped.get('attachments').saveImage({ data: Buffer.from('png'), mediaType: 'image/png' })
+      return 'late-success'
+    },
+  })
+
+  config = { visionTaskTimeoutMs: 30 }
+  watchCallback?.()
+
+  const keepAlive = setInterval(() => {}, 1_000)
+  const started = Date.now()
+  try {
+    await assert.rejects(
+      registered.execute({}, { agent: { session: { header: { cwd: '/workspace' } } } }),
+      (error) => error?.code === 'ABORT_ERR',
+    )
+    assert.ok(
+      Date.now() - started < 700,
+      'the next invocation must use the hot 30 ms deadline rather than the stale 1400 ms boot value',
+    )
+  } finally {
+    finishUnderlying?.({ attachmentId: 'late' })
+    clearInterval(keepAlive)
+  }
+})
+
 test('cancelled vision work cannot publish a temp artifact to its final target', async () => {
   const controller = new AbortController()
   const events = []


### PR DESCRIPTION
## Summary

Lock the live Settings semantics added around #417: changing `visionTaskTimeoutMs` through the real `vision-router` SettingsScope watch chain must govern the **next** Vision Router tool invocation, including a Host `attachments.saveImage()` promise that never settles.

The regression starts with a stale 1400 ms value, hot-updates the settings document to 30 ms, triggers the wrapped scope watcher, then verifies the next `vision_present` call releases with `ABORT_ERR` well before the stale budget could fire. The fake Host save is drained after the user-facing tool promise releases.

This PR changes tests only; no production bytes change.

## Verification

- Node 24 targeted reliability/cancellation/runtime-boundary suite: 27/27 pass
- Node 22 targeted reliability/cancellation/runtime-boundary suite: 27/27 pass
- new cancellation file repeated 8x on Node 22 and 8x on Node 24: all pass
- negative control: omitting the Settings watch notification keeps the stale deadline active, proving the regression is sensitive to the live-update chain
- full `pnpm test`: 1293 tests, 1292 pass, 0 fail, 1 expected skip
- backend runtime policy: 6/6 pass
- `git diff --check`