### PR TITLE
ci: require Copilot review before merge

### DIFF
--- a/.github/workflows/copilot-review-gate.yml
+++ b/.github/workflows/copilot-review-gate.yml
@@ -1,0 +1,51 @@
+name: Copilot review gate
+
+on:
+  pull_request_review:
+    types: [submitted, dismissed]
+
+permissions: {}
+
+jobs:
+  copilot-review-gate:
+    name: Copilot review gate
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Require Copilot review of current PR head
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          EVENT_ACTION: ${{ github.event.action }}
+          EVENT_REVIEW_LOGIN: ${{ github.event.review.user.login }}
+          EVENT_REVIEW_TYPE: ${{ github.event.review.user.type }}
+          EVENT_REVIEW_STATE: ${{ github.event.review.state }}
+          EVENT_REVIEW_COMMIT_SHA: ${{ github.event.review.commit_id }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "$EVENT_ACTION" == "submitted" \
+            && "$EVENT_REVIEW_LOGIN" == "copilot-pull-request-reviewer[bot]" \
+            && "$EVENT_REVIEW_TYPE" == "Bot" \
+            && "$EVENT_REVIEW_COMMIT_SHA" == "$HEAD_SHA" \
+            && "$EVENT_REVIEW_STATE" != "DISMISSED" ]]; then
+            echo "Copilot review event covers current PR head $HEAD_SHA"
+            exit 0
+          fi
+
+          MATCHING_REVIEW_ID="$(
+            gh api --paginate \
+              "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" \
+              --jq ".[] | select(.user.login == \"copilot-pull-request-reviewer[bot]\" and .user.type == \"Bot\" and .commit_id == \"$HEAD_SHA\" and .state != \"DISMISSED\") | .id" \
+              | sed -n '1p'
+          )"
+
+          if [[ -z "$MATCHING_REVIEW_ID" ]]; then
+            echo "::error::Copilot has not completed a review for current PR head $HEAD_SHA"
+            exit 1
+          fi
+
+          echo "Copilot review $MATCHING_REVIEW_ID covers current PR head $HEAD_SHA"

--- a/tests/bundle-defaults.test.js
+++ b/tests/bundle-defaults.test.js
@@ -171,6 +171,21 @@ test('release workflow confines write tokens to non-executing tag/release phases
   assert.match(workflow, /sha256sum --check --strict/)
 })
 
+test('Copilot review gate requires a bot review for the current PR head', async () => {
+  const workflow = await readFile(new URL('../.github/workflows/copilot-review-gate.yml', import.meta.url), 'utf8')
+
+  assert.match(workflow, /pull_request_review:/)
+  assert.match(workflow, /types: \[submitted, dismissed\]/)
+  assert.match(workflow, /^permissions: \{\}$/m)
+  assert.match(workflow, /pull-requests: read/)
+  assert.doesNotMatch(workflow, /contents: write|statuses: write|actions\/checkout/)
+  assert.match(workflow, /copilot-pull-request-reviewer\[bot\]/)
+  assert.match(workflow, /EVENT_REVIEW_COMMIT_SHA.*HEAD_SHA/s)
+  assert.match(workflow, /\.commit_id == \\"\$HEAD_SHA\\"/)
+  assert.match(workflow, /\.state != \\"DISMISSED\\"/)
+  assert.match(workflow, /Copilot has not completed a review for current PR head/)
+})
+
 test('release runtime exposes one benchmark UI and no production v2 acceptance control surface', async () => {
   const entry = await readFile(new URL('../entry.js', import.meta.url), 'utf8')
   const runtimeComposition = await readFile(new URL('../lib/runtime-composition.js', import.meta.url), 'utf8')


### PR DESCRIPTION
## Summary
- add a read-only Copilot review gate triggered by submitted/dismissed PR reviews
- require a real GitHub Copilot bot review covering the current PR head SHA
- treat stale/dismissed Copilot reviews as insufficient
- add a permanent contract test for the gate

## Why
Automatic Copilot review alone is advisory: CI can finish before Copilot does. This gate is intended to become a required status check after merge, so a PR cannot merge until Copilot has reviewed its latest head. New pushes invalidate old reviews automatically because the gate matches `review.commit_id` to the current head SHA.

## Security boundary
The workflow checks out no PR code, requests no secrets, and has only `pull-requests: read`.

## Validation
- bundle-defaults: 16/16
- contract: 148/148
- full: 1300 pass, 0 fail, 1 expected skip; backend policy 6/6