### PR TITLE
fix(cache): gc live model provider lifecycle

### DIFF
--- a/lib/live-model-discovery.js
+++ b/lib/live-model-discovery.js
@@ -161,15 +161,32 @@ async function saveCache(file, providers, fsOps) {
   await fsOps.rename(temporary, file)
 }
 
-function rawPiProfiles(ctx) {
+function piProfilesState(ctx) {
   try {
     const settings = ctx?.get?.('settings')
-    const value = settings?.get?.('llm-pi-ai')
+    if (!settings || typeof settings.get !== 'function') return { authoritative: false, providers: {} }
+    const value = settings.get('llm-pi-ai')
     const providers = value?.providers
-    return providers && typeof providers === 'object' && !Array.isArray(providers) ? providers : {}
+    if (!providers || typeof providers !== 'object' || Array.isArray(providers)) {
+      return { authoritative: false, providers: {} }
+    }
+    return { authoritative: true, providers }
   } catch {
-    return {}
+    return { authoritative: false, providers: {} }
   }
+}
+
+function rawPiProfiles(ctx) {
+  return piProfilesState(ctx).providers
+}
+
+function providerConfigurationToken(provider, raw) {
+  return JSON.stringify([
+    provider,
+    normalizeBaseURL(raw?.baseURL) ?? '',
+    nonEmpty(raw?.api) ?? '',
+    nonEmpty(raw?.apiKeyEnv) ?? '',
+  ])
 }
 
 function visionProviderPriority(ctx, fallbackConfig = {}) {
@@ -349,15 +366,18 @@ export function createLiveModelDiscoveryManager(ctx, options = {}) {
   let providers = new Map()
   let version = 0
   let evidenceGeneration = 0
+  let configuredProviders
+  let configuredTokens = new Map()
+  let providerGenerations = new Map()
+  let providerGenerationSequence = 0
   let active = 0
   let disposed = false
   let saveTail = Promise.resolve()
   const inflight = new Map()
+  const inflightAuthority = new Map()
   const queued = new Map()
   const backoffUntil = new Map()
-  const cacheReady = loadCache(cacheFile, fsOps).then((loaded) => {
-    if (!disposed) providers = loaded
-  })
+  const activeControllers = new Map()
 
   const persist = () => {
     saveTail = saveTail
@@ -365,6 +385,76 @@ export function createLiveModelDiscoveryManager(ctx, options = {}) {
       .catch((error) => logger?.warn?.('vision-router: live model cache write failed: %s', boundedError(error)))
     return saveTail
   }
+
+  const pruneUnconfiguredState = () => {
+    if (!(configuredProviders instanceof Set)) return false
+    let providerCacheChanged = false
+    for (const provider of [...providers.keys()]) {
+      if (configuredProviders.has(provider)) continue
+      providers.delete(provider)
+      providerCacheChanged = true
+    }
+    for (const provider of [...queued.keys()]) {
+      if (!configuredProviders.has(provider)) queued.delete(provider)
+    }
+    for (const provider of [...backoffUntil.keys()]) {
+      if (!configuredProviders.has(provider)) backoffUntil.delete(provider)
+    }
+    for (const [provider, controller] of activeControllers.entries()) {
+      if (configuredProviders.has(provider)) continue
+      try { controller.abort() } catch {}
+    }
+    if (providerCacheChanged) version += 1
+    return providerCacheChanged
+  }
+
+  const reconcileConfiguredProviders = () => {
+    const state = piProfilesState(ctx)
+    if (!state.authoritative) return state.providers
+    const next = new Set(Object.keys(state.providers))
+    const nextTokens = new Map([...next].map((provider) => [
+      provider,
+      providerConfigurationToken(provider, state.providers[provider]),
+    ]))
+    const nextGenerations = new Map()
+    for (const provider of next) {
+      const unchanged = configuredProviders instanceof Set &&
+        configuredProviders.has(provider) &&
+        configuredTokens.get(provider) === nextTokens.get(provider)
+      if (unchanged && providerGenerations.has(provider)) {
+        nextGenerations.set(provider, providerGenerations.get(provider))
+      } else {
+        providerGenerationSequence += 1
+        nextGenerations.set(provider, providerGenerationSequence)
+      }
+    }
+    configuredProviders = next
+    configuredTokens = nextTokens
+    providerGenerations = nextGenerations
+    if (pruneUnconfiguredState()) void persist()
+    return state.providers
+  }
+
+  const currentDiscoveryAuthority = (provider) => ({
+    providerGeneration: providerGenerations.get(provider) ?? 0,
+    evidenceGeneration,
+  })
+
+  const sameDiscoveryAuthority = (left, right) => (
+    left?.providerGeneration === right?.providerGeneration &&
+    left?.evidenceGeneration === right?.evidenceGeneration
+  )
+
+  const discoveryStillCurrent = (provider, authority) => (
+    sameDiscoveryAuthority(authority, currentDiscoveryAuthority(provider)) &&
+    (!(configuredProviders instanceof Set) || configuredProviders.has(provider))
+  )
+
+  const cacheReady = loadCache(cacheFile, fsOps).then((loaded) => {
+    if (disposed) return
+    providers = loaded
+    reconcileConfiguredProviders()
+  })
 
   const visibleEntry = (entry, at = now()) => {
     if (!entry || entry.routeMismatch === true || at - entry.discoveredAt > staleMs) return undefined
@@ -391,10 +481,10 @@ export function createLiveModelDiscoveryManager(ctx, options = {}) {
     }
   }
 
-  const discover = async (provider) => {
+  const discover = async (provider, authorityAtStart) => {
     const plan = await providerPlan(ctx, provider)
-    if (!plan.ok) return
-    const generationAtStart = evidenceGeneration
+    if (!plan.ok || disposed || !discoveryStillCurrent(provider, authorityAtStart)) return
+    const generationAtStart = authorityAtStart.evidenceGeneration
     const previous = providers.get(provider)
     const at = now()
     const sameRoute = previous?.fingerprint === plan.fingerprint
@@ -414,6 +504,7 @@ export function createLiveModelDiscoveryManager(ctx, options = {}) {
     }
 
     const controller = new AbortController()
+    activeControllers.set(provider, controller)
     const timer = setTimeout(() => controller.abort(), timeoutMs)
     try {
       const headers = { accept: 'application/json' }
@@ -432,6 +523,7 @@ export function createLiveModelDiscoveryManager(ctx, options = {}) {
         label: `${provider} model listing`,
       })
       const models = normalizeOpenAIModelListing(body, { maxModels: options.maxModels })
+      if (disposed || !discoveryStillCurrent(provider, authorityAtStart)) return
       providers.set(provider, {
         provider,
         fingerprint: plan.fingerprint,
@@ -444,7 +536,7 @@ export function createLiveModelDiscoveryManager(ctx, options = {}) {
       version += 1
       void persist()
     } catch (error) {
-      if (disposed) return
+      if (disposed || !discoveryStillCurrent(provider, authorityAtStart)) return
       const current = providers.get(provider)
       const message = boundedError(error)
       if (current) {
@@ -455,6 +547,7 @@ export function createLiveModelDiscoveryManager(ctx, options = {}) {
       logger?.debug?.('vision-router: live model discovery failed for %s: %s', provider, message)
     } finally {
       clearTimeout(timer)
+      if (activeControllers.get(provider) === controller) activeControllers.delete(provider)
     }
   }
 
@@ -470,14 +563,17 @@ export function createLiveModelDiscoveryManager(ctx, options = {}) {
       if (!picked) return
       queued.delete(picked.provider)
       active += 1
-      const task = discover(picked.provider)
+      const authorityAtStart = currentDiscoveryAuthority(picked.provider)
+      const task = discover(picked.provider, authorityAtStart)
         .catch(() => {})
         .finally(() => {
           active = Math.max(0, active - 1)
           inflight.delete(picked.provider)
+          inflightAuthority.delete(picked.provider)
           pump()
         })
       inflight.set(picked.provider, task)
+      inflightAuthority.set(picked.provider, authorityAtStart)
     }
   }
 
@@ -491,9 +587,13 @@ export function createLiveModelDiscoveryManager(ctx, options = {}) {
   }
 
   function queueConfigured() {
-    const raw = rawPiProfiles(ctx)
+    const raw = reconcileConfiguredProviders()
     const preferred = visionProviderPriority(ctx, fallbackConfig)
-    for (const provider of Object.keys(raw)) queue(provider, preferred.has(provider) ? 0 : 10)
+    for (const provider of Object.keys(raw)) {
+      const activeAuthority = inflightAuthority.get(provider)
+      if (activeAuthority && sameDiscoveryAuthority(activeAuthority, currentDiscoveryAuthority(provider))) continue
+      queue(provider, preferred.has(provider) ? 0 : 10)
+    }
   }
 
   const hasModel = (provider, model) => {
@@ -524,7 +624,12 @@ export function createLiveModelDiscoveryManager(ctx, options = {}) {
     async dispose() {
       disposed = true
       queued.clear()
+      for (const controller of activeControllers.values()) {
+        try { controller.abort() } catch {}
+      }
       await Promise.allSettled([...inflight.values(), cacheReady, saveTail])
+      activeControllers.clear()
+      inflightAuthority.clear()
     },
   }
 }

--- a/tests/live-model-discovery.test.js
+++ b/tests/live-model-discovery.test.js
@@ -75,6 +75,51 @@ function fakeDiscoveryContext({ baseURL = 'https://open.bigmodel.example/api/paa
   }
 }
 
+
+function memoryCacheFs(initial = {}) {
+  const files = new Map(Object.entries(initial))
+  return {
+    files,
+    ops: {
+      async readFile(file) {
+        if (!files.has(file)) {
+          const error = new Error('missing')
+          error.code = 'ENOENT'
+          throw error
+        }
+        return files.get(file)
+      },
+      async mkdir() {},
+      async writeFile(file, body) { files.set(file, body) },
+      async rename(from, to) {
+        files.set(to, files.get(from))
+        files.delete(from)
+      },
+    },
+  }
+}
+
+function mutableDiscoveryContext(initialProviders = {}) {
+  const state = { providers: initialProviders, settingsAvailable: true }
+  const settings = {
+    get(namespace) {
+      if (namespace === 'llm-pi-ai') return { providers: state.providers }
+      if (namespace === 'vision-router') return { providers: [] }
+      return undefined
+    },
+  }
+  return {
+    state,
+    ctx: {
+      llm: { registration() { return undefined } },
+      get(name) {
+        if (name === 'settings') return state.settingsAvailable ? settings : undefined
+        return undefined
+      },
+    },
+  }
+}
+
 test('OpenAI-compatible listing normalization proves existence only and de-duplicates ids', () => {
   assert.deepEqual(
     normalizeOpenAIModelListing({
@@ -422,4 +467,297 @@ test('index prelude injection is idempotent and runs after head boot scripts but
   assert.match(once, /data-vision-router-live-models/)
   assert.ok(once.indexOf('data-vision-router-live-models') > once.indexOf('/shell.js'))
   assert.ok(once.indexOf('data-vision-router-live-models') < once.indexOf('</head>'))
+})
+
+test('authoritative provider config prunes removed cached providers and rewrites the cache', async () => {
+  const cacheFile = '/virtual/live-models.json'
+  const cachedProviders = [
+    { provider: 'keep', fingerprint: 'keep-route', discoveredAt: 9_000, models: [{ id: 'keep-model' }] },
+    { provider: 'removed', fingerprint: 'removed-route', discoveredAt: 9_000, models: [{ id: 'removed-model' }] },
+  ]
+  const mem = memoryCacheFs({
+    [cacheFile]: JSON.stringify({ version: LIVE_MODEL_CACHE_VERSION, providers: cachedProviders }),
+  })
+  const { ctx } = mutableDiscoveryContext({
+    keep: { baseURL: 'https://keep.example/v1', api: 'openai-completions' },
+  })
+  const manager = createLiveModelDiscoveryManager(ctx, {
+    cacheFile,
+    fsOps: mem.ops,
+    now: () => 10_000,
+    fetchImpl: async () => { throw new Error('not needed') },
+  })
+
+  await manager.ready()
+  const snapshot = await manager.snapshot({ schedule: false })
+  assert.deepEqual(snapshot.providers.map((entry) => entry.provider), ['keep'])
+  assert.equal(manager.hasModel('removed', 'removed-model'), false)
+  await manager.dispose()
+  const disk = JSON.parse(mem.files.get(cacheFile))
+  assert.deepEqual(disk.providers.map((entry) => entry.provider), ['keep'])
+})
+
+test('temporarily unavailable settings never turn an empty read into provider cache deletion', async () => {
+  const cacheFile = '/virtual/live-models-unavailable.json'
+  const mem = memoryCacheFs({
+    [cacheFile]: JSON.stringify({
+      version: LIVE_MODEL_CACHE_VERSION,
+      providers: [{ provider: 'cached', fingerprint: 'cached-route', discoveredAt: 9_000, models: [{ id: 'cached-model' }] }],
+    }),
+  })
+  const { ctx, state } = mutableDiscoveryContext({})
+  state.settingsAvailable = false
+  const manager = createLiveModelDiscoveryManager(ctx, {
+    cacheFile,
+    fsOps: mem.ops,
+    now: () => 10_000,
+    fetchImpl: async () => { throw new Error('not needed') },
+  })
+
+  await manager.ready()
+  assert.deepEqual((await manager.snapshot({ schedule: false })).providers.map((entry) => entry.provider), ['cached'])
+  manager.queueConfigured()
+  assert.deepEqual((await manager.snapshot({ schedule: false })).providers.map((entry) => entry.provider), ['cached'])
+  await manager.dispose()
+})
+
+test('removed provider cannot be resurrected by a late inflight discovery completion', async () => {
+  const cacheFile = '/virtual/live-models-inflight.json'
+  const mem = memoryCacheFs()
+  const { ctx, state } = mutableDiscoveryContext({
+    zai: { baseURL: 'https://zai.example/v1', api: 'openai-completions' },
+  })
+  let release
+  let started
+  const startedPromise = new Promise((resolve) => { started = resolve })
+  const manager = createLiveModelDiscoveryManager(ctx, {
+    cacheFile,
+    fsOps: mem.ops,
+    now: () => 10_000,
+    fetchImpl: async () => {
+      started()
+      await new Promise((resolve) => { release = resolve })
+      return new Response(JSON.stringify({ data: [{ id: 'late-model' }] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    },
+  })
+
+  await manager.ready()
+  manager.queueConfigured()
+  await startedPromise
+  state.providers = {}
+  manager.queueConfigured()
+  release()
+  const settled = await waitForSettled(manager)
+  assert.equal(settled.providers.some((entry) => entry.provider === 'zai'), false)
+  assert.equal(manager.hasModel('zai', 'late-model'), false)
+  await manager.dispose()
+})
+
+test('removing a provider clears queued/backoff lifecycle state so a later re-add probes immediately', async () => {
+  const cacheFile = '/virtual/live-models-readd.json'
+  const mem = memoryCacheFs()
+  const { ctx, state } = mutableDiscoveryContext({
+    zai: { baseURL: 'https://zai.example/v1', api: 'openai-completions' },
+  })
+  let calls = 0
+  const manager = createLiveModelDiscoveryManager(ctx, {
+    cacheFile,
+    fsOps: mem.ops,
+    now: () => 10_000,
+    fetchImpl: async () => {
+      calls += 1
+      if (calls === 1) return new Response('offline', { status: 503 })
+      return new Response(JSON.stringify({ data: [{ id: 'readded-model' }] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    },
+  })
+
+  await manager.ready()
+  manager.queueConfigured()
+  await waitForSettled(manager)
+  assert.equal(calls, 1)
+
+  state.providers = {}
+  manager.queueConfigured()
+  state.providers = {
+    zai: { baseURL: 'https://zai.example/v1', api: 'openai-completions' },
+  }
+  manager.queueConfigured()
+  const live = await waitForProvider(manager, 'zai')
+  assert.equal(live.models.some((model) => model.id === 'readded-model'), true)
+  assert.equal(calls, 2, 're-added provider must not inherit the removed provider backoff window')
+  await manager.dispose()
+})
+
+test('same-name provider transport changes fence old inflight results even without an invalidation event', async () => {
+  const cacheFile = '/virtual/live-models-route-change.json'
+  const mem = memoryCacheFs()
+  const { ctx, state } = mutableDiscoveryContext({
+    zai: { baseURL: 'https://old.example/v1', api: 'openai-completions' },
+  })
+  const calls = []
+  let releaseOld
+  let oldStarted
+  const oldStartedPromise = new Promise((resolve) => { oldStarted = resolve })
+  const manager = createLiveModelDiscoveryManager(ctx, {
+    cacheFile,
+    fsOps: mem.ops,
+    now: () => 10_000,
+    fetchImpl: async (url) => {
+      calls.push(String(url))
+      if (calls.length === 1) {
+        oldStarted()
+        await new Promise((resolve) => { releaseOld = resolve })
+        return new Response(JSON.stringify({ data: [{ id: 'old-route-model' }] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      }
+      return new Response(JSON.stringify({ data: [{ id: 'new-route-model' }] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    },
+  })
+
+  await manager.ready()
+  manager.queueConfigured()
+  await oldStartedPromise
+  state.providers = {
+    zai: { baseURL: 'https://new.example/v1', api: 'openai-completions' },
+  }
+  manager.queueConfigured()
+  releaseOld()
+  const live = await waitForProvider(manager, 'zai')
+  assert.deepEqual(calls, [
+    'https://old.example/v1/models',
+    'https://new.example/v1/models',
+  ])
+  assert.deepEqual(live.models.map((model) => model.id), ['new-route-model'])
+  assert.equal(manager.hasModel('zai', 'old-route-model'), false)
+  await manager.dispose()
+})
+
+test('provider removal drops queued discovery before a concurrency slot can start it', async () => {
+  const cacheFile = '/virtual/live-models-queued-removal.json'
+  const mem = memoryCacheFs()
+  const { ctx, state } = mutableDiscoveryContext({
+    first: { baseURL: 'https://first.example/v1', api: 'openai-completions' },
+    removed: { baseURL: 'https://removed.example/v1', api: 'openai-completions' },
+  })
+  const calls = []
+  let releaseFirst
+  let firstStarted
+  const firstStartedPromise = new Promise((resolve) => { firstStarted = resolve })
+  const manager = createLiveModelDiscoveryManager(ctx, {
+    cacheFile,
+    fsOps: mem.ops,
+    concurrency: 1,
+    now: () => 10_000,
+    fetchImpl: async (url) => {
+      calls.push(String(url))
+      firstStarted()
+      await new Promise((resolve) => { releaseFirst = resolve })
+      return new Response(JSON.stringify({ data: [{ id: 'first-model' }] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    },
+  })
+
+  await manager.ready()
+  manager.queueConfigured()
+  await firstStartedPromise
+  state.providers = {
+    first: { baseURL: 'https://first.example/v1', api: 'openai-completions' },
+  }
+  manager.queueConfigured()
+  releaseFirst()
+  await waitForSettled(manager)
+  assert.deepEqual(calls, ['https://first.example/v1/models'])
+  assert.equal((await manager.snapshot()).providers.some((entry) => entry.provider === 'removed'), false)
+  await manager.dispose()
+})
+
+test('remove then re-add of the same provider creates a new lifecycle generation', async () => {
+  const cacheFile = '/virtual/live-models-reincarnation.json'
+  const mem = memoryCacheFs()
+  const config = { baseURL: 'https://same.example/v1', api: 'openai-completions' }
+  const { ctx, state } = mutableDiscoveryContext({ zai: config })
+  let calls = 0
+  let releaseOld
+  let oldStarted
+  const oldStartedPromise = new Promise((resolve) => { oldStarted = resolve })
+  const manager = createLiveModelDiscoveryManager(ctx, {
+    cacheFile,
+    fsOps: mem.ops,
+    now: () => 10_000,
+    fetchImpl: async () => {
+      calls += 1
+      if (calls === 1) {
+        oldStarted()
+        await new Promise((resolve) => { releaseOld = resolve })
+        return new Response(JSON.stringify({ data: [{ id: 'old-lifecycle-model' }] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      }
+      return new Response(JSON.stringify({ data: [{ id: 'new-lifecycle-model' }] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    },
+  })
+
+  await manager.ready()
+  manager.queueConfigured()
+  await oldStartedPromise
+  state.providers = {}
+  manager.queueConfigured()
+  state.providers = { zai: config }
+  manager.queueConfigured()
+  releaseOld()
+  const live = await waitForProvider(manager, 'zai')
+  assert.equal(calls, 2)
+  assert.deepEqual(live.models.map((model) => model.id), ['new-lifecycle-model'])
+  assert.equal(manager.hasModel('zai', 'old-lifecycle-model'), false)
+  await manager.dispose()
+})
+
+test('dispose fences a late fetch that ignores AbortSignal and never persists its result', async () => {
+  const cacheFile = '/virtual/live-models-dispose.json'
+  const mem = memoryCacheFs()
+  const { ctx } = mutableDiscoveryContext({
+    zai: { baseURL: 'https://zai.example/v1', api: 'openai-completions' },
+  })
+  let release
+  let started
+  const startedPromise = new Promise((resolve) => { started = resolve })
+  const manager = createLiveModelDiscoveryManager(ctx, {
+    cacheFile,
+    fsOps: mem.ops,
+    now: () => 10_000,
+    fetchImpl: async () => {
+      started()
+      await new Promise((resolve) => { release = resolve })
+      return new Response(JSON.stringify({ data: [{ id: 'too-late' }] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    },
+  })
+
+  await manager.ready()
+  manager.queueConfigured()
+  await startedPromise
+  const disposing = manager.dispose()
+  release()
+  await disposing
+  assert.equal((await manager.snapshot({ schedule: false })).providers.some((entry) => entry.provider === 'zai'), false)
+  assert.equal([...mem.files.values()].some((body) => String(body).includes('too-late')), false)
 })


### PR DESCRIPTION
## Summary

Makes live model discovery state follow the authoritative configured provider lifecycle without turning the existing 64-entry disk cache into a product provider limit.

- treat `llm-pi-ai.providers` as authoritative only when the settings namespace is actually available
- prune cached provider entries, queued work, and backoff state when a provider is removed
- persist cache pruning so removed providers do not reappear after restart
- abort active discovery for removed providers
- add per-provider lifecycle generations so late fetch completions cannot resurrect removed/re-added providers
- derive lifecycle tokens from non-secret transport identity (`baseURL`, `api`, `apiKeyEnv` reference)
- fence same-name transport changes even if a settings invalidation event is delayed or missed
- avoid re-queueing an unaffected provider that already has current inflight discovery
- fence late completions after plugin disposal, including fetch implementations that ignore `AbortSignal`
- keep generation/token metadata bounded to the currently configured provider set

## Compatibility constraints

- no new hard limit on configured provider count
- existing disk persistence still writes at most 64 provider cache entries
- existing per-provider model listing bound remains unchanged
- settings temporarily unavailable is fail-open for cache retention; it never means authoritative empty config
- no change to provider/model catalog wire format, cache version, credentials, or Host API

## Regression coverage

- authoritative config removes stale cached providers and rewrites disk
- unavailable settings never purge cache
- removed inflight provider cannot publish a late result
- removed queued provider never gets a later concurrency slot
- removed backoff does not block an intentional re-add
- same-name endpoint change fences the old request and publishes only the new route
- remove/re-add of the same provider creates a new lifecycle generation
- dispose rejects late fetch publication even when the fetch ignores abort

## Verification

- `node --test tests/live-model-discovery.test.js` → 15/15
- extended live-model/Host compatibility suite → 41/41 before final lifecycle additions
- `pnpm test` after final changes → 1340 pass, 1 existing skip, 0 fail; runtime policy 6/6
- `git diff --check` → pass