### PR TITLE
ci: guard Web modules overlay lifecycle

### DIFF
--- a/.github/workflows/dsh-alpha-source-contract.yml
+++ b/.github/workflows/dsh-alpha-source-contract.yml
@@ -29,7 +29,9 @@ on:
       - 'lib/vision-exact-check-client.js'
       - 'lib/vision-routing-settings-prelude.js'
       - 'scripts/dsh-alpha-source-contract.mjs'
+      - 'scripts/dsh-web-modules-overlay-contract.mjs'
       - 'tests/adapter-prepare-call-compat.test.js'
+      - 'tests/rc6-rc7-compat.test.js'
       - 'tests/alpha1-*.test.js'
       - 'tests/attachment-admission-policy.test.js'
       - 'tests/clipboard-image-paste-compat.test.js'
@@ -64,7 +66,9 @@ on:
       - 'lib/vision-exact-check-client.js'
       - 'lib/vision-routing-settings-prelude.js'
       - 'scripts/dsh-alpha-source-contract.mjs'
+      - 'scripts/dsh-web-modules-overlay-contract.mjs'
       - 'tests/adapter-prepare-call-compat.test.js'
+      - 'tests/rc6-rc7-compat.test.js'
       - 'tests/alpha1-*.test.js'
       - 'tests/attachment-admission-policy.test.js'
       - 'tests/clipboard-image-paste-compat.test.js'
@@ -128,6 +132,13 @@ jobs:
           DSH_EXPECTED_VERSION: 0.1.5-alpha.1
           DSH_EXPECTED_COMMIT: 5dda764ed3aa172535a7967b06ff95d9cbfe536a
         run: pnpm exec tsx ../dvr/scripts/dsh-alpha-source-contract.mjs
+
+      - name: Assert modules -> webServer compatibility overlay still belongs to DVR
+        working-directory: dsh-alpha
+        env:
+          DSH_SOURCE_ROOT: ${{ github.workspace }}/dsh-alpha
+          DSH_MODULES_WEBSERVER_EXPECTED: shim-required
+        run: pnpm exec tsx ../dvr/scripts/dsh-web-modules-overlay-contract.mjs
 
       - name: Run DVR alpha compatibility unit contracts
         working-directory: dvr

--- a/.github/workflows/dsh-upstream-web-modules-watch.yml
+++ b/.github/workflows/dsh-upstream-web-modules-watch.yml
@@ -1,0 +1,86 @@
+name: DSH upstream Web modules watch
+
+on:
+  pull_request:
+    paths:
+      - 'cordis.patch.yml'
+      - 'scripts/dsh-web-modules-overlay-contract.mjs'
+      - 'tests/rc6-rc7-compat.test.js'
+      - '.github/workflows/dsh-upstream-web-modules-watch.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'cordis.patch.yml'
+      - 'scripts/dsh-web-modules-overlay-contract.mjs'
+      - 'tests/rc6-rc7-compat.test.js'
+      - '.github/workflows/dsh-upstream-web-modules-watch.yml'
+  schedule:
+    - cron: '17 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  upstream-web-modules-watch:
+    name: current master modules -> webServer ownership
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout Vision Router
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+          path: dvr
+
+      # Intentionally moving: this job is a retirement/drift sentinel, not a
+      # release evidence gate. Exact supported Host commits remain pinned in
+      # the stable/preview compatibility workflows.
+      - name: Checkout current DSH master
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          repository: deepseek-ai/deepseek-harness
+          ref: master
+          persist-credentials: false
+          path: dsh
+
+      - name: Resolve DSH package manager
+        id: package-manager
+        working-directory: dsh
+        shell: bash
+        run: |
+          package_manager="$(node -p "require('./package.json').packageManager")"
+          case "$package_manager" in
+            pnpm@*) echo "version=${package_manager#pnpm@}" >> "$GITHUB_OUTPUT" ;;
+            *) echo "Unsupported DSH packageManager for this watch: $package_manager" >&2; exit 1 ;;
+          esac
+
+      - name: Install DSH package manager
+        uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0
+        with:
+          version: ${{ steps.package-manager.outputs.version }}
+
+      - name: Install Node contract runtime
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22.19.0
+          cache: pnpm
+          cache-dependency-path: dsh/pnpm-lock.yaml
+
+      - name: Install current DSH source dependencies
+        working-directory: dsh
+        env:
+          CI: 'true'
+          LEFTHOOK: '0'
+        run: pnpm install --frozen-lockfile
+
+      - name: Require DVR overlay to remain necessary and non-destructive
+        working-directory: dsh
+        env:
+          DSH_SOURCE_ROOT: ${{ github.workspace }}/dsh
+          DSH_MODULES_WEBSERVER_EXPECTED: shim-required
+        run: pnpm exec tsx ../dvr/scripts/dsh-web-modules-overlay-contract.mjs

--- a/scripts/dsh-web-modules-overlay-contract.mjs
+++ b/scripts/dsh-web-modules-overlay-contract.mjs
@@ -1,0 +1,99 @@
+import path from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+export const WEB_MODULES_ROW_ID = 'modules'
+export const WEB_MODULES_PACKAGE = '@deepseek-ai/dsh-client-modules'
+export const WEB_SERVER_SERVICE = 'webServer'
+
+function result(status, reason, row, inject = []) {
+  return Object.freeze({ status, reason, row, inject: Object.freeze([...inject]) })
+}
+
+export function classifyWebModulesRows(rows) {
+  const list = Array.isArray(rows) ? rows : []
+  const matches = list.filter((row) => row && row.id === WEB_MODULES_ROW_ID)
+  if (matches.length !== 1) {
+    return result(
+      'dangerous-drift',
+      `expected exactly one official Web ${WEB_MODULES_ROW_ID} row, found ${matches.length}`,
+      matches[0],
+    )
+  }
+
+  const row = matches[0]
+  if (row.name !== WEB_MODULES_PACKAGE) {
+    return result(
+      'dangerous-drift',
+      `official Web ${WEB_MODULES_ROW_ID} row changed identity to ${String(row.name)}`,
+      row,
+    )
+  }
+
+  if (row.inject === undefined) {
+    return result('shim-required', 'official Web modules row still declares no activation dependencies', row)
+  }
+  if (!Array.isArray(row.inject) || row.inject.some((value) => typeof value !== 'string' || value === '')) {
+    return result('dangerous-drift', 'official Web modules inject field is no longer a string array', row)
+  }
+
+  const inject = [...new Set(row.inject)]
+  if (inject.includes(WEB_SERVER_SERVICE)) {
+    return result(
+      'retire-ready',
+      inject.length === 1
+        ? 'official Web modules row now owns the webServer activation dependency'
+        : `official Web modules row now owns webServer plus ${inject.length - 1} additional activation dependency/dependencies`,
+      row,
+      inject,
+    )
+  }
+  if (inject.length === 0) {
+    return result('shim-required', 'official Web modules row still has no activation dependency', row)
+  }
+  return result(
+    'dangerous-drift',
+    `official Web modules row gained activation dependencies without webServer: ${inject.join(', ')}`,
+    row,
+    inject,
+  )
+}
+
+export async function inspectDshWebModulesOverlay(dshRoot) {
+  const root = path.resolve(dshRoot || '')
+  if (!dshRoot) throw new Error('DSH_SOURCE_ROOT is required')
+  const appBootUrl = pathToFileURL(path.join(root, 'packages/boot/app-boot/src/index.ts')).href
+  const { loadOverlayPatches } = await import(appBootUrl)
+  const patchPath = path.join(root, 'packages/bundle/web-app/cordis.patch.yml')
+  const patches = loadOverlayPatches('dvr modules/webServer overlay contract', patchPath)
+  const insertedRows = patches.flatMap((patch) => Array.isArray(patch?.insert) ? patch.insert : [])
+  return classifyWebModulesRows(insertedRows)
+}
+
+async function main() {
+  const dshRoot = String(process.env.DSH_SOURCE_ROOT || '').trim()
+  const expected = String(process.env.DSH_MODULES_WEBSERVER_EXPECTED || '').trim()
+  const inspected = await inspectDshWebModulesOverlay(dshRoot)
+  const payload = {
+    ok: inspected.status !== 'dangerous-drift' && (!expected || inspected.status === expected),
+    status: inspected.status,
+    expected: expected || undefined,
+    reason: inspected.reason,
+    inject: inspected.inject,
+  }
+  console.log(JSON.stringify(payload))
+
+  if (inspected.status === 'dangerous-drift') {
+    throw new Error(`DSH Web modules compatibility overlay is unsafe: ${inspected.reason}`)
+  }
+  if (expected && inspected.status !== expected) {
+    if (inspected.status === 'retire-ready') {
+      throw new Error(
+        `DSH Web now owns modules -> webServer; retire DVR's compatibility overlay before admitting this Host train (${inspected.reason})`,
+      )
+    }
+    throw new Error(`expected DSH Web modules state ${expected}, got ${inspected.status}: ${inspected.reason}`)
+  }
+}
+
+const invoked = process.argv[1] && path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url))
+if (invoked) await main()

--- a/tests/rc6-rc7-compat.test.js
+++ b/tests/rc6-rc7-compat.test.js
@@ -2,6 +2,7 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 import { readFile } from 'node:fs/promises'
 import { Config as EntryConfig, SETTINGS_CONTRACT_REVISION } from '../entry.js'
+import { classifyWebModulesRows } from '../scripts/dsh-web-modules-overlay-contract.mjs'
 import {
   attachmentContextForContract,
   hasBatchAttachmentContract,
@@ -183,6 +184,26 @@ test('manifest publishes the DVR 2.1 rc8 host floor while admitting verified sta
   assert.equal(pkg.peerDependencies['@deepseek-ai/dsh-llm-deepseek'], expectedHostPeerRange)
   assert.equal(pkg.peerDependencies['@deepseek-ai/dsh-anonymous-user-id'], expectedHostPeerRange)
   assert.equal(pkg.peerDependencies['@deepseek-ai/dsh-settings'], undefined)
+})
+
+test('modules/webServer overlay lifecycle classifies required, retire-ready, and dangerous Host drift', () => {
+  const base = { id: 'modules', name: '@deepseek-ai/dsh-client-modules' }
+  assert.equal(classifyWebModulesRows([base]).status, 'shim-required')
+  assert.equal(classifyWebModulesRows([{ ...base, inject: [] }]).status, 'shim-required')
+  assert.equal(classifyWebModulesRows([{ ...base, inject: ['webServer'] }]).status, 'retire-ready')
+  assert.equal(
+    classifyWebModulesRows([{ ...base, inject: ['newCarrier', 'webServer'] }]).status,
+    'retire-ready',
+  )
+  assert.equal(
+    classifyWebModulesRows([{ ...base, inject: ['newCarrier'] }]).status,
+    'dangerous-drift',
+  )
+  assert.equal(
+    classifyWebModulesRows([{ ...base, name: '@deepseek-ai/renamed-modules' }]).status,
+    'dangerous-drift',
+  )
+  assert.equal(classifyWebModulesRows([]).status, 'dangerous-drift')
 })
 
 test('web client modules wait for the official webServer carrier across supported Host trains', async () => {


### PR DESCRIPTION
## Summary

Add an explicit lifecycle contract for the temporary `modules -> webServer` compatibility overlay tracked in #448, without changing the overlay itself or the supported DSH window.

The goal is to make this shim self-auditing instead of relying on a future manual reminder.

## What changes

### Three-state Host ownership classifier

`scripts/dsh-web-modules-overlay-contract.mjs` loads DSH's **own** Web bundle patch through `@deepseek-ai/dsh-app-boot` / `loadOverlayPatches()` and classifies the official `modules` row as:

1. **`shim-required`** — the official row has no activation dependency yet; DVR's current overlay is still needed.
2. **`retire-ready`** — the official row now includes `webServer`; DVR must retire its overlay before admitting that Host train.
3. **`dangerous-drift`** — the row changed identity/disappeared/duplicated, or gained other `inject` dependencies without `webServer`; keeping DVR's current field override could erase upstream dependencies and therefore fails closed.

The existing browser-side/runtime compatibility overlay in `cordis.patch.yml` is intentionally unchanged.

### Exact supported Host gate

The existing `0.1.5-alpha.1` source-contract matrix now asserts `shim-required` on Windows/macOS/Linux. This proves the currently supported preview evidence still needs the DVR-owned compatibility edge.

### Moving upstream retirement/drift watch

A new `DSH upstream Web modules watch` workflow intentionally checks current `deepseek-ai/deepseek-harness@master` on PRs touching this contract, after relevant pushes, daily, and on manual dispatch.

It expects `shim-required` today. If upstream starts owning `webServer`, the job fails with an explicit **retire DVR overlay** diagnostic. If upstream adds a different dependency first, it fails as **dangerous drift** instead of silently letting DVR replace the new dependency list.

This moving watch is deliberately separate from pinned release-evidence gates: it can warn about future ownership changes without making DSH master part of DVR's support promise.

## Validation

Current official sources:

- `dsh-v0.1.5-alpha.1` -> `shim-required`
- current upstream `master@b2e3b2a0125854567a4a5fcba75782e42fe84901` / `0.1.5-alpha.2` -> `shim-required`

Retirement canary:

- applying the prepared upstream ownership fix `ysr666/deepseek-harness@0780921caede536a8a100b09c2471ec7dbfe50f0` makes the watch exit non-zero with `status=retire-ready` and the expected `retire DVR's compatibility overlay` diagnostic.

Local DVR validation:

- lifecycle classifier contract: 11/11 passed;
- full `pnpm test`: 1318 passed, 0 failed, 1 skipped;
- backend runtime policy: 6/6 passed;
- workflow YAML parses successfully;
- `git diff --check` passed;
- new script/workflow are outside the npm `files` allow-list, so this does not increase the published package / Store source aggregate.

## Non-goals

- does **not** remove or weaken `name: '@deepseek-ai/dsh-client-modules'`;
- does **not** change `inject: [webServer]` yet;
- does **not** raise the DSH peer/support floor;
- does **not** treat moving DSH master as release evidence;
- does **not** resolve the separate Store protected-namespace classification in AI-Scarlett/DSH-Store#686.

Refs #448