### PR TITLE
fix: close remaining CodeQL security alerts

### DIFF
--- a/lib/live-model-discovery.js
+++ b/lib/live-model-discovery.js
@@ -66,14 +66,12 @@ export function liveModelCachePath(dshHome = resolveDshHome()) {
   return path.join(dshHome, 'cache', 'vision-router', 'live-models.json')
 }
 
-export function routeFingerprint({ provider, baseURL, api, credentialRef, credentialSource }) {
+export function routeFingerprint({ provider, baseURL, api }) {
   return createHash('sha256')
     .update(JSON.stringify({
       provider: String(provider ?? ''),
       baseURL: String(baseURL ?? ''),
       api: String(api ?? ''),
-      credentialRef: String(credentialRef ?? ''),
-      credentialSource: String(credentialSource ?? ''),
     }))
     .digest('hex')
 }
@@ -323,8 +321,6 @@ async function providerPlan(ctx, provider) {
       provider,
       baseURL: transport.baseURL,
       api: transport.api,
-      credentialRef: transport.apiKeyEnv,
-      credentialSource: credential.source,
     }),
   }
 }

--- a/lib/live-model-discovery.js
+++ b/lib/live-model-discovery.js
@@ -7,7 +7,7 @@ import { MODEL_RESPONSE_MAX_BYTES, readResponseJsonBounded } from './http-body-l
 import { stripTrailingSlashes } from './string-normalization.js'
 
 export const LIVE_MODELS_PATH = '/_dsh/vision-router/live-models'
-export const LIVE_MODEL_CACHE_VERSION = 1
+export const LIVE_MODEL_CACHE_VERSION = 2
 export const DEFAULT_LIVE_MODEL_FRESH_MS = 15 * 60 * 1000
 export const DEFAULT_LIVE_MODEL_STALE_MS = 24 * 60 * 60 * 1000
 export const DEFAULT_LIVE_MODEL_TIMEOUT_MS = 6_000
@@ -66,21 +66,16 @@ export function liveModelCachePath(dshHome = resolveDshHome()) {
   return path.join(dshHome, 'cache', 'vision-router', 'live-models.json')
 }
 
-export function routeFingerprint({ provider, baseURL, api, credentialFingerprint }) {
+export function routeFingerprint({ provider, baseURL, api, credentialRef, credentialSource }) {
   return createHash('sha256')
     .update(JSON.stringify({
       provider: String(provider ?? ''),
       baseURL: String(baseURL ?? ''),
       api: String(api ?? ''),
-      credentialFingerprint: String(credentialFingerprint ?? ''),
+      credentialRef: String(credentialRef ?? ''),
+      credentialSource: String(credentialSource ?? ''),
     }))
     .digest('hex')
-}
-
-function credentialFingerprint(value) {
-  const text = typeof value === 'string' ? value : ''
-  if (text === '') return 'none'
-  return createHash('sha256').update(text).digest('hex').slice(0, 24)
 }
 
 function listingURL(baseURL) {
@@ -308,7 +303,7 @@ async function providerPlan(ctx, provider) {
   // DSH llm-pi-ai treats a named apiKeyEnv as mandatory. Sending `/models`
   // without that key is both misleading (the user sees a spurious 401) and can
   // poison route fingerprints/cache evidence. Defer instead; the browser's
-  // refresh polling and credentials/updated invalidation will retry once the
+  // refresh polling and credential-reference invalidation will retry once the
   // credential seam is ready or the user stores the key.
   if (credential.required && credential.value === undefined) {
     return {
@@ -328,7 +323,8 @@ async function providerPlan(ctx, provider) {
       provider,
       baseURL: transport.baseURL,
       api: transport.api,
-      credentialFingerprint: credentialFingerprint(apiKey),
+      credentialRef: transport.apiKeyEnv,
+      credentialSource: credential.source,
     }),
   }
 }
@@ -550,11 +546,25 @@ export function installLiveModelDiscovery(ctx, options = {}) {
   }
   scheduleStartup()
 
-  const onInvalidate = () => manager.invalidate()
+  let credentialInvalidationQueued = false
+  let lifecycleDisposed = false
+  const onInvalidate = () => {
+    if (!lifecycleDisposed) manager.invalidate()
+  }
+  const onCredentialInvalidate = () => {
+    if (lifecycleDisposed || credentialInvalidationQueued) return
+    credentialInvalidationQueued = true
+    manager.invalidate()
+    Promise.resolve().then(() => { credentialInvalidationQueued = false })
+  }
   const disposers = []
   try {
-    for (const event of ['settings/document-updated', 'credentials/updated', 'llm/adapters-updated']) {
+    for (const event of ['settings/document-updated', 'llm/adapters-updated']) {
       const dispose = ctx?.on?.(event, onInvalidate)
+      if (typeof dispose === 'function') disposers.push(dispose)
+    }
+    for (const event of ['credentials/reference-updated', 'credentials/updated']) {
+      const dispose = ctx?.on?.(event, onCredentialInvalidate)
       if (typeof dispose === 'function') disposers.push(dispose)
     }
   } catch {
@@ -584,6 +594,7 @@ export function installLiveModelDiscovery(ctx, options = {}) {
 
   try {
     ctx?.effect?.(() => () => {
+      lifecycleDisposed = true
       if (startupTimer !== undefined) clearTimeout(startupTimer)
       for (const dispose of disposers) {
         try { dispose() } catch { /* best effort */ }

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -2337,10 +2337,11 @@ test('hostMatchesAny matches exact hosts and subdomains only', () => {
 })
 
 test('DEFAULT_PROXY_HOSTS covers the common foreign AI API domains', () => {
+  const proxyHosts = new Set(DEFAULT_PROXY_HOSTS)
   for (const host of ['api.openrouter.ai', 'openrouter.ai', 'api.openai.com', 'api.anthropic.com', 'api.mistral.ai', 'api.together.xyz']) {
-    assert.ok(DEFAULT_PROXY_HOSTS.includes(host), `missing ${host}`)
+    assert.equal(proxyHosts.has(host), true, `missing ${host}`)
   }
-  assert.ok(!DEFAULT_PROXY_HOSTS.includes('api.deepseek.com'), 'DeepSeek stays direct')
+  assert.equal(proxyHosts.has('api.deepseek.com'), false, 'DeepSeek stays direct')
 })
 
 // ── batch 1: vision_detect + structured describe ────────────────────────────

--- a/tests/live-model-discovery.test.js
+++ b/tests/live-model-discovery.test.js
@@ -97,21 +97,19 @@ test('OpenAI-compatible listing normalization proves existence only and de-dupli
   )
 })
 
-test('route fingerprint uses non-secret route identity and ignores credential values', () => {
+test('route fingerprint is credential-independent and covers only provider transport identity', () => {
   const base = {
     provider: 'zai',
     baseURL: 'https://example.test/v1',
     api: 'openai-completions',
-    credentialRef: 'ZAI_API_KEY',
-    credentialSource: 'credentials',
   }
   assert.equal(routeFingerprint(base), routeFingerprint({ ...base }))
   assert.equal(
-    routeFingerprint({ ...base, apiKey: 'secret-alpha' }),
-    routeFingerprint({ ...base, apiKey: 'secret-beta' }),
+    routeFingerprint({ ...base, apiKey: 'secret-alpha', apiKeyEnv: 'ALPHA_KEY' }),
+    routeFingerprint({ ...base, apiKey: 'secret-beta', apiKeyEnv: 'BETA_KEY' }),
   )
-  assert.notEqual(routeFingerprint(base), routeFingerprint({ ...base, credentialRef: 'OTHER_API_KEY' }))
-  assert.notEqual(routeFingerprint(base), routeFingerprint({ ...base, credentialSource: 'launch-environment' }))
+  assert.notEqual(routeFingerprint(base), routeFingerprint({ ...base, provider: 'other' }))
+  assert.notEqual(routeFingerprint(base), routeFingerprint({ ...base, api: 'openai-responses' }))
   assert.notEqual(routeFingerprint(base), routeFingerprint({ ...base, baseURL: 'https://other.test/v1' }))
 })
 

--- a/tests/live-model-discovery.test.js
+++ b/tests/live-model-discovery.test.js
@@ -7,6 +7,8 @@ import vm from 'node:vm'
 
 import {
   createLiveModelDiscoveryManager,
+  installLiveModelDiscovery,
+  LIVE_MODEL_CACHE_VERSION,
   liveModelCachePath,
   normalizeOpenAIModelListing,
   routeFingerprint,
@@ -95,15 +97,21 @@ test('OpenAI-compatible listing normalization proves existence only and de-dupli
   )
 })
 
-test('route fingerprint changes with endpoint, protocol, or credential fingerprint', () => {
+test('route fingerprint uses non-secret route identity and ignores credential values', () => {
   const base = {
     provider: 'zai',
     baseURL: 'https://example.test/v1',
     api: 'openai-completions',
-    credentialFingerprint: 'a',
+    credentialRef: 'ZAI_API_KEY',
+    credentialSource: 'credentials',
   }
   assert.equal(routeFingerprint(base), routeFingerprint({ ...base }))
-  assert.notEqual(routeFingerprint(base), routeFingerprint({ ...base, credentialFingerprint: 'b' }))
+  assert.equal(
+    routeFingerprint({ ...base, apiKey: 'secret-alpha' }),
+    routeFingerprint({ ...base, apiKey: 'secret-beta' }),
+  )
+  assert.notEqual(routeFingerprint(base), routeFingerprint({ ...base, credentialRef: 'OTHER_API_KEY' }))
+  assert.notEqual(routeFingerprint(base), routeFingerprint({ ...base, credentialSource: 'launch-environment' }))
   assert.notEqual(routeFingerprint(base), routeFingerprint({ ...base, baseURL: 'https://other.test/v1' }))
 })
 
@@ -147,6 +155,7 @@ test('Host discovery uses configured transport/credential and disk cache is disp
 
     const cacheText = await readFile(liveModelCachePath(dshHome), 'utf8')
     assert.equal(cacheText.includes('super-secret-live-discovery-key'), false)
+    assert.equal(JSON.parse(cacheText).version, LIVE_MODEL_CACHE_VERSION)
     assert.match(cacheText, /glm-4v-flash/)
 
     const cachedManager = createLiveModelDiscoveryManager(ctx, {
@@ -166,6 +175,115 @@ test('Host discovery uses configured transport/credential and disk cache is disp
     assert.equal(cachedManager.hasModel('zai', 'glm-4v-flash'), false)
     await cachedManager.dispose()
   } finally {
+    await rm(dshHome, { recursive: true, force: true })
+  }
+})
+
+test('credential rotation invalidates live evidence through current and legacy Host events without hashing the key', async () => {
+  const dshHome = await mkdtemp(path.join(os.tmpdir(), 'vision-router-credential-events-'))
+  let apiKey = 'rotation-alpha'
+  let lifecycleCleanup
+  const listeners = new Map()
+  const calls = []
+  const blocked = []
+  const settings = {
+    get(namespace) {
+      if (namespace === 'llm-pi-ai') {
+        return {
+          providers: {
+            zai: {
+              baseURL: 'https://example.test/v1',
+              api: 'openai-completions',
+              apiKeyEnv: 'ZAI_API_KEY',
+            },
+          },
+        }
+      }
+      if (namespace === 'vision-router') {
+        return { providers: [{ provider: 'zai', model: 'glm-live', fallbacks: [] }] }
+      }
+      return undefined
+    },
+  }
+  const ctx = {
+    llm: { registration() { return undefined } },
+    get(name) {
+      if (name === 'settings') return settings
+      if (name === 'credentials') {
+        return { async resolve() { return { value: apiKey, source: 'memory' } } }
+      }
+      return undefined
+    },
+    on(event, handler) {
+      listeners.set(event, handler)
+      return () => listeners.delete(event)
+    },
+    inject() {},
+    effect(factory) {
+      lifecycleCleanup = factory()
+      return lifecycleCleanup
+    },
+  }
+  const manager = installLiveModelDiscovery(ctx, {
+    dshHome,
+    fetchImpl: async (_url, options) => {
+      const call = { authorization: options?.headers?.authorization }
+      calls.push(call)
+      if (calls.length > 1) {
+        await new Promise((resolve) => blocked.push(resolve))
+      }
+      return new Response(JSON.stringify({ data: [{ id: 'glm-live' }] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    },
+  })
+
+  const waitFor = async (predicate, timeoutMs = 1500) => {
+    const deadline = Date.now() + timeoutMs
+    while (Date.now() < deadline) {
+      if (predicate()) return
+      await new Promise((resolve) => setTimeout(resolve, 5))
+    }
+    throw new Error('timed out waiting for credential invalidation')
+  }
+
+  try {
+    await manager.ready()
+    manager.queueConfigured()
+    await waitForSettled(manager)
+    assert.equal(manager.hasModel('zai', 'glm-live'), true)
+    assert.deepEqual(calls, [{ authorization: 'Bearer rotation-alpha' }])
+    assert.equal(listeners.has('credentials/reference-updated'), true)
+    assert.equal(listeners.has('credentials/updated'), true)
+
+    const versionBefore = (await manager.snapshot()).version
+    apiKey = 'rotation-beta'
+    listeners.get('credentials/reference-updated')('ZAI_API_KEY')
+    assert.equal(manager.hasModel('zai', 'glm-live'), false, 'current Host event must revoke evidence synchronously')
+    listeners.get('credentials/updated')('ZAI_API_KEY')
+    await Promise.resolve()
+    await waitFor(() => calls.length === 2 && blocked.length === 1)
+    assert.equal((await manager.snapshot()).version, versionBefore + 1)
+    assert.equal(manager.hasModel('zai', 'glm-live'), false)
+    assert.equal(calls[1].authorization, 'Bearer rotation-beta')
+    blocked.shift()()
+    await waitForSettled(manager)
+    assert.equal(manager.hasModel('zai', 'glm-live'), true)
+    assert.equal(calls.length, 2, 'current+legacy aliases in one turn must coalesce to one refresh')
+
+    apiKey = 'rotation-gamma'
+    listeners.get('credentials/updated')('ZAI_API_KEY')
+    await Promise.resolve()
+    await waitFor(() => calls.length === 3 && blocked.length === 1)
+    assert.equal(manager.hasModel('zai', 'glm-live'), false)
+    assert.equal(calls[2].authorization, 'Bearer rotation-gamma')
+    blocked.shift()()
+    await waitForSettled(manager)
+    assert.equal(manager.hasModel('zai', 'glm-live'), true)
+  } finally {
+    lifecycleCleanup?.()
+    await manager.dispose()
     await rm(dshHome, { recursive: true, force: true })
   }
 })

--- a/tests/vision-toggle-root-hardening.test.js
+++ b/tests/vision-toggle-root-hardening.test.js
@@ -142,8 +142,20 @@ test('root hardening rewrites only the existing #284 seams and removes the offic
   assert.match(hardened, /raw\.status === 'selecting' \|\| raw\.status === 'loading'/)
 })
 
-function scriptsOf(html) {
-  return [...html.matchAll(/<script[^>]*>([\s\S]*?)<\/script>/g)].map((match) => match[1])
+function scriptsOfInjectedFixture(html) {
+  const scripts = []
+  let cursor = 0
+  while (cursor < html.length) {
+    const open = html.indexOf('<script', cursor)
+    if (open === -1) break
+    const body = html.indexOf('>', open + '<script'.length)
+    const close = body === -1 ? -1 : html.indexOf('</script>', body + 1)
+    assert.notEqual(body, -1, 'generated fixture script tag must have an opening delimiter')
+    assert.notEqual(close, -1, 'generated fixture script tag must have a closing delimiter')
+    scripts.push(html.slice(body + 1, close))
+    cursor = close + '</script>'.length
+  }
+  return scripts
 }
 
 test('root hardening patches a loader returned from create and every later global loader replacement', () => {
@@ -173,7 +185,7 @@ test('root hardening patches a loader returned from create and every later globa
     Error,
     console,
   }
-  for (const source of scriptsOf(html)) vm.runInNewContext(source, context)
+  for (const source of scriptsOfInjectedFixture(html)) vm.runInNewContext(source, context)
 
   const created = initial.create()
   assert.equal(created, returned)
@@ -187,7 +199,7 @@ test('root hardening patches a loader returned from create and every later globa
 test('selection transport rejection is recoverable without mutating the Host directory store and identical double-clicks coalesce', async () => {
   const window = { fetch: async () => ({ ok: true, json: async () => ({ revision: 0, routes: [] }) }) }
   const html = hardenVisionToggleHtml('<html><head></head></html>')
-  const source = scriptsOf(html).find((script) => script.includes('__dshVisionRouterRootHardening'))
+  const source = scriptsOfInjectedFixture(html).find((script) => script.includes('__dshVisionRouterRootHardening'))
   assert.ok(source)
   vm.runInNewContext(source, {
     window,


### PR DESCRIPTION
## Summary

- remove API-key-derived material from persisted live-model route fingerprints and bump the cache format
- invalidate live model evidence synchronously on the current `credentials/reference-updated` Host event while retaining the legacy alias with same-tick coalescing
- replace two test-only CodeQL false-positive patterns with precise `Set.has` / controlled fixture scanning

## Security / behavior

Credential values now flow only into the Authorization header. Persisted route identity is derived from provider, endpoint, protocol, credential reference, and credential source; disk cache remains display-only until current-process live evidence revalidates it.

## Tests

- focused live-model / credential / root-hardening tests: pass
- `pnpm test`: 1296 tests, 1295 pass, 0 fail, 1 expected skip; backend runtime policy 6/6
- `pnpm test:contract`: 145/145
