### PR TITLE
ci: run DSH build cache actions on Node 24

### DIFF
--- a/.github/workflows/alpha-browser-cold-toggle-smoke.yml
+++ b/.github/workflows/alpha-browser-cold-toggle-smoke.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Restore trusted DSH web build cache
         id: dsh-build-cache
-        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             dsh-alpha/lib
@@ -106,7 +106,7 @@ jobs:
 
       - name: Save trusted DSH web build cache from main
         if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.dsh-build-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             dsh-alpha/lib

--- a/.github/workflows/dsh-preview-browser-smoke.yml
+++ b/.github/workflows/dsh-preview-browser-smoke.yml
@@ -112,7 +112,7 @@ jobs:
 
       - name: Restore trusted DSH web build cache
         id: dsh-build-cache
-        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             dsh-preview/lib
@@ -128,7 +128,7 @@ jobs:
 
       - name: Save trusted DSH web build cache from main
         if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.dsh-build-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             dsh-preview/lib

--- a/tests/bundle-defaults.test.js
+++ b/tests/bundle-defaults.test.js
@@ -263,7 +263,7 @@ test('release runtime exposes one benchmark UI and no production v2 acceptance c
 })
 
 test('real DSH browser workflows use exact main-written build caches without skipping Host smoke', async () => {
-  const cacheSha = '0400d5f644dc74513175e3cd8d07132dd4860809'
+  const cacheSha = '55cc8345863c7cc4c66a329aec7e433d2d1c52a9'
   const cases = [
     ['dsh-preview-browser-smoke.yml', 'dsh-preview', 'Build preview web runtime', 'Run cold Vision toggle against preview Host and Chromium'],
     ['alpha-browser-cold-toggle-smoke.yml', 'dsh-alpha', 'Build exact alpha web runtime', 'Run cold Vision toggle against real Host and Chromium'],


### PR DESCRIPTION
## Summary
- move the trusted DSH build cache restore/save actions from actions/cache v4.2.4 to v6.1.0
- keep the exact key, PR restore-only, main-only save, and real Host + Chromium smoke semantics unchanged
- remove the Node 20 action-runtime deprecation warning seen on current GitHub-hosted runners

## Compatibility evidence
- actions/cache v6.1.0 restore/save entrypoints use node24
- GitHub documents runner >=2.327.1 for the Node 24 cache action line; current DVR hosted jobs run runner 2.337.0
- focused bundle/defaults contract: 19/19 pass
- full pnpm test: pass
- git diff --check: pass