### PR TITLE
fix(settings): inject webServer for remote RPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Bilingual (Chinese + English) release notes for every version — the GitHub Rel
 
 ### 修复 / Fixes
 
+- **DSH 0.1.5 远程设置 `webServer` 注入根修（#465）**：远程设置 RPC 现在在同一个 Cordis caller fiber 上显式声明 `settings`、`connection` 与 `webServer`。DSH 0.1.5 的 `connection.rpc.handle()` 会把通道路由注册到调用方 Context 的 `webServer`；此前只注入前两项会在 rc.1/rc.2 的严格 service-access 语义下触发 `cannot get property "webServer" without inject`。修复不修改 Host bundle overlay，也不放宽远程设置的 trusted-host / allow-list 安全边界。
+- **DSH 0.1.5 remote-settings `webServer` injection fix (#465)**: remote-settings RPC registration now declares `settings`, `connection`, and `webServer` on the same Cordis caller fiber. DSH 0.1.5 `connection.rpc.handle()` mounts its channel route through the caller Context's `webServer`; injecting only the first two services could therefore throw `cannot get property "webServer" without inject` under rc.1/rc.2 strict service-access semantics. The fix does not change the Host bundle overlay or relax the trusted-host / allow-list security boundary.
+
 - **代理生命周期单一所有权收敛**：#462/#463 后所有 DVR ProxyAgent 已由共享 lease/retire dispatcher pool 显式拥有，删除已不可达的 `ProxyDispatcherTracker`、`vision-tool-runtime-boundary` 全局 `fetch` 观察器以及仅为该观察器存在的 WeakSet dispatcher 标记。运行时不再维护第三套“看到 dispatcher 再猜所有权并关闭”的生命周期；Router-owned 与 Host-owned scoped 两条显式代理路径继续由同一 pool 负责热切换、清空配置、同步失败、pending construction 与卸载回收。
 - **Single-owner proxy lifecycle convergence**: after #462/#463 every DVR ProxyAgent is explicitly owned by the shared lease/retire dispatcher pool, so the now-unreachable `ProxyDispatcherTracker`, the `vision-tool-runtime-boundary` global-`fetch` observer, and its marker-only WeakSet are removed. Runtime no longer keeps a third lifecycle system that observes dispatchers and infers ownership after the fact; Router-owned and scoped Host-owned proxy paths continue to share the same pool for hot replacement, proxy clear, synchronous failure, pending construction, and unload cleanup.
 

--- a/lib/remote-settings-bridge.js
+++ b/lib/remote-settings-bridge.js
@@ -213,7 +213,11 @@ export function createVisionRouterRemoteSettingsHandler(settings, logger) {
 }
 
 export function installVisionRouterRemoteSettingsBridge(ctx, logger) {
-  ctx.inject(['settings', 'connection'], (remoteCtx) => {
+  // DSH client-connection scopes rpc.handle() registrations to the caller
+  // Context and mounts their WebRoute through owner.webServer. Keep webServer
+  // on this exact injected fiber so strict Cordis service access in 0.1.5+
+  // cannot turn remote-settings registration into a startup error.
+  ctx.inject(['settings', 'connection', 'webServer'], (remoteCtx) => {
     const handler = createVisionRouterRemoteSettingsHandler(remoteCtx.settings, logger ?? remoteCtx.logger)
     remoteCtx.effect(
       () => remoteCtx.connection.rpc.handle(REMOTE_SETTINGS_CHANNEL, handler, { authority: 'trusted-host' }),

--- a/tests/remote-settings-bridge.test.js
+++ b/tests/remote-settings-bridge.test.js
@@ -175,12 +175,25 @@ test('bridge remains behind the DSH trusted-host carrier fence', () => {
   const indexTaps = []
   const ctx = {
     inject(deps, callback) {
-      if (deps.length === 2 && deps[0] === 'settings' && deps[1] === 'connection') {
-        callback({
+      if (deps[0] === 'settings' && deps[1] === 'connection') {
+        assert.deepEqual(deps, ['settings', 'connection', 'webServer'])
+        const declared = new Set(deps)
+        const remoteCtx = {
           settings: makeSettings().settings,
-          connection: { rpc: { handle(channel, _handler, options) { registrations.push([channel, options]); return () => {} } } },
+          webServer: { register() { return () => {} } },
           effect(factory) { factory() },
-        })
+        }
+        remoteCtx.connection = {
+          rpc: {
+            handle(channel, _handler, options) {
+              if (!declared.has('webServer')) throw new Error('cannot get property "webServer" without inject')
+              remoteCtx.webServer.register({ kind: 'prefix', path: channel })
+              registrations.push([channel, options])
+              return () => {}
+            },
+          },
+        }
+        callback(remoteCtx)
         return
       }
       if (deps.length === 1 && deps[0] === 'webServer') {


### PR DESCRIPTION
Closes #465

## Summary

Fix the DSH 0.1.5 remote-settings startup error by declaring the actual Cordis services required by `connection.rpc.handle()` on the same caller fiber.

- change the remote-settings registration fiber from `['settings', 'connection']` to `['settings', 'connection', 'webServer']`
- lock that service contract in `remote-settings-bridge.test.js` with a fixture that reproduces the DSH 0.1.5 `cannot get property "webServer" without inject` failure when `webServer` is not declared
- keep the existing trusted-host authority, remote field allow-list, risk confirmation, Settings IA, and local-only sensitive settings unchanged
- leave `cordis.patch.yml` untouched: #448's `modules -> webServer` bundle activation overlay is a separate Host startup dependency and should not become a workaround for this caller-fiber contract

## Root cause

Current DSH 0.1.5 `HostConnectionService.rpc.handle()` scopes registration to the Context that reads the `connection` service. Its private `register(owner, ...)` then mounts the route with `owner.webServer.register(...)`. Under strict Cordis service-access semantics, the DVR caller Context must therefore have declared `webServer` before invoking `connection.rpc.handle()`.

This contract is present in DSH 0.1.5-rc.2 and current upstream source; the bug is in DVR's caller declaration rather than the Host bundle overlay.

## Validation

- remote settings / Settings IA focused suite: 38/38 pass
- full main suite: 1320 pass, 0 fail, 1 Windows-only skip
- backend policy suite: 6/6 pass
- `git diff --check` clean

Public DSH support floor and persisted settings schema are unchanged.