### PR TITLE
ci: add trusted-base PR impact shadow classifier

### DIFF
--- a/.github/workflows/ci-impact-shadow.yml
+++ b/.github/workflows/ci-impact-shadow.yml
@@ -1,0 +1,51 @@
+name: CI impact shadow
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ci-impact-shadow-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  classify:
+    if: ${{ !github.event.pull_request.draft }}
+    name: trusted impact shadow
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    env:
+      GH_TOKEN: ${{ github.token }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+    steps:
+      - name: Checkout trusted base classifier
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+          path: trusted-base      - name: Install Node 24 for trusted classifier
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: '24'
+
+      - name: Collect changed filenames as JSON lines
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$PR_NUMBER" =~ ^[0-9]+$ ]] || { echo "::error::invalid PR number"; exit 1; }
+          gh api --paginate \
+            "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files?per_page=100" \
+            --jq '.[].filename | @json' \
+            > "$RUNNER_TEMP/dvr-ci-impact-files.jsonl"
+          test -s "$RUNNER_TEMP/dvr-ci-impact-files.jsonl"
+
+      - name: Report trusted shadow decision
+        shell: bash
+        run: |
+          set -euo pipefail
+          node trusted-base/scripts/ci-impact-classifier.mjs --json-lines \
+            < "$RUNNER_TEMP/dvr-ci-impact-files.jsonl"

--- a/.github/workflows/ci-impact-shadow.yml
+++ b/.github/workflows/ci-impact-shadow.yml
@@ -27,7 +27,9 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           persist-credentials: false
-          path: trusted-base      - name: Install Node 24 for trusted classifier
+          path: trusted-base
+
+      - name: Install Node 24 for trusted classifier
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: '24'

--- a/scripts/ci-impact-classifier.mjs
+++ b/scripts/ci-impact-classifier.mjs
@@ -38,16 +38,21 @@ const ROUTING_META = [
   /^tests\/bundle-defaults\.test\.js$/,
 ]
 
+const failClosedImpact = (reason) => ({
+  files: [], docsOnly: false, core: true, browser: true, host: true, windows: true, resource: true, native: true, full: true, reasons: [reason],
+})
+
 export function classifyCiImpact(paths) {
-  const normalized = paths.map((value) => String(value).trim()).filter(Boolean)
+  const normalized = paths.map((value) => String(value))
   const inputBytes = normalized.reduce((total, value) => total + Buffer.byteLength(value, 'utf8') + 1, 0)
   if (normalized.length > MAX_CI_IMPACT_PATHS || inputBytes > MAX_CI_IMPACT_INPUT_BYTES) {
-    return { files: [], docsOnly: false, core: true, browser: true, host: true, windows: true, resource: true, native: true, full: true, reasons: ['change-set exceeds classifier budget: fail closed'] }
+    return failClosedImpact('change-set exceeds classifier budget: fail closed')
   }
   const files = [...new Set(normalized)].sort()
-  if (files.length === 0) {
-    return { files, docsOnly: false, core: true, browser: true, host: true, windows: true, resource: true, native: true, full: true, reasons: ['empty-change-set: fail closed'] }
-  }
+  if (files.length === 0) return failClosedImpact('empty-change-set: fail closed')
+  const unsafe = files.filter((path) => path === '' || /[\u0000-\u001f\u007f]/.test(path)
+    || path.startsWith('/') || path.startsWith('./') || path === '..' || path.startsWith('../') || path.includes('/../'))
+  if (unsafe.length > 0) return failClosedImpact('unsafe changed path encoding: fail closed')
 
   const docsOnly = files.every((path) => matches(path, DOCS))
   const result = {
@@ -76,6 +81,28 @@ export function classifyCiImpact(paths) {
   return result
 }
 
+export function classifyCiImpactJsonLines(input) {
+  const text = String(input ?? '')
+  if (Buffer.byteLength(text, 'utf8') > MAX_CI_IMPACT_INPUT_BYTES) {
+    return failClosedImpact('change-set input exceeds classifier budget: fail closed')
+  }
+  const lines = text.split(/\r?\n/).filter((line) => line !== '')
+  if (lines.length > MAX_CI_IMPACT_PATHS) {
+    return failClosedImpact('change-set exceeds classifier path budget: fail closed')
+  }
+  const paths = []
+  try {
+    for (const line of lines) {
+      const value = JSON.parse(line)
+      if (typeof value !== 'string') throw new TypeError('changed-file entry must be a JSON string')
+      paths.push(value)
+    }
+  } catch {
+    return failClosedImpact('invalid JSON-lines changed-file input: fail closed')
+  }
+  return classifyCiImpact(paths)
+}
+
 async function main() {
   let stdin = ''
   let inputBytes = 0
@@ -90,8 +117,10 @@ async function main() {
     stdin += chunk
   }
   const result = oversized
-    ? classifyCiImpact(Array(MAX_CI_IMPACT_PATHS + 1).fill('oversized'))
-    : classifyCiImpact(stdin.split(/\r?\n/))
+    ? failClosedImpact('change-set input exceeds classifier budget: fail closed')
+    : process.argv.includes('--json-lines')
+      ? classifyCiImpactJsonLines(stdin)
+      : classifyCiImpact(stdin.split(/\r?\n/).filter((line) => line !== ''))
   process.stdout.write(`${JSON.stringify(result)}\n`)
   const summary = process.env.GITHUB_STEP_SUMMARY
   if (summary) {

--- a/tests/bundle-defaults.test.js
+++ b/tests/bundle-defaults.test.js
@@ -222,8 +222,8 @@ test('PR workflows cancel superseded heads and Windows screenshot avoids pnpm se
   assert.doesNotMatch(windows, /pnpm\/action-setup|pnpm install|cache: pnpm/)
 })
 
-test('CI impact classifier is fail-closed before trusted-base shadow wiring', async () => {
-  const { classifyCiImpact, MAX_CI_IMPACT_INPUT_BYTES, MAX_CI_IMPACT_PATHS } = await import('../scripts/ci-impact-classifier.mjs')
+test('CI impact classifier is bounded and fail-closed for trusted shadow input', async () => {
+  const { classifyCiImpact, classifyCiImpactJsonLines, MAX_CI_IMPACT_INPUT_BYTES, MAX_CI_IMPACT_PATHS } = await import('../scripts/ci-impact-classifier.mjs')
 
   assert.equal(classifyCiImpact(['docs/doctor.md', 'README.md']).docsOnly, true)
   assert.equal(classifyCiImpact(['lib/windows-desktop-capture.js']).windows, true)
@@ -235,6 +235,27 @@ test('CI impact classifier is fail-closed before trusted-base shadow wiring', as
   assert.equal(classifyCiImpact([]).full, true)
   assert.equal(classifyCiImpact(Array(MAX_CI_IMPACT_PATHS + 1).fill('lib/client.js')).full, true)
   assert.equal(classifyCiImpact(['x'.repeat(MAX_CI_IMPACT_INPUT_BYTES + 1)]).full, true)
+
+  assert.equal(classifyCiImpactJsonLines('\"docs/doctor.md\"\n\"README.md\"\n').docsOnly, true)
+  assert.equal(classifyCiImpactJsonLines('\"docs/ok.md\\nREADME.md\"\n').full, true)
+  assert.equal(classifyCiImpactJsonLines('{not-json}\n').full, true)
+  assert.equal(classifyCiImpactJsonLines('42\n').full, true)
+})
+
+test('CI impact shadow executes only the trusted base classifier', async () => {
+  const workflow = await readFile(new URL('../.github/workflows/ci-impact-shadow.yml', import.meta.url), 'utf8')
+
+  assert.match(workflow, /pull_request_target:/)
+  assert.match(workflow, /contents: read/)
+  assert.match(workflow, /pull-requests: read/)
+  assert.doesNotMatch(workflow, /contents: write|statuses: write|id-token: write|secrets\./)
+  assert.match(workflow, /ref: \$\{\{ github\.event\.pull_request\.base\.sha \}\}/)
+  assert.match(workflow, /persist-credentials: false/)
+  assert.match(workflow, /path: trusted-base/)
+  assert.doesNotMatch(workflow, /pull_request\.head/)
+  assert.match(workflow, /\.filename \| @json/)
+  assert.match(workflow, /node trusted-base\/scripts\/ci-impact-classifier\.mjs --json-lines/)
+  assert.match(workflow, /timeout-minutes: 2/)
 })
 
 test('release runtime exposes one benchmark UI and no production v2 acceptance control surface', async () => {


### PR DESCRIPTION
## Summary

Add the second-stage CI impact classifier in shadow mode only.

- runs under `pull_request_target`
- checks out only the trusted base SHA
- never executes the PR's classifier implementation
- obtains changed filenames from GitHub and transports them as JSON Lines
- filenames containing newlines/quotes/control characters cannot escape the protocol
- malformed JSON, input-budget overflow, empty/unknown paths, and CI/package/workflow metadata changes all fail closed to `full=true`
- classification is observational only: **no existing required test is skipped**

## Validation already run on the branch

- real #430 changed-file set => `full=true`
- newline-containing fake docs filename => fail closed
- invalid JSON => fail closed
- contract: 151/151
- full suite: 1303 pass / 0 fail / 1 skip

This PR is intentionally only the shadow-observation stage. We should collect real PR classifications before using impact results to conditionally skip heavy Host/browser jobs.