### PR TITLE
ci: bound adversarial fuzz and security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,12 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+
+  # Keep ordinary npm version churn out of the support policy. DSH latest/preview
+  # movement is handled by the dedicated canaries; this entry exists so
+  # Dependabot can still open vulnerability-only package updates.
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0

--- a/.github/workflows/adversarial-fuzz.yml
+++ b/.github/workflows/adversarial-fuzz.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
-      DVR_FUZZ_CASES: ${{ github.event_name == 'schedule' && '10000' || '1500' }}
+      DVR_FUZZ_CASES: ${{ github.event_name == 'schedule' && '1500' || '500' }}
       DVR_FUZZ_SEED: '1592639710'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  phin: 3.7.1
+
 importers:
 
   .:
@@ -630,10 +633,6 @@ packages:
   parse-headers@2.0.6:
     resolution: {integrity: sha512-Tz11t3uKztEW5FEVZnj1ox8GKblWn+PvHY9TmJV5Mll2uHEwRdR/5Li1OlXoECjLYkApdhWy44ocONwXLiKO5A==}
 
-  phin@2.9.3:
-    resolution: {integrity: sha512-CzFr90qM24ju5f88quFC/6qohjC144rehe5n6DH900lgXmUe86+xCKc10ev56gRKC4/BkHUoG4uSiQgBiIXwDA==}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
-
   phin@3.7.1:
     resolution: {integrity: sha512-GEazpTWwTZaEQ9RhL7Nyz0WwqilbqgLahDM3D0hxWwmVDI52nXEybHqiN6/elwpkJBhcuj+WbBu+QfT0uhPGfQ==}
     engines: {node: '>= 8'}
@@ -979,7 +978,7 @@ snapshots:
       file-type: 9.0.0
       load-bmfont: 1.4.2
       mkdirp: 0.5.6
-      phin: 2.9.3
+      phin: 3.7.1
       pixelmatch: 4.0.2
       tinycolor2: 1.6.0
     transitivePeerDependencies:
@@ -1350,8 +1349,6 @@ snapshots:
       xml2js: 0.5.0
 
   parse-headers@2.0.6: {}
-
-  phin@2.9.3: {}
 
   phin@3.7.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,3 +6,8 @@ allowBuilds:
 # exempts only that one version and goes stale on the next release.
 minimumReleaseAgeExclude:
   - '@deepseek-ai/*'
+
+# potrace -> Jimp 0.14 accepts phin's callback API; pin the patched major so
+# Jimp cannot retain the vulnerable redirect/header implementation (GHSA-x565-32qp-m3vf).
+overrides:
+  phin: 3.7.1

--- a/scripts/security-adversarial-fuzz.mjs
+++ b/scripts/security-adversarial-fuzz.mjs
@@ -10,7 +10,7 @@ import { redactDiagnosticText } from '../lib/diagnostic-redaction.js'
 import { resolveVisionRoutingAuthority } from '../lib/vision-routing-authority.js'
 import { isOfficialOpenCodeGoUrl, wireSessionAffinityId } from '../lib/session-affinity.js'
 
-const cases = Math.max(100, Math.min(100_000, Number(process.env.DVR_FUZZ_CASES) || 1_500))
+const cases = Math.max(100, Math.min(10_000, Number(process.env.DVR_FUZZ_CASES) || 500))
 let state = Number(process.env.DVR_FUZZ_SEED) || 0x5eedc0de
 
 function random() {
@@ -82,6 +82,29 @@ for (let i = 0; i < cases; i += 1) {
     assert.match(wire, /^[\x21-\x7e](?:[\x20-\x7e]*[\x21-\x7e])?$/)
   }
 }
+// Exercise the exact bounded extremes once instead of rebuilding an enormous
+// random shape thousands of times. Random cases search shape combinations; this
+// deterministic case proves the provider/fallback caps themselves.
+const boundaryConfig = normalizeRuntimeVisionConfig({
+  providers: Array.from({ length: MAX_RUNTIME_PROVIDER_ROWS + 16 }, (_, index) => ({
+    provider: `provider-${index}`,
+    model: `model-${index}`,
+    fallbacks: Array.from(
+      { length: MAX_RUNTIME_FALLBACKS_PER_ROW + 16 },
+      (_, fallback) => `fallback-${fallback}`,
+    ),
+  })),
+  fallbacks: Array.from(
+    { length: MAX_RUNTIME_FALLBACKS_PER_ROW + 16 },
+    (_, index) => `root-${index}`,
+  ),
+})
+assert.equal(boundaryConfig.providers.length, MAX_RUNTIME_PROVIDER_ROWS)
+assert.equal(boundaryConfig.fallbacks.length, MAX_RUNTIME_FALLBACKS_PER_ROW)
+for (const row of boundaryConfig.providers) {
+  assert.equal(row.fallbacks.length, MAX_RUNTIME_FALLBACKS_PER_ROW)
+}
+
 const bearer = `Bearer ${'A'.repeat(48)}`
 const apiKey = `sk-proj-${'B'.repeat(32)}`
 const diagnostic = redactDiagnosticText(


### PR DESCRIPTION
## Summary
- bound randomized adversarial fuzz so PR/nightly security jobs stay fast and deterministic
- keep exact provider/fallback upper bounds as explicit worst-case assertions
- configure npm Dependabot for vulnerability-only updates while leaving ordinary DSH version movement to stable/preview canaries
- fix Dependabot alert #1 by overriding the transitive Jimp `phin@2.9.3` to patched `phin@3.7.1`

## Security finding closed by this PR
Enabling the security automation surfaced GHSA-x565-32qp-m3vf (`phin <3.7.1`, Moderate) through `potrace -> jimp -> @jimp/core`. Jimp uses the same callback API retained by 3.7.1; after the workspace override the dependency graph contains one `phin@3.7.1` only.

## Validation
- adversarial fuzz: 500 cases ~3.2s; 1500 cases ~9.2s
- Potrace/SVG worker + timeout regressions: 6/6
- `pnpm test:contract`: 146/146
- `pnpm test`: 1298 pass, 0 fail, 1 expected skip; backend policy 6/6
- workflow/dependabot YAML parse; `git diff --check`

This follow-up also exercises the automatic Copilot adversarial review ruleset enabled by #424.
