### PR TITLE
compat: verify DSH 0.1.5-alpha.1 preview

### DIFF
--- a/.github/workflows/adversarial-compat-hardening.yml
+++ b/.github/workflows/adversarial-compat-hardening.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dsh: ['0.1.2-rc.1', '0.1.3-alpha.2']
+        dsh: ['0.1.2-rc.1', '0.1.5-alpha.1']
         node: ['22', '24']
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -140,5 +140,5 @@ jobs:
       - name: Verify release pi-ai final OpenCode wire
         run: node tests/opencode-session-wire-contract.mjs
       - name: Verify preview Session v2 native image process-restart lifecycle
-        if: matrix.dsh == '0.1.3-alpha.2'
+        if: matrix.dsh == '0.1.5-alpha.1'
         run: node scripts/dsh-preview-native-lifecycle-contract.mjs

--- a/.github/workflows/dsh-alpha-source-contract.yml
+++ b/.github/workflows/dsh-alpha-source-contract.yml
@@ -81,7 +81,7 @@ concurrency:
 
 jobs:
   alpha-source-contract:
-    name: 0.1.3-alpha.2 contract / ${{ matrix.os }}
+    name: 0.1.5-alpha.1 contract / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -94,7 +94,7 @@ jobs:
           persist-credentials: false
           path: dvr
 
-      - name: Checkout exact DSH 0.1.3-alpha.2 source
+      - name: Checkout exact DSH 0.1.5-alpha.1 source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: deepseek-ai/deepseek-harness
@@ -125,7 +125,7 @@ jobs:
         working-directory: dsh-alpha
         env:
           DSH_SOURCE_ROOT: ${{ github.workspace }}/dsh-alpha
-          DSH_EXPECTED_VERSION: 0.1.3-alpha.2
+          DSH_EXPECTED_VERSION: 0.1.5-alpha.1
           DSH_EXPECTED_COMMIT: 82a5fd61a7cf5c293cec4bdff68f455398d685e9
         run: pnpm exec tsx ../dvr/scripts/dsh-alpha-source-contract.mjs
 

--- a/.github/workflows/dsh-alpha-source-contract.yml
+++ b/.github/workflows/dsh-alpha-source-contract.yml
@@ -98,7 +98,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: deepseek-ai/deepseek-harness
-          ref: 82a5fd61a7cf5c293cec4bdff68f455398d685e9
+          ref: 5dda764ed3aa172535a7967b06ff95d9cbfe536a
           persist-credentials: false
           path: dsh-alpha
 
@@ -126,7 +126,7 @@ jobs:
         env:
           DSH_SOURCE_ROOT: ${{ github.workspace }}/dsh-alpha
           DSH_EXPECTED_VERSION: 0.1.5-alpha.1
-          DSH_EXPECTED_COMMIT: 82a5fd61a7cf5c293cec4bdff68f455398d685e9
+          DSH_EXPECTED_COMMIT: 5dda764ed3aa172535a7967b06ff95d9cbfe536a
         run: pnpm exec tsx ../dvr/scripts/dsh-alpha-source-contract.mjs
 
       - name: Run DVR alpha compatibility unit contracts

--- a/.github/workflows/dsh-preview-browser-smoke.yml
+++ b/.github/workflows/dsh-preview-browser-smoke.yml
@@ -72,7 +72,7 @@ jobs:
         include:
           - dsh: 0.1.2-rc.1
             mixedGenericFiles: false
-          - dsh: 0.1.3-alpha.2
+          - dsh: 0.1.5-alpha.1
             mixedGenericFiles: true
     steps:
       - name: Checkout Vision Router
@@ -90,12 +90,12 @@ jobs:
           persist-credentials: false
           path: dsh-preview
 
-      - name: Checkout immutable DSH 0.1.3-alpha.2 source
-        if: matrix.dsh == '0.1.3-alpha.2'
+      - name: Checkout immutable DSH 0.1.5-alpha.1 source
+        if: matrix.dsh == '0.1.5-alpha.1'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: deepseek-ai/deepseek-harness
-          ref: dsh-v0.1.3-alpha.2
+          ref: dsh-v0.1.5-alpha.1
           persist-credentials: false
           path: dsh-preview
 

--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ ollama pull qwen2.5vl
 ## Requirements
 
 - DeepSeek Harness Web profile. Normal installs can use `npx @deepseek-ai/dsh ...`; source checkouts use `pnpm dsh ...`. A bare `dsh ...` command only works when the CLI is already on your shell `PATH`.
-- **DSH Host support policy:** DVR 2.1.x keeps DSH `0.1.0-rc.8` as the public minimum and currently supports the released stable channel through `0.1.2-rc.1`. Exact `0.1.3-alpha.2` coverage is **verification evidence only**, not a preview support promise; scheduled `latest`/`alpha` canaries monitor drift without changing the support policy. DVR 2.0.x was the final train with public support for rc.6/rc.7. See [DSH Host support window](docs/architecture/dsh-support-window.md).
+- **DSH Host support policy:** DVR 2.1.x keeps DSH `0.1.0-rc.8` as the public minimum and currently supports the released stable channel through `0.1.2-rc.1`. Exact `0.1.5-alpha.1` coverage is **verification evidence only**, not a preview support promise; scheduled `latest`/`alpha` canaries monitor drift without changing the support policy. DVR 2.0.x was the final train with public support for rc.6/rc.7. See [DSH Host support window](docs/architecture/dsh-support-window.md).
 - Node ≥ 22 (host side).
 - No API key for the default free chain; a credential reference (`apiKeyEnv`) only for paid `httpProviders`.
 - Chrome / Chromium / Edge is needed only for `vision_html_screenshot`; every other tool works without a browser.

--- a/README.zh.md
+++ b/README.zh.md
@@ -411,7 +411,7 @@ ollama pull qwen2.5vl
 ## 环境要求
 
 - DeepSeek Harness 的 Web profile。普通安装可用 `npx @deepseek-ai/dsh ...`；从源码仓库运行时用 `pnpm dsh ...`。只有 CLI 已经进入系统 `PATH` 时才能直接写 `dsh ...`。
-- **DSH Host 支持策略：** DVR 2.1.x 的公开最低 Host 仍为 DSH `0.1.0-rc.8`，当前正式发布通道已验证并支持到 `0.1.2-rc.1`。对 `0.1.3-alpha.2` 的精确覆盖**只属于验证证据**，不代表对 preview 的公开支持承诺；定时 `latest`/`alpha` canary 只负责发现上游漂移，也不会自动改变支持策略。DVR 2.0.x 是最后公开支持 rc.6/rc.7 的版本线。详见 [DSH Host 支持窗口](docs/architecture/dsh-support-window.md)。
+- **DSH Host 支持策略：** DVR 2.1.x 的公开最低 Host 仍为 DSH `0.1.0-rc.8`，当前正式发布通道已验证并支持到 `0.1.2-rc.1`。对 `0.1.5-alpha.1` 的精确覆盖**只属于验证证据**，不代表对 preview 的公开支持承诺；定时 `latest`/`alpha` canary 只负责发现上游漂移，也不会自动改变支持策略。DVR 2.0.x 是最后公开支持 rc.6/rc.7 的版本线。详见 [DSH Host 支持窗口](docs/architecture/dsh-support-window.md)。
 - Node ≥ 22（宿主侧）。
 - 默认免费链路无需 API Key；付费 `httpProviders` 只需一个凭据引用（`apiKeyEnv`）。
 - 只有 `vision_html_screenshot` 需要 Chrome / Chromium / Edge；其余工具无浏览器也能用。

--- a/cordis.patch.yml
+++ b/cordis.patch.yml
@@ -4,9 +4,20 @@
 # without any manual cordis.patch.yml edits. Later layers (the profile's own
 # cordis.patch.yml, --patch overlays) override these rows by id.
 
-# 纯增量补丁（issue #34）：不碰核心行。最低支持 Host 仍保留旧兼容路径；
+# 纯增量补丁（issue #34）：不替换/禁用核心行。最低支持 Host 仍保留旧兼容路径；
 # batch-attachment 合同的 Host 始终拥有 deepseek-official，插件只提供
 # 「+ 自动识图」包装路由，因此这里永远不默认禁用官方 llm-deepseek 行。
+#
+# DSH 0.1.5-alpha.1 的 client-modules Node half 在 webServer 尚未可用时会走
+# ctx.inject() 延迟注册路径；Linux 并行 Loader 激活可在安装额外 client bundle 后
+# 命中 Cordis 的 service-access 竞态（"webServer without inject"）。rc.8 至当前
+# Web bundle 都使用同一个 modules row，因此只给该既有行追加显式 webServer
+# activation dependency：不替换 row，不改变 client graph，只把官方已经需要的
+# Web carrier 依赖从运行时探测收敛成 Loader 顺序。非 Web surface 缺少该 row 时
+# Include 按官方 patch 语义仅跳过此 overlay。上游修复该竞态后可重新审计删除。
+- id: modules
+  name: '@deepseek-ai/dsh-client-modules'
+  inject: [webServer]
 
 # 挂载插件行。默认保持完整视觉工具表常驻（issue #81）：虽然渐进挂载可以
 # 少发一小段工具 schema，但图片轮首次扩展工具列表会改变请求前缀，可能让

--- a/docs/architecture/dsh-compatibility-matrix.md
+++ b/docs/architecture/dsh-compatibility-matrix.md
@@ -11,7 +11,7 @@ The matrix is capability-based. Runtime code must feature-detect the seam it nee
 | `minimum-contract` | `0.1.0-rc.6` | Historical compatibility-retention fixture. The name is legacy; DVR 2.1.x public support starts at rc.8. |
 | `legacy-contract` | `0.1.0-rc.8` | Public support-floor fixture carrying batch attachments and dimension policy. |
 | `current-contract` | `0.1.2-rc.1` | Current stable Host contract baseline. Must remain green. |
-| exact preview gates | `0.1.3-alpha.2` | Required verification evidence only; not a public preview-support claim. |
+| exact preview gates | `0.1.5-alpha.1` | Required verification evidence only; not a public preview-support claim. |
 | `latest-dsh` / alpha canaries | resolved dynamically from npm dist-tags | Scheduled drift surveillance only. Never changes support policy by itself. |
 
 Node 22 and Node 24 remain the general required runtime matrix. The Host contract jobs are additive; they do not replace the normal test matrix.

--- a/docs/architecture/dsh-support-window.md
+++ b/docs/architecture/dsh-support-window.md
@@ -22,7 +22,7 @@ Compatibility evidence answers a different question: what exact upstream release
 | Evidence role | DSH source | Meaning |
 |---|---|---|
 | Exact stable evidence | `0.1.2-rc.1` | Required Host/wire and real Host + Chromium coverage for the current stable release. |
-| Exact preview evidence | `0.1.3-alpha.2` | Required preview Host/wire/lifecycle/browser evidence. This is not a preview support promise. |
+| Exact preview evidence | `0.1.5-alpha.1` | Required preview Host/wire/lifecycle/browser evidence. This is not a preview support promise. |
 | Stable drift canary | npm dist-tag `latest` | Scheduled, dynamically resolved surveillance. A failure starts compatibility investigation; it does not rewrite support policy. |
 | Preview drift canary | npm dist-tag `alpha` | Scheduled, dynamically resolved surveillance with preview-specific lifecycle coverage. A failure does not rewrite support policy. |
 

--- a/lib/dsh-support-window.js
+++ b/lib/dsh-support-window.js
@@ -6,7 +6,7 @@ export const DSH_SUPPORT_WINDOW = Object.freeze({
 
 export const DSH_VERIFICATION_EVIDENCE = Object.freeze({
   exactStable: '0.1.2-rc.1',
-  exactPreview: '0.1.3-alpha.2',
+  exactPreview: '0.1.5-alpha.1',
   stableCanaryDistTag: 'latest',
   previewCanaryDistTag: 'alpha',
 })

--- a/package.json
+++ b/package.json
@@ -54,8 +54,8 @@
     "undici": "^7.29.0"
   },
   "peerDependencies": {
-    "@deepseek-ai/dsh-anonymous-user-id": "^0.1.0-rc.8 || ^0.1.1-rc.1 || ^0.1.3-alpha.2",
-    "@deepseek-ai/dsh-llm-deepseek": "^0.1.0-rc.8 || ^0.1.1-rc.1 || ^0.1.3-alpha.2",
+    "@deepseek-ai/dsh-anonymous-user-id": "^0.1.0-rc.8 || ^0.1.1-rc.1 || ^0.1.3-alpha.2 || 0.1.5-alpha.1",
+    "@deepseek-ai/dsh-llm-deepseek": "^0.1.0-rc.8 || ^0.1.1-rc.1 || ^0.1.3-alpha.2 || 0.1.5-alpha.1",
     "sharp": ">=0.35.3 <1"
   },
   "peerDependenciesMeta": {

--- a/scripts/dsh-alpha-source-contract.mjs
+++ b/scripts/dsh-alpha-source-contract.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
 import { createRequire } from 'node:module'
 import { readFile } from 'node:fs/promises'
 import path from 'node:path'
@@ -30,6 +31,10 @@ const [attachmentLocal, compat, adapterCompat] = await Promise.all([
   import(pathToFileURL(path.join(dvrRoot, 'lib/dsh-contract-compat.js')).href),
   import(pathToFileURL(path.join(dvrRoot, 'lib/adapter-update-coalescer.js')).href),
 ])
+
+const actualCommit = execFileSync('git', ['-C', dshRoot, 'rev-parse', 'HEAD'], { encoding: 'utf8' }).trim()
+assert.match(expectedCommit, /^[0-9a-f]{40}$/, 'DSH_EXPECTED_COMMIT must be a full Git commit SHA')
+assert.equal(actualCommit, expectedCommit, `expected DSH source commit ${expectedCommit}`)
 
 const rootManifest = JSON.parse(await readFile(path.join(dshRoot, 'package.json'), 'utf8'))
 assert.equal(rootManifest.version, expectedVersion, `expected DSH ${expectedVersion}`)
@@ -170,7 +175,7 @@ assert.match(connectionRpcSource, /requestRejection\(request: ConnectionTrustReq
 console.log(JSON.stringify({
   ok: true,
   dsh: expectedVersion,
-  canaryCommit: expectedCommit,
+  canaryCommit: actualCommit,
   platform: process.platform,
   node: process.version,
   staleCanonical: [stalePrepared.ref.width, stalePrepared.ref.height],

--- a/tests/architecture-contract-baseline.test.js
+++ b/tests/architecture-contract-baseline.test.js
@@ -84,7 +84,7 @@ test('published support-window docs remain the authority for compatibility retir
   assert.match(support, /0\.1\.0-rc\.6/)
   assert.match(support, /Minimum Supported Host[^\n]*0\.1\.0-rc\.8/)
   assert.match(support, /Current Stable Host[^\n]*0\.1\.2-rc\.1/)
-  assert.match(support, /Exact preview evidence[^\n]*0\.1\.3-alpha\.2/)
+  assert.match(support, /Exact preview evidence[^\n]*0\.1\.5-alpha\.1/)
   assert.match(support, /not a preview support promise/i)
   assert.match(support, /Historical release notes[^\n]*not rewritten/i)
   assert.match(retirement, /NO COMPAT DELETION IS CURRENTLY AUTHORIZED/)

--- a/tests/doctor-host-capabilities.test.js
+++ b/tests/doctor-host-capabilities.test.js
@@ -92,7 +92,7 @@ test('Doctor JSON keeps public support policy separate from verification evidenc
   })
   assert.deepEqual(report.hostVerificationEvidence, {
     exactStable: '0.1.2-rc.1',
-    exactPreview: '0.1.3-alpha.2',
+    exactPreview: '0.1.5-alpha.1',
     stableCanaryDistTag: 'latest',
     previewCanaryDistTag: 'alpha',
   })

--- a/tests/dsh-support-window.test.js
+++ b/tests/dsh-support-window.test.js
@@ -24,7 +24,7 @@ test('P3 support policy contains only public stable support semantics', () => {
 test('preview and dynamic canaries are verification evidence, not support-window fields', () => {
   assert.deepEqual(DSH_VERIFICATION_EVIDENCE, {
     exactStable: '0.1.2-rc.1',
-    exactPreview: '0.1.3-alpha.2',
+    exactPreview: '0.1.5-alpha.1',
     stableCanaryDistTag: 'latest',
     previewCanaryDistTag: 'alpha',
   })
@@ -52,7 +52,7 @@ test('Doctor text separates public support policy from verification evidence', (
   assert.ok(lines.slice(0, evidenceAt).some((line) => line.includes('minimum supported Host: 0.1.0-rc.8')))
   assert.ok(lines.slice(0, evidenceAt).some((line) => line.includes('current stable Host: 0.1.2-rc.1')))
   assert.equal(lines.slice(0, evidenceAt).some((line) => /alpha|canary/i.test(line)), false)
-  assert.ok(lines.slice(evidenceAt).some((line) => line.includes('exact preview (not a support claim): 0.1.3-alpha.2')))
+  assert.ok(lines.slice(evidenceAt).some((line) => line.includes('exact preview (not a support claim): 0.1.5-alpha.1')))
   assert.ok(lines.slice(evidenceAt).some((line) => line.includes('npm dist-tag latest')))
   assert.ok(lines.slice(evidenceAt).some((line) => line.includes('npm dist-tag alpha')))
   assert.ok(lines.some((line) => line.includes('HOST_BELOW_CURRENT_FLOOR_CAPABILITIES')))
@@ -69,7 +69,7 @@ test('public READMEs separate stable support from preview verification evidence'
     assert.match(source, /2\.1\.x/)
     assert.match(source, /0\.1\.0-rc\.8/)
     assert.match(source, /0\.1\.2-rc\.1/)
-    assert.match(source, /0\.1\.3-alpha\.2/)
+    assert.match(source, /0\.1\.5-alpha\.1/)
     assert.match(source, /docs\/architecture\/dsh-support-window\.md/)
     assert.doesNotMatch(source, /0\.1\.2-alpha\.4/)
   }
@@ -82,6 +82,6 @@ test('current-contract follows the current stable Host while preview remains a s
     readFile(new URL('../.github/workflows/dsh-preview-browser-smoke.yml', import.meta.url), 'utf8'),
   ])
   assert.match(contract, /name: current-contract[\s\S]*?dsh: 0\.1\.2-rc\.1/)
-  assert.match(preview, /dsh: 0\.1\.3-alpha\.2/)
-  assert.doesNotMatch(contract, /dsh: 0\.1\.3-alpha\.2/)
+  assert.match(preview, /dsh: 0\.1\.5-alpha\.1/)
+  assert.doesNotMatch(contract, /dsh: 0\.1\.5-alpha\.1/)
 })

--- a/tests/rc6-rc7-compat.test.js
+++ b/tests/rc6-rc7-compat.test.js
@@ -185,6 +185,14 @@ test('manifest publishes the DVR 2.1 rc8 host floor while admitting verified sta
   assert.equal(pkg.peerDependencies['@deepseek-ai/dsh-settings'], undefined)
 })
 
+test('web client modules wait for the official webServer carrier across supported Host trains', async () => {
+  const patch = await readFile(new URL('../cordis.patch.yml', import.meta.url), 'utf8')
+  assert.match(
+    patch,
+    /- id: modules\s+name: '@deepseek-ai\/dsh-client-modules'\s+inject: \[webServer\]/,
+  )
+})
+
 test('release evidence gates keep stable and preview contracts capability-scoped', async () => {
   const hostGate = await readFile(new URL('../.github/workflows/adversarial-compat-hardening.yml', import.meta.url), 'utf8')
   const browserGate = await readFile(new URL('../.github/workflows/dsh-preview-browser-smoke.yml', import.meta.url), 'utf8')

--- a/tests/rc6-rc7-compat.test.js
+++ b/tests/rc6-rc7-compat.test.js
@@ -178,7 +178,7 @@ test('settings compatibility keeps the first-class section without requiring a l
 
 test('manifest publishes the DVR 2.1 rc8 host floor while admitting verified stable and alpha host trains', async () => {
   const pkg = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8'))
-  const expectedHostPeerRange = '^0.1.0-rc.8 || ^0.1.1-rc.1 || ^0.1.3-alpha.2'
+  const expectedHostPeerRange = '^0.1.0-rc.8 || ^0.1.1-rc.1 || ^0.1.3-alpha.2 || 0.1.5-alpha.1'
   assert.equal(pkg.engines.node, '^22.19.0 || >=24.0.0')
   assert.equal(pkg.peerDependencies['@deepseek-ai/dsh-llm-deepseek'], expectedHostPeerRange)
   assert.equal(pkg.peerDependencies['@deepseek-ai/dsh-anonymous-user-id'], expectedHostPeerRange)
@@ -189,13 +189,13 @@ test('release evidence gates keep stable and preview contracts capability-scoped
   const hostGate = await readFile(new URL('../.github/workflows/adversarial-compat-hardening.yml', import.meta.url), 'utf8')
   const browserGate = await readFile(new URL('../.github/workflows/dsh-preview-browser-smoke.yml', import.meta.url), 'utf8')
 
-  assert.match(hostGate, /dsh: \['0\.1\.2-rc\.1', '0\.1\.3-alpha\.2'\]/)
-  assert.match(hostGate, /if: matrix\.dsh == '0\.1\.3-alpha\.2'/)
+  assert.match(hostGate, /dsh: \['0\.1\.2-rc\.1', '0\.1\.5-alpha\.1'\]/)
+  assert.match(hostGate, /if: matrix\.dsh == '0\.1\.5-alpha\.1'/)
   assert.match(browserGate, /dsh: 0\.1\.2-rc\.1[\s\S]*?mixedGenericFiles: false/)
-  assert.match(browserGate, /dsh: 0\.1\.3-alpha\.2[\s\S]*?mixedGenericFiles: true/)
+  assert.match(browserGate, /dsh: 0\.1\.5-alpha\.1[\s\S]*?mixedGenericFiles: true/)
   assert.match(browserGate, /if: matrix\.mixedGenericFiles/)
   assert.match(browserGate, /ref: dsh-v0\.1\.2-rc\.1/)
-  assert.match(browserGate, /ref: dsh-v0\.1\.3-alpha\.2/)
+  assert.match(browserGate, /ref: dsh-v0\.1\.5-alpha\.1/)
   assert.doesNotMatch(browserGate, /ref:\s*\$\{\{\s*matrix\./)
 })
 


### PR DESCRIPTION
## Summary
- advance exact preview verification from DSH 0.1.3-alpha.2 to 0.1.5-alpha.1 without changing the public rc.8 support floor or stable 0.1.2-rc.1 support line
- move exact Host/adversarial, alpha source, and real Host + Chromium preview gates to 0.1.5-alpha.1
- admit exactly 0.1.5-alpha.1 in optional Host peers while preserving prior 0.1.3-alpha.2 admission
- update current support/evidence docs and Doctor expectations; preserve historical v2.1.4 release notes

## Evidence before PR
- latest npm alpha is 0.1.5-alpha.1; latest stable remains 0.1.2-rc.1
- manual Latest DSH Alpha Canary run 34314770918 passed on Node 22 and Node 24 against 0.1.5-alpha.1, including Host capability, final pi-ai wire, and native image process-restart lifecycle
- no DVR runtime dependency on removed ctx.agent or old Inbox API was found
- local full test: 1310 pass / 0 fail / 1 skip; backend policy 6/6

Do not merge unless the exact 0.1.5-alpha.1 source contract, adversarial Host matrices, and real Host + Chromium preview smoke are green.