### PR TITLE
fix(cache): bound persistent live state

### DIFF
--- a/lib/vision-background-stop-store.js
+++ b/lib/vision-background-stop-store.js
@@ -50,6 +50,25 @@ function recordKey(value) {
   return `${value.fingerprint}\u0000${value.axis}`
 }
 
+function selectRetainedStops(values, at, maxEntries = MAX_ENTRIES) {
+  const seen = new Set()
+  return [...values]
+    .map(cleanStop)
+    .filter((item) => item && item.expiresAt > at)
+    .sort((a, b) => b.recordedAt - a.recordedAt || recordKey(a).localeCompare(recordKey(b)))
+    .filter((item) => {
+      const key = recordKey(item)
+      if (seen.has(key)) return false
+      seen.add(key)
+      return true
+    })
+    .slice(0, maxEntries)
+}
+
+function retainedStopMap(values, at, maxEntries = MAX_ENTRIES) {
+  return new Map(selectRetainedStops(values, at, maxEntries).map((item) => [recordKey(item), item]))
+}
+
 export function backgroundBenchmarkStopCachePath(dshHome = resolveDshHome()) {
   return path.join(dshHome, 'cache', 'vision-router', 'background-benchmark-stops.json')
 }
@@ -59,10 +78,7 @@ async function load(file, fsOps, at) {
     const raw = await fsOps.readFile(file, 'utf8')
     const body = JSON.parse(raw)
     if (!body || !Array.isArray(body.stops) || ![2, CACHE_VERSION].includes(body.version)) return new Map()
-    const records = new Map(body.stops
-      .map(cleanStop)
-      .filter((item) => item && item.expiresAt > at)
-      .map((item) => [recordKey(item), item]))
+    const records = retainedStopMap(body.stops, at)
     if (body.version === 2) await save(file, records, fsOps, at)
     return records
   } catch (error) {
@@ -73,11 +89,7 @@ async function load(file, fsOps, at) {
 
 async function save(file, records, fsOps, at) {
   const temporary = `${file}.${process.pid}.${Date.now()}.tmp`
-  const stops = [...records.values()]
-    .map(cleanStop)
-    .filter((item) => item && item.expiresAt > at)
-    .sort((a, b) => b.recordedAt - a.recordedAt)
-    .slice(0, MAX_ENTRIES)
+  const stops = selectRetainedStops(records.values(), at)
   await fsOps.mkdir(path.dirname(file), { recursive: true })
   await fsOps.writeFile(temporary, JSON.stringify({ version: CACHE_VERSION, stops }), { encoding: 'utf8', mode: 0o600 })
   await fsOps.rename(temporary, file)
@@ -105,22 +117,19 @@ export function createBackgroundBenchmarkStopStore(options = {}) {
     return saveTail
   }
 
-  const pruneExpired = () => {
+  const reconcile = () => {
     const at = Number(now())
-    let removed = false
-    for (const [key, record] of records.entries()) {
-      if (record.expiresAt > at) continue
-      records.delete(key)
-      removed = true
-    }
-    return removed
+    const retained = retainedStopMap(records.values(), at)
+    const changed = retained.size !== records.size || [...retained.keys()].some((key) => !records.has(key))
+    records = retained
+    return changed
   }
 
   return {
     file,
     async list() {
       await ready
-      if (pruneExpired()) await persist()
+      if (reconcile()) await persist()
       return [...records.values()].sort((a, b) => b.recordedAt - a.recordedAt)
     },
     async mark({
@@ -135,7 +144,7 @@ export function createBackgroundBenchmarkStopStore(options = {}) {
       expiresAt,
     } = {}) {
       await ready
-      pruneExpired()
+      reconcile()
       const clean = cleanStop({
         fingerprint,
         key,
@@ -150,8 +159,9 @@ export function createBackgroundBenchmarkStopStore(options = {}) {
       })
       if (!clean) return undefined
       records.set(recordKey(clean), clean)
+      reconcile()
       await persist()
-      return clean
+      return records.get(recordKey(clean))
     },
     async clearStop(fingerprint, axis) {
       await ready

--- a/lib/vision-capability-probe.js
+++ b/lib/vision-capability-probe.js
@@ -338,21 +338,34 @@ export async function runExactCapabilityBenchmark({
   return { record, results }
 }
 
+function selectRetainedCapabilityProfiles(values, maxEntries) {
+  const seen = new Set()
+  return [...values]
+    .map(sanitizeCapabilityProfileRecord)
+    .filter(Boolean)
+    .sort((a, b) => b.measuredAt - a.measuredAt || a.fingerprint.localeCompare(b.fingerprint))
+    .filter((record) => {
+      if (seen.has(record.fingerprint)) return false
+      seen.add(record.fingerprint)
+      return true
+    })
+    .slice(0, maxEntries)
+}
+
+function retainedCapabilityProfileMap(values, maxEntries) {
+  return new Map(selectRetainedCapabilityProfiles(values, maxEntries).map((record) => [record.fingerprint, record]))
+}
+
 function cacheEnvelope(records) {
   return { version: CAPABILITY_PROFILE_CACHE_VERSION, profiles: records }
 }
 
-async function loadCache(file, fsOps) {
+async function loadCache(file, fsOps, maxEntries) {
   try {
     const raw = await fsOps.readFile(file, 'utf8')
     const body = JSON.parse(raw)
     if (!body || body.version !== CAPABILITY_PROFILE_CACHE_VERSION || !Array.isArray(body.profiles)) return new Map()
-    return new Map(
-      body.profiles
-        .map(sanitizeCapabilityProfileRecord)
-        .filter(Boolean)
-        .map((record) => [record.fingerprint, record]),
-    )
+    return retainedCapabilityProfileMap(body.profiles, maxEntries)
   } catch (error) {
     if (error?.code === 'ENOENT') return new Map()
     return new Map()
@@ -362,11 +375,7 @@ async function loadCache(file, fsOps) {
 async function saveCache(file, records, fsOps, maxEntries) {
   const directory = path.dirname(file)
   const temporary = `${file}.${process.pid}.${Date.now()}.tmp`
-  const profiles = [...records.values()]
-    .map(sanitizeCapabilityProfileRecord)
-    .filter(Boolean)
-    .sort((a, b) => b.measuredAt - a.measuredAt || a.fingerprint.localeCompare(b.fingerprint))
-    .slice(0, maxEntries)
+  const profiles = selectRetainedCapabilityProfiles(records.values(), maxEntries)
   await fsOps.mkdir(directory, { recursive: true })
   await fsOps.writeFile(temporary, JSON.stringify(cacheEnvelope(profiles)), { encoding: 'utf8', mode: 0o600 })
   await fsOps.rename(temporary, file)
@@ -384,7 +393,7 @@ export function createCapabilityProfileStore(options = {}) {
   const logger = options.logger
   let records = new Map()
   let saveTail = Promise.resolve()
-  const ready = loadCache(file, fsOps).then((loaded) => { records = loaded })
+  const ready = loadCache(file, fsOps, maxEntries).then((loaded) => { records = loaded })
 
   const persist = () => {
     saveTail = saveTail
@@ -412,8 +421,9 @@ export function createCapabilityProfileStore(options = {}) {
       if (merged === undefined) throw new TypeError('invalid merged capability profile record')
       if (existing && JSON.stringify(existing) === JSON.stringify(merged)) return existing
       records.set(clean.fingerprint, merged)
+      records = retainedCapabilityProfileMap(records.values(), maxEntries)
       await persist()
-      return merged
+      return records.get(clean.fingerprint)
     },
     async remove(fingerprint) {
       await ready

--- a/lib/vision-image-input-verdict.js
+++ b/lib/vision-image-input-verdict.js
@@ -38,12 +38,30 @@ export function imageInputVerdictCachePath(dshHome = resolveDshHome()) {
   return path.join(dshHome, 'cache', 'vision-router', 'image-input-verdicts.json')
 }
 
+function selectRetainedVerdicts(values, maxEntries = MAX_ENTRIES) {
+  const seen = new Set()
+  return [...values]
+    .map(cleanVerdict)
+    .filter(Boolean)
+    .sort((a, b) => b.measuredAt - a.measuredAt || a.fingerprint.localeCompare(b.fingerprint))
+    .filter((item) => {
+      if (seen.has(item.fingerprint)) return false
+      seen.add(item.fingerprint)
+      return true
+    })
+    .slice(0, maxEntries)
+}
+
+function retainedVerdictMap(values, maxEntries = MAX_ENTRIES) {
+  return new Map(selectRetainedVerdicts(values, maxEntries).map((item) => [item.fingerprint, item]))
+}
+
 async function load(file, fsOps) {
   try {
     const raw = await fsOps.readFile(file, 'utf8')
     const body = JSON.parse(raw)
     if (!body || body.version !== CACHE_VERSION || !Array.isArray(body.verdicts)) return new Map()
-    return new Map(body.verdicts.map(cleanVerdict).filter(Boolean).map((item) => [item.fingerprint, item]))
+    return retainedVerdictMap(body.verdicts)
   } catch (error) {
     if (error?.code === 'ENOENT') return new Map()
     return new Map()
@@ -52,11 +70,7 @@ async function load(file, fsOps) {
 
 async function save(file, records, fsOps) {
   const temporary = `${file}.${process.pid}.${Date.now()}.tmp`
-  const verdicts = [...records.values()]
-    .map(cleanVerdict)
-    .filter(Boolean)
-    .sort((a, b) => b.measuredAt - a.measuredAt)
-    .slice(0, MAX_ENTRIES)
+  const verdicts = selectRetainedVerdicts(records.values())
   await fsOps.mkdir(path.dirname(file), { recursive: true })
   await fsOps.writeFile(temporary, JSON.stringify({ version: CACHE_VERSION, verdicts }), { encoding: 'utf8', mode: 0o600 })
   await fsOps.rename(temporary, file)
@@ -101,8 +115,9 @@ export function createImageInputVerdictStore(options = {}) {
       })
       if (!clean) return undefined
       records.set(clean.fingerprint, clean)
+      records = retainedVerdictMap(records.values())
       await persist()
-      return clean
+      return records.get(clean.fingerprint)
     },
     async clear(fingerprint) {
       await ready

--- a/tests/vision-background-lifecycle.test.js
+++ b/tests/vision-background-lifecycle.test.js
@@ -117,6 +117,68 @@ test('background stop cache v3 drops secret-derived auth stops and expires bound
   }
 })
 
+
+
+test('oversized background stop cache is bounded in memory and persists the same survivor set', async () => {
+  const root = await mkdtemp(path.join(tmpdir(), 'vision-background-stop-bounds-'))
+  const cacheFile = path.join(root, 'stops.json')
+  const clock = 10_000
+  try {
+    const stops = Array.from({ length: 270 }, (_, index) => ({
+      fingerprint: `ep2_${(index + 1).toString(16).padStart(32, '0')}`,
+      key: `provider/model-${index + 1}`,
+      provider: 'provider',
+      model: `model-${index + 1}`,
+      axis: 'general',
+      errorClass: 'protocol',
+      recordedAt: index + 1,
+      expiresAt: clock + 100_000,
+      suiteRevision: CAPABILITY_BENCHMARK_SUITE_REVISION,
+    }))
+    await writeFile(cacheFile, JSON.stringify({ version: 3, stops }))
+    const store = createBackgroundBenchmarkStopStore({ cacheFile, now: () => clock })
+
+    const loaded = await store.list()
+    assert.equal(loaded.length, 256)
+    assert.equal(loaded[0].recordedAt, 270)
+    assert.equal(loaded.at(-1).recordedAt, 15)
+
+    const newestFingerprint = `ep2_${'f'.repeat(32)}`
+    assert.ok(await store.mark({
+      fingerprint: newestFingerprint,
+      key: 'provider/newest',
+      provider: 'provider',
+      model: 'newest',
+      axis: 'general',
+      errorClass: 'protocol',
+      recordedAt: 1_000,
+      expiresAt: clock + 100_000,
+    }))
+    const live = await store.list()
+    assert.equal(live.length, 256)
+    await store.flush()
+    const disk = JSON.parse(await readFile(cacheFile, 'utf8')).stops
+    assert.deepEqual(
+      disk.map((item) => `${item.fingerprint}:${item.axis}`),
+      live.map((item) => `${item.fingerprint}:${item.axis}`),
+    )
+
+    const tooOldFingerprint = `ep2_${'e'.repeat(32)}`
+    assert.equal(await store.mark({
+      fingerprint: tooOldFingerprint,
+      key: 'provider/too-old',
+      provider: 'provider',
+      model: 'too-old',
+      axis: 'general',
+      errorClass: 'protocol',
+      recordedAt: 1,
+      expiresAt: clock + 100_000,
+    }), undefined)
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
 test('AUTH background stop is in-memory, transport-wide, and credential change releases it immediately', async () => {
   const paidA = {
     name: 'paid-cloud-a',

--- a/tests/vision-capability-probe.test.js
+++ b/tests/vision-capability-probe.test.js
@@ -232,3 +232,43 @@ test('wrong-suite evidence is ignored rather than compared with the current suit
   })
   assert.deepEqual(await createCapabilityProfileStore({ cacheFile, fsOps: mem.ops }).list(), [])
 })
+
+test('capability profile live state is bounded on load and matches persisted survivors after put', async () => {
+  const cacheFile = '/virtual/capability-profiles.json'
+  const profiles = Array.from({ length: 5 }, (_, index) => recordBase({
+    fingerprint: `ep2_${(index + 1).toString(16).padStart(32, '0')}`,
+    model: `model-${index + 1}`,
+    measuredAt: index + 1,
+    measuredAtByAxis: { general: index + 1 },
+  }))
+  const mem = memoryFs({
+    [cacheFile]: JSON.stringify({ version: CAPABILITY_PROFILE_CACHE_VERSION, profiles }),
+  })
+  const store = createCapabilityProfileStore({ cacheFile, fsOps: mem.ops, maxEntries: 3 })
+
+  const loaded = await store.list()
+  assert.equal(loaded.length, 3)
+  assert.deepEqual(loaded.map((item) => item.measuredAt), [5, 4, 3])
+
+  const newestFingerprint = `ep2_${'f'.repeat(32)}`
+  assert.ok(await store.put(recordBase({
+    fingerprint: newestFingerprint,
+    model: 'newest',
+    measuredAt: 100,
+    measuredAtByAxis: { general: 100 },
+  })))
+  const live = await store.list()
+  assert.equal(live.length, 3)
+  await store.flush()
+  const disk = JSON.parse(mem.files.get(cacheFile)).profiles
+  assert.deepEqual(disk.map((item) => item.fingerprint), live.map((item) => item.fingerprint))
+
+  const tooOldFingerprint = `ep2_${'e'.repeat(32)}`
+  assert.equal(await store.put(recordBase({
+    fingerprint: tooOldFingerprint,
+    model: 'too-old',
+    measuredAt: 1,
+    measuredAtByAxis: { general: 1 },
+  })), undefined)
+  assert.equal((await store.list()).some((item) => item.fingerprint === tooOldFingerprint), false)
+})

--- a/tests/vision-image-input-verdict.test.js
+++ b/tests/vision-image-input-verdict.test.js
@@ -1,6 +1,7 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import { createImageInputVerdictStore } from '../lib/vision-image-input-verdict.js'
+import { CAPABILITY_BENCHMARK_SUITE_REVISION } from '../lib/vision-capability-benchmark.js'
 
 function memoryFs(initial = {}) {
   const files = new Map(Object.entries(initial))
@@ -67,4 +68,51 @@ test('successful explicit retest clears the exact fingerprint verdict', async ()
   assert.ok(await store.get(fingerprint))
   assert.equal(await store.clear(fingerprint), true)
   assert.equal(await store.get(fingerprint), undefined)
+})
+
+test('oversized verdict cache is bounded on load and live survivors match the next persisted set', async () => {
+  const file = '/virtual/image-input-verdicts.json'
+  const verdicts = Array.from({ length: 140 }, (_, index) => ({
+    fingerprint: `ep2_${(index + 1).toString(16).padStart(32, '0')}`,
+    key: `provider/model-${index + 1}`,
+    provider: 'provider',
+    model: `model-${index + 1}`,
+    state: 'unsupported',
+    reason: 'provider-rejected-image',
+    measuredAt: index + 1,
+    suiteRevision: CAPABILITY_BENCHMARK_SUITE_REVISION,
+  }))
+  const mem = memoryFs({
+    [file]: JSON.stringify({ version: 1, verdicts }),
+  })
+  const store = createImageInputVerdictStore({ cacheFile: file, fsOps: mem.ops })
+
+  const loaded = await store.list()
+  assert.equal(loaded.length, 128)
+  assert.equal(loaded[0].measuredAt, 140)
+  assert.equal(loaded.at(-1).measuredAt, 13)
+
+  const newestFingerprint = `ep2_${'f'.repeat(32)}`
+  assert.ok(await store.markUnsupported({
+    fingerprint: newestFingerprint,
+    key: 'provider/newest',
+    provider: 'provider',
+    model: 'newest',
+    measuredAt: 1_000,
+  }))
+  const live = await store.list()
+  assert.equal(live.length, 128)
+  await store.flush()
+  const disk = JSON.parse(mem.files.get(file)).verdicts
+  assert.deepEqual(disk.map((item) => item.fingerprint), live.map((item) => item.fingerprint))
+
+  const tooOldFingerprint = `ep2_${'e'.repeat(32)}`
+  assert.equal(await store.markUnsupported({
+    fingerprint: tooOldFingerprint,
+    key: 'provider/too-old',
+    provider: 'provider',
+    model: 'too-old',
+    measuredAt: 1,
+  }), undefined)
+  assert.equal((await store.list()).some((item) => item.fingerprint === tooOldFingerprint), false)
 })


### PR DESCRIPTION
## Summary

Makes persistent cache live state obey the same deterministic survivor policy as disk persistence.

- image input verdicts: sanitize/sort/dedupe/cap on load and after mutation, matching save behavior
- background benchmark stops: apply TTL + deterministic sort/dedupe/cap through one survivor selector for load/live/save
- capability profiles: use the configured maxEntries for load/live/save with identical ordering and dedupe semantics
- return the actual retained live value after writes, avoiding successful-looking results for entries immediately evicted by capacity policy
- keep cache versions, file formats, public method names, TTL semantics, and profile merge behavior unchanged

## Regression coverage

- oversized legacy/current cache files are bounded immediately on first live read
- mutation-time live state remains within capacity without requiring restart
- persisted survivor fingerprints/keys exactly match live survivors after a write
- duplicate persisted keys deterministically retain the newest record before capacity slicing
- too-old writes that cannot survive capacity return undefined rather than pretending to persist

## Verification

- focused store/background/routing suite: 72/72
- targeted three-store suite: 16/16
- `pnpm test`: 1332 pass, 1 existing skip, 0 fail; runtime policy 6/6
- `git diff --check`: pass

No `live-model-discovery` changes are included here; provider lifecycle GC remains a separate follow-up so the 64-entry disk cache is not accidentally turned into a new provider product limit.