### PR TITLE
fix: reconcile wrapped vision twins with live providers

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,6 +106,7 @@ import {
 import { writeArtifactFile } from './lib/artifact-boundary.js'
 import { stripTrailingSlashes } from './lib/string-normalization.js'
 import { parseVersionComparator } from './lib/version-range.js'
+import { createCoalescingRunner } from './lib/adapter-update-coalescer.js'
 import { captureWindowsDesktop } from './lib/windows-desktop-capture.js'
 
 import {
@@ -1250,8 +1251,9 @@ export function apply(ctx, config = {}, runtime = {}) {
   // A session model on a third-party text-only route (e.g. opencode-go) is
   // rejected by the host admission once the session contains images, because
   // that route's catalog declares input:[text] and the admission runs before
-  // any plugin can rewrite the turn. `wrappedProviders` registers a twin
-  // route "<provider>-vision" that mirrors the original models but declares
+  // any plugin can rewrite the turn. `wrappedProviders` declares a twin
+  // route "<provider>-vision" that is materialized while its source is live,
+  // mirrors the original models, and declares
   // image input, so the user gets an image-capable entry for exactly the
   // routes they use. Text turns delegate byte-for-byte to the original
   // adapter; image blocks are handled by the shared wrapper body (cached
@@ -1266,36 +1268,40 @@ export function apply(ctx, config = {}, runtime = {}) {
         (route) => route !== undefined && route !== null && route !== '',
       ),
     )
-  // Auto-discovery is registry-driven rather than settings-file-driven. This
-  // intentionally follows the providers DSH can actually serve right now and
-  // reacts to later Settings changes through llm/adapters-updated. Explicit
-  // wrappedProviders entries below override the auto-discovered model filter.
-  const autoWrappedProviders = () => {
-    if (current().autoWrapProviders !== true || typeof ctx.llm.listProviders !== 'function') return []
+  // Auto-discovery is registry-driven rather than settings-file-driven. A
+  // configured wrapper is intent only: materialize its twin only while the
+  // source route is live, so provider metadata is never snapshotted from the
+  // fallback route id before a settings-backed adapter has registered.
+  const liveProviderDirectory = () => {
+    if (typeof ctx.llm.listProviders !== 'function') return new Map()
     try {
-      return ctx.llm
-        .listProviders()
-        .map((entry) => (entry && typeof entry.id === 'string' ? entry.id : ''))
-        .filter(
-          (provider) =>
-            provider !== '' &&
-            !ownRoutes().has(provider) &&
-            !provider.endsWith('-vision'),
-        )
+      return new Map(
+        ctx.llm
+          .listProviders()
+          .filter((entry) => entry && typeof entry.id === 'string' && entry.id !== '')
+          .map((entry) => [
+            entry.id,
+            {
+              id: entry.id,
+              name:
+                typeof entry.name === 'string' && entry.name !== ''
+                  ? entry.name
+                  : entry.id,
+            },
+          ]),
+      )
     } catch {
-      return []
+      return new Map()
     }
   }
-  // The twin must NOT resolve its source adapter eagerly: providers backed by
-  // user settings (llm-pi-ai's openrouter/deepseek) register their routes LIVE
-  // once the settings document loads, i.e. AFTER this plugin's apply. Same for
-  // wrappedProviders itself: the settings document loads asynchronously, so at
-  // apply time the scope may only contain composition defaults. The twins are
-  // therefore synced reactively — on settings changes and on every
-  // `llm/adapters-updated` event — and each twin delegates lazily per call.
-  const twinHandles = new Map() // provider -> { handle, modelsKey }
+  // Twins still delegate lazily per call because a live source adapter may be
+  // replaced without changing its route. The registration itself, however,
+  // is reconciled against live topology so a dormant configured provider does
+  // not publish a ghost `*-vision` route.
+  const twinHandles = new Map() // provider -> { handle, state, key }
   const twinModelsKey = (models) => models.slice().sort().join('\u0000')
-  const makeTwinAdapter = (provider, models) => {
+  const twinSpecKey = (models, sourceName) => JSON.stringify([twinModelsKey(models), sourceName])
+  const makeTwinAdapter = (provider, state) => {
     const twinRoute = `${provider}-vision`
     const originalAdapter = () => {
       try {
@@ -1322,14 +1328,7 @@ export function apply(ctx, config = {}, runtime = {}) {
     // later steps that arrive without one.
     return {
       providerInfo() {
-        const original = originalAdapter()
-        let info
-        try {
-          info = original && typeof original.providerInfo === 'function' ? original.providerInfo(provider) : undefined
-        } catch {
-          info = undefined
-        }
-        return { id: twinRoute, name: `${info && info.name ? info.name : provider} + 自动识图` }
+        return { id: twinRoute, name: `${state.sourceName} + 自动识图` }
       },
       providerRetryPolicy() {
         const original = originalAdapter()
@@ -1347,7 +1346,7 @@ export function apply(ctx, config = {}, runtime = {}) {
         try {
           const listed = await original.listModels(provider)
           return listed
-            .filter((model) => models.length === 0 || models.includes(model.id))
+            .filter((model) => state.models.length === 0 || state.models.includes(model.id))
             .map((model) => ({ ...model, provider: twinRoute, inputModalities: ['text', 'image'] }))
         } catch {
           return []
@@ -1375,43 +1374,88 @@ export function apply(ctx, config = {}, runtime = {}) {
       }),
     }
   }
-  const syncTwins = () => {
+  const reconcileTwins = () => {
+    const liveProviders = liveProviderDirectory()
     const wanted = new Map()
     // Default path: every live non-router provider gets a twin. The source
     // route remains untouched, including native multimodal models; this adds a
     // separate + auto-vision choice that deliberately uses vision-router.
-    for (const provider of autoWrappedProviders()) wanted.set(provider, [])
+    if (current().autoWrapProviders === true) {
+      for (const [provider, info] of liveProviders) {
+        if (ownRoutes().has(provider) || provider.endsWith('-vision')) continue
+        wanted.set(provider, { models: [], sourceName: info.name })
+      }
+    }
     // Explicit settings win for a provider and can narrow the twin to selected
-    // model ids. They still work when auto discovery is disabled, and can be
-    // registered before a settings-backed source adapter appears.
+    // model ids. A dormant entry remains configuration intent only; the twin
+    // appears when the source route becomes live and `llm/adapters-updated`
+    // drives this reconciliation again.
     for (const entry of wrappedProviders()) {
       const provider = entry.provider
       if (ownRoutes().has(provider) || provider.endsWith('-vision')) continue
+      const source = liveProviders.get(provider)
+      if (source === undefined) continue
       const models = Array.isArray(entry.models)
         ? entry.models.filter((model) => typeof model === 'string' && model !== '')
         : []
-      wanted.set(provider, models)
+      wanted.set(provider, { models, sourceName: source.name })
     }
-    // Drop twins that are no longer wanted, and rebuild ones whose model
-    // selection changed (the adapter closure captures the model filter).
+
+    // Withdraw twins whose source/intent disappeared. For a still-live twin,
+    // update presentation metadata/model filters through the Host's atomic
+    // registration replace seam: DSH re-reads providerInfo/retryPolicy before
+    // publishing, so active sessions never observe a dispose/register gap.
     for (const [provider, held] of [...twinHandles.entries()]) {
-      const models = wanted.get(provider)
-      if (models === undefined || twinModelsKey(models) !== held.key) {
-        held.handle()
-        twinHandles.delete(provider)
-      } else {
-        wanted.delete(provider) // already current
+      const spec = wanted.get(provider)
+      if (spec === undefined) {
+        try {
+          held.handle()
+          twinHandles.delete(provider)
+        } catch (error) {
+          ctx.logger?.warn(
+            'vision-router: twin route %s disposal failed: %s',
+            `${provider}-vision`,
+            error && error.message ? error.message : String(error),
+          )
+        }
+        continue
       }
+      const nextKey = twinSpecKey(spec.models, spec.sourceName)
+      if (nextKey !== held.key) {
+        const previousModels = held.state.models
+        const previousSourceName = held.state.sourceName
+        held.state.models = spec.models
+        held.state.sourceName = spec.sourceName
+        try {
+          held.handle.replace([`${provider}-vision`])
+          held.key = nextKey
+        } catch (error) {
+          held.state.models = previousModels
+          held.state.sourceName = previousSourceName
+          ctx.logger?.warn(
+            'vision-router: twin route %s refresh failed: %s',
+            `${provider}-vision`,
+            error && error.message ? error.message : String(error),
+          )
+        }
+      }
+      wanted.delete(provider)
     }
-    // Register the missing twins. Runs idempotently: our own registration
-    // emits llm/adapters-updated, and the second pass sees the generated
-    // `*-vision` route but excludes it from auto discovery.
-    for (const [provider, models] of wanted) {
+
+    // Register only twins whose source is live. Registration publishes the
+    // correct display name on the first snapshot, fixing #446 without weakening
+    // the client's fail-closed ownership/name checks.
+    for (const [provider, spec] of wanted) {
       const twinRoute = `${provider}-vision`
+      const state = { models: spec.models, sourceName: spec.sourceName }
       try {
-        const handle = ctx.llm.registerAdapter([twinRoute], makeTwinAdapter(provider, models))
+        const handle = ctx.llm.registerAdapter([twinRoute], makeTwinAdapter(provider, state))
         ctx.effect(() => handle, `vision-router: twin route ${twinRoute}`)
-        twinHandles.set(provider, { handle, key: twinModelsKey(models) })
+        twinHandles.set(provider, {
+          handle,
+          state,
+          key: twinSpecKey(spec.models, spec.sourceName),
+        })
       } catch (error) {
         ctx.logger?.warn(
           'vision-router: twin route %s registration failed: %s',
@@ -1421,6 +1465,14 @@ export function apply(ctx, config = {}, runtime = {}) {
       }
     }
   }
+  const syncTwins = createCoalescingRunner(reconcileTwins, {
+    onNonConverging({ passes }) {
+      ctx.logger?.error?.(
+        'vision-router: twin reconciliation did not converge after %d synchronous passes; stopping this cycle',
+        passes,
+      )
+    },
+  })
   syncTwins()
   ctx.on('llm/adapters-updated', syncTwins)
 

--- a/lib/twin-image-capability-fallback.js
+++ b/lib/twin-image-capability-fallback.js
@@ -408,12 +408,12 @@ export function contextWithTwinImageCapabilityFallback(ctx, options = {}) {
       if (!looksLikeGeneratedTwin) return llm.registerAdapter(providers, adapter, ...rest)
       const sourceProvider = route.slice(0, -TWIN_SUFFIX.length)
       // This context is private to Core.apply, and Core creates its generated
-      // twins as single `<source>-vision` registrations. Do not require the
-      // source route to exist *yet*: explicit wrappedProviders are allowed to
-      // register before a settings-backed source adapter appears, then delegate
-      // lazily once that source is mounted. Main/custom wrapper and chain routes
-      // are excluded above, so preserving this lazy lifecycle does not broaden
-      // the boundary to other Core-owned registrations.
+      // twins as single `<source>-vision` registrations. Current Core waits for
+      // the source route before materializing a configured twin (#446), but keep
+      // this lower compatibility wrapper tolerant of out-of-order registration:
+      // older Core builds and focused boundary tests can still present the twin
+      // first. Main/custom wrapper and chain routes are excluded above, so that
+      // tolerance does not broaden the boundary to other Core-owned routes.
       return llm.registerAdapter(providers, wrapTwinAdapter(adapter, sourceProvider), ...rest)
     },
   })

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -1231,7 +1231,11 @@ function mockHarnessCtx({ stockRoute = false, config0 = {}, skills = false, atta
       },
     }
     adapters.set('deepseek-official', stock)
-    registrations.set('deepseek-official', { adapter: stock, retryPolicy: 'retry' })
+    registrations.set('deepseek-official', {
+      adapter: stock,
+      provider: { id: 'deepseek-official', name: 'DeepSeek' },
+      retryPolicy: 'retry',
+    })
   }
   if (opencodeGo) {
     // A pi-ai-shaped adapter for the opencode-go route: the catalog-correction
@@ -1272,7 +1276,11 @@ function mockHarnessCtx({ stockRoute = false, config0 = {}, skills = false, atta
       },
     }
     adapters.set('opencode-go', adapter)
-    registrations.set('opencode-go', { adapter, retryPolicy: undefined })
+    registrations.set('opencode-go', {
+      adapter,
+      provider: { id: 'opencode-go', name: 'OpenCode Go' },
+      retryPolicy: undefined,
+    })
   }
   const ctx = {
     get(name) {
@@ -1330,27 +1338,66 @@ function mockHarnessCtx({ stockRoute = false, config0 = {}, skills = false, atta
     tools: { register: (tool) => { captured.tools.push(tool); return () => {} } },
     llm: {
       registerAdapter(providers, adapter) {
-        for (const provider of providers) {
-          if (adapters.has(provider)) {
-            const error = new Error(`an adapter for provider "${provider}" is already registered`)
-            error.code = 'DUPLICATE_ADAPTER'
+        const owned = new Set()
+        let released = false
+        const prepare = (next) => {
+          const prepared = []
+          const seen = new Set()
+          for (const provider of next) {
+            if (seen.has(provider) || (adapters.has(provider) && !owned.has(provider))) {
+              const error = new Error(`an adapter for provider "${provider}" is already registered`)
+              error.code = 'DUPLICATE_ADAPTER'
+              throw error
+            }
+            const info = adapter.providerInfo ? adapter.providerInfo(provider) : { id: provider, name: provider }
+            if (!info || info.id !== provider || typeof info.name !== 'string' || info.name === '') {
+              const error = new Error(`invalid adapter metadata for provider "${provider}"`)
+              error.code = 'INVALID_ADAPTER'
+              throw error
+            }
+            seen.add(provider)
+            prepared.push({
+              provider,
+              info: { id: info.id, name: info.name },
+              retryPolicy: adapter.providerRetryPolicy ? adapter.providerRetryPolicy(provider) : undefined,
+            })
+          }
+          return prepared
+        }
+        const commit = (prepared) => {
+          for (const provider of owned) {
+            if (adapters.get(provider) === adapter) adapters.delete(provider)
+            const registration = registrations.get(provider)
+            if (registration && registration.adapter === adapter) registrations.delete(provider)
+          }
+          owned.clear()
+          for (const entry of prepared) {
+            adapters.set(entry.provider, adapter)
+            registrations.set(entry.provider, {
+              adapter,
+              provider: entry.info,
+              retryPolicy: entry.retryPolicy,
+            })
+            owned.add(entry.provider)
+          }
+        }
+        commit(prepare(providers))
+        // Mirror DSH's registration handle closely enough to catch snapshot
+        // metadata regressions: providerInfo/retryPolicy are captured at commit
+        // time, and replace() re-reads them before an atomic same-route swap.
+        const handle = () => {
+          if (released) return
+          released = true
+          commit([])
+        }
+        handle.replace = (next) => {
+          if (released) {
+            const error = new Error('registration disposed')
+            error.code = 'REGISTRATION_DISPOSED'
             throw error
           }
+          commit(prepare(next))
         }
-        for (const provider of providers) {
-          adapters.set(provider, adapter)
-          registrations.set(provider, { adapter, retryPolicy: adapter.providerRetryPolicy(provider) })
-        }
-        // mirror the real handle: calling it disposes the registration
-        const handle = () => {
-          for (const provider of providers) {
-            if (adapters.get(provider) === adapter) adapters.delete(provider)
-            if (registrations.get(provider) && registrations.get(provider).adapter === adapter) {
-              registrations.delete(provider)
-            }
-          }
-        }
-        handle.replace = () => {}
         return handle
       },
       registration(provider) {
@@ -1363,15 +1410,7 @@ function mockHarnessCtx({ stockRoute = false, config0 = {}, skills = false, atta
         return { replace: () => {} }
       },
       listProviders() {
-        return [...registrations.entries()].map(([provider, registration]) => {
-          let info
-          try {
-            info = registration.adapter.providerInfo ? registration.adapter.providerInfo(provider) : undefined
-          } catch {
-            info = undefined
-          }
-          return { id: provider, name: info && info.name ? info.name : provider }
-        })
+        return [...registrations.values()].map((registration) => ({ ...registration.provider }))
       },
       async listModels(provider) {
         const hit = registrations.get(provider)
@@ -2085,21 +2124,19 @@ test('twin wrapper leaves the effort untouched when nothing was seen or configur
   assert.equal(calls[0].reasoningEffort, undefined)
 })
 
-test('twin route registers before its source adapter appears (live provider registration)', async () => {
-  // llm-pi-ai mounts dormant: its routes (openrouter/deepseek) register LIVE
-  // once the settings document loads, i.e. AFTER other plugins' apply().
-  // wrappedProviders must therefore register the twin up front and resolve
-  // the source adapter lazily per call.
-  const { ctx, adapters } = mockHarnessCtx()
+test('issue #446 keeps explicit wrapper intent dormant until the source route is live', async () => {
+  // llm-pi-ai-style providers can be configured before their adapter route is
+  // registered. Publishing the twin early makes DSH snapshot the fallback
+  // route id as its display name and the browser then fails closed forever.
+  const { ctx, adapters, captured } = mockHarnessCtx()
   apply(ctx, Config({
-    wrappedProviders: [{ provider: 'opencode-go', models: [] }],
+    autoWrapProviders: false,
+    wrappedProviders: [{ provider: 'ctyun', models: [] }],
   }))
-  assert.ok(adapters.has('opencode-go-vision'), 'expected the twin route before the source adapter exists')
-  const twin = adapters.get('opencode-go-vision')
-  // before the source appears: empty catalog, no crash
-  assert.deepEqual(await twin.listModels('opencode-go-vision'), [])
+  assert.equal(adapters.has('ctyun-vision'), false, 'dormant intent must not publish a ghost twin')
+
   const thirdParty = {
-    providerInfo: (p) => ({ id: p, name: 'Opencode' }),
+    providerInfo: (p) => ({ id: p, name: '天翼云' }),
     providerRetryPolicy: () => 'retry',
     listModels: async (p) => [
       { provider: p, id: 'deepseek-v4-flash', name: 'DeepSeek-V4-Flash', inputModalities: ['text'] },
@@ -2112,13 +2149,175 @@ test('twin route registers before its source adapter appears (live provider regi
       yield { type: 'finish', reason: { kind: 'stop' } }
     },
   }
-  ctx.llm.registerAdapter(['opencode-go'], thirdParty)
-  // after the source appears: mirrored catalog with image input declared
-  const listed = await twin.listModels('opencode-go-vision')
+  ctx.llm.registerAdapter(['ctyun'], thirdParty)
+  const fire = captured.on.get('llm/adapters-updated')
+  assert.ok(fire, 'expected the adapters-updated listener to be registered')
+  fire()
+
+  const twin = adapters.get('ctyun-vision')
+  assert.ok(twin, 'expected the twin after the source adapter becomes live')
+  assert.deepEqual(
+    ctx.llm.listProviders().find((entry) => entry.id === 'ctyun-vision'),
+    { id: 'ctyun-vision', name: '天翼云 + 自动识图' },
+  )
+  const listed = await twin.listModels('ctyun-vision')
   assert.deepEqual(listed.map((m) => m.id), ['deepseek-v4-flash', 'deepseek-v4-pro'])
   for (const model of listed) assert.deepEqual(model.inputModalities, ['text', 'image'])
-  const resolved = await twin.resolveModel('opencode-go-vision', 'deepseek-v4-flash')
+  const resolved = await twin.resolveModel('ctyun-vision', 'deepseek-v4-flash')
   assert.deepEqual(resolved.inputModalities, ['text', 'image'])
+})
+
+test('issue #446 atomically refreshes twin presentation metadata without changing its adapter instance', () => {
+  const { ctx, adapters, captured } = mockHarnessCtx()
+  let displayName = '天翼云'
+  const source = {
+    providerInfo: (p) => ({ id: p, name: displayName }),
+    providerRetryPolicy: () => 'retry',
+    listModels: async () => [],
+    resolveModel: async (p, m) => ({ provider: p, id: m, name: m, inputModalities: ['text'] }),
+    stream: async function* () {
+      yield { type: 'finish', reason: { kind: 'stop' } }
+    },
+  }
+  const sourceHandle = ctx.llm.registerAdapter(['ctyun'], source)
+  apply(ctx, Config({
+    autoWrapProviders: false,
+    wrappedProviders: [{ provider: 'ctyun', models: [] }],
+  }))
+  const fire = captured.on.get('llm/adapters-updated')
+  assert.ok(fire)
+  const twin = adapters.get('ctyun-vision')
+  assert.ok(twin)
+  assert.equal(
+    ctx.llm.listProviders().find((entry) => entry.id === 'ctyun-vision')?.name,
+    '天翼云 + 自动识图',
+  )
+
+  displayName = '天翼云模型服务'
+  sourceHandle.replace(['ctyun'])
+  fire()
+  assert.strictEqual(adapters.get('ctyun-vision'), twin, 'same twin adapter should survive metadata refresh')
+  assert.equal(
+    ctx.llm.listProviders().find((entry) => entry.id === 'ctyun-vision')?.name,
+    '天翼云模型服务 + 自动识图',
+  )
+})
+
+test('issue #446 withdraws a twin when its live source disappears and restores it when the source returns', () => {
+  const { ctx, adapters, captured } = mockHarnessCtx()
+  const makeSource = (name) => ({
+    providerInfo: (p) => ({ id: p, name }),
+    providerRetryPolicy: () => 'retry',
+    listModels: async () => [],
+    resolveModel: async (p, m) => ({ provider: p, id: m, name: m, inputModalities: ['text'] }),
+    stream: async function* () {
+      yield { type: 'finish', reason: { kind: 'stop' } }
+    },
+  })
+  let sourceHandle = ctx.llm.registerAdapter(['ctyun'], makeSource('天翼云'))
+  apply(ctx, Config({
+    autoWrapProviders: false,
+    wrappedProviders: [{ provider: 'ctyun', models: [] }],
+  }))
+  const fire = captured.on.get('llm/adapters-updated')
+  assert.ok(fire)
+  assert.ok(adapters.has('ctyun-vision'))
+
+  sourceHandle()
+  fire()
+  assert.equal(adapters.has('ctyun-vision'), false)
+
+  sourceHandle = ctx.llm.registerAdapter(['ctyun'], makeSource('天翼云重载'))
+  fire()
+  assert.ok(adapters.has('ctyun-vision'))
+  assert.equal(
+    ctx.llm.listProviders().find((entry) => entry.id === 'ctyun-vision')?.name,
+    '天翼云重载 + 自动识图',
+  )
+  sourceHandle()
+})
+
+test('issue #446 twin reconciliation converges under synchronous adapters-updated re-entry', () => {
+  const { ctx, adapters, captured } = mockHarnessCtx()
+  apply(ctx, Config({
+    autoWrapProviders: false,
+    wrappedProviders: [{ provider: 'ctyun', models: [] }],
+  }))
+  const fire = captured.on.get('llm/adapters-updated')
+  assert.ok(fire)
+
+  // The real DSH registry emits adapters-updated synchronously from register,
+  // replace and disposal. Decorate this test mock after apply so a twin
+  // mutation re-enters syncTwins exactly while the outer reconciliation runs.
+  const rawRegister = ctx.llm.registerAdapter.bind(ctx.llm)
+  ctx.llm.registerAdapter = (providers, adapter) => {
+    const rawHandle = rawRegister(providers, adapter)
+    const handle = () => {
+      rawHandle()
+      fire()
+    }
+    handle.replace = (next) => {
+      rawHandle.replace(next)
+      fire()
+    }
+    fire()
+    return handle
+  }
+
+  let displayName = '天翼云'
+  const source = {
+    providerInfo: (p) => ({ id: p, name: displayName }),
+    providerRetryPolicy: () => 'retry',
+    listModels: async () => [],
+    resolveModel: async (p, m) => ({ provider: p, id: m, name: m, inputModalities: ['text'] }),
+    stream: async function* () {
+      yield { type: 'finish', reason: { kind: 'stop' } }
+    },
+  }
+  const sourceHandle = ctx.llm.registerAdapter(['ctyun'], source)
+  assert.ok(adapters.has('ctyun-vision'))
+
+  displayName = '天翼云模型服务'
+  sourceHandle.replace(['ctyun'])
+  assert.equal(
+    ctx.llm.listProviders().find((entry) => entry.id === 'ctyun-vision')?.name,
+    '天翼云模型服务 + 自动识图',
+  )
+
+  sourceHandle()
+  assert.equal(adapters.has('ctyun-vision'), false)
+})
+
+test('issue #446 model-filter edits refresh one live twin without replacing its adapter instance', async () => {
+  const userDoc = {
+    autoWrapProviders: false,
+    wrappedProviders: [{ provider: 'ctyun', models: ['model-a'] }],
+  }
+  const { ctx, adapters, settingsWatchers } = mockHarnessCtx({ config0: userDoc })
+  const source = {
+    providerInfo: (p) => ({ id: p, name: '天翼云' }),
+    providerRetryPolicy: () => 'retry',
+    listModels: async (p) => [
+      { provider: p, id: 'model-a', name: 'A', inputModalities: ['text'] },
+      { provider: p, id: 'model-b', name: 'B', inputModalities: ['text'] },
+    ],
+    resolveModel: async (p, m) => ({ provider: p, id: m, name: m, inputModalities: ['text'] }),
+    stream: async function* () {
+      yield { type: 'finish', reason: { kind: 'stop' } }
+    },
+  }
+  ctx.llm.registerAdapter(['ctyun'], source)
+  apply(ctx, Config(userDoc))
+  const twin = adapters.get('ctyun-vision')
+  assert.ok(twin)
+  assert.deepEqual((await twin.listModels('ctyun-vision')).map((model) => model.id), ['model-a'])
+
+  userDoc.wrappedProviders = [{ provider: 'ctyun', models: ['model-b'] }]
+  assert.ok(settingsWatchers.length > 0)
+  for (const watch of settingsWatchers) watch()
+
+  assert.strictEqual(adapters.get('ctyun-vision'), twin)
+  assert.deepEqual((await twin.listModels('ctyun-vision')).map((model) => model.id), ['model-b'])
 })
 
 test('auto-wrap also exposes a twin for an already image-capable GLM model', async () => {

--- a/tests/twin-image-custom-wrapper.test.js
+++ b/tests/twin-image-custom-wrapper.test.js
@@ -208,8 +208,9 @@ test('generated twin registered before its settings-backed source still gains ru
     },
   }
 
-  // Core explicitly supports this lifecycle: wrappedProviders may create the
-  // twin before a settings-backed source adapter has mounted.
+  // The compatibility wrapper remains tolerant of this historical ordering
+  // even though current Core (#446) waits for a live source before publishing
+  // a configured twin.
   wrapped.llm.registerAdapter(['src-vision'], generatedTwin)
   assert.equal(registrations.has('src'), false)
 


### PR DESCRIPTION
## Summary

Fix the wrapped-provider twin lifecycle behind #446 without weakening the existing browser-side fail-closed ownership checks.

The root cause was not just a stale label. `wrappedProviders` intent could materialize `<provider>-vision` before the source adapter existed, so DSH snapshotted fallback metadata such as `ctyun + 自动识图`. When the real source later registered as `天翼云`, the existing twin was retained because the sync key only tracked the model filter. The browser correctly rejected the mismatched pair and left the Vision toggle unavailable.

## What changes

- Treat `wrappedProviders` as configuration intent, not proof that a source route is live.
- Materialize generic `*-vision` twins only when the source provider is present in the live LLM directory.
- Capture the source display name from the live provider snapshot on first registration, so the first published twin metadata is already correct.
- Track both source presentation metadata and model-filter state in the twin reconciliation key.
- Refresh an existing twin through DSH's atomic `AdapterRegistrationHandle.replace()` when its display name or model filter changes, avoiding a dispose/register gap for active sessions.
- Withdraw the twin when its source disappears and recreate it when the source returns.
- Reuse the repository's bounded `createCoalescingRunner` for synchronous `llm/adapters-updated` re-entry instead of introducing a second unbounded reconciliation loop.
- Keep the lower twin-image compatibility wrapper tolerant of the historical twin-before-source ordering so older Core/focused compatibility paths remain supported.

## Compatibility / non-goals

This intentionally does **not** change the client-side Vision ownership matcher. Route/model/config/name checks remain fail-closed, so a foreign plugin that happens to register `<provider>-vision` is not newly trusted.

This also does not expand the existing dependency on DSH's private `registration()` helper. Lifecycle decisions use the public live-provider directory; the existing lazy delegation seam is left unchanged for this focused fix.

No DSH support window, Node support, platform policy, Store patch, or #447/#448 behavior is changed here.

## Regression coverage

Added/updated coverage proves:

- explicit wrapper intent stays dormant until the source adapter is live;
- the first twin snapshot uses the real source display name (`天翼云 + 自动识图`);
- a source display-name change refreshes twin metadata atomically while preserving the same twin adapter instance;
- source removal withdraws the twin and source restoration recreates it;
- synchronous `llm/adapters-updated` re-entry converges safely;
- runtime `wrappedProviders[].models` edits refresh one live twin without replacing its adapter instance;
- existing auto-wrap, native multimodal, reasoning-effort, #284 and #431 Vision-mode behavior remains intact.

Local verification on the final diff:

- focused twin/Vision suites: 235/235 passed;
- full `pnpm test`: 1317 passed, 0 failed, 1 skipped;
- backend runtime policy: 6/6 passed;
- `npm pack --dry-run` passed;
- `git diff --check` passed;
- `index.js` remains below the Store single-file 262,144-byte limit (~233.5 KB).

Closes #446