### PR TITLE
fix(client): bound presented image resource lifetime

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -4252,20 +4252,20 @@ window.__ModuleLoader__.load({
       )
     }
 
-    const PRESENTED_IMAGE_IDLE_MAX_ENTRIES = 32
-    const PRESENTED_IMAGE_IDLE_MAX_BYTES = 64 * 1024 * 1024
+    const PRESENTED_IMAGE_CACHE_MAX_ENTRIES = 32
+    const PRESENTED_IMAGE_CACHE_MAX_BYTES = 64 * 1024 * 1024
 
     function presentedImageResourceKey(sessionId, attachment) {
       return `${String(sessionId)}:${String(attachment && attachment.attachmentId)}`
     }
 
     function createPresentedImageResourceCache(options = {}) {
-      const maxIdleEntries = Number.isFinite(options.maxIdleEntries)
-        ? Math.max(0, Math.floor(options.maxIdleEntries))
-        : PRESENTED_IMAGE_IDLE_MAX_ENTRIES
-      const maxIdleBytes = Number.isFinite(options.maxIdleBytes)
-        ? Math.max(0, Math.floor(options.maxIdleBytes))
-        : PRESENTED_IMAGE_IDLE_MAX_BYTES
+      const maxEntries = Number.isFinite(options.maxEntries)
+        ? Math.max(0, Math.floor(options.maxEntries))
+        : PRESENTED_IMAGE_CACHE_MAX_ENTRIES
+      const maxBytes = Number.isFinite(options.maxBytes)
+        ? Math.max(0, Math.floor(options.maxBytes))
+        : PRESENTED_IMAGE_CACHE_MAX_BYTES
       const nativeObjectUrls =
         typeof URL !== 'undefined' &&
         typeof URL.createObjectURL === 'function' &&
@@ -4293,12 +4293,10 @@ window.__ModuleLoader__.load({
           }
       const useObjectUrls = typeof createObjectURL === 'function' && typeof revokeObjectURL === 'function'
       const entries = new Map()
-      const pins = new Map()
       let sequence = 0
       let disposed = false
 
       const touch = (entry) => { entry.lastUsed = ++sequence }
-      const pinCount = (key) => pins.get(key) || 0
       const dataBytes = (data) => {
         const value = Number(data && (data.byteLength ?? data.length))
         return Number.isFinite(value) && value > 0 ? value : 0
@@ -4312,48 +4310,36 @@ window.__ModuleLoader__.load({
         }
         return true
       }
-      const idleEntries = () => [...entries.values()]
-        .filter((entry) => entry.settled && pinCount(entry.key) === 0)
-        .sort((left, right) => left.lastUsed - right.lastUsed)
+      const settledEntries = () => [...entries.values()].filter((entry) => entry.settled)
       const trim = () => {
-        const idle = idleEntries()
-        let count = idle.length
-        let bytes = idle.reduce((total, entry) => total + entry.weight, 0)
-        for (const entry of idle) {
-          if (count <= maxIdleEntries && bytes <= maxIdleBytes) break
+        const settled = settledEntries()
+        let count = settled.length
+        let bytes = settled.reduce((total, entry) => total + entry.weight, 0)
+        const victims = settled.sort((left, right) => {
+          const leftOwned = left.owners.size > 0 ? 1 : 0
+          const rightOwned = right.owners.size > 0 ? 1 : 0
+          return leftOwned - rightOwned || left.lastUsed - right.lastUsed
+        })
+        for (const entry of victims) {
+          if (count <= maxEntries && bytes <= maxBytes) break
           if (!remove(entry)) continue
           count -= 1
           bytes = Math.max(0, bytes - entry.weight)
         }
       }
 
-      const pin = (keyValue) => {
-        if (disposed) return false
-        const key = String(keyValue)
-        pins.set(key, pinCount(key) + 1)
-        const entry = entries.get(key)
-        if (entry) touch(entry)
-        return true
-      }
-      const unpin = (keyValue) => {
-        const key = String(keyValue)
-        const count = pinCount(key)
-        if (count <= 1) pins.delete(key)
-        else pins.set(key, count - 1)
-        const entry = entries.get(key)
-        if (entry) touch(entry)
-        trim()
-      }
-      const load = (keyValue, loader) => {
+      const load = (keyValue, loader, ownerToken) => {
         if (disposed) return Promise.reject(new Error('vision_present: image resource cache disposed'))
         const key = String(keyValue)
         const cached = entries.get(key)
         if (cached) {
+          if (ownerToken !== undefined) cached.owners.add(ownerToken)
           touch(cached)
           return cached.promise
         }
         const entry = {
           key,
+          owners: new Set(ownerToken === undefined ? [] : [ownerToken]),
           promise: undefined,
           url: undefined,
           revocable: false,
@@ -4392,31 +4378,42 @@ window.__ModuleLoader__.load({
         entries.set(key, entry)
         return pending
       }
+      const release = (keyValue, ownerToken, releaseOptions = {}) => {
+        const key = String(keyValue)
+        const entry = entries.get(key)
+        if (!entry) return false
+        if (ownerToken !== undefined) entry.owners.delete(ownerToken)
+        touch(entry)
+        if (releaseOptions.purge === true && entry.owners.size === 0) {
+          return remove(entry)
+        }
+        trim()
+        return true
+      }
       const dispose = () => {
         if (disposed) return
         disposed = true
-        pins.clear()
         for (const entry of [...entries.values()]) remove(entry)
         entries.clear()
       }
       const stats = () => {
-        const idle = idleEntries()
+        const settled = settledEntries()
         return {
           entries: entries.size,
-          pinnedKeys: pins.size,
-          idleEntries: idle.length,
-          idleBytes: idle.reduce((total, entry) => total + entry.weight, 0),
+          settledEntries: settled.length,
+          residentBytes: settled.reduce((total, entry) => total + entry.weight, 0),
+          ownedEntries: settled.filter((entry) => entry.owners.size > 0).length,
           disposed,
         }
       }
 
-      return { pin, unpin, load, dispose, stats }
+      return { load, release, dispose, stats }
     }
 
     function apply(ctx) {
       const localScope = ctx.settingsScope.bind({ namespace: 'vision-router' })
       const presentedImageResources = createPresentedImageResourceCache()
-      const loadPresentedImage = (sessionId, attachment) => {
+      const loadPresentedImage = (sessionId, attachment, ownerToken) => {
         const key = presentedImageResourceKey(sessionId, attachment)
         return presentedImageResources.load(key, async () => {
           const binding = ctx.sessions.binding(sessionId)
@@ -4429,7 +4426,7 @@ window.__ModuleLoader__.load({
             data: result.value.data,
             mediaType: result.value.attachment.mediaType,
           }
-        })
+        }, ownerToken)
       }
       // Follow the app language: register our dictionaries and re-read them
       // whenever the user switches the locale in Settings → General.
@@ -4443,26 +4440,24 @@ window.__ModuleLoader__.load({
           .map((item) => ({ attachment: item.attachment }))
         const imageKeys = images.map(({ attachment }) => presentedImageResourceKey(sessionId, attachment))
         const imageKeySignature = JSON.stringify(imageKeys)
+        const imageOwnerToken = React.useRef({}).current
         const ownedImageKeys = React.useRef(new Set())
         React.useEffect(() => {
           const current = new Set(imageKeys)
           for (const key of ownedImageKeys.current) {
             if (current.has(key)) continue
-            presentedImageResources.unpin(key)
+            presentedImageResources.release(key, imageOwnerToken, { purge: true })
             ownedImageKeys.current.delete(key)
           }
         }, [imageKeySignature])
         React.useEffect(() => () => {
-          for (const key of ownedImageKeys.current) presentedImageResources.unpin(key)
+          for (const key of ownedImageKeys.current) presentedImageResources.release(key, imageOwnerToken, { purge: true })
           ownedImageKeys.current.clear()
         }, [])
         const loadOwnedPresentedImage = (attachment) => {
           const key = presentedImageResourceKey(sessionId, attachment)
-          if (!ownedImageKeys.current.has(key)) {
-            presentedImageResources.pin(key)
-            ownedImageKeys.current.add(key)
-          }
-          return loadPresentedImage(sessionId, attachment)
+          ownedImageKeys.current.add(key)
+          return loadPresentedImage(sessionId, attachment, imageOwnerToken)
         }
         if (images.length === 0) {
           return React.createElement(
@@ -4612,8 +4607,8 @@ window.__ModuleLoader__.load({
     exports.createRemoteSettingsScope = createRemoteSettingsScope
     exports.shouldUseRemoteSettings = shouldUseRemoteSettings
     exports.installSettingsPersistence = installSettingsPersistence
-    exports.PRESENTED_IMAGE_IDLE_MAX_ENTRIES = PRESENTED_IMAGE_IDLE_MAX_ENTRIES
-    exports.PRESENTED_IMAGE_IDLE_MAX_BYTES = PRESENTED_IMAGE_IDLE_MAX_BYTES
+    exports.PRESENTED_IMAGE_CACHE_MAX_ENTRIES = PRESENTED_IMAGE_CACHE_MAX_ENTRIES
+    exports.PRESENTED_IMAGE_CACHE_MAX_BYTES = PRESENTED_IMAGE_CACHE_MAX_BYTES
     exports.presentedImageResourceKey = presentedImageResourceKey
     exports.createPresentedImageResourceCache = createPresentedImageResourceCache
     exports.GUIDE_STATE = GUIDE_STATE

--- a/lib/client.js
+++ b/lib/client.js
@@ -4252,40 +4252,184 @@ window.__ModuleLoader__.load({
       )
     }
 
+    const PRESENTED_IMAGE_IDLE_MAX_ENTRIES = 32
+    const PRESENTED_IMAGE_IDLE_MAX_BYTES = 64 * 1024 * 1024
+
+    function presentedImageResourceKey(sessionId, attachment) {
+      return `${String(sessionId)}:${String(attachment && attachment.attachmentId)}`
+    }
+
+    function createPresentedImageResourceCache(options = {}) {
+      const maxIdleEntries = Number.isFinite(options.maxIdleEntries)
+        ? Math.max(0, Math.floor(options.maxIdleEntries))
+        : PRESENTED_IMAGE_IDLE_MAX_ENTRIES
+      const maxIdleBytes = Number.isFinite(options.maxIdleBytes)
+        ? Math.max(0, Math.floor(options.maxIdleBytes))
+        : PRESENTED_IMAGE_IDLE_MAX_BYTES
+      const nativeObjectUrls =
+        typeof URL !== 'undefined' &&
+        typeof URL.createObjectURL === 'function' &&
+        typeof URL.revokeObjectURL === 'function' &&
+        typeof Blob === 'function'
+      const createObjectURL = typeof options.createObjectURL === 'function'
+        ? options.createObjectURL
+        : nativeObjectUrls
+          ? (data, mediaType) => URL.createObjectURL(new Blob([data], { type: mediaType }))
+          : undefined
+      const revokeObjectURL = typeof options.revokeObjectURL === 'function'
+        ? options.revokeObjectURL
+        : nativeObjectUrls
+          ? (url) => URL.revokeObjectURL(url)
+          : undefined
+      const encodeDataURL = typeof options.encodeDataURL === 'function'
+        ? options.encodeDataURL
+        : (data, mediaType) => {
+            let binary = ''
+            const chunk = 0x8000
+            for (let offset = 0; offset < data.length; offset += chunk) {
+              binary += String.fromCharCode(...data.subarray(offset, offset + chunk))
+            }
+            return `data:${mediaType};base64,${btoa(binary)}`
+          }
+      const useObjectUrls = typeof createObjectURL === 'function' && typeof revokeObjectURL === 'function'
+      const entries = new Map()
+      const pins = new Map()
+      let sequence = 0
+      let disposed = false
+
+      const touch = (entry) => { entry.lastUsed = ++sequence }
+      const pinCount = (key) => pins.get(key) || 0
+      const dataBytes = (data) => {
+        const value = Number(data && (data.byteLength ?? data.length))
+        return Number.isFinite(value) && value > 0 ? value : 0
+      }
+      const remove = (entry) => {
+        if (!entry || entries.get(entry.key) !== entry) return false
+        entries.delete(entry.key)
+        if (entry.revocable && entry.url) {
+          try { revokeObjectURL(entry.url) } catch {}
+          entry.revocable = false
+        }
+        return true
+      }
+      const idleEntries = () => [...entries.values()]
+        .filter((entry) => entry.settled && pinCount(entry.key) === 0)
+        .sort((left, right) => left.lastUsed - right.lastUsed)
+      const trim = () => {
+        const idle = idleEntries()
+        let count = idle.length
+        let bytes = idle.reduce((total, entry) => total + entry.weight, 0)
+        for (const entry of idle) {
+          if (count <= maxIdleEntries && bytes <= maxIdleBytes) break
+          if (!remove(entry)) continue
+          count -= 1
+          bytes = Math.max(0, bytes - entry.weight)
+        }
+      }
+
+      const pin = (keyValue) => {
+        if (disposed) return false
+        const key = String(keyValue)
+        pins.set(key, pinCount(key) + 1)
+        const entry = entries.get(key)
+        if (entry) touch(entry)
+        return true
+      }
+      const unpin = (keyValue) => {
+        const key = String(keyValue)
+        const count = pinCount(key)
+        if (count <= 1) pins.delete(key)
+        else pins.set(key, count - 1)
+        const entry = entries.get(key)
+        if (entry) touch(entry)
+        trim()
+      }
+      const load = (keyValue, loader) => {
+        if (disposed) return Promise.reject(new Error('vision_present: image resource cache disposed'))
+        const key = String(keyValue)
+        const cached = entries.get(key)
+        if (cached) {
+          touch(cached)
+          return cached.promise
+        }
+        const entry = {
+          key,
+          promise: undefined,
+          url: undefined,
+          revocable: false,
+          settled: false,
+          weight: 0,
+          lastUsed: 0,
+        }
+        touch(entry)
+        const pending = Promise.resolve()
+          .then(() => loader())
+          .then(({ data, mediaType }) => {
+            if (disposed || entries.get(key) !== entry) {
+              throw new Error('vision_present: image resource cache disposed')
+            }
+            const rawBytes = dataBytes(data)
+            if (useObjectUrls) {
+              entry.url = createObjectURL(data, mediaType)
+              entry.revocable = true
+              entry.weight = rawBytes
+            } else {
+              entry.url = encodeDataURL(data, mediaType)
+              // JS strings are commonly two-byte code units; budget the fallback
+              // conservatively instead of pretending base64 retains raw bytes.
+              entry.weight = entry.url.length * 2
+            }
+            entry.settled = true
+            touch(entry)
+            trim()
+            return entry.url
+          })
+          .catch((error) => {
+            remove(entry)
+            throw error
+          })
+        entry.promise = pending
+        entries.set(key, entry)
+        return pending
+      }
+      const dispose = () => {
+        if (disposed) return
+        disposed = true
+        pins.clear()
+        for (const entry of [...entries.values()]) remove(entry)
+        entries.clear()
+      }
+      const stats = () => {
+        const idle = idleEntries()
+        return {
+          entries: entries.size,
+          pinnedKeys: pins.size,
+          idleEntries: idle.length,
+          idleBytes: idle.reduce((total, entry) => total + entry.weight, 0),
+          disposed,
+        }
+      }
+
+      return { pin, unpin, load, dispose, stats }
+    }
+
     function apply(ctx) {
       const localScope = ctx.settingsScope.bind({ namespace: 'vision-router' })
-      const presentedImageUrls = new Map()
-      const createdImageUrls = new Set()
+      const presentedImageResources = createPresentedImageResourceCache()
       const loadPresentedImage = (sessionId, attachment) => {
-        const key = `${String(sessionId)}:${String(attachment.attachmentId)}`
-        const cached = presentedImageUrls.get(key)
-        if (cached !== undefined) return cached
-        const pending = (async () => {
+        const key = presentedImageResourceKey(sessionId, attachment)
+        return presentedImageResources.load(key, async () => {
           const binding = ctx.sessions.binding(sessionId)
           if (binding === undefined) throw new Error(`vision_present: unknown session ${String(sessionId)}`)
           const result = await binding.session.readAttachment(attachment.attachmentId)
           if (!result.ok) {
             throw new Error(`vision_present: ${result.error.code}: ${result.error.message}`)
           }
-          const ref = result.value.attachment
-          const data = result.value.data
-          if (typeof URL.createObjectURL === 'function') {
-            const url = URL.createObjectURL(new Blob([data], { type: ref.mediaType }))
-            createdImageUrls.add(url)
-            return url
+          return {
+            data: result.value.data,
+            mediaType: result.value.attachment.mediaType,
           }
-          let binary = ''
-          const chunk = 0x8000
-          for (let offset = 0; offset < data.length; offset += chunk) {
-            binary += String.fromCharCode(...data.subarray(offset, offset + chunk))
-          }
-          return `data:${ref.mediaType};base64,${btoa(binary)}`
-        })().catch((error) => {
-          presentedImageUrls.delete(key)
-          throw error
         })
-        presentedImageUrls.set(key, pending)
-        return pending
       }
       // Follow the app language: register our dictionaries and re-read them
       // whenever the user switches the locale in Settings → General.
@@ -4297,6 +4441,29 @@ window.__ModuleLoader__.load({
         const images = content
           .filter((item) => item && item.type === 'image' && item.attachment)
           .map((item) => ({ attachment: item.attachment }))
+        const imageKeys = images.map(({ attachment }) => presentedImageResourceKey(sessionId, attachment))
+        const imageKeySignature = JSON.stringify(imageKeys)
+        const ownedImageKeys = React.useRef(new Set())
+        React.useEffect(() => {
+          const current = new Set(imageKeys)
+          for (const key of ownedImageKeys.current) {
+            if (current.has(key)) continue
+            presentedImageResources.unpin(key)
+            ownedImageKeys.current.delete(key)
+          }
+        }, [imageKeySignature])
+        React.useEffect(() => () => {
+          for (const key of ownedImageKeys.current) presentedImageResources.unpin(key)
+          ownedImageKeys.current.clear()
+        }, [])
+        const loadOwnedPresentedImage = (attachment) => {
+          const key = presentedImageResourceKey(sessionId, attachment)
+          if (!ownedImageKeys.current.has(key)) {
+            presentedImageResources.pin(key)
+            ownedImageKeys.current.add(key)
+          }
+          return loadPresentedImage(sessionId, attachment)
+        }
         if (images.length === 0) {
           return React.createElement(
             'div',
@@ -4331,16 +4498,12 @@ window.__ModuleLoader__.load({
             images,
             align: 'start',
             labels,
-            load: (attachment) => loadPresentedImage(sessionId, attachment),
+            load: loadOwnedPresentedImage,
           }),
         )
       }
       ctx.effect(
-        () => () => {
-          for (const url of createdImageUrls) URL.revokeObjectURL(url)
-          createdImageUrls.clear()
-          presentedImageUrls.clear()
-        },
+        () => () => presentedImageResources.dispose(),
         'vision-router: presented image URL cache',
       )
       // Lazily reach the client `connection` service for the model catalog.
@@ -4449,6 +4612,10 @@ window.__ModuleLoader__.load({
     exports.createRemoteSettingsScope = createRemoteSettingsScope
     exports.shouldUseRemoteSettings = shouldUseRemoteSettings
     exports.installSettingsPersistence = installSettingsPersistence
+    exports.PRESENTED_IMAGE_IDLE_MAX_ENTRIES = PRESENTED_IMAGE_IDLE_MAX_ENTRIES
+    exports.PRESENTED_IMAGE_IDLE_MAX_BYTES = PRESENTED_IMAGE_IDLE_MAX_BYTES
+    exports.presentedImageResourceKey = presentedImageResourceKey
+    exports.createPresentedImageResourceCache = createPresentedImageResourceCache
     exports.GUIDE_STATE = GUIDE_STATE
     exports.GUIDE_EVENT = GUIDE_EVENT
     exports.guideTransition = guideTransition

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -1049,100 +1049,110 @@ test('reverse-proxy route failures are classified with an actionable UI path', a
 })
 
 
-test('presented image resource cache pins active URLs and revokes them once idle', async () => {
+test('presented image resource cache keeps hard bounds even when the loaded history stays mounted', async () => {
   const bundle = loadClientBundle()
   const revoked = []
   let nextUrl = 0
   const cache = bundle.createPresentedImageResourceCache({
-    maxIdleEntries: 0,
-    maxIdleBytes: 0,
-    createObjectURL: () => `blob:test-${++nextUrl}`,
+    maxEntries: 2,
+    maxBytes: 6,
+    createObjectURL: () => `blob:bounded-${++nextUrl}`,
     revokeObjectURL: (url) => revoked.push(url),
   })
-
-  cache.pin('session:attachment')
-  const url = await cache.load('session:attachment', async () => ({
-    data: new Uint8Array(8),
+  const ownerB = {}
+  const ownerC = {}
+  const ownerD = {}
+  const load = (key, bytes, ownerToken) => cache.load(key, async () => ({
+    data: new Uint8Array(bytes),
     mediaType: 'image/png',
-  }))
-  assert.equal(url, 'blob:test-1')
-  assert.deepEqual(revoked, [])
+  }), ownerToken)
+
+  await load('idle-a', 4)
+  await load('owned-b', 4, ownerB)
+  assert.deepEqual(revoked, ['blob:bounded-1'], 'unowned entries are evicted before owned entries')
   assert.deepEqual(cache.stats(), {
     entries: 1,
-    pinnedKeys: 1,
-    idleEntries: 0,
-    idleBytes: 0,
+    settledEntries: 1,
+    residentBytes: 4,
+    ownedEntries: 1,
     disposed: false,
   })
 
-  cache.unpin('session:attachment')
-  assert.deepEqual(revoked, ['blob:test-1'])
-  assert.equal(cache.stats().entries, 0)
+  await load('owned-c', 2, ownerC)
+  await load('owned-d', 1, ownerD)
+  assert.deepEqual(
+    revoked,
+    ['blob:bounded-1', 'blob:bounded-2'],
+    'the oldest owned entry is still evicted when the hard budget requires it',
+  )
+  assert.deepEqual(cache.stats(), {
+    entries: 2,
+    settledEntries: 2,
+    residentBytes: 3,
+    ownedEntries: 2,
+    disposed: false,
+  })
 })
 
-test('presented image resource cache enforces both idle entry and byte budgets in LRU order', async () => {
+test('presented image resource cache deduplicates owners and purges only after the final card releases', async () => {
   const bundle = loadClientBundle()
   const revoked = []
-  let nextUrl = 0
-  const cache = bundle.createPresentedImageResourceCache({
-    maxIdleEntries: 2,
-    maxIdleBytes: 6,
-    createObjectURL: () => `blob:lru-${++nextUrl}`,
-    revokeObjectURL: (url) => revoked.push(url),
-  })
-  const load = (key, bytes) => cache.load(key, async () => ({
-    data: new Uint8Array(bytes),
-    mediaType: 'image/png',
-  }))
-
-  await load('a', 4)
-  await load('b', 4)
-  assert.deepEqual(revoked, ['blob:lru-1'])
-  assert.equal(cache.stats().idleBytes, 4)
-
-  await load('c', 2)
-  assert.equal(cache.stats().idleEntries, 2)
-  assert.equal(cache.stats().idleBytes, 6)
-  await load('d', 1)
-  assert.deepEqual(revoked, ['blob:lru-1', 'blob:lru-2'])
-  assert.equal(cache.stats().idleEntries, 2)
-  assert.equal(cache.stats().idleBytes, 3)
-})
-
-test('presented image resource cache deduplicates inflight loads and permits retry after failure', async () => {
-  const bundle = loadClientBundle()
   let calls = 0
-  let release
-  const gate = new Promise((resolve) => { release = resolve })
+  let releaseLoad
+  const gate = new Promise((resolve) => { releaseLoad = resolve })
   const cache = bundle.createPresentedImageResourceCache({
     createObjectURL: () => 'blob:shared',
-    revokeObjectURL: () => {},
+    revokeObjectURL: (url) => revoked.push(url),
   })
+  const ownerA = {}
+  const ownerB = {}
   const loader = async () => {
     calls += 1
     await gate
-    return { data: new Uint8Array(1), mediaType: 'image/png' }
+    return { data: new Uint8Array(8), mediaType: 'image/png' }
   }
-  const first = cache.load('same', loader)
-  const second = cache.load('same', loader)
+
+  const first = cache.load('same', loader, ownerA)
+  const second = cache.load('same', loader, ownerB)
   assert.equal(first, second)
-  release()
+  releaseLoad()
   assert.equal(await first, 'blob:shared')
   assert.equal(calls, 1)
+  assert.equal(cache.stats().ownedEntries, 1)
 
-  await assert.rejects(cache.load('retry', async () => { throw new Error('first failure') }), /first failure/)
+  assert.equal(cache.release('same', ownerA, { purge: true }), true)
+  assert.deepEqual(revoked, [])
+  assert.equal(cache.release('same', ownerB, { purge: true }), true)
+  assert.deepEqual(revoked, ['blob:shared'])
+  assert.equal(cache.stats().entries, 0)
+})
+
+test('presented image resource cache permits retry after a failed owned load', async () => {
+  const bundle = loadClientBundle()
+  const owner = {}
+  const cache = bundle.createPresentedImageResourceCache({
+    createObjectURL: () => 'blob:retry',
+    revokeObjectURL: () => {},
+  })
+
+  await assert.rejects(
+    cache.load('retry', async () => { throw new Error('first failure') }, owner),
+    /first failure/,
+  )
+  assert.equal(cache.stats().entries, 0)
   assert.equal(await cache.load('retry', async () => ({
     data: new Uint8Array(1),
     mediaType: 'image/png',
-  })), 'blob:shared')
+  }), owner), 'blob:retry')
+  assert.equal(cache.stats().ownedEntries, 1)
 })
 
 test('presented image resource cache disposal rejects late loads without creating orphan URLs', async () => {
   const bundle = loadClientBundle()
   const created = []
   const revoked = []
-  let release
-  const gate = new Promise((resolve) => { release = resolve })
+  let releaseLoad
+  const gate = new Promise((resolve) => { releaseLoad = resolve })
   const cache = bundle.createPresentedImageResourceCache({
     createObjectURL: () => {
       created.push('blob:late')
@@ -1151,21 +1161,20 @@ test('presented image resource cache disposal rejects late loads without creatin
     revokeObjectURL: (url) => revoked.push(url),
   })
 
-  cache.pin('late')
   const pending = cache.load('late', async () => {
     await gate
     return { data: new Uint8Array(16), mediaType: 'image/png' }
-  })
+  }, {})
   cache.dispose()
-  release()
+  releaseLoad()
   await assert.rejects(pending, /cache disposed/)
   assert.deepEqual(created, [])
   assert.deepEqual(revoked, [])
   assert.deepEqual(cache.stats(), {
     entries: 0,
-    pinnedKeys: 0,
-    idleEntries: 0,
-    idleBytes: 0,
+    settledEntries: 0,
+    residentBytes: 0,
+    ownedEntries: 0,
     disposed: true,
   })
 })

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -1047,3 +1047,125 @@ test('reverse-proxy route failures are classified with an actionable UI path', a
   assert.equal(source.includes('/vision-router-settings/*'), true)
   await scope.dispose()
 })
+
+
+test('presented image resource cache pins active URLs and revokes them once idle', async () => {
+  const bundle = loadClientBundle()
+  const revoked = []
+  let nextUrl = 0
+  const cache = bundle.createPresentedImageResourceCache({
+    maxIdleEntries: 0,
+    maxIdleBytes: 0,
+    createObjectURL: () => `blob:test-${++nextUrl}`,
+    revokeObjectURL: (url) => revoked.push(url),
+  })
+
+  cache.pin('session:attachment')
+  const url = await cache.load('session:attachment', async () => ({
+    data: new Uint8Array(8),
+    mediaType: 'image/png',
+  }))
+  assert.equal(url, 'blob:test-1')
+  assert.deepEqual(revoked, [])
+  assert.deepEqual(cache.stats(), {
+    entries: 1,
+    pinnedKeys: 1,
+    idleEntries: 0,
+    idleBytes: 0,
+    disposed: false,
+  })
+
+  cache.unpin('session:attachment')
+  assert.deepEqual(revoked, ['blob:test-1'])
+  assert.equal(cache.stats().entries, 0)
+})
+
+test('presented image resource cache enforces both idle entry and byte budgets in LRU order', async () => {
+  const bundle = loadClientBundle()
+  const revoked = []
+  let nextUrl = 0
+  const cache = bundle.createPresentedImageResourceCache({
+    maxIdleEntries: 2,
+    maxIdleBytes: 6,
+    createObjectURL: () => `blob:lru-${++nextUrl}`,
+    revokeObjectURL: (url) => revoked.push(url),
+  })
+  const load = (key, bytes) => cache.load(key, async () => ({
+    data: new Uint8Array(bytes),
+    mediaType: 'image/png',
+  }))
+
+  await load('a', 4)
+  await load('b', 4)
+  assert.deepEqual(revoked, ['blob:lru-1'])
+  assert.equal(cache.stats().idleBytes, 4)
+
+  await load('c', 2)
+  assert.equal(cache.stats().idleEntries, 2)
+  assert.equal(cache.stats().idleBytes, 6)
+  await load('d', 1)
+  assert.deepEqual(revoked, ['blob:lru-1', 'blob:lru-2'])
+  assert.equal(cache.stats().idleEntries, 2)
+  assert.equal(cache.stats().idleBytes, 3)
+})
+
+test('presented image resource cache deduplicates inflight loads and permits retry after failure', async () => {
+  const bundle = loadClientBundle()
+  let calls = 0
+  let release
+  const gate = new Promise((resolve) => { release = resolve })
+  const cache = bundle.createPresentedImageResourceCache({
+    createObjectURL: () => 'blob:shared',
+    revokeObjectURL: () => {},
+  })
+  const loader = async () => {
+    calls += 1
+    await gate
+    return { data: new Uint8Array(1), mediaType: 'image/png' }
+  }
+  const first = cache.load('same', loader)
+  const second = cache.load('same', loader)
+  assert.equal(first, second)
+  release()
+  assert.equal(await first, 'blob:shared')
+  assert.equal(calls, 1)
+
+  await assert.rejects(cache.load('retry', async () => { throw new Error('first failure') }), /first failure/)
+  assert.equal(await cache.load('retry', async () => ({
+    data: new Uint8Array(1),
+    mediaType: 'image/png',
+  })), 'blob:shared')
+})
+
+test('presented image resource cache disposal rejects late loads without creating orphan URLs', async () => {
+  const bundle = loadClientBundle()
+  const created = []
+  const revoked = []
+  let release
+  const gate = new Promise((resolve) => { release = resolve })
+  const cache = bundle.createPresentedImageResourceCache({
+    createObjectURL: () => {
+      created.push('blob:late')
+      return 'blob:late'
+    },
+    revokeObjectURL: (url) => revoked.push(url),
+  })
+
+  cache.pin('late')
+  const pending = cache.load('late', async () => {
+    await gate
+    return { data: new Uint8Array(16), mediaType: 'image/png' }
+  })
+  cache.dispose()
+  release()
+  await assert.rejects(pending, /cache disposed/)
+  assert.deepEqual(created, [])
+  assert.deepEqual(revoked, [])
+  assert.deepEqual(cache.stats(), {
+    entries: 0,
+    pinnedKeys: 0,
+    idleEntries: 0,
+    idleBytes: 0,
+    disposed: true,
+  })
+})


### PR DESCRIPTION
## Summary

Bounds `vision_present` browser presentation resources without changing the Host attachment contract or DSH ImageGallery API.

- replace plugin-lifetime unbounded Blob/Data URL retention with a globally bounded presentation resource cache
- enforce hard settled-resource limits of 32 entries / 64 MiB even when the Host keeps the full chat history mounted
- use card ownership only as eviction priority: unowned resources go first, but owned resources cannot bypass the hard cap
- keep owner metadata inside resident entries, so ownership metadata is bounded with the cache itself
- purge a resource when the final owning card releases it on content/session change or unmount
- deduplicate inflight attachment reads per session+attachment across multiple owners
- remove failed loads so retries remain possible
- reject late completions after plugin disposal before creating an orphan URL

## Why the hard cap does not depend on React mount lifetime

Current DSH chat renders the loaded conversation by mapping the whole ordered node list rather than virtualizing chat rows. A mount-based exemption would therefore become unbounded in long sessions. Ownership is only a soft victim-order hint; settled resident resources always converge to the global entry/byte budget.

## Compatibility constraints

- no change to attachment storage or Host `readAttachment` semantics
- no change to `ImageGallery`'s `load(attachment) -> Promise<url>` contract
- no DSH/Node support-floor change
- no native-image, routing, settings, or provider behavior change

## Verification

- focused presentation/resource suite: 67/67
- `pnpm test`: 1329 pass, 1 skip, 0 fail; runtime policy 6/6
- `pnpm test:web`: 137/137 on the first implementation pass
- `pnpm test:resources`: 33/33 on the first implementation pass
- `git diff --check`: pass
