### PR TITLE
fix(hardening): close post-merge release blockers

### DIFF
--- a/.github/workflows/dsh-alpha-source-contract.yml
+++ b/.github/workflows/dsh-alpha-source-contract.yml
@@ -104,6 +104,12 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
+            dsh: 0.1.5-rc.1
+          - os: macos-latest
+            dsh: 0.1.5-rc.1
+          - os: windows-latest
+            dsh: 0.1.5-rc.1
+          - os: ubuntu-latest
             dsh: 0.1.5-rc.2
           - os: macos-latest
             dsh: 0.1.5-rc.2
@@ -121,6 +127,15 @@ jobs:
         with:
           persist-credentials: false
           path: dvr
+
+      - name: Checkout exact DSH 0.1.5-rc.1 source
+        if: matrix.dsh == '0.1.5-rc.1'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          repository: deepseek-ai/deepseek-harness
+          ref: 183f08e9c6dde7e36cd2318eaee70b0da08fb35e
+          persist-credentials: false
+          path: dsh-exact
 
       - name: Checkout exact DSH 0.1.5-rc.2 source
         if: matrix.dsh == '0.1.5-rc.2'
@@ -156,6 +171,15 @@ jobs:
           CI: 'true'
           LEFTHOOK: '0'
         run: pnpm install --frozen-lockfile
+
+      - name: Run Vision Router against exact 0.1.5-rc.1 source contracts
+        if: matrix.dsh == '0.1.5-rc.1'
+        working-directory: dsh-exact
+        env:
+          DSH_SOURCE_ROOT: ${{ github.workspace }}/dsh-exact
+          DSH_EXPECTED_VERSION: 0.1.5-rc.1
+          DSH_EXPECTED_COMMIT: 183f08e9c6dde7e36cd2318eaee70b0da08fb35e
+        run: pnpm exec tsx ../dvr/scripts/dsh-alpha-source-contract.mjs
 
       - name: Run Vision Router against exact 0.1.5-rc.2 source contracts
         if: matrix.dsh == '0.1.5-rc.2'

--- a/.github/workflows/dsh-preview-browser-smoke.yml
+++ b/.github/workflows/dsh-preview-browser-smoke.yml
@@ -74,6 +74,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - dsh: 0.1.5-rc.1
+            mixedGenericFiles: false
           - dsh: 0.1.5-rc.2
             mixedGenericFiles: true
           - dsh: 0.1.5-alpha.2
@@ -84,6 +86,15 @@ jobs:
         with:
           persist-credentials: false
           path: dvr
+
+      - name: Checkout immutable DSH 0.1.5-rc.1 source
+        if: matrix.dsh == '0.1.5-rc.1'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          repository: deepseek-ai/deepseek-harness
+          ref: 183f08e9c6dde7e36cd2318eaee70b0da08fb35e
+          persist-credentials: false
+          path: dsh-preview
 
       - name: Checkout immutable DSH 0.1.5-rc.2 source
         if: matrix.dsh == '0.1.5-rc.2'

--- a/lib/client.js
+++ b/lib/client.js
@@ -4254,6 +4254,8 @@ window.__ModuleLoader__.load({
 
     const PRESENTED_IMAGE_CACHE_MAX_ENTRIES = 32
     const PRESENTED_IMAGE_CACHE_MAX_BYTES = 64 * 1024 * 1024
+    const PRESENTED_IMAGE_CACHE_MAX_ACTIVE_LOADS = 3
+    const PRESENTED_IMAGE_CACHE_MAX_PENDING_ENTRIES = 256
 
     function presentedImageResourceKey(sessionId, attachment) {
       return `${String(sessionId)}:${String(attachment && attachment.attachmentId)}`
@@ -4266,6 +4268,12 @@ window.__ModuleLoader__.load({
       const maxBytes = Number.isFinite(options.maxBytes)
         ? Math.max(0, Math.floor(options.maxBytes))
         : PRESENTED_IMAGE_CACHE_MAX_BYTES
+      const maxActiveLoads = Number.isFinite(options.maxActiveLoads)
+        ? Math.max(1, Math.floor(options.maxActiveLoads))
+        : PRESENTED_IMAGE_CACHE_MAX_ACTIVE_LOADS
+      const maxPendingEntries = Number.isFinite(options.maxPendingEntries)
+        ? Math.max(0, Math.floor(options.maxPendingEntries))
+        : PRESENTED_IMAGE_CACHE_MAX_PENDING_ENTRIES
       const nativeObjectUrls =
         typeof URL !== 'undefined' &&
         typeof URL.createObjectURL === 'function' &&
@@ -4293,17 +4301,34 @@ window.__ModuleLoader__.load({
           }
       const useObjectUrls = typeof createObjectURL === 'function' && typeof revokeObjectURL === 'function'
       const entries = new Map()
+      const loadQueue = []
       let sequence = 0
       let disposed = false
+      let activeLoads = 0
+      let pendingEntries = 0
 
+      const resourceError = (code, message) => {
+        const error = new Error(message)
+        error.code = code
+        return error
+      }
       const touch = (entry) => { entry.lastUsed = ++sequence }
       const dataBytes = (data) => {
         const value = Number(data && (data.byteLength ?? data.length))
         return Number.isFinite(value) && value > 0 ? value : 0
       }
-      const remove = (entry) => {
+      const remove = (entry, reason) => {
         if (!entry || entries.get(entry.key) !== entry) return false
         entries.delete(entry.key)
+        if (!entry.settled) {
+          pendingEntries = Math.max(0, pendingEntries - 1)
+          entry.cancelled = true
+          entry.cancelReason = reason ?? resourceError(
+            'VISION_PRESENT_LOAD_RELEASED',
+            'vision_present: image resource load released',
+          )
+          if (!entry.started && typeof entry.reject === 'function') entry.reject(entry.cancelReason)
+        }
         if (entry.revocable && entry.url) {
           try { revokeObjectURL(entry.url) } catch {}
           entry.revocable = false
@@ -4327,9 +4352,57 @@ window.__ModuleLoader__.load({
           bytes = Math.max(0, bytes - entry.weight)
         }
       }
+      const pump = () => {
+        if (disposed) return
+        while (activeLoads < maxActiveLoads && loadQueue.length > 0) {
+          const entry = loadQueue.shift()
+          if (!entry || entries.get(entry.key) !== entry || entry.started || entry.cancelled) continue
+          entry.started = true
+          activeLoads += 1
+          Promise.resolve()
+            .then(() => entry.loader())
+            .then(({ data, mediaType }) => {
+              if (disposed || entry.cancelled || entries.get(entry.key) !== entry) {
+                throw entry.cancelReason ?? resourceError(
+                  'VISION_PRESENT_CACHE_DISPOSED',
+                  'vision_present: image resource cache disposed',
+                )
+              }
+              const rawBytes = dataBytes(data)
+              if (useObjectUrls) {
+                entry.url = createObjectURL(data, mediaType)
+                entry.revocable = true
+                entry.weight = rawBytes
+              } else {
+                entry.url = encodeDataURL(data, mediaType)
+                entry.weight = entry.url.length * 2
+              }
+              entry.settled = true
+              pendingEntries = Math.max(0, pendingEntries - 1)
+              entry.loader = undefined
+              touch(entry)
+              trim()
+              activeLoads = Math.max(0, activeLoads - 1)
+              pump()
+              entry.resolve(entry.url)
+            })
+            .catch((error) => {
+              const retained = entries.get(entry.key) === entry
+              if (retained) remove(entry, error)
+              activeLoads = Math.max(0, activeLoads - 1)
+              pump()
+              entry.reject(error)
+            })
+        }
+      }
 
       const load = (keyValue, loader, ownerToken) => {
-        if (disposed) return Promise.reject(new Error('vision_present: image resource cache disposed'))
+        if (disposed) {
+          return Promise.reject(resourceError(
+            'VISION_PRESENT_CACHE_DISPOSED',
+            'vision_present: image resource cache disposed',
+          ))
+        }
         const key = String(keyValue)
         const cached = entries.get(key)
         if (cached) {
@@ -4337,45 +4410,39 @@ window.__ModuleLoader__.load({
           touch(cached)
           return cached.promise
         }
+        if (pendingEntries >= maxPendingEntries) {
+          return Promise.reject(resourceError(
+            'VISION_PRESENT_CACHE_BUSY',
+            'vision_present: too many image resources are waiting to load; retry when earlier images finish',
+          ))
+        }
+        let resolvePending
+        let rejectPending
+        const pending = new Promise((resolve, reject) => {
+          resolvePending = resolve
+          rejectPending = reject
+        })
         const entry = {
           key,
           owners: new Set(ownerToken === undefined ? [] : [ownerToken]),
-          promise: undefined,
+          promise: pending,
+          resolve: resolvePending,
+          reject: rejectPending,
+          loader,
           url: undefined,
           revocable: false,
           settled: false,
+          started: false,
+          cancelled: false,
+          cancelReason: undefined,
           weight: 0,
           lastUsed: 0,
         }
         touch(entry)
-        const pending = Promise.resolve()
-          .then(() => loader())
-          .then(({ data, mediaType }) => {
-            if (disposed || entries.get(key) !== entry) {
-              throw new Error('vision_present: image resource cache disposed')
-            }
-            const rawBytes = dataBytes(data)
-            if (useObjectUrls) {
-              entry.url = createObjectURL(data, mediaType)
-              entry.revocable = true
-              entry.weight = rawBytes
-            } else {
-              entry.url = encodeDataURL(data, mediaType)
-              // JS strings are commonly two-byte code units; budget the fallback
-              // conservatively instead of pretending base64 retains raw bytes.
-              entry.weight = entry.url.length * 2
-            }
-            entry.settled = true
-            touch(entry)
-            trim()
-            return entry.url
-          })
-          .catch((error) => {
-            remove(entry)
-            throw error
-          })
-        entry.promise = pending
         entries.set(key, entry)
+        pendingEntries += 1
+        loadQueue.push(entry)
+        pump()
         return pending
       }
       const release = (keyValue, ownerToken, releaseOptions = {}) => {
@@ -4393,14 +4460,23 @@ window.__ModuleLoader__.load({
       const dispose = () => {
         if (disposed) return
         disposed = true
-        for (const entry of [...entries.values()]) remove(entry)
+        const reason = resourceError(
+          'VISION_PRESENT_CACHE_DISPOSED',
+          'vision_present: image resource cache disposed',
+        )
+        for (const entry of [...entries.values()]) remove(entry, reason)
+        loadQueue.length = 0
         entries.clear()
       }
       const stats = () => {
         const settled = settledEntries()
+        const queuedLoads = [...entries.values()].filter((entry) => !entry.settled && !entry.started).length
         return {
           entries: entries.size,
           settledEntries: settled.length,
+          pendingEntries,
+          activeLoads,
+          queuedLoads,
           residentBytes: settled.reduce((total, entry) => total + entry.weight, 0),
           ownedEntries: settled.filter((entry) => entry.owners.size > 0).length,
           disposed,
@@ -4609,6 +4685,8 @@ window.__ModuleLoader__.load({
     exports.installSettingsPersistence = installSettingsPersistence
     exports.PRESENTED_IMAGE_CACHE_MAX_ENTRIES = PRESENTED_IMAGE_CACHE_MAX_ENTRIES
     exports.PRESENTED_IMAGE_CACHE_MAX_BYTES = PRESENTED_IMAGE_CACHE_MAX_BYTES
+    exports.PRESENTED_IMAGE_CACHE_MAX_ACTIVE_LOADS = PRESENTED_IMAGE_CACHE_MAX_ACTIVE_LOADS
+    exports.PRESENTED_IMAGE_CACHE_MAX_PENDING_ENTRIES = PRESENTED_IMAGE_CACHE_MAX_PENDING_ENTRIES
     exports.presentedImageResourceKey = presentedImageResourceKey
     exports.createPresentedImageResourceCache = createPresentedImageResourceCache
     exports.GUIDE_STATE = GUIDE_STATE

--- a/lib/live-model-discovery.js
+++ b/lib/live-model-discovery.js
@@ -5,6 +5,7 @@ import process from 'node:process'
 import { resolveDshHome } from './doctor.js'
 import { MODEL_RESPONSE_MAX_BYTES, readResponseJsonBounded } from './http-body-limit.js'
 import { stripTrailingSlashes } from './string-normalization.js'
+import { isLocalUiRequest } from './web-capability-boundary.js'
 
 export const LIVE_MODELS_PATH = '/_dsh/vision-router/live-models'
 export const LIVE_MODEL_CACHE_VERSION = 2
@@ -684,7 +685,11 @@ export function installLiveModelDiscovery(ctx, options = {}) {
         }
         try {
           const url = new URL(req.url ?? LIVE_MODELS_PATH, 'http://localhost')
-          const schedule = url.searchParams.get('refresh') !== '0'
+          // The snapshot itself is safe for an authenticated remote Settings UI,
+          // but refresh drives Host-side provider I/O and may resolve stored
+          // credentials. Preserve local ?refresh=1 behavior while making every
+          // remote GET a passive read of already-owned discovery state.
+          const schedule = isLocalUiRequest(req) && url.searchParams.get('refresh') !== '0'
           sendJson(res, 200, await manager.snapshot({ schedule }))
         } catch (error) {
           sendJson(res, 500, { ok: false, error: boundedError(error) })

--- a/lib/remote-settings-bridge.js
+++ b/lib/remote-settings-bridge.js
@@ -3,7 +3,7 @@ import { installRemoteSettingsRiskConfirmationBridge } from './remote-settings-r
 import { installSettingsIaClientPrelude } from './settings-ia-client-prelude.js'
 import { installLegacySettingsMigration } from './settings-migration.js'
 import { installV2SettingsIaIntegration } from './v2-settings-ia-integration.js'
-import { runtimeConfigFieldBudgetError } from './runtime-config-normalizer.js'
+import { remoteConfigFieldAdmissionError } from './runtime-config-normalizer.js'
 
 const SETTINGS_NS = 'vision-router'
 
@@ -109,7 +109,7 @@ function validateMutation(payload, descriptor) {
   const value = descriptor && descriptor.value
   if (typeof value !== 'object' || value === null || Array.isArray(value) || !Object.prototype.hasOwnProperty.call(value, field)) return { error: 'unknown Vision Router settings field ' + JSON.stringify(field) }
   if (op.op === 'set') {
-    const budgetError = runtimeConfigFieldBudgetError(field, op.value)
+    const budgetError = remoteConfigFieldAdmissionError(field, op.value)
     if (budgetError) return { error: budgetError }
   }
   return { ops: [op], expectedRevision }

--- a/lib/replay-delegation.js
+++ b/lib/replay-delegation.js
@@ -12,7 +12,6 @@ const dynamicWrapperAdapters = new WeakMap()
 const NATIVE_DEEPSEEK_ROUTE = 'deepseek-official-native'
 const OFFICIAL_DEEPSEEK_ROUTE = 'deepseek-official'
 const VISION_HTTP_ROUTE = 'vision-http'
-const MAIN_WRAPPER_MODEL_IDS = new Set(['deepseek-v4-pro', 'deepseek-v4-flash'])
 
 // One entry per (sessionId, provider, model) tuple: a long-running dsh web
 // process would otherwise grow the reasoning-effort memory without bound as
@@ -153,45 +152,52 @@ function withoutReasoningEffort(options) {
   return rest
 }
 
-async function mainWrapperModels(ctx, fallbackWrapperRoute) {
+async function mainWrapperCatalog(ctx) {
   // When the hidden native route is active the public stock DeepSeek row owns
   // the picker and the legacy wrapper is intentionally hidden.
-  if (nativeDeepSeekActive(ctx)) return []
+  if (nativeDeepSeekActive(ctx)) return { adapter: undefined, models: [] }
   let registration
   try {
     registration = ctx?.llm?.registration(OFFICIAL_DEEPSEEK_ROUTE)
   } catch {
-    return []
+    return { adapter: undefined, models: [] }
   }
   const adapter = registration && registration.adapter
-  if (!adapter || typeof adapter.listModels !== 'function') return []
+  if (!adapter || typeof adapter.listModels !== 'function') {
+    return { adapter, models: [] }
+  }
   try {
     const listed = await adapter.listModels(OFFICIAL_DEEPSEEK_ROUTE)
-    const route = currentWrapperRoute(ctx, fallbackWrapperRoute)
-    return (Array.isArray(listed) ? listed : [])
-      .filter((model) => model && MAIN_WRAPPER_MODEL_IDS.has(model.id))
-      .map((model) => ({
-        ...model,
-        provider: route,
-        inputModalities: ['text', 'image'],
-      }))
+    return {
+      adapter,
+      models: (Array.isArray(listed) ? listed : []).filter(
+        (entry) => entry && isNonEmptyString(entry.id),
+      ),
+    }
   } catch {
-    return []
+    return { adapter, models: [] }
   }
 }
 
+async function mainWrapperModels(ctx, fallbackWrapperRoute) {
+  const { models } = await mainWrapperCatalog(ctx)
+  const route = currentWrapperRoute(ctx, fallbackWrapperRoute)
+  return models.map((model) => ({
+    ...model,
+    provider: route,
+    inputModalities: ['text', 'image'],
+  }))
+}
+
 async function mainWrapperModel(ctx, fallbackWrapperRoute, model, signal) {
-  // Composite legacy vision-chain entries are not DeepSeek models; leave them
-  // to the core wrapper's existing resolver.
-  if (!MAIN_WRAPPER_MODEL_IDS.has(model) || nativeDeepSeekActive(ctx)) return undefined
-  let registration
-  try {
-    registration = ctx?.llm?.registration(OFFICIAL_DEEPSEEK_ROUTE)
-  } catch {
-    return undefined
-  }
-  const adapter = registration && registration.adapter
+  // The special wrapper mirrors the *live official DeepSeek catalog* rather
+  // than a frozen list of model ids. DSH stable can add a new default model
+  // without requiring a Vision Router release, while membership still fails
+  // closed to the official provider and cannot follow textProvider/relay rows.
+  if (!isNonEmptyString(model) || nativeDeepSeekActive(ctx)) return undefined
+  const { adapter, models } = await mainWrapperCatalog(ctx)
   if (!adapter || typeof adapter.resolveModel !== 'function') return undefined
+  if (!models.some((entry) => entry.id === model)) return undefined
   const base = await adapter.resolveModel(OFFICIAL_DEEPSEEK_ROUTE, model, signal)
   return {
     ...base,
@@ -246,6 +252,7 @@ function dynamicWrapperAdapter(adapter, ctx, fallbackWrapperRoute) {
           const pinned = await mainWrapperModels(ctx, fallbackWrapperRoute)
           if (typeof original !== 'function') return pinned
           const route = currentWrapperRoute(ctx, fallbackWrapperRoute)
+          const pinnedIds = new Set(pinned.map((model) => model.id))
           let composites = []
           try {
             const listed = await original.apply(target, args)
@@ -254,14 +261,13 @@ function dynamicWrapperAdapter(adapter, ctx, fallbackWrapperRoute) {
               // ("provider/model（视觉）", published when whole-turn routing is
               // enabled) so the legacy routing mode keeps its picker entries.
               // These rows are structurally composite ids (`provider/model`);
-              // any DeepSeek mirror — and any other row the core might emit —
-              // is dropped here: normal DeepSeek models must keep coming from
-              // the pinned official/native identity above, never from the
-              // possibly-stale textProvider.
+              // any official DeepSeek mirror — and any other row the core may
+              // emit — is dropped here. Normal DeepSeek models come only from
+              // the live official catalog above, never from textProvider.
               composites = listed.filter(
                 (row) => row
                   && row.provider === route
-                  && !MAIN_WRAPPER_MODEL_IDS.has(row.id)
+                  && !pinnedIds.has(row.id)
                   && String(row.id ?? '').includes('/'),
               )
             }

--- a/lib/runtime-config-normalizer.js
+++ b/lib/runtime-config-normalizer.js
@@ -12,6 +12,12 @@ export const MAX_RUNTIME_EXTRA_VISION_MODELS = 256
 export const MAX_RUNTIME_WRAPPED_PROVIDER_ROWS = 32
 export const MAX_RUNTIME_WRAPPED_MODELS_PER_PROVIDER = 128
 export const MAX_RUNTIME_COMPLEX_FIELD_BYTES = 256 * 1024
+export const MAX_RUNTIME_GUIDANCE_OVERRIDES = 14
+export const MAX_RUNTIME_GUIDANCE_CHARS = 2_000
+export const MAX_REMOTE_MUTATION_VALUE_BYTES = 256 * 1024
+export const MAX_REMOTE_MUTATION_STRING_BYTES = 64 * 1024
+export const MAX_REMOTE_MUTATION_NODES = 8_192
+export const MAX_REMOTE_MUTATION_DEPTH = 16
 export const RETIRED_RUNTIME_CONFIG_KEYS = Object.freeze([
   'visionGuideStep',
   'instantDescribe',
@@ -32,6 +38,67 @@ function validIdentifier(value) {
 
 function identifierBytes(value) {
   return Buffer.byteLength(value, 'utf8')
+}
+
+function unknownKeys(value, allowed) {
+  if (!plainObject(value)) return []
+  return Object.keys(value).filter((key) => !allowed.has(key))
+}
+
+/** Bound the complete value before remote Settings clones or persists it. */
+export function remoteMutationValueBudgetError(value) {
+  const stack = [{ value, depth: 0 }]
+  const seen = new Set()
+  let bytes = 0
+  let nodes = 0
+  while (stack.length > 0) {
+    const current = stack.pop()
+    if (current.depth > MAX_REMOTE_MUTATION_DEPTH) {
+      return `remote settings values may be nested at most ${MAX_REMOTE_MUTATION_DEPTH} levels`
+    }
+    nodes += 1
+    if (nodes > MAX_REMOTE_MUTATION_NODES) {
+      return `remote settings values may contain at most ${MAX_REMOTE_MUTATION_NODES} nodes`
+    }
+    const item = current.value
+    if (item === null) {
+      bytes += 4
+    } else if (typeof item === 'string') {
+      const weight = identifierBytes(item)
+      if (weight > MAX_REMOTE_MUTATION_STRING_BYTES) {
+        return `remote settings strings may contain at most ${MAX_REMOTE_MUTATION_STRING_BYTES} UTF-8 bytes`
+      }
+      bytes += weight
+    } else if (typeof item === 'number') {
+      if (!Number.isFinite(item)) return 'remote settings values must be JSON-compatible'
+      bytes += 16
+    } else if (typeof item === 'boolean') {
+      bytes += 5
+    } else if (Array.isArray(item)) {
+      if (seen.has(item)) return 'remote settings values must be an acyclic JSON tree'
+      seen.add(item)
+      bytes += 2
+      for (let index = item.length - 1; index >= 0; index -= 1) {
+        stack.push({ value: item[index], depth: current.depth + 1 })
+      }
+    } else if (plainObject(item)) {
+      if (seen.has(item)) return 'remote settings values must be an acyclic JSON tree'
+      seen.add(item)
+      bytes += 2
+      const entries = Object.entries(item)
+      for (let index = entries.length - 1; index >= 0; index -= 1) {
+        const [key, child] = entries[index]
+        bytes += identifierBytes(key)
+        stack.push({ value: child, depth: current.depth + 1 })
+      }
+    } else {
+      return 'remote settings values must be JSON-compatible'
+    }
+    if (bytes > MAX_REMOTE_MUTATION_VALUE_BYTES) {
+      return `remote settings values exceed the ${MAX_REMOTE_MUTATION_VALUE_BYTES}-byte admission budget`
+    }
+  }
+  return undefined
 }
 
 function normalizeFallbacks(value) {
@@ -91,7 +158,6 @@ function normalizeWrappedProviders(value) {
     if (entry.models.length > 0 && models.values.length === 0) continue
 
     out.push({
-      ...entry,
       provider: entry.provider,
       models: models.values,
     })
@@ -109,6 +175,68 @@ function normalizeWrappedProviders(value) {
  * persisted profiles fail to load.
  */
 export function runtimeConfigFieldBudgetError(field, value) {
+  if (field === 'providers') {
+    if (!Array.isArray(value)) return undefined
+    if (value.length > MAX_RUNTIME_PROVIDER_ROWS) {
+      return `providers may contain at most ${MAX_RUNTIME_PROVIDER_ROWS} rows`
+    }
+    for (const entry of value) {
+      if (!plainObject(entry)) continue
+      if (unknownKeys(entry, new Set(['provider', 'model', 'fallbacks'])).length > 0) {
+        return 'providers rows may contain only provider, model and fallbacks'
+      }
+      for (const [label, identifier] of [['provider', entry.provider], ['model', entry.model]]) {
+        if (typeof identifier === 'string' && identifier.length > MAX_RUNTIME_MODEL_ID_CHARS) {
+          return `providers ${label} ids may contain at most ${MAX_RUNTIME_MODEL_ID_CHARS} characters`
+        }
+      }
+      if (Array.isArray(entry.fallbacks)) {
+        if (entry.fallbacks.length > MAX_RUNTIME_FALLBACKS_PER_ROW) {
+          return `providers rows may contain at most ${MAX_RUNTIME_FALLBACKS_PER_ROW} fallbacks`
+        }
+        for (const fallback of entry.fallbacks) {
+          if (typeof fallback === 'string' && fallback.length > MAX_RUNTIME_MODEL_ID_CHARS) {
+            return `providers fallback ids may contain at most ${MAX_RUNTIME_MODEL_ID_CHARS} characters`
+          }
+        }
+      }
+    }
+    return undefined
+  }
+
+  if (field === 'textProvider') {
+    if (!plainObject(value)) return undefined
+    if (unknownKeys(value, new Set(['provider', 'model'])).length > 0) {
+      return 'textProvider may contain only provider and model'
+    }
+    for (const [label, identifier] of [['provider', value.provider], ['model', value.model]]) {
+      if (typeof identifier === 'string' && identifier.length > MAX_RUNTIME_MODEL_ID_CHARS) {
+        return `textProvider ${label} may contain at most ${MAX_RUNTIME_MODEL_ID_CHARS} characters`
+      }
+    }
+    return undefined
+  }
+
+  if (field === 'guidanceOverrides') {
+    if (!Array.isArray(value)) return undefined
+    if (value.length > MAX_RUNTIME_GUIDANCE_OVERRIDES) {
+      return `guidanceOverrides may contain at most ${MAX_RUNTIME_GUIDANCE_OVERRIDES} rows`
+    }
+    for (const entry of value) {
+      if (!plainObject(entry)) continue
+      if (unknownKeys(entry, new Set(['kind', 'text'])).length > 0) {
+        return 'guidanceOverrides rows may contain only kind and text'
+      }
+      if (typeof entry.kind === 'string' && entry.kind.length > MAX_RUNTIME_MODEL_ID_CHARS) {
+        return `guidanceOverrides kinds may contain at most ${MAX_RUNTIME_MODEL_ID_CHARS} characters`
+      }
+      if (typeof entry.text === 'string' && entry.text.length > MAX_RUNTIME_GUIDANCE_CHARS) {
+        return `guidanceOverrides text may contain at most ${MAX_RUNTIME_GUIDANCE_CHARS} characters`
+      }
+    }
+    return undefined
+  }
+
   if (field === 'extraVisionModels') {
     if (!Array.isArray(value)) return undefined
     if (value.length > MAX_RUNTIME_EXTRA_VISION_MODELS) {
@@ -136,6 +264,9 @@ export function runtimeConfigFieldBudgetError(field, value) {
     let bytes = 0
     for (const entry of value) {
       if (!plainObject(entry)) continue
+      if (unknownKeys(entry, new Set(['provider', 'models'])).length > 0) {
+        return 'wrappedProviders rows may contain only provider and models'
+      }
       if (typeof entry.provider === 'string') {
         if (entry.provider.length > MAX_RUNTIME_MODEL_ID_CHARS) {
           return `wrappedProviders provider ids may contain at most ${MAX_RUNTIME_MODEL_ID_CHARS} characters`
@@ -165,6 +296,10 @@ export function runtimeConfigFieldBudgetError(field, value) {
   return undefined
 }
 
+export function remoteConfigFieldAdmissionError(field, value) {
+  return remoteMutationValueBudgetError(value) ?? runtimeConfigFieldBudgetError(field, value)
+}
+
 /**
  * Normalize only bounded runtime-facing fields. Settings normally validates
  * these through Schemastery, but direct apply() callers, migrations, corrupted
@@ -187,7 +322,6 @@ export function normalizeRuntimeVisionConfig(value) {
     for (const entry of source.providers) {
       if (!plainObject(entry) || !validIdentifier(entry.provider) || !validIdentifier(entry.model)) continue
       providers.push({
-        ...entry,
         provider: entry.provider,
         model: entry.model,
         fallbacks: normalizeFallbacks(entry.fallbacks),

--- a/lib/web-capability-boundary.js
+++ b/lib/web-capability-boundary.js
@@ -31,8 +31,31 @@ const ROUTE_CAPABILITY_POLICIES = new Map([
   // Model-invoking capability measurements spend user/provider quota and may
   // resolve stored credentials, so they inherit the local transport boundary.
   ['/_dsh/vision-router/capability-benchmark', new Map([
+    ['GET', { remote: WEB_ROUTE_REMOTE_CAPABILITY.ALLOW_REMOTE }],
     ['POST', { remote: WEB_ROUTE_REMOTE_CAPABILITY.LOCAL_ONLY, legacyMutation: true }],
     ['DELETE', { remote: WEB_ROUTE_REMOTE_CAPABILITY.LOCAL_ONLY, legacyMutation: true }],
+  ])],
+  ['/_dsh/vision-router/capability-runtime', new Map([
+    ['GET', { remote: WEB_ROUTE_REMOTE_CAPABILITY.ALLOW_REMOTE }],
+    ['POST', { remote: WEB_ROUTE_REMOTE_CAPABILITY.LOCAL_ONLY, legacyMutation: true }],
+  ])],
+  ['/_dsh/vision-router/host-capabilities', new Map([
+    ['GET', { remote: WEB_ROUTE_REMOTE_CAPABILITY.ALLOW_REMOTE }],
+  ])],
+  // Remote settings may consume already-discovered model ids, but a remote GET
+  // must never gain the Host-side network refresh capability. The handler
+  // independently suppresses scheduling unless the transport is local.
+  ['/_dsh/vision-router/live-models', new Map([
+    ['GET', { remote: WEB_ROUTE_REMOTE_CAPABILITY.ALLOW_REMOTE }],
+  ])],
+  ['/_dsh/vision-router/model-capabilities', new Map([
+    ['GET', { remote: WEB_ROUTE_REMOTE_CAPABILITY.ALLOW_REMOTE }],
+  ])],
+  ['/_dsh/vision-router/remote-settings-permission', new Map([
+    ['POST', { remote: WEB_ROUTE_REMOTE_CAPABILITY.LOCAL_ONLY, legacyMutation: true }],
+  ])],
+  ['/_dsh/vision-router/route-ownership', new Map([
+    ['GET', { remote: WEB_ROUTE_REMOTE_CAPABILITY.ALLOW_REMOTE }],
   ])],
   // A connectivity probe is a GET, but it drives the Host to contact configured
   // local/private model endpoints and returns endpoint health metadata. Treat
@@ -45,7 +68,9 @@ const ROUTE_CAPABILITY_POLICIES = new Map([
   ])],
 ])
 
-const DEFAULT_ROUTE_POLICY = Object.freeze({ remote: WEB_ROUTE_REMOTE_CAPABILITY.ALLOW_REMOTE })
+// DVR-owned browser routes are closed-world capabilities: a new route is local-only
+// until its exact method is reviewed and declared above. This makes omission fail closed.
+const DEFAULT_ROUTE_POLICY = Object.freeze({ remote: WEB_ROUTE_REMOTE_CAPABILITY.LOCAL_ONLY })
 
 function routeCapabilityPolicy(path, method) {
   const methods = ROUTE_CAPABILITY_POLICIES.get(String(path ?? ''))

--- a/scripts/alpha-browser-cold-toggle-smoke.mjs
+++ b/scripts/alpha-browser-cold-toggle-smoke.mjs
@@ -200,6 +200,30 @@ async function selectedWorkspaceName(page) {
   return { selector, name: (await selector.innerText()).trim() }
 }
 
+async function assertVisionToggleSettledWithPair(toggle, phase) {
+  const deadline = Date.now() + 10_000
+  let state
+  while (Date.now() < deadline) {
+    state = await toggle.evaluate((element) => ({
+      disabled: Boolean(element.disabled),
+      title: element.getAttribute('title') || '',
+      ariaLabel: element.getAttribute('aria-label') || '',
+    }))
+    const detail = `${state.title}
+${state.ariaLabel}`
+    if (/No matching.*Auto Vision|没有对应.*自动识图/i.test(detail)) {
+      const error = new Error(`${phase} Vision toggle has no matching Vision Router twin: ${detail.trim()}`)
+      error.code = 'VISION_TWIN_UNAVAILABLE'
+      throw error
+    }
+    if (!/Loading model information|正在读取模型信息/i.test(detail)) return state
+    await toggle.page().waitForTimeout(250)
+  }
+  const error = new Error(`${phase} Vision toggle did not settle its model directory in 10s`)
+  error.code = 'VISION_TWIN_DIRECTORY_TIMEOUT'
+  throw error
+}
+
 async function ensureExistingWorkspaceSelected(page, expectedName) {
   let current = await selectedWorkspaceName(page)
   if (current.name === expectedName) return
@@ -309,6 +333,7 @@ try {
   const toggle = page.locator('[data-vision-router-mode-toggle="true"]')
   await toggle.waitFor({ state: 'visible', timeout: 30_000 })
   await page.waitForTimeout(750)
+  const firstToggleState = await assertVisionToggleSettledWithPair(toggle, 'first session')
 
   let injectionErrors = diagnostics.filter((line) =>
     /cannot get property ["']remote\.session["'] without inject/i.test(line),
@@ -344,11 +369,13 @@ try {
   // Do not open the stock model picker. The Vision slot must be the first
   // consumer that can cold-resolve this session-scoped model directory.
   stage = 'cold-toggle'
-  await page.locator('[data-vision-router-mode-toggle="true"]').waitFor({
+  const coldToggle = page.locator('[data-vision-router-mode-toggle="true"]')
+  await coldToggle.waitFor({
     state: 'visible',
     timeout: 30_000,
   })
   await page.waitForTimeout(750)
+  const coldToggleState = await assertVisionToggleSettledWithPair(coldToggle, 'refreshed session')
 
   stage = 'diagnostics'
   injectionErrors = diagnostics.filter((line) =>
@@ -372,13 +399,17 @@ try {
     workspaceAdoptedThroughRealUi: true,
     firstSessionIntentVisionToggleVisible: true,
     refreshedSessionIntentVisionToggleVisible: true,
+    firstSessionVisionToggleState: firstToggleState,
+    refreshedSessionVisionToggleState: coldToggleState,
     nativeModelPickerOpened: false,
     modelRequestSent: false,
   }))
 } catch (error) {
   failed = true
   const message = error instanceof Error ? error.message : String(error)
-  if (/cannot get property ["']remote\.session["'] without inject/i.test(message)) {
+  if (error && (error.code === 'VISION_TWIN_UNAVAILABLE' || error.code === 'VISION_TWIN_DIRECTORY_TIMEOUT')) {
+    failureKind = 'vision-twin-unavailable'
+  } else if (/cannot get property ["']remote\.session["'] without inject/i.test(message)) {
     failureKind = 'product-injection-regression'
   } else if (/pageerror:/i.test(message)) {
     failureKind = 'browser-pageerror'

--- a/scripts/dsh-alpha-source-contract.mjs
+++ b/scripts/dsh-alpha-source-contract.mjs
@@ -128,6 +128,11 @@ assert.equal(Buffer.compare(Buffer.from(migratedPrepared.data), Buffer.from(sour
 const llmSource = await readFile(path.join(dshRoot, 'packages/llm/llm/src/index.ts'), 'utf8')
 assert.match(
   llmSource,
+  /listProviders\(\): LlmProviderInfo\[\]/,
+  'supported 0.1.5 Hosts must expose the live provider registry used by Vision twin reconciliation',
+)
+assert.match(
+  llmSource,
   /imageRequestPricing\(_provider: string, _model: string\): LlmImageRequestPricing \| undefined \{\s*return undefined/,
 )
 assert.match(

--- a/tests/alpha1-web-auth-boundary.test.js
+++ b/tests/alpha1-web-auth-boundary.test.js
@@ -143,10 +143,10 @@ test('authenticated alpha.1 requests continue into the existing local-machine po
   }
 })
 
-test('pre-alpha Hosts without requestRejection preserve the existing DVR route behavior', () => {
+test('pre-alpha Hosts preserve declared remote reads while undeclared DVR routes fail closed', () => {
   const mounted = registerThroughBoundary({
     connection: {},
-    path: '/_dsh/vision-router/product-state',
+    path: '/_dsh/vision-router/host-capabilities',
   })
   try {
     const { response, state } = responseRecorder()
@@ -156,6 +156,16 @@ test('pre-alpha Hosts without requestRejection preserve the existing DVR route b
     assert.equal(state.body, 'ok')
   } finally {
     mounted.dispose()
+  }
+
+  const undeclared = registerThroughBoundary({ connection: {}, path: '/_dsh/vision-router/product-state' })
+  try {
+    const { response, state } = responseRecorder()
+    undeclared.route().handler(realRequest(), response)
+    assert.equal(undeclared.calls(), 0)
+    assert.equal(state.status, 403)
+  } finally {
+    undeclared.dispose()
   }
 })
 

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -1073,6 +1073,9 @@ test('presented image resource cache keeps hard bounds even when the loaded hist
   assert.deepEqual(cache.stats(), {
     entries: 1,
     settledEntries: 1,
+    pendingEntries: 0,
+    activeLoads: 0,
+    queuedLoads: 0,
     residentBytes: 4,
     ownedEntries: 1,
     disposed: false,
@@ -1088,10 +1091,94 @@ test('presented image resource cache keeps hard bounds even when the loaded hist
   assert.deepEqual(cache.stats(), {
     entries: 2,
     settledEntries: 2,
+    pendingEntries: 0,
+    activeLoads: 0,
+    queuedLoads: 0,
     residentBytes: 3,
     ownedEntries: 2,
     disposed: false,
   })
+})
+
+
+test('presented image resource cache bounds active reads and pending admission before bytes settle', async () => {
+  const bundle = loadClientBundle()
+  let releaseGate
+  const gate = new Promise((resolve) => { releaseGate = resolve })
+  let calls = 0
+  let active = 0
+  let maxActive = 0
+  const cache = bundle.createPresentedImageResourceCache({
+    maxActiveLoads: 2,
+    maxPendingEntries: 4,
+    maxEntries: 8,
+    maxBytes: 1024,
+    createObjectURL: (_data, mediaType) => `blob:${mediaType}:${calls}`,
+    revokeObjectURL: () => {},
+  })
+  const loader = async () => {
+    calls += 1
+    active += 1
+    maxActive = Math.max(maxActive, active)
+    await gate
+    active -= 1
+    return { data: new Uint8Array(8), mediaType: 'image/png' }
+  }
+
+  const accepted = [0, 1, 2, 3].map((index) => cache.load(`pending-${index}`, loader, {}))
+  await assert.rejects(
+    cache.load('overflow', loader, {}),
+    (error) => error && error.code === 'VISION_PRESENT_CACHE_BUSY',
+  )
+  await Promise.resolve()
+  assert.equal(calls, 2, 'only the configured number of attachment reads may start')
+  assert.deepEqual(cache.stats(), {
+    entries: 4,
+    settledEntries: 0,
+    pendingEntries: 4,
+    activeLoads: 2,
+    queuedLoads: 2,
+    residentBytes: 0,
+    ownedEntries: 0,
+    disposed: false,
+  })
+
+  releaseGate()
+  await Promise.all(accepted)
+  assert.equal(calls, 4)
+  assert.equal(maxActive, 2)
+  assert.equal(cache.stats().pendingEntries, 0)
+  assert.equal(cache.stats().activeLoads, 0)
+})
+
+test('purging a queued presentation rejects it without consuming a read slot', async () => {
+  const bundle = loadClientBundle()
+  let releaseGate
+  const gate = new Promise((resolve) => { releaseGate = resolve })
+  let calls = 0
+  const cache = bundle.createPresentedImageResourceCache({
+    maxActiveLoads: 1,
+    maxPendingEntries: 2,
+    createObjectURL: () => 'blob:queued',
+    revokeObjectURL: () => {},
+  })
+  const ownerA = {}
+  const ownerB = {}
+  const first = cache.load('active', async () => {
+    calls += 1
+    await gate
+    return { data: new Uint8Array(1), mediaType: 'image/png' }
+  }, ownerA)
+  const queued = cache.load('queued', async () => {
+    calls += 1
+    return { data: new Uint8Array(1), mediaType: 'image/png' }
+  }, ownerB)
+  assert.equal(cache.release('queued', ownerB, { purge: true }), true)
+  await assert.rejects(queued, /load released/)
+  assert.equal(calls, 1)
+  releaseGate()
+  await first
+  assert.equal(calls, 1)
 })
 
 test('presented image resource cache deduplicates owners and purges only after the final card releases', async () => {
@@ -1173,6 +1260,9 @@ test('presented image resource cache disposal rejects late loads without creatin
   assert.deepEqual(cache.stats(), {
     entries: 0,
     settledEntries: 0,
+    pendingEntries: 0,
+    activeLoads: 0,
+    queuedLoads: 0,
     residentBytes: 0,
     ownedEntries: 0,
     disposed: true,

--- a/tests/live-model-discovery.test.js
+++ b/tests/live-model-discovery.test.js
@@ -222,6 +222,85 @@ test('Host discovery uses configured transport/credential and disk cache is disp
   }
 })
 
+
+test('remote live-model snapshot cannot schedule Host provider I/O while local refresh still can', async () => {
+  const cacheFile = '/virtual/live-models-remote-boundary.json'
+  const mem = memoryCacheFs()
+  const calls = []
+  let route
+  let lifecycleCleanup
+  const settings = {
+    get(namespace) {
+      if (namespace === 'llm-pi-ai') {
+        return { providers: { zai: { baseURL: 'https://zai.example/v1', api: 'openai-completions' } } }
+      }
+      if (namespace === 'vision-router') return { providers: [] }
+      return undefined
+    },
+  }
+  const webServer = {
+    register(candidate) {
+      route = candidate
+      return () => { route = undefined }
+    },
+  }
+  const ctx = {
+    llm: { registration() { return undefined } },
+    get(name) {
+      if (name === 'settings') return settings
+      return undefined
+    },
+    on() { return () => {} },
+    inject(deps, callback) {
+      assert.deepEqual(deps, ['webServer'])
+      callback({ webServer, effect(factory) { return factory() } })
+    },
+    effect(factory) {
+      lifecycleCleanup = factory()
+      return lifecycleCleanup
+    },
+  }
+  const manager = installLiveModelDiscovery(ctx, {
+    cacheFile,
+    fsOps: mem.ops,
+    fetchImpl: async (url) => {
+      calls.push(String(url))
+      return new Response(JSON.stringify({ data: [{ id: 'glm-live' }] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    },
+  })
+  const invoke = async ({ remoteAddress, host }) => {
+    const state = { status: 0, body: '' }
+    await route.handler({
+      method: 'GET',
+      url: '/_dsh/vision-router/live-models?refresh=1',
+      headers: { host },
+      socket: { remoteAddress },
+    }, {
+      writeHead(status) { state.status = status },
+      setHeader() {},
+      end(body = '') { state.body += String(body ?? '') },
+    })
+    return state
+  }
+  try {
+    await manager.ready()
+    const remote = await invoke({ remoteAddress: '192.168.1.20', host: 'router.example.com' })
+    assert.equal(remote.status, 200)
+    assert.equal(calls.length, 0, 'remote refresh=1 must remain a passive snapshot read')
+
+    const local = await invoke({ remoteAddress: '127.0.0.1', host: 'localhost:3000' })
+    assert.equal(local.status, 200)
+    await waitForSettled(manager)
+    assert.deepEqual(calls, ['https://zai.example/v1/models'])
+  } finally {
+    lifecycleCleanup?.()
+    await manager.dispose()
+  }
+})
+
 test('credential rotation invalidates live evidence through current and legacy Host events without hashing the key', async () => {
   const dshHome = await mkdtemp(path.join(os.tmpdir(), 'vision-router-credential-events-'))
   let apiKey = 'rotation-alpha'

--- a/tests/rc6-rc7-compat.test.js
+++ b/tests/rc6-rc7-compat.test.js
@@ -224,23 +224,27 @@ test('release evidence gates keep stable and preview contracts capability-scoped
   assert.match(hostGate, /dsh: \['0\.1\.5-rc\.2', '0\.1\.5-alpha\.2'\]/)
   assert.match(hostGate, /Verify release-family Session native image process-restart lifecycle[\s\S]*?run: node scripts\/dsh-preview-native-lifecycle-contract\.mjs/)
   assert.doesNotMatch(hostGate, /if: matrix\.dsh ==/)
+  assert.match(browserGate, /dsh: 0\.1\.5-rc\.1[\s\S]*?mixedGenericFiles: false/)
   assert.match(browserGate, /dsh: 0\.1\.5-rc\.2[\s\S]*?mixedGenericFiles: true/)
   assert.match(browserGate, /dsh: 0\.1\.5-alpha\.2[\s\S]*?mixedGenericFiles: true/)
   assert.match(browserGate, /if: matrix\.mixedGenericFiles/)
+  assert.match(browserGate, /ref: 183f08e9c6dde7e36cd2318eaee70b0da08fb35e/)
   assert.match(browserGate, /ref: fb2c4b9e698e30edb738bca4cf0618587db7d203/)
   assert.match(browserGate, /ref: dsh-v0\.1\.5-alpha\.2/)
   assert.doesNotMatch(browserGate, /ref:\s*\$\{\{\s*matrix\./)
 
   assert.match(sourceGate, /name: DSH exact source contract/)
+  assert.equal((sourceGate.match(/dsh: 0\.1\.5-rc\.1/g) ?? []).length, 3)
   assert.equal((sourceGate.match(/dsh: 0\.1\.5-rc\.2/g) ?? []).length, 3)
   assert.equal((sourceGate.match(/dsh: 0\.1\.5-alpha\.2/g) ?? []).length, 3)
+  assert.equal((sourceGate.match(/183f08e9c6dde7e36cd2318eaee70b0da08fb35e/g) ?? []).length, 2)
   assert.equal((sourceGate.match(/fb2c4b9e698e30edb738bca4cf0618587db7d203/g) ?? []).length, 2)
   assert.equal((sourceGate.match(/b2e3b2a0125854567a4a5fcba75782e42fe84901/g) ?? []).length, 2)
   assert.doesNotMatch(sourceGate, /ref:\s*\$\{\{\s*matrix\./)
   assert.doesNotMatch(sourceGate, /cache:\s*pnpm/)
   assert.doesNotMatch(sourceGate, /cache-dependency-path:/)
   for (const os of ['ubuntu-latest', 'macos-latest', 'windows-latest']) {
-    assert.equal((sourceGate.match(new RegExp(`os: ${os}`, 'g')) ?? []).length, 2)
+    assert.equal((sourceGate.match(new RegExp(`os: ${os}`, 'g')) ?? []).length, 3)
   }
 })
 

--- a/tests/replay-delegation.test.js
+++ b/tests/replay-delegation.test.js
@@ -138,6 +138,7 @@ function liveWrapperHarness({ initialProvider = 'deepseek-official', native = fa
     adapter: {
       async listModels(provider) {
         return [
+          { provider, id: 'deepseek-flash', name: 'DeepSeek-V41-Flash', inputModalities: ['text', 'image'] },
           { provider, id: 'deepseek-v4-pro', name: 'DeepSeek V4 Pro', inputModalities: ['text'] },
           { provider, id: 'deepseek-v4-flash', name: 'DeepSeek V4 Flash', inputModalities: ['text'] },
         ]
@@ -261,11 +262,11 @@ test('main DeepSeek auto-vision wrapper never follows an arbitrary live textProv
   ])
 })
 
-test('main wrapper metadata stays DeepSeek even when textProvider is a Kimi/relay route', async () => {
+test('issue #469: main wrapper mirrors the live official DeepSeek catalog even when textProvider is a relay', async () => {
   const harness = liveWrapperHarness({ initialProvider: 'relay-openai' })
   const adapter = harness.adapter()
   const listed = await adapter.listModels('deepseek-vision')
-  assert.deepEqual(listed.map((model) => model.id), ['deepseek-v4-pro', 'deepseek-v4-flash'])
+  assert.deepEqual(listed.map((model) => model.id), ['deepseek-flash', 'deepseek-v4-pro', 'deepseek-v4-flash'])
   assert.ok(listed.every((model) => model.provider === 'deepseek-vision'))
   assert.ok(listed.every((model) => model.inputModalities.includes('image')))
 
@@ -273,6 +274,10 @@ test('main wrapper metadata stays DeepSeek even when textProvider is a Kimi/rela
   assert.equal(resolved.provider, 'deepseek-vision')
   assert.equal(resolved.id, 'deepseek-v4-pro')
   assert.deepEqual(resolved.inputModalities, ['text', 'image'])
+  const stableDefault = await adapter.resolveModel('deepseek-vision', 'deepseek-flash')
+  assert.equal(stableDefault.provider, 'deepseek-vision')
+  assert.equal(stableDefault.id, 'deepseek-flash')
+  assert.deepEqual(stableDefault.inputModalities, ['text', 'image'])
   assert.equal(adapter.providerRetryPolicy('deepseek-vision'), 'deepseek-retry')
 })
 
@@ -287,6 +292,7 @@ test('main wrapper listModels restores only config-driven composite rows while p
     adapter: {
       async listModels(provider) {
         return [
+          { provider, id: 'deepseek-flash', name: 'DeepSeek-V41-Flash', inputModalities: ['text', 'image'] },
           { provider, id: 'deepseek-v4-pro', name: 'DeepSeek V4 Pro', inputModalities: ['text'] },
           { provider, id: 'deepseek-v4-flash', name: 'DeepSeek V4 Flash', inputModalities: ['text'] },
         ]
@@ -392,7 +398,7 @@ test('main wrapper listModels restores only config-driven composite rows while p
 
   // routing=false: pinned official DeepSeek only, no composite noise.
   const listedOff = await registeredAdapter.listModels('deepseek-vision')
-  assert.deepEqual(listedOff.map((model) => model.id), ['deepseek-v4-pro', 'deepseek-v4-flash'])
+  assert.deepEqual(listedOff.map((model) => model.id), ['deepseek-flash', 'deepseek-v4-pro', 'deepseek-v4-flash'])
   assert.ok(listedOff.every((model) => model.provider === 'deepseek-vision'))
   assert.ok(listedOff.every((model) => model.inputModalities.includes('image')))
 
@@ -401,7 +407,7 @@ test('main wrapper listModels restores only config-driven composite rows while p
   routingEnabled = true
   const listedOn = await registeredAdapter.listModels('deepseek-vision')
   const idsOn = listedOn.map((model) => model.id)
-  assert.ok(idsOn.includes('deepseek-v4-pro') && idsOn.includes('deepseek-v4-flash'))
+  assert.ok(idsOn.includes('deepseek-flash') && idsOn.includes('deepseek-v4-pro') && idsOn.includes('deepseek-v4-flash'))
   assert.ok(idsOn.includes('zhipu/glm-4.6v-flash'), 'authorized composite row kept')
   assert.ok(!idsOn.includes('k3'), 'stray non-composite row dropped')
   assert.ok(!idsOn.some((id) => id.includes('kimi') || id.includes('xiaomi')), 'DSH-only providers never listed')

--- a/tests/runtime-boundary-fixes.test.js
+++ b/tests/runtime-boundary-fixes.test.js
@@ -445,8 +445,8 @@ test('local mutation boundary preserves injected child identity and rejects remo
     { method: 'GET', socket: { remoteAddress: '10.0.0.8' }, headers: { host: 'router.example.com' } },
     res,
   )
-  assert.equal(res.status, 200)
-  assert.equal(calls, 2)
+  assert.equal(res.status, 403, 'undeclared methods on a DVR capability route fail closed')
+  assert.equal(calls, 1)
 
   for (const cleanup of cleanups.reverse()) cleanup()
 })

--- a/tests/security-resource-boundaries.test.js
+++ b/tests/security-resource-boundaries.test.js
@@ -10,6 +10,7 @@ import {
 import {
   MAX_RUNTIME_COMPLEX_FIELD_BYTES,
   MAX_RUNTIME_EXTRA_VISION_MODELS,
+  MAX_RUNTIME_GUIDANCE_CHARS,
   MAX_RUNTIME_WRAPPED_MODELS_PER_PROVIDER,
   MAX_RUNTIME_WRAPPED_PROVIDER_ROWS,
   normalizeRuntimeVisionConfig,
@@ -115,8 +116,21 @@ test('web route capability policy classifies side-effecting GET without changing
     WEB_ROUTE_REMOTE_CAPABILITY.REDACT_REMOTE,
   )
   assert.equal(
-    webRouteRemoteCapability('/_dsh/vision-router/product-state', 'GET'),
+    webRouteRemoteCapability('/_dsh/vision-router/live-models', 'GET'),
     WEB_ROUTE_REMOTE_CAPABILITY.ALLOW_REMOTE,
+  )
+  assert.equal(
+    webRouteRemoteCapability('/_dsh/vision-router/capability-runtime', 'GET'),
+    WEB_ROUTE_REMOTE_CAPABILITY.ALLOW_REMOTE,
+  )
+  assert.equal(
+    webRouteRemoteCapability('/_dsh/vision-router/capability-runtime', 'POST'),
+    WEB_ROUTE_REMOTE_CAPABILITY.LOCAL_ONLY,
+  )
+  assert.equal(
+    webRouteRemoteCapability('/_dsh/vision-router/product-state', 'GET'),
+    WEB_ROUTE_REMOTE_CAPABILITY.LOCAL_ONLY,
+    'undeclared DVR routes must fail closed',
   )
 })
 
@@ -148,12 +162,17 @@ test('runtime normalization bounds complex model lists without broadening malfor
   }
   raw.wrappedProviders.unshift({ provider: 'malformed', models: { not: 'an array' } })
 
+  raw.wrappedProviders[1].padding = 'legacy-ignored-field'
+  raw.providers = [{ provider: 'p', model: 'm', fallbacks: [], padding: 'legacy-ignored-field' }]
+
   const normalized = normalizeRuntimeVisionConfig(raw)
   assert.equal(normalized.extraVisionModels.length, MAX_RUNTIME_EXTRA_VISION_MODELS)
   assert.equal(normalized.extraVisionModels[0], 'vision-0')
   assert.ok(normalized.wrappedProviders.length <= MAX_RUNTIME_WRAPPED_PROVIDER_ROWS)
   assert.equal(normalized.wrappedProviders.some((entry) => entry.provider === 'malformed'), false)
   assert.ok(normalized.wrappedProviders.every((entry) => entry.models.length <= MAX_RUNTIME_WRAPPED_MODELS_PER_PROVIDER))
+  assert.equal(Object.hasOwn(normalized.wrappedProviders[0], 'padding'), false)
+  assert.deepEqual(normalized.providers, [{ provider: 'p', model: 'm', fallbacks: [] }])
 
   const explicitAll = normalizeRuntimeVisionConfig({
     wrappedProviders: [{ provider: 'intentional-all', models: [] }],
@@ -188,6 +207,9 @@ function remoteSettingsFixture() {
     [REMOTE_SETTINGS_PERMISSION]: true,
     extraVisionModels: [],
     wrappedProviders: [],
+    providers: [],
+    guidanceOverrides: [],
+    textProvider: { provider: 'deepseek-official', model: 'deepseek-v4-pro' },
     routing: false,
   }
   const calls = []
@@ -212,6 +234,25 @@ function remoteSettingsFixture() {
   }
   return { settings, calls }
 }
+
+
+test('remote admission rejects whole-value amplification and unknown nested payloads', async () => {
+  for (const [field, value, expected] of [
+    ['wrappedProviders', [{ provider: 'p', models: ['m'], padding: 'x'.repeat(5 * 1024 * 1024) }], /remote settings strings|admission budget|only provider and models/],
+    ['providers', [{ provider: 'p', model: 'm', fallbacks: [], padding: 'x'.repeat(1_000) }], /only provider, model and fallbacks/],
+    ['guidanceOverrides', [{ kind: 'document', text: 'x'.repeat(MAX_RUNTIME_GUIDANCE_CHARS + 1) }], /guidanceOverrides text/],
+    ['textProvider', { provider: 'p', model: 'm', padding: 'x' }, /textProvider may contain only/],
+  ]) {
+    const fixture = remoteSettingsFixture()
+    const result = await createVisionRouterRemoteSettingsHandler(fixture.settings)('mutate', {
+      expectedRevision: 4,
+      ops: [{ op: 'set', path: [field], value }],
+    })
+    assert.equal(result.ok, false, field)
+    assert.match(result.error.message, expected, field)
+    assert.equal(fixture.calls.length, 0, `${field} must fail before settings.mutate`)
+  }
+})
 
 test('remote bridge rejects oversized complex settings before settings.mutate while accepting bounded values', async () => {
   const oversized = remoteSettingsFixture()


### PR DESCRIPTION
## Summary

Closes the post-merge release blockers found after #470-#473:

- make DVR browser route capabilities closed-world and keep remote live-model reads passive
- bound complete remote Settings mutation values and strip unknown runtime fields
- bound pending `vision_present` attachment reads before bytes settle
- add exact DSH 0.1.5-rc.1 source + real Host/Chromium coverage and fail when Vision has no matching twin

## Security / resource behavior

- undeclared DVR route/methods now default to local-only
- remote `/live-models` may read cached discovery state but cannot schedule Host provider I/O
- remote Settings values are bounded by total UTF-8 bytes, per-string bytes, node count and nesting depth before mutation
- known complex settings keep exact runtime shapes rather than carrying unknown object fields
- presented-image reads are capped at 3 active loads and 256 pending entries; queued loads are purged without consuming a slot
- settled presentation cache remains capped at 32 entries / 64 MiB

## Compatibility gate

DSH 0.1.5-rc.1 is now exercised on Ubuntu/macOS/Windows exact source and the real Chromium Host smoke. The browser smoke waits for the model directory to settle and fails explicitly on the user-visible `No matching + Auto Vision` / `没有对应 + 自动识图` state instead of merely checking that the button exists.

## Local validation

- `pnpm test`: 1344 pass, 1 existing skip, 0 fail
- runtime policy suite: 6/6
- `test:web`: 139/139
- focused web/security/live-model suite: 43/43
- focused presentation cache suite: 53/53
