### PR TITLE
fix(security): enforce Actions source policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,6 +25,12 @@ unmergeable when no second maintainer is available. Automated/AI review is usefu
 additional evidence, but is not represented as human approval. This policy should
 be revisited when a second active maintainer can reliably review changes.
 
+GitHub Actions is also restricted at the repository policy layer: external actions
+must use full-length commit SHAs, and executable action sources are limited to
+GitHub-owned actions plus the explicitly approved `ossf/scorecard-action` and
+`pnpm/action-setup` repositories. The workflow contract tests mirror this allow-list
+so source changes cannot silently drift away from the platform policy.
+
 Security-sensitive input boundaries also have deterministic adversarial fuzzing.
 Pull requests replay a fixed seed for regression stability; scheduled and manual
 runs add a rotating seed for broader exploration. A failing run reports the seed

--- a/tests/manifest-dependencies.test.js
+++ b/tests/manifest-dependencies.test.js
@@ -240,6 +240,28 @@ test('all GitHub Actions dependencies are pinned to immutable commit SHAs', asyn
   }
 })
 
+test('workflow action sources stay within the repository execution allow-list', async () => {
+  const workflowDir = new URL('../.github/workflows/', import.meta.url)
+  const names = await readdir(workflowDir)
+  const allowedThirdParty = new Set([
+    'ossf/scorecard-action',
+    'pnpm/action-setup',
+  ])
+
+  for (const name of names.filter((entry) => entry.endsWith('.yml') || entry.endsWith('.yaml'))) {
+    const source = await readFile(new URL(name, workflowDir), 'utf8')
+    const uses = [...source.matchAll(/^\s*-?\s*uses:\s*([^\s#]+)(?:\s*#.*)?$/gm)].map((match) => match[1])
+    for (const spec of uses) {
+      if (spec.startsWith('./') || spec.startsWith('docker://')) continue
+      const actionPath = spec.slice(0, spec.lastIndexOf('@'))
+      const [owner, repo] = actionPath.split('/')
+      const repository = `${owner}/${repo}`
+      const allowed = owner === 'actions' || owner === 'github' || allowedThirdParty.has(repository)
+      assert.equal(allowed, true, `${name}: action source ${repository} is not allowed by the repository Actions policy`)
+    }
+  }
+})
+
 test('large-image stress policy cannot regress to a one-off development branch gate', async () => {
   const workflow = await readFile(new URL('../.github/workflows/resource-stress.yml', import.meta.url), 'utf8')
   assert.match(workflow, /pull_request:/)


### PR DESCRIPTION
## Summary

Hardens GitHub Actions execution at both the repository-policy and source-contract layers.

- repository Actions policy is now `allowed_actions=selected`
- GitHub-owned actions remain allowed
- the only explicitly permitted third-party action repositories are `ossf/scorecard-action` and `pnpm/action-setup`
- repository policy now requires every action to be pinned to a full-length commit SHA (`sha_pinning_required=true`)
- adds a permanent workflow contract test that rejects action sources outside the same allow-list
- documents the platform policy in `SECURITY.md`

## Repository-side hardening already applied

This PR accompanies a real GitHub repository setting change, not a simulated config file.

Current Actions policy:

```json
{"enabled":true,"allowed_actions":"selected","sha_pinning_required":true}
```

Selected sources:

```json
{"github_owned_allowed":true,"verified_allowed":false,"patterns_allowed":["ossf/scorecard-action@*","pnpm/action-setup@*"]}
```

The default workflow token policy remains unchanged and least-privilege:

```json
{"default_workflow_permissions":"read","can_approve_pull_request_reviews":false}
```

GitHub's full-SHA policy and the in-repo 40-character SHA test now reinforce each other: deleting or weakening one layer is not enough to make a floating external action executable.

## Validation

- workflow source allow-list contract — 33/33
- `pnpm test:contract` — 163/163
- `pnpm test` — 1348 pass / 1 existing skip / 0 fail
- runtime policy suite — 6/6
- current `main` inventory contains no external action reference outside the platform allow-list and no non-full-SHA external action reference
- `git diff --check` — clean
- original doctor worktree remains untouched

No runtime, dependency, package, release, or DSH support-window changes.