### PR TITLE
fix: preserve Vision when switching wrapped models

### DIFF
--- a/lib/client-presentation-boundary-main.js
+++ b/lib/client-presentation-boundary-main.js
@@ -431,21 +431,21 @@ export const CLIENT_PRESENTATION_PRELUDE = String.raw`(function(){
     if (next.zh && typeof next.zh === 'object') {
       next.zh = Object.assign({}, next.zh, {
         quickStartTitle: '聊天模型 + 识图模式',
-        quickStartBody: '先选择你平时使用的聊天模型。需要看图时，点击输入框旁的「识图」；出现 ✓ 表示已开启。开启后会持续生效，直到你关闭或手动切回普通模型。',
+        quickStartBody: '先选择你平时使用的聊天模型。需要看图时，点击输入框旁的「识图」；出现 ✓ 表示已开启。开启后会持续生效；在同一模型组内切换到另一个支持识图模式的模型也会保持开启，直到你主动关闭或切到没有对应识图模式的普通模型。',
         onboardingStep1Title: '1 · 选择聊天模型并开启识图',
         onboardingStep1Body: '先在聊天页右下角选择你平时使用的模型。需要看图时，点击模型选择器左侧的「识图」；出现 ✓ 表示已开启，不需要时再主动关闭。',
         guideStep1Title: '第 1 步 · 选择聊天模型并认识「识图」',
-        guideStep1Body: '高亮的是聊天模型选择器；它左侧就是「识图」按钮。先选择你平时使用的聊天模型；需要看图时点击「识图」，出现 ✓ 表示已开启。开启后会持续生效，直到你关闭或手动切回普通模型。选好后点击「下一步」。'
+        guideStep1Body: '高亮的是聊天模型选择器；它左侧就是「识图」按钮。先选择你平时使用的聊天模型；需要看图时点击「识图」，出现 ✓ 表示已开启。开启后会持续生效；在同一模型组内切换到另一个支持识图模式的模型也会保持开启，直到你主动关闭或切到没有对应识图模式的普通模型。选好后点击「下一步」。'
       });
     }
     if (next.en && typeof next.en === 'object') {
       next.en = Object.assign({}, next.en, {
         quickStartTitle: 'Chat model + Vision mode',
-        quickStartBody: 'Choose the chat model you normally use first. When you need image understanding, click “Vision” beside the composer; a ✓ means it is on. It stays on until you turn it off or manually switch back to a normal model.',
+        quickStartBody: 'Choose the chat model you normally use first. When you need image understanding, click “Vision” beside the composer; a ✓ means it is on. It stays on when you switch to another Vision-enabled model in the same model group, until you turn it off or choose a normal model with no matching Vision route.',
         onboardingStep1Title: '1 · Choose your chat model and enable Vision',
         onboardingStep1Body: 'Choose the model you normally use from the lower-right chat selector. When you need image understanding, click “Vision” immediately to the left of the model selector; a ✓ means it is on. Turn it off again when you no longer need it.',
         guideStep1Title: 'Step 1 · Choose your chat model and find “Vision”',
-        guideStep1Body: 'The highlighted control is the chat model selector; the “Vision” button is immediately to its left. Choose your normal chat model first, then click “Vision” when you need image understanding. A ✓ means it is on, and it stays on until you turn it off or manually switch back to a normal model. Click “Next” when done.'
+        guideStep1Body: 'The highlighted control is the chat model selector; the “Vision” button is immediately to its left. Choose your normal chat model first, then click “Vision” when you need image understanding. A ✓ means it is on. It stays on when you switch to another Vision-enabled model in the same model group, until you turn it off or choose a normal model with no matching Vision route. Click “Next” when done.'
       });
     }
     return next;

--- a/lib/vision-model-visibility-boundary-main.js
+++ b/lib/vision-model-visibility-boundary-main.js
@@ -141,9 +141,11 @@ export function projectVisionModeDirectoryState(state, config) {
 
 /**
  * Translate a presentation-layer selection back to the real current wrapper
- * only when the user is editing the same visible model (for example changing
- * reasoning effort). Picking a different model/provider deliberately leaves
- * the wrapper and therefore turns Vision mode off.
+ * while Vision mode is active. Edits within the same visible source provider
+ * stay on the wrapper whenever that wrapper actually exposes the selected
+ * model. Provider changes, or same-provider models absent from the wrapper,
+ * deliberately fall through to the ordinary route and therefore turn Vision
+ * mode off.
  */
 export function mapVisionPresentationSelection(state, selection, config) {
   if (!selection || typeof selection !== 'object') return selection
@@ -154,7 +156,8 @@ export function mapVisionPresentationSelection(state, selection, config) {
   const currentGroup = visionPresentationGroup(state.groups, current.provider)
   const sourceProvider = visionPresentationSourceForGroup(state.groups, currentGroup, config)
   if (!sourceProvider) return selection
-  if (selection.provider !== sourceProvider || selection.model !== current.model) return selection
+  if (selection.provider !== sourceProvider) return selection
+  if (!visionPresentationHasModel(currentGroup, selection.model)) return selection
   return {
     ...selection,
     provider: current.provider,

--- a/tests/issue-284-model-visibility.test.js
+++ b/tests/issue-284-model-visibility.test.js
@@ -269,7 +269,7 @@ test('issue #284 changing only reasoning effort while Vision is on keeps the hid
   assert.equal(selected[0].reasoningEffort, 'low')
 })
 
-test('issue #284 selecting a different model while Vision is on leaves the wrapper and turns Vision off', async () => {
+test('issue #431 selecting another model in the same wrapped provider keeps Vision on', async () => {
   const input = state({
     current: { provider: 'opencode-go-vision', model: 'qwen3.6-plus', reasoningEffort: 'high' },
     groups: [
@@ -284,8 +284,45 @@ test('issue #284 selecting a different model while Vision is on leaves the wrapp
 
   await visibleDirectory.select({ provider: 'opencode-go', model: 'other-model' })
   assert.equal(selected.length, 1)
-  assert.equal(selected[0].provider, 'opencode-go')
+  assert.equal(selected[0].provider, 'opencode-go-vision')
   assert.equal(selected[0].model, 'other-model')
+  assert.equal(Object.prototype.hasOwnProperty.call(selected[0], 'reasoningEffort'), false)
+})
+
+test('issue #431 DeepSeek V4 Flash to V4 Pro stays on the configured wrapper before Host selection', async () => {
+  const input = state({
+    current: { provider: 'deepseek-vision', model: 'deepseek-v4-flash', reasoningEffort: 'high' },
+    groups: [
+      group('deepseek-official', 'DeepSeek', ['deepseek-v4-flash', 'deepseek-v4-pro']),
+      group('deepseek-vision', 'DeepSeek + 自动识图', ['deepseek-v4-flash', 'deepseek-v4-pro']),
+    ],
+  })
+  const { visibleDirectory, selected } = visibilityPluginHarness(input, {
+    autoWrapProviders: true,
+    wrapperRoute: 'deepseek-vision',
+  })
+
+  await visibleDirectory.select({ provider: 'deepseek-official', model: 'deepseek-v4-pro' })
+  assert.equal(selected.length, 1)
+  assert.equal(selected[0].provider, 'deepseek-vision')
+  assert.equal(selected[0].model, 'deepseek-v4-pro')
+})
+
+test('issue #431 same-provider model without a wrapper counterpart still turns Vision off', async () => {
+  const input = state({
+    current: { provider: 'vendor-vision', model: 'wrapped-model', reasoningEffort: 'high' },
+    groups: [
+      group('vendor', 'Vendor', ['wrapped-model', 'plain-model']),
+      group('vendor-vision', 'Vendor + 自动识图', ['wrapped-model']),
+    ],
+  })
+  const { visibleDirectory, selected } = visibilityPluginHarness(input, {
+    autoWrapProviders: true,
+    wrapperRoute: 'deepseek-vision',
+  })
+
+  await visibleDirectory.select({ provider: 'vendor', model: 'plain-model' })
+  assert.deepEqual(selected, [{ provider: 'vendor', model: 'plain-model' }])
 })
 
 test('issue #284 selecting another provider while Vision is on submits that ordinary route and turns Vision off', async () => {

--- a/tests/issue-284-vision-selection-effort.test.js
+++ b/tests/issue-284-vision-selection-effort.test.js
@@ -53,7 +53,7 @@ test('issue #284 choosing another provider while Vision is on leaves the wrapper
   assert.equal(Object.prototype.hasOwnProperty.call(mapped, 'reasoningEffort'), false)
 })
 
-test('issue #284 choosing another model in the same provider leaves Vision and preserves Provider Default semantics', () => {
+test('issue #431 choosing another model in the same wrapped provider keeps Vision and Provider Default semantics', () => {
   const mapped = mapVisionPresentationSelection(
     activeState(),
     { provider: 'alpha', model: 'alpha-2' },
@@ -61,7 +61,7 @@ test('issue #284 choosing another model in the same provider leaves Vision and p
   )
 
   assert.deepEqual(mapped, {
-    provider: 'alpha',
+    provider: 'alpha-vision',
     model: 'alpha-2',
   })
   assert.equal(Object.prototype.hasOwnProperty.call(mapped, 'reasoningEffort'), false)
@@ -143,9 +143,9 @@ test('issue #284 a nested -vision-vision lookalike is never treated as a Vision 
   ), { mode: 'unavailable' })
 })
 
-test('issue #284 guide copy says a manual ordinary-model change turns Vision off', () => {
-  assert.equal(CLIENT_PRESENTATION_PRELUDE.includes('手动切回普通模型'), true)
-  assert.equal(CLIENT_PRESENTATION_PRELUDE.includes('manually switch back to a normal model'), true)
-  assert.equal(CLIENT_PRESENTATION_PRELUDE.includes('切换聊天模型时也会继续保持识图模式'), false)
-  assert.equal(CLIENT_PRESENTATION_PRELUDE.includes('Changing chat models keeps Vision mode on'), false)
+test('issue #431 guide copy explains when model changes preserve or leave Vision mode', () => {
+  assert.equal(CLIENT_PRESENTATION_PRELUDE.includes('同一模型组内切换到另一个支持识图模式的模型也会保持开启'), true)
+  assert.equal(CLIENT_PRESENTATION_PRELUDE.includes('switch to another Vision-enabled model in the same model group'), true)
+  assert.equal(CLIENT_PRESENTATION_PRELUDE.includes('没有对应识图模式的普通模型'), true)
+  assert.equal(CLIENT_PRESENTATION_PRELUDE.includes('normal model with no matching Vision route'), true)
 })


### PR DESCRIPTION
## Summary
Fixes #431.

When Vision mode is active, the stock model picker sees the hidden wrapper projected as its ordinary source provider. Before this fix, selecting a different model in that same provider deliberately dropped back to the ordinary text route, which lets DSH correctly reject the selection once the session already contains images.

This changes only the presentation selection projection:
- same source provider + target model exists on the active wrapper -> keep the wrapper and switch models
- target model has no wrapper counterpart -> keep the existing behavior and fall back to the ordinary route / Vision off
- provider changes -> keep the existing behavior and leave Vision mode
- DSH's image-session guard and durable image history remain untouched

The onboarding copy now explains that switching among Vision-enabled models in the same model group keeps Vision enabled.

## Verification
- regression-first: exact DeepSeek V4 Flash -> V4 Pro case failed on main by selecting `deepseek-official/deepseek-v4-pro`
- focused model visibility / Vision toggle / effort suite: 39/39 pass
- browser lifecycle + alpha compatibility focused suite: 57/57 pass
- full `pnpm test`: 1306 pass / 0 fail / 1 skip; backend policy 6/6
- `node --check` on changed runtime files
- `git diff --check`