### PR TITLE
ci: cache trusted DSH web builds

### DIFF
--- a/.github/workflows/alpha-browser-cold-toggle-smoke.yml
+++ b/.github/workflows/alpha-browser-cold-toggle-smoke.yml
@@ -65,6 +65,22 @@ jobs:
           cache: pnpm
           cache-dependency-path: dsh-alpha/pnpm-lock.yaml
 
+      - name: Compute exact DSH web build cache key
+        id: dsh-build-key
+        working-directory: dsh-alpha
+        shell: bash
+        run: |
+          set -euo pipefail
+          DSH_SHA="$(git rev-parse HEAD)"
+          LOCK_SHA="$(sha256sum pnpm-lock.yaml | awk '{print $1}')"
+          TREE_SHA="$(git ls-tree -r --full-tree HEAD | sha256sum | awk '{print $1}')"
+          [[ "$DSH_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo "::error::invalid DSH source SHA"; exit 1; }
+          [[ "$LOCK_SHA" =~ ^[0-9a-f]{64}$ ]] || { echo "::error::invalid DSH lock hash"; exit 1; }
+          [[ "$TREE_SHA" =~ ^[0-9a-f]{64}$ ]] || { echo "::error::invalid DSH build-input hash"; exit 1; }
+          KEY="dsh-web-v1-${RUNNER_OS}-node22-pnpm11.7.0-${DSH_SHA}-${LOCK_SHA}-${TREE_SHA}"
+          printf 'key=%s\n' "$KEY" >> "$GITHUB_OUTPUT"
+          printf 'Exact DSH build cache key: %s\n' "$KEY"
+
       - name: Install exact alpha workspace dependencies
         working-directory: dsh-alpha
         env:
@@ -72,9 +88,32 @@ jobs:
           LEFTHOOK: '0'
         run: pnpm install --frozen-lockfile
 
+      - name: Restore trusted DSH web build cache
+        id: dsh-build-cache
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: |
+            dsh-alpha/lib
+            dsh-alpha/packages/*/*/lib
+            dsh-alpha/apps/web/dist
+            dsh-alpha/.dsh-build
+          key: ${{ steps.dsh-build-key.outputs.key }}
+
       - name: Build exact alpha web runtime
+        if: steps.dsh-build-cache.outputs.cache-hit != 'true'
         working-directory: dsh-alpha
         run: pnpm run build
+
+      - name: Save trusted DSH web build cache from main
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.dsh-build-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: |
+            dsh-alpha/lib
+            dsh-alpha/packages/*/*/lib
+            dsh-alpha/apps/web/dist
+            dsh-alpha/.dsh-build
+          key: ${{ steps.dsh-build-key.outputs.key }}
 
       - name: Install Chromium for DSH Playwright
         working-directory: dsh-alpha

--- a/.github/workflows/dsh-preview-browser-smoke.yml
+++ b/.github/workflows/dsh-preview-browser-smoke.yml
@@ -87,6 +87,22 @@ jobs:
           cache: pnpm
           cache-dependency-path: dsh-preview/pnpm-lock.yaml
 
+      - name: Compute exact DSH web build cache key
+        id: dsh-build-key
+        working-directory: dsh-preview
+        shell: bash
+        run: |
+          set -euo pipefail
+          DSH_SHA="$(git rev-parse HEAD)"
+          LOCK_SHA="$(sha256sum pnpm-lock.yaml | awk '{print $1}')"
+          TREE_SHA="$(git ls-tree -r --full-tree HEAD | sha256sum | awk '{print $1}')"
+          [[ "$DSH_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo "::error::invalid DSH source SHA"; exit 1; }
+          [[ "$LOCK_SHA" =~ ^[0-9a-f]{64}$ ]] || { echo "::error::invalid DSH lock hash"; exit 1; }
+          [[ "$TREE_SHA" =~ ^[0-9a-f]{64}$ ]] || { echo "::error::invalid DSH build-input hash"; exit 1; }
+          KEY="dsh-web-v1-${RUNNER_OS}-node22-pnpm11.7.0-${DSH_SHA}-${LOCK_SHA}-${TREE_SHA}"
+          printf 'key=%s\n' "$KEY" >> "$GITHUB_OUTPUT"
+          printf 'Exact DSH build cache key: %s\n' "$KEY"
+
       - name: Install preview workspace dependencies
         working-directory: dsh-preview
         env:
@@ -94,9 +110,32 @@ jobs:
           LEFTHOOK: '0'
         run: pnpm install --frozen-lockfile
 
+      - name: Restore trusted DSH web build cache
+        id: dsh-build-cache
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: |
+            dsh-preview/lib
+            dsh-preview/packages/*/*/lib
+            dsh-preview/apps/web/dist
+            dsh-preview/.dsh-build
+          key: ${{ steps.dsh-build-key.outputs.key }}
+
       - name: Build preview web runtime
+        if: steps.dsh-build-cache.outputs.cache-hit != 'true'
         working-directory: dsh-preview
         run: pnpm run build
+
+      - name: Save trusted DSH web build cache from main
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.dsh-build-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: |
+            dsh-preview/lib
+            dsh-preview/packages/*/*/lib
+            dsh-preview/apps/web/dist
+            dsh-preview/.dsh-build
+          key: ${{ steps.dsh-build-key.outputs.key }}
 
       - name: Install Chromium for DSH Playwright
         working-directory: dsh-preview

--- a/tests/bundle-defaults.test.js
+++ b/tests/bundle-defaults.test.js
@@ -261,3 +261,34 @@ test('release runtime exposes one benchmark UI and no production v2 acceptance c
     await assert.rejects(readFile(new URL(path, import.meta.url)), (error) => error?.code === 'ENOENT')
   }
 })
+
+test('real DSH browser workflows use exact main-written build caches without skipping Host smoke', async () => {
+  const cacheSha = '0400d5f644dc74513175e3cd8d07132dd4860809'
+  const cases = [
+    ['dsh-preview-browser-smoke.yml', 'dsh-preview', 'Build preview web runtime', 'Run cold Vision toggle against preview Host and Chromium'],
+    ['alpha-browser-cold-toggle-smoke.yml', 'dsh-alpha', 'Build exact alpha web runtime', 'Run cold Vision toggle against real Host and Chromium'],
+  ]
+
+  for (const [name, root, buildName, smokeName] of cases) {
+    const source = await readFile(new URL(`../.github/workflows/${name}`, import.meta.url), 'utf8')
+    assert.match(source, new RegExp(`actions/cache/restore@${cacheSha}`), `${name}: restore must use pinned cache v4.2.4`)
+    assert.match(source, new RegExp(`actions/cache/save@${cacheSha}`), `${name}: save must use the same pinned cache action`)
+    assert.doesNotMatch(source, /restore-keys:/, `${name}: build cache must use exact keys only`)
+    assert.match(source, /KEY="dsh-web-v1-\$\{RUNNER_OS\}-node22-pnpm11\.7\.0-\$\{DSH_SHA\}-\$\{LOCK_SHA\}-\$\{TREE_SHA\}"/)
+    assert.match(source, /DSH_SHA="\$\(git rev-parse HEAD\)"/)
+    assert.match(source, /LOCK_SHA="\$\(sha256sum pnpm-lock\.yaml/)
+    assert.match(source, /TREE_SHA="\$\(git ls-tree -r --full-tree HEAD/)
+    assert.match(source, /if: github\.event_name == 'push' && github\.ref == 'refs\/heads\/main' && steps\.dsh-build-cache\.outputs\.cache-hit != 'true'/)
+    assert.match(source, new RegExp(`- name: ${buildName}\\n\\s+if: steps\\.dsh-build-cache\\.outputs\\.cache-hit != 'true'`))
+    assert.match(source, new RegExp(`${root}/lib[\\s\\S]*${root}/packages/\\*/\\*/lib[\\s\\S]*${root}/apps/web/dist[\\s\\S]*${root}/\\.dsh-build`))
+
+    const install = source.indexOf('pnpm install --frozen-lockfile')
+    const restore = source.indexOf('Restore trusted DSH web build cache')
+    const build = source.indexOf(`- name: ${buildName}`)
+    const save = source.indexOf('Save trusted DSH web build cache from main')
+    const chromium = source.indexOf('Install Chromium for DSH Playwright')
+    const smoke = source.indexOf(smokeName)
+    assert.ok(install >= 0 && restore > install && build > restore && save > build && chromium > save && smoke > chromium,
+      `${name}: cache may skip only DSH build; dependency install, Chromium, and real Host smoke stay live`)
+  }
+})


### PR DESCRIPTION
## Summary

- add exact-key caches for immutable DSH browser build outputs in the stable/preview and historical alpha browser gates
- keep `pnpm install`, Chromium installation, real Host startup, and browser smoke live on every relevant PR
- allow PRs to restore caches only; only trusted `main` push runs may save a missing cache
- use no `restore-keys`, so a cache can never fall back across DSH source/build inputs

## Cache identity

Each key binds:

- exact DSH source SHA
- runner OS
- Node 22
- pnpm 11.7.0
- DSH `pnpm-lock.yaml` SHA-256
- full committed DSH tree SHA-256

Cached paths are build outputs only (`lib`, package `lib` outputs, `apps/web/dist`, `.dsh-build`), not `node_modules` or the whole workspace.

## Safety boundary

A hit skips only `pnpm run build`. It does **not** skip dependency installation, Playwright/Chromium setup, DSH Host startup, or the real Chromium smoke. Ordinary PRs cannot write the shared cache.

## Local verification

- YAML parse: both modified workflows OK
- `git diff --check`: clean
- focused source contract: 19/19
- full suite: 1304 pass / 0 fail / 1 skip
- backend runtime policy: 6/6

The first PR run is intentionally expected to exercise the cache-miss path and still build/launch the real Hosts. After merge, a trusted main run can populate the cache; a later main/manual run can then validate the cache-hit path without weakening the browser smoke.
