### PR TITLE
chore(release): prepare v2.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Bilingual (Chinese + English) release notes for every version — the GitHub Rel
 
 ## Unreleased
 
+## v2.1.6
+
 ### 修复 / Fixes
 
 - **DSH 0.1.5 远程设置 `webServer` 注入根修（#465）**：远程设置 RPC 现在在同一个 Cordis caller fiber 上显式声明 `settings`、`connection` 与 `webServer`。DSH 0.1.5 的 `connection.rpc.handle()` 会把通道路由注册到调用方 Context 的 `webServer`；此前只注入前两项会在 rc.1/rc.2 的严格 service-access 语义下触发 `cannot get property "webServer" without inject`。修复不修改 Host bundle overlay，也不放宽远程设置的 trusted-host / allow-list 安全边界。

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/ysr666/dsh-vision-router/releases/tag/v2.1.5"><img src="https://img.shields.io/badge/release-v2.1.5-5B4CF0?style=flat-square" alt="Release v2.1.5" /></a>
+  <a href="https://github.com/ysr666/dsh-vision-router/releases/tag/v2.1.6"><img src="https://img.shields.io/badge/release-v2.1.6-5B4CF0?style=flat-square" alt="Release v2.1.6" /></a>
   <a href="tests"><img src="https://img.shields.io/badge/verified-Node%2022%20%2B%2024-2EA44F?style=flat-square" alt="Verified: Node 22 + 24" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-2EA44F?style=flat-square" alt="License: MIT" /></a>
   <a href="package.json"><img src="https://img.shields.io/badge/Node.js-%3E%3D22-339933?style=flat-square&amp;logo=nodedotjs&amp;logoColor=white" alt="Node.js >=22" /></a>
@@ -39,9 +39,9 @@
 <p align="center">💬 <strong>QQ community group: 1105463028</strong></p>
 
 > [!WARNING]
-> 📌 **Announcement (v2.1.5)**
+> 📌 **Announcement (v2.1.6)**
 >
-> **v2.1.5:** Added support for DSH `0.1.5-rc.1`, reconciles Vision twins as providers change live, preserves Vision across wrapped-model switches, and hardens Web activation plus the release/security pipeline. [What’s new →](docs/releases/v2.1.5.md)
+> **v2.1.6:** Advances exact stable support to DSH `0.1.5-rc.2`, fixes the remote-settings `webServer` startup error, and completes Host-first proxy isolation, lifecycle, redirect-boundary, HTTP CONNECT, and SOCKS5 hardening without raising the rc.8 Host floor. [What’s new →](docs/releases/v2.1.6.md)
 
 <p align="center">
   <img src="assets/vision-demo.gif" width="640" alt="Demo: paste an image, the agent locates the send button with vision_ground / vision_crop / vision_pixel_diff and answers with coordinates" />

--- a/README.zh.md
+++ b/README.zh.md
@@ -17,7 +17,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/ysr666/dsh-vision-router/releases/tag/v2.1.5"><img src="https://img.shields.io/badge/release-v2.1.5-5B4CF0?style=flat-square" alt="Release v2.1.5" /></a>
+  <a href="https://github.com/ysr666/dsh-vision-router/releases/tag/v2.1.6"><img src="https://img.shields.io/badge/release-v2.1.6-5B4CF0?style=flat-square" alt="Release v2.1.6" /></a>
   <a href="tests"><img src="https://img.shields.io/badge/verified-Node%2022%20%2B%2024-2EA44F?style=flat-square" alt="已验证 Node 22 + 24" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-2EA44F?style=flat-square" alt="MIT 许可证" /></a>
   <a href="package.json"><img src="https://img.shields.io/badge/Node.js-%3E%3D22-339933?style=flat-square&amp;logo=nodedotjs&amp;logoColor=white" alt="Node.js >=22" /></a>
@@ -39,9 +39,9 @@
 <p align="center">💬 <strong>QQ 用户交流群：1105463028</strong></p>
 
 > [!WARNING]
-> 📌 **公告（v2.1.5）**
+> 📌 **公告（v2.1.6）**
 >
-> **v2.1.5：新增 DSH `0.1.5-rc.1` 支持，修复 live provider 变化时 Vision twin 对账与识图模式下 wrapper 模型切换，并加固 Web 激活与发版/安全链路。** [查看完整更新 →](docs/releases/v2.1.5.md)
+> **v2.1.6：正式验证 DSH `0.1.5-rc.2`，修复远程设置 `webServer` 启动报错，并完成 Host-first 代理隔离、生命周期、redirect 边界、HTTP CONNECT 与 SOCKS5 加固；公开最低 Host 仍为 rc.8。** [查看完整更新 →](docs/releases/v2.1.6.md)
 
 <p align="center">
   <img src="assets/vision-demo.gif" width="640" alt="演示：粘贴图片，Agent 用 vision_ground / vision_crop / vision_pixel_diff 定位发送按钮并给出坐标" />

--- a/docs/releases/v2.1.6.md
+++ b/docs/releases/v2.1.6.md
@@ -1,0 +1,30 @@
+# v2.1.6
+
+DVR 2.1.6 is a compatibility and network-hardening patch for the 2.1.x train. It advances exact stable validation to DSH `0.1.5-rc.2`, fixes the DSH 0.1.5 remote-settings startup error, and finishes the Host-first proxy convergence work without changing the public routing model, persisted settings schema, or minimum Host floor (`0.1.0-rc.8`).
+
+## DSH 0.1.5-rc.2 and remote Settings
+
+- Advances the fixed stable/exact Host evidence to DSH `0.1.5-rc.2`; exact `0.1.5-alpha.2` coverage remains preview verification evidence only. `0.1.5-rc.1` remains explicitly peer-compatible and the public DVR 2.1.x floor stays at `0.1.0-rc.8`.
+- Fixes #465 by declaring `settings`, `connection`, and `webServer` on the same Cordis caller fiber that invokes `connection.rpc.handle()`. This prevents `cannot get property "webServer" without inject` under DSH 0.1.5 strict service-access semantics.
+- Keeps the remote Settings security model unchanged: the RPC channel remains `trusted-host`, sensitive network/credential/local-device fields stay local-only, and the explicit remote field allow-list plus risk-confirmation flow remain authoritative.
+- Keeps the separate Web-bundle `modules -> webServer` compatibility overlay in place while current upstream DSH still lacks that Loader activation dependency; #448 continues to track its eventual retirement.
+
+## Host-first proxy convergence
+
+- Makes the DSH/Host network path authoritative whenever Vision Router's `proxy` is blank. Ordinary Host traffic no longer passes through a second DVR proxy-routing decision.
+- Keeps explicit `proxy` / `proxyHosts` as a supported, local-only Advanced override for visual traffic, including SOCKS5 and selective-host deployments that current DSH Host proxy policy cannot replace.
+- Scopes Host-owned visual adapter overrides with AsyncLocalStorage, so concurrent same-origin Host requests do not inherit DVR proxy state. Vision chain, `vision_describe`, Benchmark, and Exact Check share the same scoped authority.
+- Gives Router-owned and scoped Host-owned ProxyAgents one shared lease/retire lifecycle. Hot proxy replacement, clearing configuration, pending construction, synchronous failures, and plugin unload now retire Agents without leaking or closing in-flight work.
+- Enforces `proxyHosts` on every redirect hop after the initial request is admitted. Redirects that leave the allow-list return to the request-start Host/caller dispatcher while Fetch/Undici remains responsible for redirect semantics, body replay, header stripping, limits, and abort behavior.
+- Preserves historical `socks5h://` settings without rewriting persisted configuration: the compatibility projection to Undici-native `socks5://` happens only after a request is admitted by `proxyHosts`.
+- Removes the obsolete process-wide dispatcher tracker/global-fetch observer after lifecycle ownership moved to the shared dispatcher pool.
+
+## Protocol and regression coverage
+
+- Adds real loopback HTTP CONNECT and SOCKS5 protocol tests in addition to MockAgent/FakeProxyAgent coverage. The SOCKS case verifies proxy-side DNS by sending an unresolved domain name through the SOCKS5 tunnel.
+- Exact-source stable/preview contracts continue to run on Ubuntu, macOS, and Windows; Node 22/24 CI, routing parity, adversarial fuzzing, dependency review, CodeQL, native multimodal cold resume, Windows screenshot runtime, and host-sharp integration remain release gates.
+- Pre-release acceptance on macOS used the actual `npm pack` tarball installed through DSH `0.1.5-rc.2`, then exercised the real Chromium Settings UI, a settings write/readback round trip, cold Web restart, and a real headless vision turn. `vision_ocr`, `vision_describe`, and `vision_colors` correctly read a generated image using the machine's normal DSH model credentials.
+
+## Upgrade
+
+Upgrade to 2.1.6 and restart DSH Web/Desktop. Existing 2.1.x settings remain compatible; no migration is required.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-vision-router",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "description": "Eyes for text-only DeepSeek Harness agents: built-in free vision chain (no key) + pixel-level vision tools (Q&A, grounding, crop, pixel diff, colors, OCR, SVG trace, cutout, screenshots). One-command install, no Python, image turns work like ordinary tool-calling turns.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

Prepare the 2.1.6 patch release from the exact current `main` line.

- bump `package.json` from 2.1.5 to 2.1.6
- archive the current Unreleased changelog under `v2.1.6`
- refresh the English/Chinese README announcement and release badge
- add curated immutable release notes at `docs/releases/v2.1.6.md`
- keep the public DSH Host floor at `0.1.0-rc.8`; exact stable evidence is `0.1.5-rc.2`

## Release scope

This release contains only the changes already merged after v2.1.5: #456–#464, #466 and #467. The main themes are Host-first proxy convergence/hardening, real HTTP CONNECT + SOCKS5 protocol coverage, DSH 0.1.5-rc.2 exact compatibility, and the #465 remote-settings `webServer` caller-fiber fix.

## Validation

- `pnpm test`: 1320 pass, 0 fail, 1 platform-specific skip
- backend policy suite: 6/6 pass
- `git diff --check`: clean
- `npm view dsh-vision-router@2.1.6`: version is not published yet
- `npm pack --dry-run`: `dsh-vision-router-2.1.6.tgz`, 203 files, curated v2.1.6 notes included
- macOS real-machine acceptance on DSH `0.1.5-rc.2` using the actual `npm pack` tarball: real Chromium Settings UI, settings write/readback, cold Web restart, and a real headless image turn using `vision_ocr`, `vision_describe`, and `vision_colors` all succeeded

No runtime code is changed by this PR.