### PR TITLE
fix: quiet failed background transports and authenticated Doctor

### DIFF
--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -79,7 +79,7 @@ or `DSH_WEB_URL`. To perform offline checks only:
 npx dsh-vision-router doctor --no-runtime
 ```
 
-An unreachable DSH process is advisory rather than a doctor failure; offline checks still complete. When `--profile` is used against a reachable runtime, doctor does not attribute green route health to that profile unless the runtime exposes a verified Vision Router profile identity. If ownership cannot be proven, the human report shows `? runtime profile ownership unknown` instead of a false green binding.
+An unreachable DSH process is advisory rather than a doctor failure; offline checks still complete. DSH Web may also require its signed browser-session cookie before any `/api` route is visible. If every side-effect-free route probe is rejected with `401`, Doctor reports the runtime as **reachable but authentication-required** and keeps plugin route health/ownership unknown instead of printing false route failures or bypassing Host authentication. The JSON report exposes `runtime.authenticationRequired: true`; capability support advice remains unknown because no Host seam was actually observed. When `--profile` is used against an authenticated reachable runtime, Doctor still does not attribute green route health to that profile unless the runtime exposes a verified Vision Router profile identity. If ownership cannot be proven, the human report shows `? runtime profile ownership unknown` instead of a false green binding.
 
 ### Local capability diagnostics
 

--- a/docs/v2-capability-routing.md
+++ b/docs/v2-capability-routing.md
@@ -156,17 +156,26 @@ intentional: standing background authority is the user's permission to verify
 capability within the selected local/free/paid cost boundary, not permission to
 trust possibly stale Host modality metadata as ground truth.
 
-Transient failure state is scoped to the exact deployment fingerprint plus model
-and axis. Network, timeout, and rate-limit conditions receive retry backoff.
-Clear deployment-level non-retryable failures such as authentication failure,
-unavailable model, and unsupported protocol are persisted for the same exact
-fingerprint and stop unattended measurement across axes, including after process
-restart. Visual-proof and Benchmark-infrastructure failures remain axis-scoped;
-they do not manufacture a text-only verdict or disable other axes. An explicit
-image-input rejection is persisted separately as a measured text-only verdict.
-Ordinary settings refreshes, adapter notifications, and process restart do not
-silently clear these same-fingerprint stops. A changed deployment fingerprint
-creates a new evidence scope, and an explicit successful Test Vision clears the
+Failure lifetime follows the narrowest authority that can explain the failure.
+Timeout, network, visual-proof, and Benchmark-infrastructure failures remain
+model/axis-scoped, so one failed axis does not suppress another axis or an
+independent route. Authentication and unsupported-protocol failures apply to the
+same transport scope (provider + endpoint + protocol + credential reference), and
+rate-limit backoff is shared by sibling models on that same scope, preventing an
+invalid or throttled account/endpoint from rotating through every model and axis
+at the normal 15-second background gap.
+
+Authentication stops are process-local and bounded; Vision Router never persists
+an API-key value or deterministic derivative just to recognize a later key
+rotation. Current `credentials/reference-updated` and legacy
+`credentials/updated` notifications synchronously revoke the in-memory AUTH stop
+and rescan with the new credential. Unsupported-protocol and unavailable-model
+stops remain bounded persistent evidence (the former also suppresses sibling
+models on the same transport; the latter stays model-specific). Visual-proof and
+Benchmark-infrastructure failures do not manufacture a text-only verdict or
+disable other axes. An explicit image-input rejection is persisted separately as
+a measured text-only verdict. A changed deployment fingerprint creates a new
+evidence scope, and an explicit successful Test Vision clears the corresponding
 same-fingerprint stop. Public background status exposes only a sanitized failure
 class/code; raw provider responses and credentials are not published to the
 browser.

--- a/lib/doctor-cli-p0.js
+++ b/lib/doctor-cli-p0.js
@@ -58,7 +58,7 @@ export async function probeDoctorHostCapabilities({ baseUrl, fetchImpl = globalT
     if (!response.ok) {
       return {
         ok: false,
-        source: 'runtime-route-unavailable',
+        source: response.status === 401 ? 'runtime-auth-required' : 'runtime-route-unavailable',
         status: response.status,
         capabilities: unknownSnapshot(),
       }

--- a/lib/doctor-cli.js
+++ b/lib/doctor-cli.js
@@ -241,7 +241,10 @@ export async function run(argv = process.argv.slice(2), io = console, env = proc
 
   if (runtime) {
     if (!runtime.reachable) io.log(`– Runtime probe: DSH not reachable at ${runtime.baseUrl}; offline checks still completed.`)
-    else {
+    else if (runtime.authenticationRequired) {
+      io.log('? Runtime probe: DSH Web is reachable but browser authentication is required; plugin route health remains unknown.')
+      if (options.profile) io.log(`? runtime profile ownership unknown; authenticated route health is not attributed to ${options.profile}`)
+    } else {
       for (const route of runtime.routes) {
         io.log(`${route.ok ? '✓' : '✗'} runtime ${route.route} — ${route.ok ? 'route registered' : `status ${route.status ?? 'unreachable'}, route not confirmed`}`)
       }

--- a/lib/doctor-runtime.js
+++ b/lib/doctor-runtime.js
@@ -92,14 +92,17 @@ export async function probeRuntime({
   }))
 
   const reachable = routes.some((item) => !item.unreachable)
+  const authenticationRequired = reachable && routes.length > 0 && routes.every((item) => item.status === 401)
   const routeOk = !reachable || routes.every((item) => item.ok)
-  let ownership = { verified: false, requestedProfile, reason: requestedProfile ? 'profile-unknown' : 'not-requested' }
+  let ownership = authenticationRequired
+    ? { verified: false, requestedProfile, reason: 'runtime-auth-required' }
+    : { verified: false, requestedProfile, reason: requestedProfile ? 'profile-unknown' : 'not-requested' }
 
   // A DELETE contract proves route registration but not which DSH profile owns
   // the process. Reuse the existing GET-only log metadata route as a read-only
   // home identity proof. It never opens the log folder (that is POST only).
   // Only a unique applicable profile in that same DSH_HOME may be attributed.
-  if (reachable && routeOk && requestedProfile && typeof dshHome === 'string') {
+  if (reachable && routeOk && !authenticationRequired && requestedProfile && typeof dshHome === 'string') {
     try {
       const response = await fetchImpl(new URL('/_dsh/vision-router/logs', base).href, {
         method: 'GET',
@@ -131,8 +134,9 @@ export async function probeRuntime({
     reachable,
     routes,
     ownership,
+    authenticationRequired,
     routeOk,
-    ok: !reachable || (routeOk && (!requestedProfile || ownership.verified)),
+    ok: !reachable || authenticationRequired || (routeOk && (!requestedProfile || ownership.verified)),
   }
 }
 
@@ -302,6 +306,7 @@ function safeRuntime(runtime) {
     reachable: runtime.reachable,
     ok: runtime.ok,
     routeOk: runtime.routeOk,
+    authenticationRequired: runtime.authenticationRequired === true,
     ownership: runtime.ownership ? {
       requestedProfile: runtime.ownership.requestedProfile,
       verified: runtime.ownership.verified,

--- a/lib/vision-background-benchmark.js
+++ b/lib/vision-background-benchmark.js
@@ -7,15 +7,11 @@ import {
 } from './vision-capability-benchmark-service.js'
 import { withHardDeadline } from './vision-capability-benchmark-hardening.js'
 import { resolveVisionRoutingAuthority } from './vision-routing-authority.js'
-import { resolveVisionCredential } from './vision-capability-identity.js'
 import { redactDiagnosticText } from './diagnostic-redaction.js'
 import { injectVisionExactCheckClient } from './vision-exact-check-client.js'
 import { createImageInputVerdictStore } from './vision-image-input-verdict.js'
 import { createBackgroundBenchmarkStopStore } from './vision-background-stop-store.js'
-import {
-  backgroundFailurePolicy,
-  credentialFingerprintChanged,
-} from './vision-background-failure-policy.js'
+import { backgroundFailurePolicy } from './vision-background-failure-policy.js'
 import { isLocalUiRequest } from './web-capability-boundary.js'
 
 const FOREGROUND_VISION_TOOLS = new Set([
@@ -42,6 +38,11 @@ const MODEL_WIDE_NON_RETRYABLE_BACKGROUND_FAILURES = new Set([
   'auth',
   'protocol',
   'unavailable',
+])
+const TRANSPORT_WIDE_BACKGROUND_FAILURES = new Set([
+  'auth',
+  'protocol',
+  'rate-limit',
 ])
 const PERMANENT_MODEL_UNAVAILABLE_CODES = new Set([
   'MODEL_NOT_FOUND',
@@ -145,6 +146,21 @@ function backoffKey(candidate, axis) {
   return `${candidate?.key ?? ''}\u0000${candidate?.endpointFingerprint ?? ''}\u0000${axis}`
 }
 
+function backgroundTransportScope(candidate) {
+  const provider = typeof candidate?.provider === 'string' ? candidate.provider.trim() : ''
+  const endpoint = normalizedEndpoint(candidate?.endpoint)
+  if (!provider || !endpoint) return undefined
+  const api = typeof candidate?.endpointConfig?.api === 'string' ? candidate.endpointConfig.api.trim().toLowerCase() : ''
+  const credentialRef = typeof candidate?.endpointCredentialRef === 'string' ? candidate.endpointCredentialRef.trim() : ''
+  return JSON.stringify([provider, endpoint, api, credentialRef])
+}
+
+function transportFailureScope(candidate, errorClass) {
+  return TRANSPORT_WIDE_BACKGROUND_FAILURES.has(errorClass)
+    ? backgroundTransportScope(candidate)
+    : undefined
+}
+
 function classifyUnavailable(value) {
   const status = Number(value?.status)
   const code = String(value?.code ?? '').toUpperCase()
@@ -192,26 +208,14 @@ function publicExcludedEntries(excluded) {
     .map((entry) => ({ key: entry.key, reason: entry.reason }))
 }
 
-async function candidateCredentialFingerprint(ctx, candidate) {
-  const ref = typeof candidate?.endpointCredentialRef === 'string'
-    ? candidate.endpointCredentialRef.trim()
-    : ''
-  if (!ref) return undefined
-  try {
-    return (await resolveVisionCredential(ctx, ref)).fingerprint
-  } catch {
-    return 'unresolved'
-  }
-}
 
-async function pruneBackoff(backoff, candidates, ctx, at) {
+async function pruneBackoff(backoff, candidates, _ctx, at) {
   const valid = new Set()
   const byKey = new Map()
   for (const candidate of candidates) {
     byKey.set(candidate.key, candidate)
     for (const axis of orderedAxes()) valid.add(backoffKey(candidate, axis))
   }
-  const credentialCache = new Map()
   for (const [key, entry] of backoff.entries()) {
     if (!valid.has(key)) {
       backoff.delete(key)
@@ -222,16 +226,11 @@ async function pruneBackoff(backoff, candidates, ctx, at) {
       backoff.delete(key)
       continue
     }
-    if (entry?.errorClass !== 'auth' || !entry.credentialFingerprint) continue
-    const candidate = byKey.get(entry.key)
-    if (!candidate) continue
-    let currentFingerprint = credentialCache.get(candidate.key)
-    if (currentFingerprint === undefined) {
-      currentFingerprint = await candidateCredentialFingerprint(ctx, candidate)
-      credentialCache.set(candidate.key, currentFingerprint ?? null)
-    }
-    if (credentialFingerprintChanged(entry.credentialFingerprint, currentFingerprint ?? undefined)) {
-      backoff.delete(key)
+    if (entry?.errorClass === 'auth') {
+      const currentRef = typeof byKey.get(entry.key)?.endpointCredentialRef === 'string'
+        ? byKey.get(entry.key).endpointCredentialRef.trim()
+        : ''
+      if ((entry.credentialRef ?? '') !== currentRef) backoff.delete(key)
     }
   }
 }
@@ -243,7 +242,6 @@ async function restorePersistentStops(backoff, candidates, backgroundStopStore, 
   if (!Array.isArray(stops) || stops.length === 0) return
   const byKey = new Map(candidates.map((candidate) => [candidate.key, candidate]))
   const axes = new Set(orderedAxes())
-  const credentialCache = new Map()
   for (const stop of stops) {
     const candidate = byKey.get(stop?.key)
     if (!candidate || candidate.endpointFingerprint !== stop?.fingerprint || !axes.has(stop?.axis)) continue
@@ -251,24 +249,14 @@ async function restorePersistentStops(backoff, candidates, backgroundStopStore, 
       try { await backgroundStopStore.clearStop?.(stop.fingerprint, stop.axis) } catch {}
       continue
     }
-    if (stop.errorClass === 'auth' && stop.credentialFingerprint) {
-      let currentFingerprint = credentialCache.get(candidate.key)
-      if (currentFingerprint === undefined) {
-        currentFingerprint = await candidateCredentialFingerprint(ctx, candidate)
-        credentialCache.set(candidate.key, currentFingerprint ?? null)
-      }
-      if (credentialFingerprintChanged(stop.credentialFingerprint, currentFingerprint ?? undefined)) {
-        try { await backgroundStopStore.clearStop?.(stop.fingerprint, stop.axis) } catch {}
-        continue
-      }
-    }
+    const transportScope = transportFailureScope(candidate, stop.errorClass)
     backoff.set(backoffKey(candidate, stop.axis), {
       key: candidate.key,
       fingerprint: candidate.endpointFingerprint,
       axis: stop.axis,
       errorClass: stop.errorClass,
       ...(stop.errorCode ? { errorCode: stop.errorCode } : {}),
-      ...(stop.credentialFingerprint ? { credentialFingerprint: stop.credentialFingerprint } : {}),
+      ...(transportScope ? { transportScope } : {}),
       retryable: false,
       until: Number(stop.expiresAt),
       persisted: true,
@@ -276,14 +264,26 @@ async function restorePersistentStops(backoff, candidates, backgroundStopStore, 
   }
 }
 
-function candidateBlockedByNonRetryableFailure(backoff, candidate, at) {
+function candidateBlockedByFailure(backoff, candidate, at) {
   if (!candidate?.endpointFingerprint) return false
+  const transportScope = backgroundTransportScope(candidate)
   for (const entry of backoff.values()) {
-    if (entry?.retryable !== false) continue
     const until = Number(entry?.until)
     if (Number.isFinite(until) && until <= at) continue
-    if (entry?.key !== candidate.key || entry?.fingerprint !== candidate.endpointFingerprint) continue
-    if (MODEL_WIDE_NON_RETRYABLE_BACKGROUND_FAILURES.has(entry.errorClass)) return true
+
+    if (
+      entry?.retryable === false &&
+      entry?.key === candidate.key &&
+      entry?.fingerprint === candidate.endpointFingerprint &&
+      MODEL_WIDE_NON_RETRYABLE_BACKGROUND_FAILURES.has(entry.errorClass)
+    ) return true
+
+    if (
+      transportScope &&
+      entry?.transportScope === transportScope &&
+      TRANSPORT_WIDE_BACKGROUND_FAILURES.has(entry.errorClass) &&
+      (entry.retryable === false || (Number.isFinite(until) && until > at))
+    ) return true
   }
   return false
 }
@@ -307,7 +307,7 @@ async function chooseNextWork({ ctx, config, core, store, now, backoff, excluded
       excluded.set(candidate.key, { key: candidate.key, reason: 'measured-text-only' })
       continue
     }
-    if (candidateBlockedByNonRetryableFailure(backoff, candidate, now)) continue
+    if (candidateBlockedByFailure(backoff, candidate, now)) continue
     const eligibility = unattendedEligibility(ctx, candidate, authority.backgroundMeasurement, core)
     if (eligibility.eligible) {
       candidates.push(candidate)
@@ -674,6 +674,21 @@ export function createBackgroundCapabilityProfiler({
     }
   }
 
+  const credentialsChanged = (ref) => {
+    const changedRef = typeof ref === 'string' ? ref.trim() : ''
+    for (const [key, entry] of backoff.entries()) {
+      if (entry?.errorClass !== 'auth') continue
+      if (changedRef && entry.credentialRef && entry.credentialRef !== changedRef) continue
+      backoff.delete(key)
+    }
+    topologyDirty = true
+    yieldBackground('credential reference changed')
+    if (!runningController) {
+      topologyDirty = false
+      schedule(0)
+    }
+  }
+
   const tick = async () => {
     if (stopped || runningController) return
     const currentNow = Number(now())
@@ -784,22 +799,24 @@ export function createBackgroundCapabilityProfiler({
           : undefined
         const until = failure.retryable
           ? failureAt + transientDelay
-          : policy.persist === true && persistentTtl !== undefined
+          : persistentTtl !== undefined
             ? failureAt + persistentTtl
             : undefined
-        const credentialFingerprint = policy.credentialScoped === true
-          ? await candidateCredentialFingerprint(ctx, work.candidate)
-          : undefined
 
         if (failure.errorClass === 'unsupported-image') {
           await markCandidateUnsupported(work.candidate)
         } else {
+          const transportScope = transportFailureScope(work.candidate, failure.errorClass)
+          const credentialRef = failure.errorClass === 'auth' && typeof work.candidate.endpointCredentialRef === 'string'
+            ? work.candidate.endpointCredentialRef.trim()
+            : ''
           backoff.set(key, {
             key: work.candidate.key,
             fingerprint: work.candidate.endpointFingerprint,
             axis: work.axis,
             ...failure,
-            ...(credentialFingerprint ? { credentialFingerprint } : {}),
+            ...(transportScope ? { transportScope } : {}),
+            ...(credentialRef ? { credentialRef } : {}),
             ...(until !== undefined ? { until } : {}),
           })
         }
@@ -819,7 +836,6 @@ export function createBackgroundCapabilityProfiler({
               axis: work.axis,
               errorClass: failure.errorClass,
               errorCode: failure.errorCode,
-              credentialFingerprint,
               recordedAt: failureAt,
               expiresAt: until,
             })
@@ -886,6 +902,7 @@ export function createBackgroundCapabilityProfiler({
     wake,
     settingsChanged,
     topologyChanged,
+    credentialsChanged,
     stop,
     foregroundStart,
     foregroundEnd,
@@ -980,11 +997,21 @@ export function installBackgroundCapabilityProfiling(ctx, config, core, store, o
     if (namespace === undefined || String(namespace) === 'vision-router') profiler.settingsChanged()
   }
   const wakeForModels = () => profiler.topologyChanged()
+  const credentialAliasLatch = new Set()
+  const wakeForCredentials = (ref) => {
+    const key = typeof ref === 'string' && ref.trim() !== '' ? ref.trim() : '*'
+    if (credentialAliasLatch.has('*') || credentialAliasLatch.has(key) || (key === '*' && credentialAliasLatch.size > 0)) return
+    credentialAliasLatch.add(key)
+    queueMicrotask(() => { credentialAliasLatch.delete(key) })
+    profiler.credentialsChanged(ref)
+  }
   try {
     if (typeof ctx?.on === 'function') {
       for (const [event, handler] of [
         ['settings/updated', wakeForSettings],
         ['settings/document-updated', wakeForSettings],
+        ['credentials/reference-updated', wakeForCredentials],
+        ['credentials/updated', wakeForCredentials],
         ['llm/adapters-updated', wakeForModels],
       ]) {
         const stop = ctx.on(event, handler)

--- a/lib/vision-background-failure-policy.js
+++ b/lib/vision-background-failure-policy.js
@@ -7,64 +7,41 @@ const DEFAULT_POLICY = Object.freeze({
   persist: false,
   retryAfterMs: undefined,
   ttlMs: undefined,
-  credentialScoped: false,
 })
 
 const POLICIES = Object.freeze({
   auth: Object.freeze({
     retryable: false,
-    persist: true,
+    persist: false,
     ttlMs: BACKGROUND_AUTH_STOP_TTL_MS,
-    credentialScoped: true,
   }),
   protocol: Object.freeze({
     retryable: false,
     persist: true,
     ttlMs: BACKGROUND_ENDPOINT_STOP_TTL_MS,
-    credentialScoped: false,
   }),
   unavailable: Object.freeze({
     retryable: false,
     persist: true,
     ttlMs: BACKGROUND_ENDPOINT_STOP_TTL_MS,
-    credentialScoped: false,
   }),
   'unsupported-image': Object.freeze({
     retryable: false,
     persist: false,
-    credentialScoped: false,
   }),
   'visual-proof': Object.freeze({
     retryable: true,
     persist: false,
     retryAfterMs: BACKGROUND_TRANSIENT_RETRY_MS,
-    credentialScoped: false,
   }),
   infrastructure: Object.freeze({
     retryable: true,
     persist: false,
     retryAfterMs: BACKGROUND_TRANSIENT_RETRY_MS,
-    credentialScoped: false,
   }),
 })
 
 /** Failure lifetime is separate from failure classification. */
 export function backgroundFailurePolicy(errorClass) {
   return POLICIES[String(errorClass ?? '')] ?? DEFAULT_POLICY
-}
-
-function unresolvedFingerprint(value) {
-  return typeof value !== 'string' || value === '' || value === 'unresolved'
-}
-
-/**
- * Credential transitions are intentionally asymmetric. Losing visibility of a
- * previously resolved credential is not proof that the account changed, so the
- * old stop remains conservative. Gaining a concrete fingerprint after an
- * unresolved state is observable recovery and must release the stale stop.
- */
-export function credentialFingerprintChanged(stored, current) {
-  if (unresolvedFingerprint(current)) return false
-  if (unresolvedFingerprint(stored)) return true
-  return stored !== current
 }

--- a/lib/vision-background-stop-store.js
+++ b/lib/vision-background-stop-store.js
@@ -4,13 +4,13 @@ import process from 'node:process'
 import { resolveDshHome } from './doctor.js'
 import { CAPABILITY_BENCHMARK_SUITE_REVISION } from './vision-capability-benchmark.js'
 
-// v1 stops had no expiry and could poison a backend forever. Do not migrate
-// them: a cache-version bump intentionally drops that stale authority.
-const CACHE_VERSION = 2
+// v1 stops had no expiry; v2 AUTH stops also persisted a secret-derived
+// credential fingerprint. Do not migrate either format: v3 persists only
+// non-secret endpoint/model stop evidence.
+const CACHE_VERSION = 3
 const MAX_ENTRIES = 256
 const AXES = new Set(['ocr', 'general', 'document', 'structured', 'grounding'])
-const CLASSES = new Set(['auth', 'unavailable', 'protocol'])
-const CREDENTIAL_FINGERPRINT_RE = /^(?:cred_[0-9a-f]{24}|unresolved|none)$/
+const CLASSES = new Set(['unavailable', 'protocol'])
 
 function cleanText(value, max = 256) {
   return typeof value === 'string' && value.trim() !== '' ? value.trim().slice(0, max) : ''
@@ -27,13 +27,11 @@ function cleanStop(value) {
   const axis = cleanText(value.axis, 32)
   const errorClass = cleanText(value.errorClass, 48)
   const errorCode = cleanText(value.errorCode, 96)
-  const credentialFingerprint = cleanText(value.credentialFingerprint, 64)
   const recordedAt = Number(value.recordedAt)
   const expiresAt = Number(value.expiresAt)
   if (!key || !provider || !model || !AXES.has(axis) || !CLASSES.has(errorClass)) return undefined
   if (!Number.isFinite(recordedAt) || recordedAt <= 0) return undefined
   if (!Number.isFinite(expiresAt) || expiresAt <= recordedAt) return undefined
-  if (credentialFingerprint && !CREDENTIAL_FINGERPRINT_RE.test(credentialFingerprint)) return undefined
   return {
     fingerprint,
     key,
@@ -42,7 +40,6 @@ function cleanStop(value) {
     axis,
     errorClass,
     ...(errorCode ? { errorCode } : {}),
-    ...(errorClass === 'auth' && credentialFingerprint ? { credentialFingerprint } : {}),
     recordedAt,
     expiresAt,
     suiteRevision: CAPABILITY_BENCHMARK_SUITE_REVISION,
@@ -61,11 +58,13 @@ async function load(file, fsOps, at) {
   try {
     const raw = await fsOps.readFile(file, 'utf8')
     const body = JSON.parse(raw)
-    if (!body || body.version !== CACHE_VERSION || !Array.isArray(body.stops)) return new Map()
-    const records = body.stops
+    if (!body || !Array.isArray(body.stops) || ![2, CACHE_VERSION].includes(body.version)) return new Map()
+    const records = new Map(body.stops
       .map(cleanStop)
       .filter((item) => item && item.expiresAt > at)
-    return new Map(records.map((item) => [recordKey(item), item]))
+      .map((item) => [recordKey(item), item]))
+    if (body.version === 2) await save(file, records, fsOps, at)
+    return records
   } catch (error) {
     if (error?.code === 'ENOENT') return new Map()
     return new Map()
@@ -132,7 +131,6 @@ export function createBackgroundBenchmarkStopStore(options = {}) {
       axis,
       errorClass,
       errorCode,
-      credentialFingerprint,
       recordedAt = Number(now()),
       expiresAt,
     } = {}) {
@@ -146,7 +144,6 @@ export function createBackgroundBenchmarkStopStore(options = {}) {
         axis,
         errorClass,
         errorCode,
-        credentialFingerprint,
         recordedAt,
         expiresAt,
         suiteRevision: CAPABILITY_BENCHMARK_SUITE_REVISION,

--- a/tests/doctor-host-capabilities.test.js
+++ b/tests/doctor-host-capabilities.test.js
@@ -52,6 +52,18 @@ test('Doctor capability probe fails open to unknown', async () => {
   assert.equal(probe.capabilities.prepareCall, 'unknown')
 })
 
+test('authenticated capability route reports auth-required unknown without claiming Host capabilities', async () => {
+  const probe = await probeDoctorHostCapabilities({
+    baseUrl: 'http://127.0.0.1:3080',
+    fetchImpl: async () => ({ ok: false, status: 401 }),
+  })
+  assert.equal(probe.ok, false)
+  assert.equal(probe.source, 'runtime-auth-required')
+  assert.equal(probe.status, 401)
+  assert.equal(probe.capabilities.batchAttachments, 'unknown')
+  assert.equal(probe.capabilities.prepareCall, 'unknown')
+})
+
 test('missing capability route is advisory rather than a Doctor failure', async () => {
   const probe = await probeDoctorHostCapabilities({
     baseUrl: 'http://127.0.0.1:3080',

--- a/tests/doctor-runtime.test.js
+++ b/tests/doctor-runtime.test.js
@@ -33,6 +33,22 @@ test('runtime probe uses a side-effect-free rejected method and catches SPA fall
   assert.equal(report.ok, false)
 })
 
+test('token-authenticated DSH Web is reachable but keeps runtime route health advisory', async () => {
+  const report = await probeRuntime({
+    requestedProfile: 'web',
+    dshHome: '/tmp/dsh-home',
+    applicableProfiles: ['web'],
+    fetchImpl: async () => response(401),
+  })
+  assert.equal(report.reachable, true)
+  assert.equal(report.authenticationRequired, true)
+  assert.equal(report.routeOk, false)
+  assert.equal(report.ok, true, 'browser authentication must not make offline/static Doctor checks fail')
+  assert.equal(report.ownership.verified, false)
+  assert.equal(report.ownership.reason, 'runtime-auth-required')
+  assert.ok(report.routes.every((item) => item.status === 401 && item.ok === false))
+})
+
 test('405 plus the exact Allow contract confirms unbound routes without executing them', async () => {
   const report = await probeRuntime({ fetchImpl: async (url, init) => {
     assert.equal(init.redirect, 'manual')
@@ -114,4 +130,5 @@ test('support report is schema-versioned, identifies doctor version, and omits r
   assert.equal(json.includes('private-session-id'), false)
   assert.equal(json.includes('raw-secret-error'), false)
   assert.equal(report.runtime.baseUrl, 'http://127.0.0.1:3080/private')
+  assert.equal(report.runtime.authenticationRequired, false)
 })

--- a/tests/vision-background-benchmark-productization.test.js
+++ b/tests/vision-background-benchmark-productization.test.js
@@ -230,6 +230,53 @@ test('partial profile fills only the first missing axis instead of restarting co
   assert.deepEqual(seen, ['document'])
 })
 
+test('rate-limit backoff pauses sibling models on the same transport until retry time', async () => {
+  const config = configFor([
+    ['relay', 'vision-a'],
+    ['relay', 'vision-b'],
+  ])
+  const ctx = fakeCtx(config, {
+    piProviders: {
+      relay: {
+        baseURL: 'https://relay.example/v1',
+        api: 'openai-completions',
+        apiKeyEnv: 'RELAY_KEY',
+      },
+    },
+  })
+  let clock = 50_000
+  const seen = []
+  const profiler = createBackgroundCapabilityProfiler({
+    ctx,
+    config,
+    core: fakeCore(),
+    store: memoryStore(),
+    now: () => clock,
+    idleMs: 0,
+    gapMs: 0,
+    scanMs: 0,
+    setTimer: inertTimer,
+    clearTimer() {},
+    runAxisBenchmark: async ({ candidate, axis }) => {
+      seen.push([candidate.key, axis])
+      const error = new Error('HTTP 429 too many requests')
+      error.status = 429
+      error.code = 'RATE_LIMITED'
+      throw error
+    },
+  })
+
+  await profiler.tick()
+  assert.deepEqual(seen, [['relay/vision-a', 'ocr']])
+  await profiler.tick()
+  assert.deepEqual(seen, [['relay/vision-a', 'ocr']], 'sibling model must share the transport cooldown')
+
+  clock += 30 * 60 * 1000 + 1
+  await profiler.tick()
+  assert.equal(seen.length, 2, 'transport becomes eligible after the bounded transient retry window')
+  profiler.stop()
+})
+
 test('background failure classification distinguishes permanent and transient causes', () => {
   const auth = Object.assign(new Error('HTTP 401 unauthorized'), { status: 401 })
   assert.deepEqual(classifyBackgroundBenchmarkFailure(auth), {

--- a/tests/vision-background-benchmark.test.js
+++ b/tests/vision-background-benchmark.test.js
@@ -385,6 +385,29 @@ test('manual benchmark lease pauses and preempts background profiling until all 
   profiler.stop()
 })
 
+test('installed profiler subscribes to current and legacy credential invalidation events', () => {
+  const config = settings({ backgroundBenchmarking: 'all' })
+  const listeners = new Map()
+  const base = fakeCtx(config)
+  const ctx = {
+    ...base,
+    on(event, handler) {
+      listeners.set(event, handler)
+      return () => listeners.delete(event)
+    },
+  }
+  const store = memoryStore()
+  const installed = installBackgroundCapabilityProfiling(ctx, config, fakeCore(), store, {
+    idleMs: 60_000,
+    setTimer: inertTimer,
+    clearTimer() {},
+    runAxisBenchmark: async () => {},
+  })
+  assert.equal(typeof listeners.get('credentials/reference-updated'), 'function')
+  assert.equal(typeof listeners.get('credentials/updated'), 'function')
+  installed.profiler.stop()
+})
+
 test('installed profiler is shared through the capability store without becoming enumerable persisted data', () => {
   const config = settings()
   const store = memoryStore()

--- a/tests/vision-background-lifecycle.test.js
+++ b/tests/vision-background-lifecycle.test.js
@@ -7,9 +7,9 @@ import {
   backgroundFailurePolicy,
   BACKGROUND_AUTH_STOP_TTL_MS,
   BACKGROUND_ENDPOINT_STOP_TTL_MS,
-  credentialFingerprintChanged,
 } from '../lib/vision-background-failure-policy.js'
 import { createBackgroundBenchmarkStopStore } from '../lib/vision-background-stop-store.js'
+import { CAPABILITY_BENCHMARK_SUITE_REVISION } from '../lib/vision-capability-benchmark.js'
 import { createBackgroundCapabilityProfiler } from '../lib/vision-background-benchmark.js'
 
 const FINGERPRINT = `ep2_${'a'.repeat(32)}`
@@ -23,52 +23,75 @@ test('background failure policy separates transient retry from persistent stop a
     retryable: true,
     persist: false,
     retryAfterMs: 30 * 60 * 1000,
-    credentialScoped: false,
   })
   assert.deepEqual(backgroundFailurePolicy('infrastructure'), {
     retryable: true,
     persist: false,
     retryAfterMs: 30 * 60 * 1000,
-    credentialScoped: false,
   })
   assert.deepEqual(backgroundFailurePolicy('auth'), {
     retryable: false,
-    persist: true,
+    persist: false,
     ttlMs: BACKGROUND_AUTH_STOP_TTL_MS,
-    credentialScoped: true,
   })
   assert.equal(backgroundFailurePolicy('protocol').ttlMs, BACKGROUND_ENDPOINT_STOP_TTL_MS)
   assert.equal(backgroundFailurePolicy('unavailable').ttlMs, BACKGROUND_ENDPOINT_STOP_TTL_MS)
   assert.equal(backgroundFailurePolicy('unsupported-image').persist, false)
 })
 
-test('credential stop invalidation is conservative only while current identity is unresolved', () => {
-  assert.equal(credentialFingerprintChanged('unresolved', 'cred_111111111111111111111111'), true)
-  assert.equal(credentialFingerprintChanged('cred_aaaaaaaaaaaaaaaaaaaaaaaa', 'cred_bbbbbbbbbbbbbbbbbbbbbbbb'), true)
-  assert.equal(credentialFingerprintChanged('cred_aaaaaaaaaaaaaaaaaaaaaaaa', 'unresolved'), false)
-  assert.equal(credentialFingerprintChanged('unresolved', 'unresolved'), false)
-})
-
-test('background stop cache v2 drops legacy permanent stops and expires bounded stops', async () => {
-  const root = await mkdtemp(path.join(tmpdir(), 'vision-background-stop-v2-'))
+test('background stop cache v3 drops secret-derived auth stops and expires bounded endpoint stops', async () => {
+  const root = await mkdtemp(path.join(tmpdir(), 'vision-background-stop-v3-'))
   const cacheFile = path.join(root, 'stops.json')
   let clock = 1_000
   try {
     await writeFile(cacheFile, JSON.stringify({
-      version: 1,
-      stops: [{
-        fingerprint: FINGERPRINT,
-        key: 'http:paid/vision',
-        provider: 'vision-http',
-        model: 'paid/vision',
-        axis: 'ocr',
-        errorClass: 'auth',
-        recordedAt: 100,
-        suiteRevision: 3,
-      }],
+      version: 2,
+      stops: [
+        {
+          fingerprint: FINGERPRINT,
+          key: 'http:paid/vision',
+          provider: 'vision-http',
+          model: 'paid/vision',
+          axis: 'ocr',
+          errorClass: 'auth',
+          credentialFingerprint: 'cred_aaaaaaaaaaaaaaaaaaaaaaaa',
+          recordedAt: 100,
+          expiresAt: 1_050,
+          suiteRevision: CAPABILITY_BENCHMARK_SUITE_REVISION,
+        },
+        {
+          fingerprint: FINGERPRINT,
+          key: 'http:paid/vision',
+          provider: 'vision-http',
+          model: 'paid/vision',
+          axis: 'general',
+          errorClass: 'protocol',
+          recordedAt: 100,
+          expiresAt: 1_050,
+          suiteRevision: CAPABILITY_BENCHMARK_SUITE_REVISION,
+        },
+      ],
     }))
     const store = createBackgroundBenchmarkStopStore({ cacheFile, now: () => clock })
-    assert.deepEqual(await store.list(), [], 'v1 unbounded stop authority must not migrate')
+    const migrated = await store.list()
+    assert.equal(migrated.length, 1, 'safe v2 endpoint stops migrate while secret-derived AUTH stops are dropped')
+    assert.equal(migrated[0].errorClass, 'protocol')
+    const migratedDisk = JSON.parse(await readFile(cacheFile, 'utf8'))
+    assert.equal(migratedDisk.version, 3)
+    assert.equal(JSON.stringify(migratedDisk).includes('credentialFingerprint'), false)
+
+    const auth = await store.mark({
+      fingerprint: FINGERPRINT,
+      key: 'http:paid/vision',
+      provider: 'vision-http',
+      model: 'paid/vision',
+      axis: 'ocr',
+      errorClass: 'auth',
+      recordedAt: clock,
+      expiresAt: clock + BACKGROUND_AUTH_STOP_TTL_MS,
+    })
+    assert.equal(auth, undefined, 'AUTH stops are process-local and never enter the persistent cache')
+    await store.clearStop(FINGERPRINT, 'general')
 
     const marked = await store.mark({
       fingerprint: FINGERPRINT,
@@ -87,18 +110,25 @@ test('background stop cache v2 drops legacy permanent stops and expires bounded 
     assert.deepEqual(await store.list(), [])
     await store.flush()
     const disk = JSON.parse(await readFile(cacheFile, 'utf8'))
-    assert.equal(disk.version, 2)
+    assert.equal(disk.version, 3)
     assert.deepEqual(disk.stops, [])
   } finally {
     await rm(root, { recursive: true, force: true })
   }
 })
 
-test('AUTH background stop is invalidated when an unresolved credential becomes observable', async () => {
-  const paid = {
-    name: 'paid-cloud',
+test('AUTH background stop is in-memory, transport-wide, and credential change releases it immediately', async () => {
+  const paidA = {
+    name: 'paid-cloud-a',
     baseURL: 'https://paid.example.invalid/v1',
-    model: 'vision-paid',
+    model: 'vision-paid-a',
+    apiKeyEnv: 'PAID_KEY',
+    maxTokens: 512,
+  }
+  const paidB = {
+    name: 'paid-cloud-b',
+    baseURL: 'https://paid.example.invalid/v1',
+    model: 'vision-paid-b',
     apiKeyEnv: 'PAID_KEY',
     maxTokens: 512,
   }
@@ -106,15 +136,16 @@ test('AUTH background stop is invalidated when an unresolved credential becomes 
     routingMode: 'auto',
     routingPreference: 'balanced',
     backgroundBenchmarking: 'all',
-    providers: [{ provider: 'vision-http', model: 'paid-cloud/vision-paid', fallbacks: [] }],
-    httpProviders: [paid],
+    providers: [
+      { provider: 'vision-http', model: 'paid-cloud-a/vision-paid-a', fallbacks: [] },
+      { provider: 'vision-http', model: 'paid-cloud-b/vision-paid-b', fallbacks: [] },
+    ],
+    httpProviders: [paidA, paidB],
   }
-  let secret
   const ctx = {
     logger: { info() {}, warn() {} },
     get(name) {
       if (name === 'settings') return { get: () => config }
-      if (name === 'credentials') return { resolve: async () => ({ value: secret }) }
       return undefined
     },
     llm: {
@@ -127,33 +158,18 @@ test('AUTH background stop is invalidated when an unresolved credential becomes 
     adapterAvailable: () => true,
     decideVisionBackendCapability: () => ({ image: true, attemptable: true }),
     localProvidersOf: () => [],
-    httpProvidersOf: () => [paid],
+    httpProvidersOf: () => [paidA, paidB],
   }
   const store = {
     async get() { return undefined },
     async put(record) { return record },
   }
-  const stops = []
-  let cleared = 0
+  const persisted = []
   const backgroundStopStore = {
-    async list() { return [...stops] },
-    async mark(stop) { stops.splice(0, stops.length, stop); return stop },
-    async clearStop(fingerprint, axis) {
-      const index = stops.findIndex((item) => item.fingerprint === fingerprint && item.axis === axis)
-      if (index < 0) return false
-      stops.splice(index, 1)
-      cleared += 1
-      return true
-    },
-    async clearFingerprint(fingerprint) {
-      let removed = false
-      for (let index = stops.length - 1; index >= 0; index -= 1) {
-        if (stops[index].fingerprint !== fingerprint) continue
-        stops.splice(index, 1)
-        removed = true
-      }
-      return removed
-    },
+    async list() { return [] },
+    async mark(stop) { persisted.push(stop); return stop },
+    async clearStop() { return false },
+    async clearFingerprint() { return false },
   }
   let clock = 100_000
   let calls = 0
@@ -185,18 +201,17 @@ test('AUTH background stop is invalidated when an unresolved credential becomes 
 
   await profiler.tick()
   assert.equal(calls, 1)
-  assert.equal(stops.length, 1)
-  assert.equal(stops[0].credentialFingerprint, 'unresolved')
-  assert.equal(stops[0].expiresAt, clock + BACKGROUND_AUTH_STOP_TTL_MS)
   assert.equal(profiler.snapshot().backoffSize, 1)
+  assert.deepEqual(persisted, [], 'AUTH failures must never persist secret-derived credential identity')
 
-  secret = 'new-secret'
+  await profiler.tick()
+  assert.equal(calls, 1, 'same transport sibling must not rotate into another 401 on the next 15s slot')
+
   failAuth = false
+  profiler.credentialsChanged('PAID_KEY')
+  assert.equal(profiler.snapshot().backoffSize, 0, 'credential event releases the in-memory AUTH stop synchronously')
   clock += 1
   await profiler.tick()
-  assert.equal(calls, 2, 'newly observable credential must make the backend eligible immediately')
-  assert.equal(cleared, 1, 'the stale persistent AUTH stop must be removed')
-  assert.deepEqual(stops, [])
-  assert.equal(profiler.snapshot().backoffSize, 0)
+  assert.equal(calls, 2, 'new credential can revalidate immediately without waiting for the AUTH TTL')
   profiler.stop()
 })


### PR DESCRIPTION
## Summary

Follow up on the stable `0.1.2-rc.1` real-machine retest report without papering over Host-only limitations.

- Treat background `auth`, `protocol`, and `rate-limit` failures as transport-scoped cooldown evidence so one bad endpoint/account does not rotate through sibling models and axes every 15s.
- Keep ordinary network/timeout/visual-proof failures model/axis-scoped.
- Remove persisted AUTH credential fingerprints entirely. AUTH stops are now bounded process-local state, cleared synchronously by current `credentials/reference-updated` and legacy `credentials/updated` events.
- Migrate v2 background-stop cache to v3 by preserving safe protocol/unavailable stops while scrubbing secret-derived AUTH stop data.
- Treat an all-401 DSH Web runtime probe as reachable-but-authentication-required: route health and ownership stay unknown, but Doctor no longer prints false route failures or fails the offline/static diagnosis.
- Keep Host capability support advice unknown under 401; no browser-cookie/token bypass is introduced.

Not changed here: stable Host generic-file/drop behavior, absence of a click-upload UI in rc.1, duplicate attachments from two distinct user paste actions, or third-party memory-evolve 404s.

## Verification

- focused Doctor/background tests: 47/47
- `pnpm test:contract`: 146/146
- `pnpm test`: 1299 tests, 1298 pass, 0 fail, 1 expected skip
- backend runtime policy: 6/6
- `git diff --check`
