### PR TITLE
chore(release): prepare v2.1.4

### DIFF
--- a/docs/releases/v2.1.4.md
+++ b/docs/releases/v2.1.4.md
@@ -1,0 +1,34 @@
+# v2.1.4
+
+DVR 2.1.4 is a compatibility and reliability patch for the current DSH stable/preview trains. It hardens Windows capture, OpenCode Go session affinity, attachment/timeout lifecycle boundaries, live-model credentials, background capability measurement, and Doctor diagnostics without changing the public 2.1.x routing model.
+
+## Runtime reliability
+
+- Replaces the legacy Windows DPI screenshot shim with a dedicated PMv2 → PMv1 DPI-aware desktop capture path. Compilation uses an isolated ASCII temp directory so non-ASCII Windows user profiles no longer break `Add-Type`, while incorrect DPI contexts still fail closed instead of returning a cropped desktop.
+- Propagates the real DSH session identity through vision child calls and isolates OpenCode Go wire affinity from internal Session identity. Direct Go requests without a stable session fail closed, existing upstream `x-opencode-session` headers remain authoritative, and benchmark traffic uses isolated synthetic affinity rather than contaminating user sessions.
+- Bounds the user-facing lifetime of vision tools across Host attachment saves by combining the ambient turn signal, Host execution signal, and live `visionTaskTimeoutMs` deadline. Late plugin work observes the spent signal even though the Host attachment store itself has no physical cancellation primitive.
+- Keeps `visionTaskTimeoutMs` hot: Settings changes are read on the next invocation without restarting DSH or re-registering tools.
+
+## DSH stable / preview compatibility
+
+- Adds exact compatibility evidence for DSH `0.1.2-rc.1` and `0.1.3-alpha.2`, including real Host contracts, pi-ai wire behavior, Session-v2 restart coverage, cold Vision-toggle browser smoke, and alpha mixed generic-file paste lifecycle.
+- Splits scheduled release canaries into npm `latest` (stable) and npm `alpha` (preview). These moving canaries automatically test newly published DSH trains while fixed exact-version gates preserve reproducible compatibility evidence.
+- Hardens bitmap normalization and alpha mixed paste so MIME/extension mismatches, text+image+generic-file combinations, and duplicate lifecycle delivery cannot silently corrupt attachment intake.
+
+## Security, discovery, and diagnostics
+
+- Separates public Host support policy from compatibility verification evidence. DVR 2.1.x keeps `0.1.0-rc.8` as its public minimum and `0.1.2-rc.1` as the current stable Host, while exact preview evidence and moving npm canaries are reported separately and never become an implicit support promise.
+- Removes secret-derived data from live-model route fingerprints and from persisted background AUTH stops. Credential rotation is handled by the current `credentials/reference-updated` event with legacy-event compatibility, immediately invalidating stale evidence and revalidating with the new credential.
+- Makes unattended background failures quieter and more accurate: authentication, protocol, and rate-limit failures share bounded transport-scope cooldowns instead of rotating through sibling models/axes every short gap, while ordinary network/timeout failures remain narrowly axis-scoped.
+- Treats token-authenticated DSH Web correctly in Doctor. A blanket `401` now means “runtime reachable, browser authentication required, route health unknown” instead of a false route failure; Doctor does not bypass the Host’s signed-cookie boundary.
+- Closes the remaining CodeQL findings without dismissing them; current Code Scanning is clean.
+
+## Validation
+
+- Covered by Node 22/24, DSH rc.6/rc.7/rc.8 contracts, exact stable `0.1.2-rc.1`, exact preview `0.1.3-alpha.2`, Windows Node 24 screenshot runtime, provider transport, routing parity, Session surfaces, real browser lifecycle gates, and CodeQL.
+- Local release-candidate verification completed with the full test suite at zero failures, contract tests at zero failures, and backend runtime policy coverage green.
+- No Settings migration is required. Restart DSH Web/Desktop after upgrading so the new runtime and browser-side compatibility logic are loaded.
+
+## Upgrade
+
+Upgrade to 2.1.4 and restart DSH Web/Desktop. Existing Vision Router settings remain compatible.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-vision-router",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Eyes for text-only DeepSeek Harness agents: built-in free vision chain (no key) + pixel-level vision tools (Q&A, grounding, crop, pixel diff, colors, OCR, SVG trace, cutout, screenshots). One-command install, no Python, image turns work like ordinary tool-calling turns.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
- bump package version to 2.1.4
- add curated v2.1.4 release notes for the post-2.1.3 reliability/compatibility fixes

## Local release gates
- pnpm test: 1299 tests, 1298 pass, 0 fail, 1 expected skip; backend runtime policy 6/6
- pnpm test:contract: 146/146
- npm pack --dry-run: dsh-vision-router@2.1.4
- git diff --check

After merge, dispatch release.yml with tag v2.1.4 and the exact merged main SHA.