### PR TITLE
chore: prepare v2.1.5 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/ysr666/dsh-vision-router/releases/tag/v2.1.0"><img src="https://img.shields.io/badge/release-v2.1.0-5B4CF0?style=flat-square" alt="Release v2.1.0" /></a>
+  <a href="https://github.com/ysr666/dsh-vision-router/releases/tag/v2.1.5"><img src="https://img.shields.io/badge/release-v2.1.5-5B4CF0?style=flat-square" alt="Release v2.1.5" /></a>
   <a href="tests"><img src="https://img.shields.io/badge/verified-Node%2022%20%2B%2024-2EA44F?style=flat-square" alt="Verified: Node 22 + 24" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-2EA44F?style=flat-square" alt="License: MIT" /></a>
   <a href="package.json"><img src="https://img.shields.io/badge/Node.js-%3E%3D22-339933?style=flat-square&amp;logo=nodedotjs&amp;logoColor=white" alt="Node.js >=22" /></a>
@@ -39,9 +39,9 @@
 <p align="center">💬 <strong>QQ community group: 1105463028</strong></p>
 
 > [!WARNING]
-> 📌 **Announcement (v2.1.0)**
+> 📌 **Announcement (v2.1.5)**
 >
-> **v2.1.0:** Native five-card Settings, explicit Vision mode, runtime i18n, hardened capability routing/benchmarks, and the DSH rc.8 support floor. [What’s new →](docs/releases/v2.1.0.md)
+> **v2.1.5:** Verified against DSH `0.1.5-alpha.1`, fixes Vision-preserving wrapped-model switches, and hardens Web activation plus the release/security pipeline. Stable Host support remains through `0.1.2-rc.1`. [What’s new →](docs/releases/v2.1.5.md)
 
 <p align="center">
   <img src="assets/vision-demo.gif" width="640" alt="Demo: paste an image, the agent locates the send button with vision_ground / vision_crop / vision_pixel_diff and answers with coordinates" />

--- a/README.zh.md
+++ b/README.zh.md
@@ -17,7 +17,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/ysr666/dsh-vision-router/releases/tag/v2.1.0"><img src="https://img.shields.io/badge/release-v2.1.0-5B4CF0?style=flat-square" alt="Release v2.1.0" /></a>
+  <a href="https://github.com/ysr666/dsh-vision-router/releases/tag/v2.1.5"><img src="https://img.shields.io/badge/release-v2.1.5-5B4CF0?style=flat-square" alt="Release v2.1.5" /></a>
   <a href="tests"><img src="https://img.shields.io/badge/verified-Node%2022%20%2B%2024-2EA44F?style=flat-square" alt="已验证 Node 22 + 24" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-2EA44F?style=flat-square" alt="MIT 许可证" /></a>
   <a href="package.json"><img src="https://img.shields.io/badge/Node.js-%3E%3D22-339933?style=flat-square&amp;logo=nodedotjs&amp;logoColor=white" alt="Node.js >=22" /></a>
@@ -39,9 +39,9 @@
 <p align="center">💬 <strong>QQ 用户交流群：1105463028</strong></p>
 
 > [!WARNING]
-> 📌 **公告（v2.1.0）**
+> 📌 **公告（v2.1.5）**
 >
-> **v2.1.0：原生五卡设置、输入框识图、运行时双语、能力路由/测评加固，并正式启用 DSH rc.8 最低支持线。** [查看完整更新 →](docs/releases/v2.1.0.md)
+> **v2.1.5：已完成 DSH `0.1.5-alpha.1` 精确兼容验证，修复识图模式下同源 wrapper 模型切换，并加固 Web 激活与发版/安全链路；稳定 Host 支持仍到 `0.1.2-rc.1`。** [查看完整更新 →](docs/releases/v2.1.5.md)
 
 <p align="center">
   <img src="assets/vision-demo.gif" width="640" alt="演示：粘贴图片，Agent 用 vision_ground / vision_crop / vision_pixel_diff 定位发送按钮并给出坐标" />

--- a/docs/releases/v2.1.5.md
+++ b/docs/releases/v2.1.5.md
@@ -1,0 +1,31 @@
+# v2.1.5
+
+DVR 2.1.5 is a compatibility, reliability, and release-hardening patch. It brings the fixed preview evidence forward to DSH `0.1.5-alpha.1`, fixes a Vision-mode model-switch edge case, and strengthens Web activation plus the project security/release gates without changing the public 2.1.x routing model or Host support floor.
+
+## DSH 0.1.5 preview compatibility
+
+- Adds exact verification for DSH `0.1.5-alpha.1` on Node 22/24, exact-source contracts on Ubuntu/macOS/Windows, and a real Host + Chromium browser lifecycle. Public support policy is unchanged: DVR 2.1.x still has DSH `0.1.0-rc.8` as the minimum supported Host and `0.1.2-rc.1` as the current stable Host; `0.1.5-alpha.1` remains preview evidence rather than a blanket preview support promise.
+- Makes the existing Web `@deepseek-ai/dsh-client-modules` row explicitly wait for the official `webServer` carrier. This closes the Linux activation race exposed by the 0.1.5 preview while preserving the same upstream row, loader dependency, client graph, and stable/rc.8 behavior.
+- Pins exact alpha source evidence to the real `dsh-v0.1.5-alpha.1` commit and verifies the checkout SHA before running source contracts, preventing a mislabeled preview gate from silently testing older upstream source.
+
+## Vision-mode reliability
+
+- Preserves Vision mode when the user switches to another model that has a matching hidden Vision Router wrapper in the same visible source provider. The stock model picker still owns ordinary selection; cross-provider switches or targets without a wrapper still leave Vision mode.
+- Keeps DSH safety boundaries intact: the fix does not bypass image-session model guards, does not rewrite durable history, and does not expose hidden wrapper routes in the ordinary model list.
+
+## Security and release hardening
+
+- Updates the development `sharp` runtime past the libheif advisory while keeping the public shared-Host peer contract at `sharp >=0.35.3 <1`, so the security fix does not raise the Host floor.
+- Reworks the trusted PR impact shadow so `pull_request_target` never checks out PR code. The classifier is fetched from the trusted base commit through the GitHub Contents API, base64-decoded, size-bounded, and verified against the Git blob SHA before Node executes it; permissions remain read-only.
+- Adds deterministic adversarial security fuzzing, dependency review, OpenSSF Scorecard coverage, Private Vulnerability Reporting guidance, and stronger immutable release verification. These are release/supply-chain gates rather than runtime behavior changes.
+- Expands audited browser-impact triggers so client preludes, model-visibility boundaries, Web modules, Settings client surfaces, and exact browser compatibility modules cannot change without the corresponding real browser/source gates running.
+
+## Validation
+
+- Verified on Node 22/24, DSH rc.6/rc.7/rc.8 compatibility contracts, current stable `0.1.2-rc.1`, exact preview `0.1.5-alpha.1`, Ubuntu/macOS/Windows exact-source contracts, Windows screenshot runtime, host-sharp on all three desktop OSes, routing parity, native multimodal cold resume, large-image resource stress, deterministic hostile-input fuzz, dependency review, CodeQL, and real Chromium lifecycle gates for both stable and preview Hosts.
+- The compatibility head and post-merge `main` gates are green, including the `0.1.5-alpha.1` real Host + Chromium run.
+- No Settings migration is required. Restart DSH Web/Desktop after upgrading so the updated Host and browser compatibility logic is loaded.
+
+## Upgrade
+
+Upgrade to 2.1.5 and restart DSH Web/Desktop. Existing Vision Router settings remain compatible.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-vision-router",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "Eyes for text-only DeepSeek Harness agents: built-in free vision chain (no key) + pixel-level vision tools (Q&A, grounding, crop, pixel diff, colors, OCR, SVG trace, cutout, screenshots). One-command install, no Python, image turns work like ordinary tool-calling turns.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

- bump package identity from 2.1.4 to 2.1.5
- add curated v2.1.5 release notes for DSH 0.1.5-alpha.1 verification, Vision-mode model-switch reliability, and security/release hardening
- refresh the English/Chinese README release badge and announcement

## Release policy

- public minimum Host remains DSH 0.1.0-rc.8
- current stable Host remains DSH 0.1.2-rc.1
- DSH 0.1.5-alpha.1 remains exact preview verification evidence, not a blanket preview support promise

## Local verification

- focused release/manifest/compat contracts: 77/77 pass
- full suite: 1311 pass / 0 fail / 1 skip; backend runtime policy 6/6
- npm pack --dry-run: dsh-vision-router-2.1.5.tgz, 196 files, curated v2.1.5 notes included, no suspicious test/CI/node_modules paths
- release tag identity: v2.1.5 matches package.json
- npm registry: 2.1.5 not yet published

This PR prepares main for release only; it does not create the tag or publish to npm.